### PR TITLE
Replace deprecated assert functions in test files.

### DIFF
--- a/extensions/resource-deployment/src/test/SemVerProxy.test.ts
+++ b/extensions/resource-deployment/src/test/SemVerProxy.test.ts
@@ -80,7 +80,7 @@ function validate(test: TestDefinition, semVerProxy: SymVerProxyTest) {
 	for (const key in test.expected) {
 		const expected = test.expected[key];
 		if (expected) {
-			assert.equal(semVerProxy[key].toString(), expected.toString(), `validation for property ${key} failed.`);
+			assert.strictEqual(semVerProxy[key].toString(), expected.toString(), `validation for property ${key} failed.`);
 		}
 	}
 }

--- a/extensions/resource-deployment/src/test/services/toolsService.test.ts
+++ b/extensions/resource-deployment/src/test/services/toolsService.test.ts
@@ -57,6 +57,6 @@ describe('Tools Service Tests', function (): void {
 			return tool!;
 		});
 		toolsService.toolsForCurrentProvider = iTools;
-		assert.deepEqual(iTools, toolsService.toolsForCurrentProvider, 'toolsForCurrentProvider did not return the value we set');
+		assert.deepStrictEqual(iTools, toolsService.toolsForCurrentProvider, 'toolsForCurrentProvider did not return the value we set');
 	});
 });

--- a/extensions/resource-deployment/src/test/services/toolsService.test.ts
+++ b/extensions/resource-deployment/src/test/services/toolsService.test.ts
@@ -38,7 +38,7 @@ describe('Tools Service Tests', function (): void {
 		tools.forEach(toolInfo => {
 			const tool = toolsService.getToolByName(toolInfo.name);
 			assert(!!tool, `The tool: ${toolInfo.name} is not recognized`);
-			assert.equal(tool!.type, toolInfo.type, 'returned tool name does not match expected value');
+			assert.strictEqual(tool!.type, toolInfo.type, 'returned tool name does not match expected value');
 		});
 	});
 
@@ -53,7 +53,7 @@ describe('Tools Service Tests', function (): void {
 		const iTools: ITool[] = tools.map(toolInfo => {
 			const tool = toolsService.getToolByName(toolInfo.name);
 			assert(!!tool, `The tool: ${toolInfo.name} is not recognized`);
-			assert.equal(tool!.type, toolInfo.type, 'returned notebook name does not match expected value');
+			assert.strictEqual(tool!.type, toolInfo.type, 'returned notebook name does not match expected value');
 			return tool!;
 		});
 		toolsService.toolsForCurrentProvider = iTools;

--- a/src/sql/base/test/browser/dom.test.ts
+++ b/src/sql/base/test/browser/dom.test.ts
@@ -11,48 +11,48 @@ suite('DOM Tests', () => {
 	test('Convert size should add px', () => {
 		const expected = '100px';
 		const actual = convertSize(100);
-		assert.equal(expected, actual);
+		assert.strictEqual(expected, actual);
 	});
 
 	test('Convert size should not add px if it already has it', () => {
 		const expected = '100px';
 		const actual = convertSize('100px');
-		assert.equal(expected, actual);
+		assert.strictEqual(expected, actual);
 	});
 
 	test('Convert size should not add px if it is a percent value', () => {
 		const expected = '100%';
 		const actual = convertSize('100%');
-		assert.equal(expected, actual);
+		assert.strictEqual(expected, actual);
 	});
 
 	test('Convert size should return the default value given undefined value', () => {
 		const expected = '200';
 		const actual = convertSize(undefined, '200');
-		assert.equal(expected, actual);
+		assert.strictEqual(expected, actual);
 	});
 
 	test('Convert to number should return size without px', () => {
 		const expected = 200;
 		const actual = convertSizeToNumber('200px');
-		assert.equal(expected, actual);
+		assert.strictEqual(expected, actual);
 	});
 
 	test('Convert to number should return same value if already plain text number', () => {
 		const expected = 200;
 		const actual = convertSizeToNumber('200');
-		assert.equal(expected, actual);
+		assert.strictEqual(expected, actual);
 	});
 
 	test('Convert to number should return same value if already plain number', () => {
 		const expected = 200;
 		const actual = convertSizeToNumber(200);
-		assert.equal(expected, actual);
+		assert.strictEqual(expected, actual);
 	});
 
 	test('Convert to number should return 0 given undefined', () => {
 		const expected = 0;
 		const actual = convertSizeToNumber(undefined);
-		assert.equal(expected, actual);
+		assert.strictEqual(expected, actual);
 	});
 });

--- a/src/sql/base/test/browser/ui/scrollableView/scrollableView.test.ts
+++ b/src/sql/base/test/browser/ui/scrollableView/scrollableView.test.ts
@@ -59,7 +59,7 @@ suite.skip('ScrollableView', () => { // TODO chgagnon Fix these tests
 	test('creates empty view', () => {
 		const scrollableView = new ScrollableView(container);
 		scrollableView.layout(200, 200);
-		assert.equal(container.firstElementChild!.firstElementChild!.firstElementChild!.childElementCount, 0, 'view should be empty');
+		assert.strictEqual(container.firstElementChild!.firstElementChild!.firstElementChild!.childElementCount, 0, 'view should be empty');
 		scrollableView.dispose();
 	});
 
@@ -79,12 +79,12 @@ suite.skip('ScrollableView', () => { // TODO chgagnon Fix these tests
 		await waitForAnimation();
 
 		let viewQuery = getViewChildren(container);
-		assert.equal(viewQuery.length, 3, 'split view should have 3 views');
+		assert.strictEqual(viewQuery.length, 3, 'split view should have 3 views');
 
 		scrollableView.clear();
 
 		viewQuery = getViewChildren(container);
-		assert.equal(viewQuery.length, 0, 'split view should have no views');
+		assert.strictEqual(viewQuery.length, 0, 'split view should have no views');
 
 		view1.dispose();
 		view2.dispose();
@@ -104,22 +104,22 @@ suite.skip('ScrollableView', () => { // TODO chgagnon Fix these tests
 
 		await waitForAnimation();
 
-		assert.equal(view1.size, 200, 'view1 is entire size');
+		assert.strictEqual(view1.size, 200, 'view1 is entire size');
 
 		scrollableView.addView(view2);
 
 		await waitForAnimation();
 
-		assert.equal(view1.size, 100, 'view1 is half size');
-		assert.equal(view2.size, 100, 'view2 is half size');
+		assert.strictEqual(view1.size, 100, 'view1 is half size');
+		assert.strictEqual(view2.size, 100, 'view2 is half size');
 
 		scrollableView.addView(view3);
 
 		await waitForAnimation();
 
-		assert.equal(view1.size, 66, 'view1 is third size');
-		assert.equal(view2.size, 67, 'view2 is third size');
-		assert.equal(view3.size, 67, 'view3 is third size');
+		assert.strictEqual(view1.size, 66, 'view1 is third size');
+		assert.strictEqual(view2.size, 67, 'view2 is third size');
+		assert.strictEqual(view3.size, 67, 'view3 is third size');
 	});
 
 	test('honors minimum size', async () => {
@@ -134,9 +134,9 @@ suite.skip('ScrollableView', () => { // TODO chgagnon Fix these tests
 
 		await waitForAnimation();
 
-		assert.equal(view1.size, 100, 'view1 is minimum size');
-		assert.equal(view2.size, 100, 'view2 is minimum size');
-		assert.equal(view3.size, 0, 'view3 should not have been layout yet');
+		assert.strictEqual(view1.size, 100, 'view1 is minimum size');
+		assert.strictEqual(view2.size, 100, 'view2 is minimum size');
+		assert.strictEqual(view3.size, 0, 'view3 should not have been layout yet');
 	});
 
 	test('reacts to changes in views', async () => {
@@ -156,9 +156,9 @@ suite.skip('ScrollableView', () => { // TODO chgagnon Fix these tests
 
 		await waitForAnimation();
 
-		assert.equal(view1.size, 130, 'view1 should be 130');
-		assert.equal(view2.size, 100, 'view2 should still be minimum size');
-		assert.equal(view3.size, 0, 'view3 should not have been layout yet');
+		assert.strictEqual(view1.size, 130, 'view1 should be 130');
+		assert.strictEqual(view2.size, 100, 'view2 should still be minimum size');
+		assert.strictEqual(view3.size, 0, 'view3 should not have been layout yet');
 	});
 
 	test('programmatically scrolls', async () => {
@@ -173,18 +173,18 @@ suite.skip('ScrollableView', () => { // TODO chgagnon Fix these tests
 
 		await waitForAnimation();
 
-		assert.equal(view1.size, 100, 'view1 is minimum size');
-		assert.equal(view2.size, 100, 'view2 is minimum size');
-		assert.equal(view3.size, 0, 'view3 should not have been layout yet');
-		assert.equal(getViewChildren(container).length, 2, 'only 2 views are rendered');
+		assert.strictEqual(view1.size, 100, 'view1 is minimum size');
+		assert.strictEqual(view2.size, 100, 'view2 is minimum size');
+		assert.strictEqual(view3.size, 0, 'view3 should not have been layout yet');
+		assert.strictEqual(getViewChildren(container).length, 2, 'only 2 views are rendered');
 
 		scrollableView.setScrollTop(100);
 
 		await waitForAnimation();
 
-		assert.equal(view2.size, 100, 'view2 is minimum size');
-		assert.equal(view3.size, 100, 'view3 is minimum size');
-		assert.equal(getViewChildren(container).length, 2, 'only 2 views are rendered');
+		assert.strictEqual(view2.size, 100, 'view2 is minimum size');
+		assert.strictEqual(view3.size, 100, 'view3 is minimum size');
+		assert.strictEqual(getViewChildren(container).length, 2, 'only 2 views are rendered');
 	});
 });
 

--- a/src/sql/base/test/browser/ui/table/gridFormatters.test.ts
+++ b/src/sql/base/test/browser/ui/table/gridFormatters.test.ts
@@ -37,6 +37,6 @@ function verifyFormattedHtml(formattedHtml: string, expectedText: string): void 
 	let spanElement = element.children[0];
 
 	// Verify that the span element's text, not its innerHTML, matches the expected text
-	assert.equal(spanElement.textContent, testText);
+	assert.strictEqual(spanElement.textContent, testText);
 	assert.notEqual(spanElement.innerHTML, testText);
 }

--- a/src/sql/base/test/browser/ui/table/gridFormatters.test.ts
+++ b/src/sql/base/test/browser/ui/table/gridFormatters.test.ts
@@ -38,5 +38,5 @@ function verifyFormattedHtml(formattedHtml: string, expectedText: string): void 
 
 	// Verify that the span element's text, not its innerHTML, matches the expected text
 	assert.strictEqual(spanElement.textContent, testText);
-	assert.notEqual(spanElement.innerHTML, testText);
+	assert.notStrictEqual(spanElement.innerHTML, testText);
 }

--- a/src/sql/base/test/browser/ui/table/tableDataView.test.ts
+++ b/src/sql/base/test/browser/ui/table/tableDataView.test.ts
@@ -95,18 +95,18 @@ suite('TableDataView', () => {
 		const dataView = new TableDataView(originalData, searchFn);
 
 		let findValue = await dataView.find('row 2');
-		assert.deepEqual(findValue, { row: 2, col: 0 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 0 });
 		findValue = await dataView.findNext();
-		assert.deepEqual(findValue, { row: 2, col: 1 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 1 });
 		findValue = await dataView.findNext();
-		assert.deepEqual(findValue, { row: 2, col: 2 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 2 });
 		findValue = await dataView.findNext();
-		assert.deepEqual(findValue, { row: 2, col: 3 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 3 });
 		findValue = await dataView.findNext();
-		assert.deepEqual(findValue, { row: 2, col: 4 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 4 });
 		// find will loop around once it reaches the end
 		findValue = await dataView.findNext();
-		assert.deepEqual(findValue, { row: 2, col: 0 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 0 });
 	});
 
 	test('Search fails correctly', async () => {
@@ -166,12 +166,12 @@ suite('TableDataView', () => {
 		const dataView = new TableDataView(originalData, searchFn);
 
 		let findValue = await dataView.find('row 2', 2);
-		assert.deepEqual(findValue, { row: 2, col: 0 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 0 });
 		findValue = await dataView.findNext();
-		assert.deepEqual(findValue, { row: 2, col: 1 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 1 });
 		// find will loop around once it reaches the end
 		findValue = await dataView.findNext();
-		assert.deepEqual(findValue, { row: 2, col: 0 });
+		assert.deepStrictEqual(findValue, { row: 2, col: 0 });
 	});
 });
 

--- a/src/sql/base/test/browser/ui/table/tableDataView.test.ts
+++ b/src/sql/base/test/browser/ui/table/tableDataView.test.ts
@@ -35,13 +35,13 @@ suite('TableDataView', () => {
 			expectedFilterStateChangeInvokeCount: number,
 			stepName: string,
 			verifyRowCountEventParameter: boolean = true) => {
-			assert.equal(rowCountEventInvokeCount, expectedRowCountChangeInvokeCount, 'RowCountChange event count - ' + stepName);
+			assert.strictEqual(rowCountEventInvokeCount, expectedRowCountChangeInvokeCount, 'RowCountChange event count - ' + stepName);
 			if (verifyRowCountEventParameter) {
-				assert.equal(rowCountEventParameter, expectedDataLength, 'Row count passed by RowCountChange event - ' + stepName);
+				assert.strictEqual(rowCountEventParameter, expectedDataLength, 'Row count passed by RowCountChange event - ' + stepName);
 			}
-			assert.equal(obj.getLength(), expectedDataLength, 'Data length - ' + stepName);
-			assert.equal(obj.getLengthNonFiltered(), expectedNonFilteredDataLength, 'Length for all data - ' + stepName);
-			assert.equal(filterStateChangeEventInvokeCount, expectedFilterStateChangeInvokeCount, 'FilterStateChange event count - ' + stepName);
+			assert.strictEqual(obj.getLength(), expectedDataLength, 'Data length - ' + stepName);
+			assert.strictEqual(obj.getLengthNonFiltered(), expectedNonFilteredDataLength, 'Length for all data - ' + stepName);
+			assert.strictEqual(filterStateChangeEventInvokeCount, expectedFilterStateChangeInvokeCount, 'FilterStateChange event count - ' + stepName);
 		};
 
 		verify(0, rowCount, rowCount, 0, 'after initialization', false);

--- a/src/sql/base/test/common/event.ts
+++ b/src/sql/base/test/common/event.ts
@@ -24,7 +24,7 @@ export class EventVerifierSingle<T> {
 	public assertFired(expectedArgument?: T) {
 		assert.ok(this._eventFired);
 		if (expectedArgument) {
-			assert.equal(this._eventArgument, expectedArgument);
+			assert.strictEqual(this._eventArgument, expectedArgument);
 		}
 	}
 
@@ -34,7 +34,7 @@ export class EventVerifierSingle<T> {
 	}
 
 	public assertNotFired() {
-		assert.equal(this._eventFired, false);
+		assert.strictEqual(this._eventFired, false);
 	}
 
 	public get eventHandler(): (arg: T) => void {

--- a/src/sql/platform/accounts/test/common/accountPickerViewModel.test.ts
+++ b/src/sql/platform/accounts/test/common/accountPickerViewModel.test.ts
@@ -61,7 +61,7 @@ suite('Account picker view model tests', () => {
 
 		// Then:
 		// ... The event for the view models should be properly initialized
-		assert.notEqual(vm.updateAccountListEvent, undefined);
+		assert.notStrictEqual(vm.updateAccountListEvent, undefined);
 
 		// ... The event should properly fire
 		let argUpdateAccounts: UpdateAccountListEventParams = { providerId: providers[0].id, accountList: accounts };

--- a/src/sql/platform/accounts/test/common/accountPickerViewModel.test.ts
+++ b/src/sql/platform/accounts/test/common/accountPickerViewModel.test.ts
@@ -89,8 +89,8 @@ suite('Account picker view model tests', () => {
 
 				// ... The results that were returned should be an array of account
 				assert.ok(Array.isArray(results));
-				assert.equal(results.length, 2);
-				assert.equal(results, accounts);
+				assert.strictEqual(results.length, 2);
+				assert.strictEqual(results, accounts);
 			});
 	});
 
@@ -112,7 +112,7 @@ suite('Account picker view model tests', () => {
 
 				// ... The results should be an empty array
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 0);
+				assert.strictEqual(result.length, 0);
 			});
 	});
 });

--- a/src/sql/platform/accounts/test/common/accountStore.test.ts
+++ b/src/sql/platform/accounts/test/common/accountStore.test.ts
@@ -27,7 +27,7 @@ suite('Account Store Tests', () => {
 
 				// ... The memento should have been initialized and account added
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 1);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 1);
 				assertAccountEqual(memento[AccountStore.MEMENTO_KEY][0], account1);
 			});
 	});
@@ -49,7 +49,7 @@ suite('Account Store Tests', () => {
 
 				// ... The memento should have the account added
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 1);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 1);
 				assertAccountEqual(memento[AccountStore.MEMENTO_KEY][0], account1);
 			});
 	});
@@ -75,7 +75,7 @@ suite('Account Store Tests', () => {
 
 				// ... The memento should have been initialized and account updated
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 2);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 2);
 				assertAccountEqual(memento[AccountStore.MEMENTO_KEY][0], account1);
 				assertAccountEqual(memento[AccountStore.MEMENTO_KEY][1], param);
 			});
@@ -92,10 +92,10 @@ suite('Account Store Tests', () => {
 				// Then:
 				// ... I should get back an empty array
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 0);
+				assert.strictEqual(result.length, 0);
 
 				// ... Memento should not have been written
-				assert.equal(Object.keys(memento).length, 0);
+				assert.strictEqual(Object.keys(memento).length, 0);
 			});
 	});
 
@@ -110,7 +110,7 @@ suite('Account Store Tests', () => {
 			.then(result => {
 				// Then: I should get back an empty array
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 0);
+				assert.strictEqual(result.length, 0);
 			});
 	});
 
@@ -124,7 +124,7 @@ suite('Account Store Tests', () => {
 			.then(result => {
 				// Then: I should get back an empty array
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 0);
+				assert.strictEqual(result.length, 0);
 			});
 	});
 
@@ -138,7 +138,7 @@ suite('Account Store Tests', () => {
 			.then(result => {
 				// Then: I should get the accounts
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 2);
+				assert.strictEqual(result.length, 2);
 				assertAccountEqual(result[0], memento[AccountStore.MEMENTO_KEY][0]);
 				assertAccountEqual(result[1], memento[AccountStore.MEMENTO_KEY][1]);
 			});
@@ -155,10 +155,10 @@ suite('Account Store Tests', () => {
 				// Then:
 				// ... I should get back an empty array
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 0);
+				assert.strictEqual(result.length, 0);
 
 				// ... Memento should not have been written
-				assert.equal(Object.keys(memento).length, 0);
+				assert.strictEqual(Object.keys(memento).length, 0);
 			});
 	});
 
@@ -173,7 +173,7 @@ suite('Account Store Tests', () => {
 			.then(result => {
 				// Then: I should get back an empty array
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 0);
+				assert.strictEqual(result.length, 0);
 			});
 	});
 
@@ -187,7 +187,7 @@ suite('Account Store Tests', () => {
 			.then(result => {
 				// Then: I should get the accounts
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 2);
+				assert.strictEqual(result.length, 2);
 				assertAccountEqual(result[0], memento[AccountStore.MEMENTO_KEY][0]);
 				assertAccountEqual(result[1], memento[AccountStore.MEMENTO_KEY][1]);
 			});
@@ -207,7 +207,7 @@ suite('Account Store Tests', () => {
 
 				// ... The memento should have been initialized
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 0);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 0);
 			});
 	});
 
@@ -226,7 +226,7 @@ suite('Account Store Tests', () => {
 
 				// ... The memento should still be empty
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 0);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 0);
 			});
 	});
 
@@ -244,7 +244,7 @@ suite('Account Store Tests', () => {
 
 				// ... The memento should have removed the first account
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 1);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 1);
 				assertAccountEqual(memento[AccountStore.MEMENTO_KEY][0], account2);
 			});
 	});
@@ -267,7 +267,7 @@ suite('Account Store Tests', () => {
 
 				// ... The memento should have been initialized
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 0);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 0);
 
 				// ... The callback shouldn't have been called
 				updateCallback.assertNotFired();
@@ -292,7 +292,7 @@ suite('Account Store Tests', () => {
 
 				// ... The memento should still be empty
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 0);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 0);
 
 				// ... The callback shouldn't have been called
 				updateCallback.assertNotFired();
@@ -319,10 +319,10 @@ suite('Account Store Tests', () => {
 
 				// ... The memento still contains two accounts
 				assert.ok(Array.isArray(memento[AccountStore.MEMENTO_KEY]));
-				assert.equal(memento[AccountStore.MEMENTO_KEY].length, 2);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 2);
 
 				// ... Account 1 should have been updated
-				assert.equal(memento[AccountStore.MEMENTO_KEY][0].displayInfo.displayName, newDisplayName);
+				assert.strictEqual(memento[AccountStore.MEMENTO_KEY][0].displayInfo.displayName, newDisplayName);
 
 				// ... Account 2 should have stayed the same
 				assertAccountEqual(memento[AccountStore.MEMENTO_KEY][1], account2);
@@ -334,11 +334,11 @@ suite('Account Store Tests', () => {
 		memento[AccountStore.MEMENTO_KEY].push(deprecatedAccount1, deprecatedAccount2);
 		let as = new AccountStore(memento, consoleLogService);
 		// We know that we have 4 accounts now
-		assert.equal(memento[AccountStore.MEMENTO_KEY].length, 4);
+		assert.strictEqual(memento[AccountStore.MEMENTO_KEY].length, 4);
 
 		return as.getAllAccounts().then(accounts => {
 			// After pruning we will have 2 accounts
-			assert.equal(accounts.length, 2);
+			assert.strictEqual(accounts.length, 2);
 		});
 	});
 
@@ -406,12 +406,12 @@ function getTestMemento() {
 }
 
 function assertAccountEqual(a: azdata.Account, b: azdata.Account) {
-	assert.equal(a.key.providerId, b.key.providerId);
-	assert.equal(a.key.accountId, b.key.accountId);
+	assert.strictEqual(a.key.providerId, b.key.providerId);
+	assert.strictEqual(a.key.accountId, b.key.accountId);
 
-	assert.equal(a.displayInfo.contextualDisplayName, b.displayInfo.contextualDisplayName);
-	assert.equal(a.displayInfo.accountType, b.displayInfo.accountType);
-	assert.equal(a.displayInfo.displayName, b.displayInfo.displayName);
+	assert.strictEqual(a.displayInfo.contextualDisplayName, b.displayInfo.contextualDisplayName);
+	assert.strictEqual(a.displayInfo.accountType, b.displayInfo.accountType);
+	assert.strictEqual(a.displayInfo.displayName, b.displayInfo.displayName);
 
-	assert.equal(a.isStale, b.isStale);
+	assert.strictEqual(a.isStale, b.isStale);
 }

--- a/src/sql/platform/accounts/test/common/accountViewModel.test.ts
+++ b/src/sql/platform/accounts/test/common/accountViewModel.test.ts
@@ -113,9 +113,9 @@ suite('Account Management Dialog ViewModel Tests', () => {
 
 				// ... The results that were returned should be an array of account provider added event params
 				assert.ok(Array.isArray(results));
-				assert.equal(results.length, 1);
-				assert.equal(results[0].addedProvider, providers[0]);
-				assert.equal(results[0].initialAccounts, accounts);
+				assert.strictEqual(results.length, 1);
+				assert.strictEqual(results[0].addedProvider, providers[0]);
+				assert.strictEqual(results[0].initialAccounts, accounts);
 			});
 	});
 
@@ -140,7 +140,7 @@ suite('Account Management Dialog ViewModel Tests', () => {
 
 				// ... The results that were returned should be an empty array
 				assert.ok(Array.isArray(results));
-				assert.equal(results.length, 0);
+				assert.strictEqual(results.length, 0);
 			});
 	});
 
@@ -165,9 +165,9 @@ suite('Account Management Dialog ViewModel Tests', () => {
 
 				// ... The results should include the provider
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 1);
-				assert.equal(result[0].addedProvider, providers[0]);
-				assert.equal(result[0].initialAccounts, accounts);
+				assert.strictEqual(result.length, 1);
+				assert.strictEqual(result[0].addedProvider, providers[0]);
+				assert.strictEqual(result[0].initialAccounts, accounts);
 			});
 	});
 });

--- a/src/sql/platform/accounts/test/common/accountViewModel.test.ts
+++ b/src/sql/platform/accounts/test/common/accountViewModel.test.ts
@@ -68,9 +68,9 @@ suite('Account Management Dialog ViewModel Tests', () => {
 
 		// Then:
 		// ... All the events for the view models should be properly initialized
-		assert.notEqual(vm.addProviderEvent, undefined);
-		assert.notEqual(vm.removeProviderEvent, undefined);
-		assert.notEqual(vm.updateAccountListEvent, undefined);
+		assert.notStrictEqual(vm.addProviderEvent, undefined);
+		assert.notStrictEqual(vm.removeProviderEvent, undefined);
+		assert.notStrictEqual(vm.updateAccountListEvent, undefined);
 
 		// ... All the events should properly fire
 		let argAddProvider: AccountProviderAddedEventParams = { addedProvider: providers[0], initialAccounts: [] };

--- a/src/sql/platform/accounts/test/common/firewallRuleViewModel.test.ts
+++ b/src/sql/platform/accounts/test/common/firewallRuleViewModel.test.ts
@@ -16,28 +16,28 @@ suite('Firewall rule view model tests', () => {
 	test('update default values to 250.222.155.198 should calculate the correct default subnet IP range', () => {
 		let IPAddress = '250.222.155.198';
 		viewModel.updateDefaultValues(IPAddress);
-		assert.equal(IPAddress, viewModel.defaultIPAddress);
-		assert.equal('250.222.155.0', viewModel.defaultFromSubnetIPRange);
-		assert.equal('250.222.155.255', viewModel.defaultToSubnetIPRange);
+		assert.strictEqual(IPAddress, viewModel.defaultIPAddress);
+		assert.strictEqual('250.222.155.0', viewModel.defaultFromSubnetIPRange);
+		assert.strictEqual('250.222.155.255', viewModel.defaultToSubnetIPRange);
 	});
 
 	test('update default values to 250.222.155.0 should calculate the correct default subnet IP range', () => {
 		let IPAddress = '250.222.155.2';
 		viewModel.updateDefaultValues(IPAddress);
-		assert.equal(IPAddress, viewModel.defaultIPAddress);
-		assert.equal('250.222.155.0', viewModel.defaultFromSubnetIPRange);
-		assert.equal('250.222.155.255', viewModel.defaultToSubnetIPRange);
+		assert.strictEqual(IPAddress, viewModel.defaultIPAddress);
+		assert.strictEqual('250.222.155.0', viewModel.defaultFromSubnetIPRange);
+		assert.strictEqual('250.222.155.255', viewModel.defaultToSubnetIPRange);
 	});
 
 	test('subnet IP range should return the correct values', () => {
 		let IPAddress = '250.222.155.198';
 		viewModel.updateDefaultValues(IPAddress);
-		assert.equal('250.222.155.0', viewModel.fromSubnetIPRange);
-		assert.equal('250.222.155.255', viewModel.toSubnetIPRange);
+		assert.strictEqual('250.222.155.0', viewModel.fromSubnetIPRange);
+		assert.strictEqual('250.222.155.255', viewModel.toSubnetIPRange);
 
 		viewModel.fromSubnetIPRange = '250.222.155.100';
 		viewModel.toSubnetIPRange = '250.222.155.220';
-		assert.equal('250.222.155.100', viewModel.fromSubnetIPRange);
-		assert.equal('250.222.155.220', viewModel.toSubnetIPRange);
+		assert.strictEqual('250.222.155.100', viewModel.fromSubnetIPRange);
+		assert.strictEqual('250.222.155.220', viewModel.toSubnetIPRange);
 	});
 });

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -235,7 +235,7 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allGroups = config.getAllGroups();
 
-		assert.equal(allGroups.length, testGroups.length, 'did not meet the expected length');
+		assert.strictEqual(allGroups.length, testGroups.length, 'did not meet the expected length');
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
 	});
 
@@ -248,7 +248,7 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allGroups = config.getAllGroups();
 
-		assert.equal(allGroups.length, testGroups.length, 'did not meet the expected length');
+		assert.strictEqual(allGroups.length, testGroups.length, 'did not meet the expected length');
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
 		assert.ok(allGroups.slice(1).every((item, i) => allGroups[i].name <= item.name), 'the groups are not sorted correctly');
 	});
@@ -262,7 +262,7 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allGroups = config.getAllGroups();
 		let expectedGroups = deepClone(testGroups).slice(0, 3).reverse().concat(deepClone(testGroups).slice(3, testGroups.length).reverse());
-		assert.equal(allGroups.length, expectedGroups.length, 'The result groups length is invalid');
+		assert.strictEqual(allGroups.length, expectedGroups.length, 'The result groups length is invalid');
 		assert.ok(allGroups.every((item, i) => item.id === allGroups[i].id));
 	});
 
@@ -294,7 +294,7 @@ suite('ConnectionConfig', () => {
 		let savedConnectionProfile = await config.addConnection(connectionProfile);
 
 		assert.ok(!!savedConnectionProfile.id);
-		assert.equal(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length + 1);
+		assert.strictEqual(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length + 1);
 	});
 
 	test('addConnection should not add the new profile to user settings if already exists', async () => {
@@ -327,8 +327,8 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let savedConnectionProfile = await config.addConnection(connectionProfile);
 
-		assert.equal(savedConnectionProfile.id, existingConnection.id);
-		assert.equal(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length);
+		assert.strictEqual(savedConnectionProfile.id, existingConnection.id);
+		assert.strictEqual(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length);
 	});
 
 	test('addConnection should add the new group to user settings if does not exist', async () => {
@@ -358,8 +358,8 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		await config.addConnection(connectionProfile);
 
-		assert.equal(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length + 1);
-		assert.equal(configurationService.inspect<IConnectionProfileStore[]>('datasource.connectionGroups').userValue!.length, testGroups.length + 1);
+		assert.strictEqual(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length + 1);
+		assert.strictEqual(configurationService.inspect<IConnectionProfileStore[]>('datasource.connectionGroups').userValue!.length, testGroups.length + 1);
 	});
 
 	test('getConnections should return connections from user and workspace settings given getWorkspaceConnections set to true', () => {
@@ -369,7 +369,7 @@ suite('ConnectionConfig', () => {
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(true);
-		assert.equal(allConnections.length, testConnections.length);
+		assert.strictEqual(allConnections.length, testConnections.length);
 	});
 
 	test('getConnections should return connections from user settings given getWorkspaceConnections set to false', () => {
@@ -379,7 +379,7 @@ suite('ConnectionConfig', () => {
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(false);
-		assert.equal(allConnections.length, 2);
+		assert.strictEqual(allConnections.length, 2);
 	});
 
 	test('getConnections should return connections with a valid id', () => {
@@ -397,7 +397,7 @@ suite('ConnectionConfig', () => {
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(false);
-		assert.equal(allConnections.length, testConnections.length);
+		assert.strictEqual(allConnections.length, testConnections.length);
 		allConnections.forEach(connection => {
 			let userConnection = testConnections.find(u => u.options['serverName'] === connection.serverName);
 			if (userConnection !== undefined) {
@@ -406,7 +406,7 @@ suite('ConnectionConfig', () => {
 			} else {
 				let workspaceConnection = workspaceConnections.find(u => u.options['serverName'] === connection.serverName);
 				assert.notEqual(connection.id, connection.getOptionsKey());
-				assert.equal(workspaceConnection!.id, connection.id);
+				assert.strictEqual(workspaceConnection!.id, connection.id);
 			}
 		});
 	});
@@ -419,7 +419,7 @@ suite('ConnectionConfig', () => {
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(true);
-		assert.equal(allConnections.length, testConnections.length, 'The result connections length is invalid');
+		assert.strictEqual(allConnections.length, testConnections.length, 'The result connections length is invalid');
 		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title), 'The connections are not sorted correctly');
 	});
 
@@ -431,7 +431,7 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(false);
 		let expectedConnections = deepClone(testConnections).reverse();
-		assert.equal(allConnections.length, expectedConnections.length, 'The result connections length is invalid');
+		assert.strictEqual(allConnections.length, expectedConnections.length, 'The result connections length is invalid');
 		assert.ok(allConnections.every((item, i) => item.id === expectedConnections[i].id));
 	});
 
@@ -443,9 +443,9 @@ suite('ConnectionConfig', () => {
 
 		let result: ISaveGroupResult = config.saveGroup(groups, newGroups, color, newGroups);
 		assert.ok(!!result);
-		assert.equal(result.groups.length, testGroups.length + 2, 'The result groups length is invalid');
+		assert.strictEqual(result.groups.length, testGroups.length + 2, 'The result groups length is invalid');
 		let newGroup = result.groups.find(g => g.name === 'new-group2');
-		assert.equal(result.newGroupId, newGroup!.id, 'The groups id is invalid');
+		assert.strictEqual(result.newGroupId, newGroup!.id, 'The groups id is invalid');
 	});
 
 	test('saveGroup should only add the groups that are not in the tree', () => {
@@ -456,9 +456,9 @@ suite('ConnectionConfig', () => {
 
 		let result: ISaveGroupResult = config.saveGroup(groups, newGroups, color, newGroups);
 		assert.ok(!!result);
-		assert.equal(result.groups.length, testGroups.length + 1, 'The result groups length is invalid');
+		assert.strictEqual(result.groups.length, testGroups.length + 1, 'The result groups length is invalid');
 		let newGroup = result.groups.find(g => g.name === 'g2-5');
-		assert.equal(result.newGroupId, newGroup!.id, 'The groups id is invalid');
+		assert.strictEqual(result.newGroupId, newGroup!.id, 'The groups id is invalid');
 	});
 
 	test('saveGroup should not add any new group if tree already has all the groups in the full path', () => {
@@ -469,9 +469,9 @@ suite('ConnectionConfig', () => {
 
 		let result: ISaveGroupResult = config.saveGroup(groups, newGroups, color, newGroups);
 		assert.ok(!!result);
-		assert.equal(result.groups.length, testGroups.length, 'The result groups length is invalid');
+		assert.strictEqual(result.groups.length, testGroups.length, 'The result groups length is invalid');
 		let newGroup = result.groups.find(g => g.name === 'g2-1');
-		assert.equal(result.newGroupId, newGroup!.id, 'The groups id is invalid');
+		assert.strictEqual(result.newGroupId, newGroup!.id, 'The groups id is invalid');
 	});
 
 	test('deleteConnection should remove the connection from config', async () => {
@@ -501,7 +501,7 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		await config.deleteConnection(connectionProfile);
 
-		assert.equal(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length - 1);
+		assert.strictEqual(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length - 1);
 	});
 
 	test('deleteConnectionGroup should remove the children connections and subgroups from config', async () => {
@@ -537,8 +537,8 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		await config.deleteGroup(connectionProfileGroup);
 
-		assert.equal(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length - 1);
-		assert.equal(configurationService.inspect<IConnectionProfileGroup[]>('datasource.connectionGroups').userValue!.length, testGroups.length - 2);
+		assert.strictEqual(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length - 1);
+		assert.strictEqual(configurationService.inspect<IConnectionProfileGroup[]>('datasource.connectionGroups').userValue!.length, testGroups.length - 2);
 	});
 
 	test('deleteConnection should not throw error for connection not in config', async () => {
@@ -566,7 +566,7 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		await config.deleteConnection(connectionProfile);
 
-		assert.equal(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length);
+		assert.strictEqual(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length);
 	});
 
 	test('renameGroup should change group name', async () => {
@@ -579,10 +579,10 @@ suite('ConnectionConfig', () => {
 
 		let editedGroups = configurationService.inspect<IConnectionProfileGroup[]>('datasource.connectionGroups').userValue!;
 
-		assert.equal(editedGroups.length, testGroups.length);
+		assert.strictEqual(editedGroups.length, testGroups.length);
 		let editedGroup = editedGroups.find(group => group.id === 'g2');
 		assert.ok(!!editedGroup);
-		assert.equal(editedGroup!.name, 'g-renamed');
+		assert.strictEqual(editedGroup!.name, 'g-renamed');
 	});
 
 	test('edit group should throw if there is a confliction', async () => {
@@ -599,7 +599,7 @@ suite('ConnectionConfig', () => {
 			let groups = configurationService.inspect<IConnectionProfileGroup[]>('datasource.connectionGroups').userValue!;
 			let originalGroup = groups.find(g => g.id === 'g2');
 			assert.ok(!!originalGroup);
-			assert.equal(originalGroup!.name, 'g2');
+			assert.strictEqual(originalGroup!.name, 'g2');
 		}
 	});
 
@@ -614,10 +614,10 @@ suite('ConnectionConfig', () => {
 
 		let editedGroups = configurationService.inspect<IConnectionProfileGroup[]>('datasource.connectionGroups').userValue!;
 
-		assert.equal(editedGroups.length, testGroups.length);
+		assert.strictEqual(editedGroups.length, testGroups.length);
 		let editedGroup = editedGroups.find(group => group.id === 'g2');
 		assert.ok(!!editedGroup);
-		assert.equal(editedGroup!.parentId, 'g3');
+		assert.strictEqual(editedGroup!.parentId, 'g3');
 	});
 
 
@@ -671,10 +671,10 @@ suite('ConnectionConfig', () => {
 		} catch (e) {
 			let editedConnections = configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!;
 			// two
-			assert.equal(editedConnections.length, _testConnections.length);
+			assert.strictEqual(editedConnections.length, _testConnections.length);
 			let editedConnection = editedConnections.find(con => con.id === 'server3-2');
 			assert.ok(!!editedConnection);
-			assert.equal(editedConnection!.groupId, 'g3');
+			assert.strictEqual(editedConnection!.groupId, 'g3');
 		}
 	});
 
@@ -707,10 +707,10 @@ suite('ConnectionConfig', () => {
 		await config.changeGroupIdForConnection(connectionProfile, newId);
 
 		let editedConnections = configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!;
-		assert.equal(editedConnections.length, testConnections.length);
+		assert.strictEqual(editedConnections.length, testConnections.length);
 		let editedConnection = editedConnections.find(con => con.id === 'server3');
 		assert.ok(!!editedConnection);
-		assert.equal(editedConnection!.groupId, 'newid');
+		assert.strictEqual(editedConnection!.groupId, 'newid');
 	});
 
 	test('addConnection should not move the connection when editing', async () => {
@@ -732,10 +732,10 @@ suite('ConnectionConfig', () => {
 
 		// Get the connection and verify that it is in the same place and has been updated
 		let newConnections = config.getConnections(false);
-		assert.equal(newConnections.length, oldLength);
+		assert.strictEqual(newConnections.length, oldLength);
 		let editedConnection = newConnections[connectionIndex];
-		assert.equal(editedConnection.getOptionsKey(), connectionToEdit.getOptionsKey());
-		assert.equal(editedConnection.options[optionKey], optionValue);
+		assert.strictEqual(editedConnection.getOptionsKey(), connectionToEdit.getOptionsKey());
+		assert.strictEqual(editedConnection.options[optionKey], optionValue);
 	});
 
 	test('addgroup works', async () => {
@@ -755,7 +755,7 @@ suite('ConnectionConfig', () => {
 
 		let editGroups = configurationService.inspect<IConnectionProfileGroup[]>('datasource.connectionGroups').userValue!;
 
-		assert.equal(editGroups.length, testGroups.length + 1);
+		assert.strictEqual(editGroups.length, testGroups.length + 1);
 	});
 
 	test('addGroup rejects if group name already exists', async () => {
@@ -776,7 +776,7 @@ suite('ConnectionConfig', () => {
 		} catch (e) {
 			let editGroups = configurationService.inspect<IConnectionProfileGroup[]>('datasource.connectionGroups').userValue!;
 
-			assert.equal(editGroups.length, testGroups.length);
+			assert.strictEqual(editGroups.length, testGroups.length);
 		}
 	});
 });

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -401,11 +401,11 @@ suite('ConnectionConfig', () => {
 		allConnections.forEach(connection => {
 			let userConnection = testConnections.find(u => u.options['serverName'] === connection.serverName);
 			if (userConnection !== undefined) {
-				assert.notEqual(connection.id, connection.getOptionsKey());
+				assert.notStrictEqual(connection.id, connection.getOptionsKey());
 				assert.ok(!!connection.id);
 			} else {
 				let workspaceConnection = workspaceConnections.find(u => u.options['serverName'] === connection.serverName);
-				assert.notEqual(connection.id, connection.getOptionsKey());
+				assert.notStrictEqual(connection.id, connection.getOptionsKey());
 				assert.strictEqual(workspaceConnection!.id, connection.id);
 			}
 		});

--- a/src/sql/platform/connection/test/common/connectionProfile.test.ts
+++ b/src/sql/platform/connection/test/common/connectionProfile.test.ts
@@ -180,16 +180,16 @@ suite('SQL ConnectionProfileInfo tests', () => {
 		let savedProfile = storedProfile;
 		let connectionProfile = ConnectionProfile.createFromStoredProfile(savedProfile, capabilitiesService);
 		assert.strictEqual(savedProfile.groupId, connectionProfile.groupId);
-		assert.deepEqual(savedProfile.providerName, connectionProfile.providerName);
-		assert.deepEqual(savedProfile.savePassword, connectionProfile.savePassword);
-		assert.deepEqual(savedProfile.id, connectionProfile.id);
+		assert.deepStrictEqual(savedProfile.providerName, connectionProfile.providerName);
+		assert.deepStrictEqual(savedProfile.savePassword, connectionProfile.savePassword);
+		assert.deepStrictEqual(savedProfile.id, connectionProfile.id);
 	});
 
 	test('createFromStoredProfile should set the id to new guid if not set in stored profile', () => {
 		let savedProfile: IConnectionProfileStore = Object.assign({}, storedProfile, { id: undefined });
 		let connectionProfile = ConnectionProfile.createFromStoredProfile(savedProfile, capabilitiesService);
 		assert.strictEqual(savedProfile.groupId, connectionProfile.groupId);
-		assert.deepEqual(savedProfile.providerName, connectionProfile.providerName);
+		assert.deepStrictEqual(savedProfile.providerName, connectionProfile.providerName);
 		assert.strictEqual(savedProfile.savePassword, connectionProfile.savePassword);
 		assert.notStrictEqual(connectionProfile.id, undefined);
 		assert.strictEqual(savedProfile.id, undefined);

--- a/src/sql/platform/connection/test/common/connectionProfile.test.ts
+++ b/src/sql/platform/connection/test/common/connectionProfile.test.ts
@@ -134,7 +134,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 
 	test('set properties should set the values correctly', () => {
 		let conn = new ConnectionProfile(capabilitiesService, undefined!);
-		assert.equal(conn.serverName, undefined);
+		assert.strictEqual(conn.serverName, undefined);
 		conn.connectionName = connectionProfile.connectionName!;
 		conn.serverName = connectionProfile.serverName;
 		conn.databaseName = connectionProfile.databaseName!;
@@ -144,42 +144,42 @@ suite('SQL ConnectionProfileInfo tests', () => {
 		conn.groupId = connectionProfile.groupId;
 		conn.groupFullName = connectionProfile.groupFullName;
 		conn.savePassword = connectionProfile.savePassword;
-		assert.equal(conn.connectionName, connectionProfile.connectionName);
-		assert.equal(conn.serverName, connectionProfile.serverName);
-		assert.equal(conn.databaseName, connectionProfile.databaseName);
-		assert.equal(conn.authenticationType, connectionProfile.authenticationType);
-		assert.equal(conn.password, connectionProfile.password);
-		assert.equal(conn.userName, connectionProfile.userName);
-		assert.equal(conn.groupId, connectionProfile.groupId);
-		assert.equal(conn.groupFullName, connectionProfile.groupFullName);
-		assert.equal(conn.savePassword, connectionProfile.savePassword);
+		assert.strictEqual(conn.connectionName, connectionProfile.connectionName);
+		assert.strictEqual(conn.serverName, connectionProfile.serverName);
+		assert.strictEqual(conn.databaseName, connectionProfile.databaseName);
+		assert.strictEqual(conn.authenticationType, connectionProfile.authenticationType);
+		assert.strictEqual(conn.password, connectionProfile.password);
+		assert.strictEqual(conn.userName, connectionProfile.userName);
+		assert.strictEqual(conn.groupId, connectionProfile.groupId);
+		assert.strictEqual(conn.groupFullName, connectionProfile.groupFullName);
+		assert.strictEqual(conn.savePassword, connectionProfile.savePassword);
 	});
 
 	test('constructor should initialize the options given a valid model', () => {
 		let conn = new ConnectionProfile(capabilitiesService, connectionProfile);
 
-		assert.equal(conn.connectionName, connectionProfile.connectionName);
-		assert.equal(conn.serverName, connectionProfile.serverName);
-		assert.equal(conn.databaseName, connectionProfile.databaseName);
-		assert.equal(conn.authenticationType, connectionProfile.authenticationType);
-		assert.equal(conn.password, connectionProfile.password);
-		assert.equal(conn.userName, connectionProfile.userName);
-		assert.equal(conn.groupId, connectionProfile.groupId);
-		assert.equal(conn.groupFullName, connectionProfile.groupFullName);
-		assert.equal(conn.savePassword, connectionProfile.savePassword);
+		assert.strictEqual(conn.connectionName, connectionProfile.connectionName);
+		assert.strictEqual(conn.serverName, connectionProfile.serverName);
+		assert.strictEqual(conn.databaseName, connectionProfile.databaseName);
+		assert.strictEqual(conn.authenticationType, connectionProfile.authenticationType);
+		assert.strictEqual(conn.password, connectionProfile.password);
+		assert.strictEqual(conn.userName, connectionProfile.userName);
+		assert.strictEqual(conn.groupId, connectionProfile.groupId);
+		assert.strictEqual(conn.groupFullName, connectionProfile.groupFullName);
+		assert.strictEqual(conn.savePassword, connectionProfile.savePassword);
 	});
 
 	test('getOptionsKey should create a valid unique id', () => {
 		let conn = new ConnectionProfile(capabilitiesService, connectionProfile);
 		let expectedId = 'providerName:MSSQL|authenticationType:|databaseName:database|serverName:new server|userName:user|databaseDisplayName:database|group:group id';
 		let id = conn.getOptionsKey();
-		assert.equal(id, expectedId);
+		assert.strictEqual(id, expectedId);
 	});
 
 	test('createFromStoredProfile should create connection profile from stored profile', () => {
 		let savedProfile = storedProfile;
 		let connectionProfile = ConnectionProfile.createFromStoredProfile(savedProfile, capabilitiesService);
-		assert.equal(savedProfile.groupId, connectionProfile.groupId);
+		assert.strictEqual(savedProfile.groupId, connectionProfile.groupId);
 		assert.deepEqual(savedProfile.providerName, connectionProfile.providerName);
 		assert.deepEqual(savedProfile.savePassword, connectionProfile.savePassword);
 		assert.deepEqual(savedProfile.id, connectionProfile.id);
@@ -188,31 +188,31 @@ suite('SQL ConnectionProfileInfo tests', () => {
 	test('createFromStoredProfile should set the id to new guid if not set in stored profile', () => {
 		let savedProfile: IConnectionProfileStore = Object.assign({}, storedProfile, { id: undefined });
 		let connectionProfile = ConnectionProfile.createFromStoredProfile(savedProfile, capabilitiesService);
-		assert.equal(savedProfile.groupId, connectionProfile.groupId);
+		assert.strictEqual(savedProfile.groupId, connectionProfile.groupId);
 		assert.deepEqual(savedProfile.providerName, connectionProfile.providerName);
-		assert.equal(savedProfile.savePassword, connectionProfile.savePassword);
+		assert.strictEqual(savedProfile.savePassword, connectionProfile.savePassword);
 		assert.notEqual(connectionProfile.id, undefined);
-		assert.equal(savedProfile.id, undefined);
+		assert.strictEqual(savedProfile.id, undefined);
 	});
 
 	test('withoutPassword should create a new instance without password', () => {
 		let conn = new ConnectionProfile(capabilitiesService, connectionProfile);
 		assert.notEqual(conn.password, '');
 		let withoutPassword = conn.withoutPassword();
-		assert.equal(withoutPassword.password, '');
+		assert.strictEqual(withoutPassword.password, '');
 	});
 
 	test('unique id should not include password', () => {
 		let conn = new ConnectionProfile(capabilitiesService, connectionProfile);
 		let withoutPassword = conn.withoutPassword();
-		assert.equal(withoutPassword.getOptionsKey(), conn.getOptionsKey());
+		assert.strictEqual(withoutPassword.getOptionsKey(), conn.getOptionsKey());
 	});
 
 	test('cloneWithDatabase should create new profile with new id', () => {
 		let conn = new ConnectionProfile(capabilitiesService, connectionProfile);
 		let newProfile = conn.cloneWithDatabase('new db');
 		assert.notEqual(newProfile.id, conn.id);
-		assert.equal(newProfile.databaseName, 'new db');
+		assert.strictEqual(newProfile.databaseName, 'new db');
 	});
 
 	test('an empty connection profile does not cause issues', () => {

--- a/src/sql/platform/connection/test/common/connectionProfile.test.ts
+++ b/src/sql/platform/connection/test/common/connectionProfile.test.ts
@@ -191,13 +191,13 @@ suite('SQL ConnectionProfileInfo tests', () => {
 		assert.strictEqual(savedProfile.groupId, connectionProfile.groupId);
 		assert.deepEqual(savedProfile.providerName, connectionProfile.providerName);
 		assert.strictEqual(savedProfile.savePassword, connectionProfile.savePassword);
-		assert.notEqual(connectionProfile.id, undefined);
+		assert.notStrictEqual(connectionProfile.id, undefined);
 		assert.strictEqual(savedProfile.id, undefined);
 	});
 
 	test('withoutPassword should create a new instance without password', () => {
 		let conn = new ConnectionProfile(capabilitiesService, connectionProfile);
-		assert.notEqual(conn.password, '');
+		assert.notStrictEqual(conn.password, '');
 		let withoutPassword = conn.withoutPassword();
 		assert.strictEqual(withoutPassword.password, '');
 	});
@@ -211,7 +211,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 	test('cloneWithDatabase should create new profile with new id', () => {
 		let conn = new ConnectionProfile(capabilitiesService, connectionProfile);
 		let newProfile = conn.cloneWithDatabase('new db');
-		assert.notEqual(newProfile.id, conn.id);
+		assert.notStrictEqual(newProfile.id, conn.id);
 		assert.strictEqual(newProfile.databaseName, 'new db');
 	});
 

--- a/src/sql/platform/connection/test/common/connectionProfileGroup.test.ts
+++ b/src/sql/platform/connection/test/common/connectionProfileGroup.test.ts
@@ -33,13 +33,13 @@ suite('SQL ConnectionProfileGroup tests', () => {
 	});
 
 	test('Root name should be returned as empty string', () => {
-		assert.equal(root.name, '');
+		assert.strictEqual(root.name, '');
 	});
 
 	test('Fullname should return the group full name correctly', () => {
-		assert.equal(group1Node.fullName, 'G1');
-		assert.equal(group2Node.fullName, 'G2');
-		assert.equal(group11Node.fullName, 'G1/G11');
+		assert.strictEqual(group1Node.fullName, 'G1');
+		assert.strictEqual(group2Node.fullName, 'G2');
+		assert.strictEqual(group11Node.fullName, 'G1/G11');
 	});
 
 	test('getGroupFullNameParts should return a list With ROOT in it given an empty string', () => {
@@ -154,8 +154,8 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		emptyGroup.children = undefined;
 		assert(emptyGroup.hasChildren() === false, 'Group should report no children after setting children to undefined');
 		const obj = emptyGroup.toObject();
-		assert.equal(obj.id, emptyGroup.id, 'toObject result has wrong id');
-		assert.equal(obj.name, emptyGroup.name, 'toObject result has wrong name');
+		assert.strictEqual(obj.id, emptyGroup.id, 'toObject result has wrong id');
+		assert.strictEqual(obj.name, emptyGroup.name, 'toObject result has wrong name');
 		assert(emptyGroup.hasValidConnections === true, 'Expected group to have valid connections');
 		const children = emptyGroup.getChildren();
 		assert(children.length === 0, 'Expected group to have 0 children');
@@ -165,11 +165,11 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		emptyGroup.connections = undefined;
 		assert(emptyGroup.hasChildren() === false, 'Group should report no children after setting connections to undefined');
 		const obj = emptyGroup.toObject();
-		assert.equal(obj.id, emptyGroup.id, 'toObject result has wrong id');
-		assert.equal(obj.name, emptyGroup.name, 'toObject result has wrong name');
+		assert.strictEqual(obj.id, emptyGroup.id, 'toObject result has wrong id');
+		assert.strictEqual(obj.name, emptyGroup.name, 'toObject result has wrong name');
 		assert(emptyGroup.hasValidConnections === true, 'Expected group to have valid connections');
 		const children = emptyGroup.getChildren();
-		assert.equal(children.length, 0, 'Expected group to have 0 children');
+		assert.strictEqual(children.length, 0, 'Expected group to have 0 children');
 	});
 
 	test('test behavior with 1 child group', () => {
@@ -177,8 +177,8 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		assert(emptyGroup.hasChildren() === true, 'Group should have children if 1 child group is added');
 		assert(emptyGroup.hasValidConnections === true, 'Expected group to have valid connections');
 		const children = emptyGroup.getChildren();
-		assert.equal(children.length, 1, 'Expected group to have 1 child');
-		assert.equal(children[0].id, group1Node.id, 'Expected group child to be group1Node');
+		assert.strictEqual(children.length, 1, 'Expected group to have 1 child');
+		assert.strictEqual(children[0].id, group1Node.id, 'Expected group child to be group1Node');
 	});
 
 	test('test behavior with 1 child connection', () => {
@@ -186,8 +186,8 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		assert(emptyGroup.hasChildren(), 'Group should have children if 1 child group is added');
 		assert(emptyGroup.hasValidConnections === false, 'Expected group not to have valid connections');
 		const children = emptyGroup.getChildren();
-		assert.equal(children.length, 1, 'Expected group to have 1 child');
-		assert.equal(children[0].id, connectionProfile.id, 'Expected group child to be connectionProfile');
+		assert.strictEqual(children.length, 1, 'Expected group to have 1 child');
+		assert.strictEqual(children[0].id, connectionProfile.id, 'Expected group child to be connectionProfile');
 	});
 
 	test('adding undefined groups does nothing', () => {
@@ -197,8 +197,8 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		emptyGroup.addGroups([group1Node]);
 		emptyGroup.addGroups(undefined);
 		const children = emptyGroup.getChildren();
-		assert.equal(children.length, 1, 'Expected group to have 1 child still');
-		assert.equal(children[0].id, group1Node.id, 'Expected group child to be group1Node');
+		assert.strictEqual(children.length, 1, 'Expected group to have 1 child still');
+		assert.strictEqual(children[0].id, group1Node.id, 'Expected group child to be group1Node');
 	});
 
 	test('adding undefined connections does nothing', () => {
@@ -208,7 +208,7 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		emptyGroup.addConnections([connectionProfile]);
 		emptyGroup.addConnections(undefined);
 		const children = emptyGroup.getChildren();
-		assert.equal(children.length, 1, 'Expected group to have 1 child still');
-		assert.equal(children[0].id, connectionProfile.id, 'Expected group child to be connectionProfile');
+		assert.strictEqual(children.length, 1, 'Expected group to have 1 child still');
+		assert.strictEqual(children[0].id, connectionProfile.id, 'Expected group child to be connectionProfile');
 	});
 });

--- a/src/sql/platform/connection/test/common/connectionProfileGroup.test.ts
+++ b/src/sql/platform/connection/test/common/connectionProfileGroup.test.ts
@@ -46,84 +46,84 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		let groupFullName: string = '';
 		let expected: string[] = [ConnectionProfileGroup.RootGroupName];
 		let actual = ConnectionProfileGroup.getGroupFullNameParts(groupFullName);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('getGroupFullNameParts should return a list With ROOT in it given null', () => {
 		let groupFullName: string = undefined!;
 		let expected: string[] = [ConnectionProfileGroup.RootGroupName];
 		let actual = ConnectionProfileGroup.getGroupFullNameParts(groupFullName);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('getGroupFullNameParts should return a list With ROOT in it given /', () => {
 		let groupFullName: string = '/';
 		let expected: string[] = [ConnectionProfileGroup.RootGroupName];
 		let actual = ConnectionProfileGroup.getGroupFullNameParts(groupFullName);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('getGroupFullNameParts should add ROOT as first item if not added already and string starts with /', () => {
 		let groupFullName: string = '/Groups/Group1';
 		let expected: string[] = [ConnectionProfileGroup.RootGroupName, 'Groups', 'Group1'];
 		let actual = ConnectionProfileGroup.getGroupFullNameParts(groupFullName);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('getGroupFullNameParts should add ROOT as first item if not added already', () => {
 		let groupFullName: string = 'Groups/Group1';
 		let expected: string[] = [ConnectionProfileGroup.RootGroupName, 'Groups', 'Group1'];
 		let actual = ConnectionProfileGroup.getGroupFullNameParts(groupFullName);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('getGroupFullNameParts should not add ROOT if already added and string starts with /', () => {
 		let groupFullName: string = '/ROOT/Groups/Group1';
 		let expected: string[] = [ConnectionProfileGroup.RootGroupName, 'Groups', 'Group1'];
 		let actual = ConnectionProfileGroup.getGroupFullNameParts(groupFullName);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('getGroupFullNameParts should not add ROOT if already added', () => {
 		let groupFullName: string = 'ROOT/Groups/Group1';
 		let expected: string[] = [ConnectionProfileGroup.RootGroupName, 'Groups', 'Group1'];
 		let actual = ConnectionProfileGroup.getGroupFullNameParts(groupFullName);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('getGroupFullNameParts should not add ROOT if already added and it is not uppercase', () => {
 		let groupFullName: string = 'rOOT/Groups/Group1';
 		let expected: string[] = [ConnectionProfileGroup.RootGroupName, 'Groups', 'Group1'];
 		let actual = ConnectionProfileGroup.getGroupFullNameParts(groupFullName);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('isRoot should return true given empty string', () => {
 		let name: string = '';
 		let expected: boolean = true;
 		let actual = ConnectionProfileGroup.isRoot(name);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('isRoot should return true given null', () => {
 		let name: string = undefined!;
 		let expected: boolean = true;
 		let actual = ConnectionProfileGroup.isRoot(name);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('isRoot should return true given /', () => {
 		let name: string = '/';
 		let expected: boolean = true;
 		let actual = ConnectionProfileGroup.isRoot(name);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('isRoot should return true given root', () => {
 		let name: string = 'root';
 		let expected: boolean = true;
 		let actual = ConnectionProfileGroup.isRoot(name);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('sameGroupName should return true given root', () => {
@@ -131,7 +131,7 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		let name2: string = '';
 		let expected: boolean = true;
 		let actual = ConnectionProfileGroup.sameGroupName(name1, name2);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('sameGroupName should return true given same group names', () => {
@@ -139,7 +139,7 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		let name2: string = '/Group1';
 		let expected: boolean = true;
 		let actual = ConnectionProfileGroup.sameGroupName(name1, name2);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('sameGroupName should return false given two different groups', () => {
@@ -147,7 +147,7 @@ suite('SQL ConnectionProfileGroup tests', () => {
 		let name2: string = '/Group1';
 		let expected: boolean = false;
 		let actual = ConnectionProfileGroup.sameGroupName(name1, name2);
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('test behavior when children is set to undefined', () => {

--- a/src/sql/platform/connection/test/common/connectionStore.test.ts
+++ b/src/sql/platform/connection/test/common/connectionStore.test.ts
@@ -408,7 +408,7 @@ suite('ConnectionStore', () => {
 		expectedProfile.options['password'] = '';
 		expectedProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesService, expectedProfile).toIConnectionProfile();
 		let profileWithoutCredentials = connectionStore.getProfileWithoutPassword(profile);
-		assert.deepEqual(profileWithoutCredentials.toIConnectionProfile(), expectedProfile);
+		assert.deepStrictEqual(profileWithoutCredentials.toIConnectionProfile(), expectedProfile);
 	});
 
 	test('addPassword gets the password from the credentials service', async () => {

--- a/src/sql/platform/connection/test/common/connectionStore.test.ts
+++ b/src/sql/platform/connection/test/common/connectionStore.test.ts
@@ -159,14 +159,14 @@ suite('ConnectionStore', () => {
 			await connectionStore.addRecentConnection(connectionProfile);
 			const current = connectionStore.getRecentlyUsedConnections();
 			if (i >= maxRecent) {
-				assert.equal(current.length, maxRecent, `expect only top ${maxRecent} creds to be saved`);
+				assert.strictEqual(current.length, maxRecent, `expect only top ${maxRecent} creds to be saved`);
 			} else {
-				assert.equal(current.length, i + 1, `expect all credentials to be saved ${current.length}|${i + 1} `);
+				assert.strictEqual(current.length, i + 1, `expect all credentials to be saved ${current.length}|${i + 1} `);
 			}
-			assert.equal(current[0].serverName, cred.serverName, 'Expect most recently saved item to be first in list');
+			assert.strictEqual(current[0].serverName, cred.serverName, 'Expect most recently saved item to be first in list');
 			assert.ok(!current[0].password);
 		}
-		assert.equal(credentialsService.credentials.size, numCreds);
+		assert.strictEqual(credentialsService.credentials.size, numCreds);
 	});
 
 	test('getRecentlyUsedConnections should return connection for given provider', () => {
@@ -196,8 +196,8 @@ suite('ConnectionStore', () => {
 		await connectionStore.addRecentConnection(connectionProfile);
 		await connectionStore.addRecentConnection(connectionProfile);
 		const current = connectionStore.getRecentlyUsedConnections();
-		assert.equal(current.length, 2, 'expect 2 unique credentials to have been added');
-		assert.equal(current[0].serverName, cred.serverName, 'Expect most recently saved item to be first in list');
+		assert.strictEqual(current.length, 2, 'expect 2 unique credentials to have been added');
+		assert.strictEqual(current[0].serverName, cred.serverName, 'Expect most recently saved item to be first in list');
 		assert.ok(!current[0].password);
 	});
 
@@ -231,7 +231,7 @@ suite('ConnectionStore', () => {
 
 		let current = connectionStore.getRecentlyUsedConnections();
 		// Then verify that since its password based we save the password
-		assert.equal(credentialsService.credentials.size, 1);
+		assert.strictEqual(credentialsService.credentials.size, 1);
 		assert.strictEqual(recentCredential!.password, defaultNamedProfile.password);
 		assert.ok(recentCredential!.credentialId.indexOf('Profile') > -1, 'Expect credential to be marked as an Profile cred');
 		assert.ok(!current[0].password);
@@ -240,24 +240,24 @@ suite('ConnectionStore', () => {
 		await connectionStore.addRecentConnection(integratedCredConnectionProfile);
 		current = connectionStore.getRecentlyUsedConnections();
 		// then expect not to have credential store called, but MRU count upped to 2
-		assert.equal(credentialsService.credentials.size, 1);
-		assert.equal(current.length, 2);
+		assert.strictEqual(credentialsService.credentials.size, 1);
+		assert.strictEqual(current.length, 2);
 		// When add connection without password
 		const noPwdCredConnectionProfile = new ConnectionProfile(capabilitiesService, noPwdCred);
 		await connectionStore.addRecentConnection(noPwdCredConnectionProfile);
 		current = connectionStore.getRecentlyUsedConnections();
 		// then expect not to have credential store called, but MRU count upped to 3
-		assert.equal(current.length, 3);
-		assert.equal(credentialsService.credentials.size, 1);
+		assert.strictEqual(current.length, 3);
+		assert.strictEqual(credentialsService.credentials.size, 1);
 	});
 
 	test('fixupConnectionCredentials should fix blank connection profile', () => {
 		let blankConnectionProfile = new ConnectionProfile(capabilitiesService, '');
 		let resultProfile = fixupConnectionCredentials(blankConnectionProfile);
-		assert.equal(resultProfile.serverName, '');
-		assert.equal(resultProfile.databaseName, '');
-		assert.equal(resultProfile.userName, '');
-		assert.equal(resultProfile.password, '');
+		assert.strictEqual(resultProfile.serverName, '');
+		assert.strictEqual(resultProfile.databaseName, '');
+		assert.strictEqual(resultProfile.userName, '');
+		assert.strictEqual(resultProfile.password, '');
 	});
 
 	test('can clear connections list', async () => {
@@ -270,10 +270,10 @@ suite('ConnectionStore', () => {
 
 		await connectionStore.addRecentConnection(defaultNamedProfile);
 		let result = connectionStore.getRecentlyUsedConnections();
-		assert.equal(result.length, 1);
+		assert.strictEqual(result.length, 1);
 		connectionStore.clearRecentlyUsed();
 		result = connectionStore.getRecentlyUsedConnections();
-		assert.equal(result.length, 0);
+		assert.strictEqual(result.length, 0);
 		// Then test is complete
 	});
 
@@ -340,7 +340,7 @@ suite('ConnectionStore', () => {
 
 		const profile = await connectionStore.saveProfile(connectionProfile);
 		// add connection should be called with a profile without password
-		assert.equal(profile.password, password, 'The returned profile should still keep the password');
+		assert.strictEqual(profile.password, password, 'The returned profile should still keep the password');
 		assert.ok(!!profile.groupId, 'Group id should be set in the profile');
 	});
 
@@ -352,7 +352,7 @@ suite('ConnectionStore', () => {
 		const connectionStore = new ConnectionStore(storageService, configurationService,
 			credentialsService, capabilitiesService);
 		const group = connectionStore.getGroupFromId('invalidId');
-		assert.equal(group, undefined, 'Returned group was not undefined when there was no group with the given ID');
+		assert.strictEqual(group, undefined, 'Returned group was not undefined when there was no group with the given ID');
 	});
 
 	test('getGroupFromId returns the group that has the given ID', () => {
@@ -386,11 +386,11 @@ suite('ConnectionStore', () => {
 
 		// If I look up the parent group using its ID, then I get back the correct group
 		let actualGroup = connectionStore.getGroupFromId(parentGroupId)!;
-		assert.equal(actualGroup.id, parentGroupId, 'Did not get the parent group when looking it up with its ID');
+		assert.strictEqual(actualGroup.id, parentGroupId, 'Did not get the parent group when looking it up with its ID');
 
 		// If I look up the child group using its ID, then I get back the correct group
 		actualGroup = connectionStore.getGroupFromId(childGroupId)!;
-		assert.equal(actualGroup.id, childGroupId, 'Did not get the child group when looking it up with its ID');
+		assert.strictEqual(actualGroup.id, childGroupId, 'Did not get the child group when looking it up with its ID');
 	});
 
 	test('getProfileWithoutPassword can return the profile without credentials in the password property or options dictionary', () => {
@@ -428,7 +428,7 @@ suite('ConnectionStore', () => {
 
 		const passwordProfile = (await connectionStore.addSavedPassword(profile)).profile;
 
-		assert.equal(passwordProfile.password, password);
+		assert.strictEqual(passwordProfile.password, password);
 	});
 
 	test('getConnectionProfileGroups', async () => {
@@ -481,7 +481,7 @@ suite('ConnectionStore', () => {
 			const connectionProfile = new ConnectionProfile(capabilitiesService, cred);
 			await connectionStore.addRecentConnection(connectionProfile);
 			const current = connectionStore.getRecentlyUsedConnections();
-			assert.equal(current.length, i + 1);
+			assert.strictEqual(current.length, i + 1);
 		}
 
 		for (let i = 0; i < 5; i++) {
@@ -489,7 +489,7 @@ suite('ConnectionStore', () => {
 			const connectionProfile = new ConnectionProfile(capabilitiesService, cred);
 			connectionStore.removeRecentConnection(connectionProfile);
 			const current = connectionStore.getRecentlyUsedConnections();
-			assert.equal(current.length, 4 - i);
+			assert.strictEqual(current.length, 4 - i);
 		}
 	});
 
@@ -533,6 +533,6 @@ suite('ConnectionStore', () => {
 
 		const connections = connectionStore.getRecentlyUsedConnections();
 
-		assert.equal(connections[0].groupFullName, parentGroupName);
+		assert.strictEqual(connections[0].groupFullName, parentGroupName);
 	});
 });

--- a/src/sql/platform/connection/test/common/providerConnectionInfo.test.ts
+++ b/src/sql/platform/connection/test/common/providerConnectionInfo.test.ts
@@ -132,62 +132,62 @@ suite('SQL ProviderConnectionInfo tests', () => {
 
 	test('constructor should accept undefined parameters', () => {
 		let conn = new ProviderConnectionInfo(undefined!, undefined!);
-		assert.equal(conn.serverName, undefined);
+		assert.strictEqual(conn.serverName, undefined);
 	});
 
 	test('set properties should set the values correctly', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, mssqlProviderName);
-		assert.equal(conn.serverName, undefined);
+		assert.strictEqual(conn.serverName, undefined);
 		conn.connectionName = connectionProfile.connectionName!;
 		conn.serverName = connectionProfile.serverName;
 		conn.databaseName = connectionProfile.databaseName!;
 		conn.authenticationType = connectionProfile.authenticationType;
 		conn.password = connectionProfile.password;
 		conn.userName = connectionProfile.userName;
-		assert.equal(conn.connectionName, connectionProfile.connectionName);
-		assert.equal(conn.serverName, connectionProfile.serverName);
-		assert.equal(conn.databaseName, connectionProfile.databaseName);
-		assert.equal(conn.authenticationType, connectionProfile.authenticationType);
-		assert.equal(conn.password, connectionProfile.password);
-		assert.equal(conn.userName, connectionProfile.userName);
+		assert.strictEqual(conn.connectionName, connectionProfile.connectionName);
+		assert.strictEqual(conn.serverName, connectionProfile.serverName);
+		assert.strictEqual(conn.databaseName, connectionProfile.databaseName);
+		assert.strictEqual(conn.authenticationType, connectionProfile.authenticationType);
+		assert.strictEqual(conn.password, connectionProfile.password);
+		assert.strictEqual(conn.userName, connectionProfile.userName);
 	});
 
 	test('set properties should store the values in the options', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, mssqlProviderName);
-		assert.equal(conn.serverName, undefined);
+		assert.strictEqual(conn.serverName, undefined);
 		conn.serverName = connectionProfile.serverName;
 		conn.databaseName = connectionProfile.databaseName!;
 		conn.authenticationType = connectionProfile.authenticationType;
 		conn.password = connectionProfile.password;
 		conn.userName = connectionProfile.userName;
-		assert.equal(conn.getOptionValue('serverName'), connectionProfile.serverName);
-		assert.equal(conn.getOptionValue('databaseName'), connectionProfile.databaseName);
-		assert.equal(conn.getOptionValue('authenticationType'), connectionProfile.authenticationType);
-		assert.equal(conn.getOptionValue('password'), connectionProfile.password);
-		assert.equal(conn.getOptionValue('userName'), connectionProfile.userName);
+		assert.strictEqual(conn.getOptionValue('serverName'), connectionProfile.serverName);
+		assert.strictEqual(conn.getOptionValue('databaseName'), connectionProfile.databaseName);
+		assert.strictEqual(conn.getOptionValue('authenticationType'), connectionProfile.authenticationType);
+		assert.strictEqual(conn.getOptionValue('password'), connectionProfile.password);
+		assert.strictEqual(conn.getOptionValue('userName'), connectionProfile.userName);
 	});
 
 	test('constructor should initialize the options given a valid model', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 
-		assert.equal(conn.connectionName, connectionProfile.connectionName);
-		assert.equal(conn.serverName, connectionProfile.serverName);
-		assert.equal(conn.databaseName, connectionProfile.databaseName);
-		assert.equal(conn.authenticationType, connectionProfile.authenticationType);
-		assert.equal(conn.password, connectionProfile.password);
-		assert.equal(conn.userName, connectionProfile.userName);
+		assert.strictEqual(conn.connectionName, connectionProfile.connectionName);
+		assert.strictEqual(conn.serverName, connectionProfile.serverName);
+		assert.strictEqual(conn.databaseName, connectionProfile.databaseName);
+		assert.strictEqual(conn.authenticationType, connectionProfile.authenticationType);
+		assert.strictEqual(conn.password, connectionProfile.password);
+		assert.strictEqual(conn.userName, connectionProfile.userName);
 	});
 
 	test('clone should create a new instance that equals the old one', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 
 		let conn2 = conn.clone();
-		assert.equal(conn.connectionName, conn2.connectionName);
-		assert.equal(conn.serverName, conn2.serverName);
-		assert.equal(conn.databaseName, conn2.databaseName);
-		assert.equal(conn.authenticationType, conn2.authenticationType);
-		assert.equal(conn.password, conn2.password);
-		assert.equal(conn.userName, conn2.userName);
+		assert.strictEqual(conn.connectionName, conn2.connectionName);
+		assert.strictEqual(conn.serverName, conn2.serverName);
+		assert.strictEqual(conn.databaseName, conn2.databaseName);
+		assert.strictEqual(conn.authenticationType, conn2.authenticationType);
+		assert.strictEqual(conn.password, conn2.password);
+		assert.strictEqual(conn.userName, conn2.userName);
 	});
 
 	test('Changing the cloned object should not change the original one', () => {
@@ -204,20 +204,20 @@ suite('SQL ProviderConnectionInfo tests', () => {
 		let conn2 = Object.assign({}, connectionProfile, { options: options });
 		let conn = new ProviderConnectionInfo(capabilitiesService, conn2);
 
-		assert.equal(conn.connectionName, conn2.connectionName);
-		assert.equal(conn.serverName, conn2.serverName);
-		assert.equal(conn.databaseName, conn2.databaseName);
-		assert.equal(conn.authenticationType, conn2.authenticationType);
-		assert.equal(conn.password, conn2.password);
-		assert.equal(conn.userName, conn2.userName);
-		assert.equal(conn.options['encrypt'], 'test value');
+		assert.strictEqual(conn.connectionName, conn2.connectionName);
+		assert.strictEqual(conn.serverName, conn2.serverName);
+		assert.strictEqual(conn.databaseName, conn2.databaseName);
+		assert.strictEqual(conn.authenticationType, conn2.authenticationType);
+		assert.strictEqual(conn.password, conn2.password);
+		assert.strictEqual(conn.userName, conn2.userName);
+		assert.strictEqual(conn.options['encrypt'], 'test value');
 	});
 
 	test('getOptionsKey should create a valid unique id', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 		let expectedId = 'providerName:MSSQL|authenticationType:|databaseName:database|serverName:new server|userName:user';
 		let id = conn.getOptionsKey();
-		assert.equal(id, expectedId);
+		assert.strictEqual(id, expectedId);
 	});
 
 	test('getOptionsKey should create different id for different server names', () => {
@@ -230,18 +230,18 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	test('titleParts should return server, database and auth type as first items', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 		let titleParts = conn.titleParts;
-		assert.equal(titleParts.length, 4);
-		assert.equal(titleParts[0], connectionProfile.serverName);
-		assert.equal(titleParts[1], connectionProfile.databaseName);
-		assert.equal(titleParts[2], connectionProfile.authenticationType);
-		assert.equal(titleParts[3], connectionProfile.userName);
+		assert.strictEqual(titleParts.length, 4);
+		assert.strictEqual(titleParts[0], connectionProfile.serverName);
+		assert.strictEqual(titleParts[1], connectionProfile.databaseName);
+		assert.strictEqual(titleParts[2], connectionProfile.authenticationType);
+		assert.strictEqual(titleParts[3], connectionProfile.userName);
 	});
 
 	test('getProviderFromOptionsKey should return the provider name from the options key successfully', () => {
 		let optionsKey = `providerName:${mssqlProviderName}|authenticationType:|databaseName:database|serverName:new server|userName:user`;
 		let actual = ProviderConnectionInfo.getProviderFromOptionsKey(optionsKey);
 
-		assert.equal(mssqlProviderName, actual);
+		assert.strictEqual(mssqlProviderName, actual);
 	});
 
 	test('getProviderFromOptionsKey should return empty string give null', () => {
@@ -249,7 +249,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 		let expectedProviderId: string = '';
 		let actual = ProviderConnectionInfo.getProviderFromOptionsKey(optionsKey);
 
-		assert.equal(expectedProviderId, actual);
+		assert.strictEqual(expectedProviderId, actual);
 	});
 
 	test('getProviderFromOptionsKey should return empty string give key without provider name', () => {
@@ -257,6 +257,6 @@ suite('SQL ProviderConnectionInfo tests', () => {
 		let expectedProviderId: string = '';
 		let actual = ProviderConnectionInfo.getProviderFromOptionsKey(optionsKey);
 
-		assert.equal(expectedProviderId, actual);
+		assert.strictEqual(expectedProviderId, actual);
 	});
 });

--- a/src/sql/platform/connection/test/common/providerConnectionInfo.test.ts
+++ b/src/sql/platform/connection/test/common/providerConnectionInfo.test.ts
@@ -195,7 +195,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 
 		let conn2 = conn.clone();
 		conn2.serverName = conn.serverName + '1';
-		assert.notEqual(conn.serverName, conn2.serverName);
+		assert.notStrictEqual(conn.serverName, conn2.serverName);
 	});
 
 	test('constructor should initialize the options given a valid model with options', () => {
@@ -224,7 +224,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 		let conn2 = new ProviderConnectionInfo(capabilitiesService, Object.assign({}, connectionProfile, { serverName: connectionProfile.serverName + '1' }));
 
-		assert.notEqual(conn.getOptionsKey(), conn2.getOptionsKey());
+		assert.notStrictEqual(conn.getOptionsKey(), conn2.getOptionsKey());
 	});
 
 	test('titleParts should return server, database and auth type as first items', () => {

--- a/src/sql/platform/connection/test/node/connectionStatusManager.test.ts
+++ b/src/sql/platform/connection/test/node/connectionStatusManager.test.ts
@@ -95,40 +95,40 @@ suite('SQL ConnectionStatusManager tests', () => {
 		let id: string = 'invalid id';
 		let expected = undefined;
 		let actual = connections.findConnection(id);
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('findConnection should return connection given valid id', () => {
 		let id: string = connection1Id;
 		let actual = connections.findConnection(id);
-		assert.equal(connectionProfileObject.matches(actual!.connectionProfile), true);
+		assert.strictEqual(connectionProfileObject.matches(actual!.connectionProfile), true);
 	});
 
 	test('getConnectionProfile should return undefined given invalid id', () => {
 		let id: string = 'invalid id';
 		let expected = undefined;
 		let actual = connections.getConnectionProfile(id);
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('getConnectionProfile should return connection given valid id', () => {
 		let id: string = connection1Id;
 		let actual = connections.getConnectionProfile(id);
-		assert.equal(connectionProfileObject.matches(actual!), true);
+		assert.strictEqual(connectionProfileObject.matches(actual!), true);
 	});
 
 	test('hasConnection should return false given invalid id', () => {
 		let id: string = 'invalid id';
 		let expected = false;
 		let actual = connections.hasConnection(id);
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('hasConnection should return true given valid id', () => {
 		let id: string = connection1Id;
 		let expected = true;
 		let actual = connections.hasConnection(id);
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('addConnection should set connecting to true', () => {
@@ -144,7 +144,7 @@ suite('SQL ConnectionStatusManager tests', () => {
 		};
 		connections.onConnectionComplete(summary);
 		let actual = connections.addConnection(connectionProfile, connection1Id).connecting;
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('onConnectionComplete should set connecting to false', () => {
@@ -160,9 +160,9 @@ suite('SQL ConnectionStatusManager tests', () => {
 		};
 		connections.onConnectionComplete(summary);
 		let actual = connections.findConnection(connection1Id)!.connecting;
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 		actual = connections.isConnecting(connection1Id);
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('updateConnection should update the connection info', () => {
@@ -176,9 +176,9 @@ suite('SQL ConnectionStatusManager tests', () => {
 		let newId = Utils.generateUri(updatedConnection);
 		let actual = connections.getConnectionProfile(newId)!.groupId;
 		let actualConnectionId = connections.getConnectionProfile(newId)!.id;
-		assert.equal(actual, expected);
-		assert.equal(actualId, newId);
-		assert.equal(actualConnectionId, expectedConnectionId);
+		assert.strictEqual(actual, expected);
+		assert.strictEqual(actualId, newId);
+		assert.strictEqual(actualConnectionId, expectedConnectionId);
 	});
 
 	test('updateDatabaseName should update the database name in connection', () => {
@@ -204,7 +204,7 @@ suite('SQL ConnectionStatusManager tests', () => {
 		//Verify database name changed after connection is complete
 		connections.updateDatabaseName(summary);
 		connectionStatus = connections.findConnection(connection3Id);
-		assert.equal(connectionStatus!.connectionProfile.databaseName, dbName);
+		assert.strictEqual(connectionStatus!.connectionProfile.databaseName, dbName);
 	});
 
 	test('getOriginalOwnerUri should return the original uri given uri with db name', () => {
@@ -234,13 +234,13 @@ suite('SQL ConnectionStatusManager tests', () => {
 
 		//The uri assigned to connection without db name should be the original one
 		let connectionWitDbStatus = connections.getOriginalOwnerUri(ownerUriWithDbName);
-		assert.equal(connectionWitDbStatus, connection3Id);
+		assert.strictEqual(connectionWitDbStatus, connection3Id);
 	});
 
 	test('getOriginalOwnerUri should return given uri if the original uri is the same as the given uri', () => {
 
 		let connectionStatus = connections.getOriginalOwnerUri(connection2Id);
-		assert.equal(connectionStatus, connection2Id);
+		assert.strictEqual(connectionStatus, connection2Id);
 	});
 
 	test('getActiveConnectionProfiles should return a list of all the unique connections that the status manager knows about', () => {
@@ -254,7 +254,7 @@ suite('SQL ConnectionStatusManager tests', () => {
 
 		// Get the connections and verify that the duplicate is only returned once
 		let activeConnections = connections.getActiveConnectionProfiles();
-		assert.equal(activeConnections.length, 4);
-		assert.equal(activeConnections.filter(connection => connection.matches(newConnection)).length, 1, 'Did not find newConnection in active connections');
+		assert.strictEqual(activeConnections.length, 4);
+		assert.strictEqual(activeConnections.filter(connection => connection.matches(newConnection)).length, 1, 'Did not find newConnection in active connections');
 	});
 });

--- a/src/sql/workbench/contrib/accounts/test/browser/accountDialogController.test.ts
+++ b/src/sql/workbench/contrib/accounts/test/browser/accountDialogController.test.ts
@@ -43,7 +43,7 @@ suite('Account Management Dialog Controller Tests', () => {
 		controller.openAccountDialog();
 
 		// Then: It should be the same dialog that already existed
-		assert.equal(controller.accountDialog, accountDialog);
+		assert.strictEqual(controller.accountDialog, accountDialog);
 	});
 
 	test('Add Account Failure - Error Message Shown', () => {

--- a/src/sql/workbench/contrib/assessment/test/browser/asmtActions.test.ts
+++ b/src/sql/workbench/contrib/assessment/test/browser/asmtActions.test.ts
@@ -134,8 +134,8 @@ suite('Assessment Actions', () => {
 		const connectionManagementService = createConnectionManagementService(dbListResult);
 
 		const action = new AsmtServerSelectItemsAction(connectionManagementService.object, new NullLogService(), mockAssessmentService.object, new NullAdsTelemetryService());
-		assert.equal(action.id, AsmtServerSelectItemsAction.ID, 'Get Server Rules id action mismatch');
-		assert.equal(action.label, AsmtServerSelectItemsAction.LABEL, 'Get Server Rules label action mismatch');
+		assert.strictEqual(action.id, AsmtServerSelectItemsAction.ID, 'Get Server Rules id action mismatch');
+		assert.strictEqual(action.label, AsmtServerSelectItemsAction.LABEL, 'Get Server Rules label action mismatch');
 
 		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAsmtViewComponent.verify(s => s.showProgress(AssessmentType.AvailableRules), TypeMoq.Times.once());
@@ -157,8 +157,8 @@ suite('Assessment Actions', () => {
 		const connectionManagementService = createConnectionManagementService(dbListResult);
 
 		const action = new AsmtServerInvokeItemsAction(connectionManagementService.object, new NullLogService(), mockAssessmentService.object, new NullAdsTelemetryService());
-		assert.equal(action.id, AsmtServerInvokeItemsAction.ID, 'Invoke Server Assessment id action mismatch');
-		assert.equal(action.label, AsmtServerInvokeItemsAction.LABEL, 'Invoke Server Assessment label action mismatch');
+		assert.strictEqual(action.id, AsmtServerInvokeItemsAction.ID, 'Invoke Server Assessment id action mismatch');
+		assert.strictEqual(action.label, AsmtServerInvokeItemsAction.LABEL, 'Invoke Server Assessment label action mismatch');
 
 		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAsmtViewComponent.verify(s => s.showProgress(AssessmentType.InvokeAssessment), TypeMoq.Times.once());
@@ -173,7 +173,7 @@ suite('Assessment Actions', () => {
 
 	test('Get Assessment Items Database Action', async () => {
 		const action = new AsmtDatabaseSelectItemsAction('databaseName', mockAssessmentService.object, new NullAdsTelemetryService());
-		assert.equal(action.id, AsmtDatabaseSelectItemsAction.ID, 'Get Database Rules id action mismatch');
+		assert.strictEqual(action.id, AsmtDatabaseSelectItemsAction.ID, 'Get Database Rules id action mismatch');
 
 		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAsmtViewComponent.verify(s => s.showProgress(AssessmentType.AvailableRules), TypeMoq.Times.once());
@@ -185,7 +185,7 @@ suite('Assessment Actions', () => {
 
 	test('Invoke Database Assessment Action', async () => {
 		const action = new AsmtDatabaseInvokeItemsAction('databaseName', mockAssessmentService.object, new NullAdsTelemetryService());
-		assert.equal(action.id, AsmtDatabaseInvokeItemsAction.ID, 'Invoke Database Assessment id action mismatch');
+		assert.strictEqual(action.id, AsmtDatabaseInvokeItemsAction.ID, 'Invoke Database Assessment id action mismatch');
 
 		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAsmtViewComponent.verify(s => s.showProgress(AssessmentType.InvokeAssessment), TypeMoq.Times.once());
@@ -197,8 +197,8 @@ suite('Assessment Actions', () => {
 
 	test('Generate Script Action', async () => {
 		const action = new AsmtExportAsScriptAction(mockAssessmentService.object, new NullAdsTelemetryService());
-		assert.equal(action.id, AsmtExportAsScriptAction.ID, 'Generate Assessment script id action mismatch');
-		assert.equal(action.label, AsmtExportAsScriptAction.LABEL, 'Generate Assessment script label action mismatch');
+		assert.strictEqual(action.id, AsmtExportAsScriptAction.ID, 'Generate Assessment script id action mismatch');
+		assert.strictEqual(action.label, AsmtExportAsScriptAction.LABEL, 'Generate Assessment script label action mismatch');
 
 		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAssessmentService.verify(s => s.generateAssessmentScript(TypeMoq.It.isAnyString(), TypeMoq.It.isAny()), TypeMoq.Times.once());
@@ -209,8 +209,8 @@ suite('Assessment Actions', () => {
 		openerService.setup(s => s.open(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
 
 		const action = new AsmtSamplesLinkAction(openerService.object, new NullAdsTelemetryService());
-		assert.equal(action.id, AsmtSamplesLinkAction.ID, 'Samples Link id action mismatch');
-		assert.equal(action.label, AsmtSamplesLinkAction.LABEL, 'Samples Link label action mismatch');
+		assert.strictEqual(action.id, AsmtSamplesLinkAction.ID, 'Samples Link id action mismatch');
+		assert.strictEqual(action.label, AsmtSamplesLinkAction.LABEL, 'Samples Link label action mismatch');
 
 		await action.run();
 		openerService.verify(s => s.open(TypeMoq.It.isAny()), TypeMoq.Times.once());
@@ -251,8 +251,8 @@ suite('Assessment Actions', () => {
 			new NullAdsTelemetryService(),
 			notificationService.object,
 			fileDialogService);
-		assert.equal(action.id, AsmtGenerateHTMLReportAction.ID, 'Generate HTML Report id action mismatch');
-		assert.equal(action.label, AsmtGenerateHTMLReportAction.LABEL, 'Generate HTML Report label action mismatch');
+		assert.strictEqual(action.id, AsmtGenerateHTMLReportAction.ID, 'Generate HTML Report id action mismatch');
+		assert.strictEqual(action.label, AsmtGenerateHTMLReportAction.LABEL, 'Generate HTML Report label action mismatch');
 
 		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		notificationService.verify(s => s.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -150,7 +150,7 @@ suite('commandLineService tests', () => {
 		let contribution = getCommandLineContribution(connectionManagementService.object, configurationService.object);
 		return contribution.processCommandLine(new TestParsedArgs()).then(() => {
 			connectionManagementService.verifyAll();
-		}, error => { assert.fail(error, null, 'processCommandLine rejected ' + error); });
+		}, error => { assert.fail('processCommandLine rejected ' + error); });
 	});
 
 	test('processCommandLine does nothing if no server name and command name is provided and the configuration \'workbench.showConnectDialogOnStartup\' is set to false, even if registered servers exist', async () => {
@@ -183,7 +183,7 @@ suite('commandLineService tests', () => {
 			await contribution.processCommandLine(new TestParsedArgs());
 			connectionManagementService.verifyAll();
 		} catch (error) {
-			assert.fail(error, null, 'processCommandLine rejected ' + error);
+			assert.fail('processCommandLine rejected ' + error);
 		}
 	});
 

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -275,7 +275,7 @@ suite('commandLineService tests', () => {
 		connectionManagementService.verifyAll();
 		commandService.verifyAll();
 		assert(!isUndefinedOrNull(actualProfile));
-		assert.equal(actualProfile.connectionProfile.serverName, args.server);
+		assert.strictEqual(actualProfile.connectionProfile.serverName, args.server);
 
 	});
 
@@ -433,7 +433,7 @@ suite('commandLineService tests', () => {
 			let result = await contribution.handleURL(uri);
 
 			// Then I expect connection management service to have been called
-			assert.equal(result, false, 'Expected URL to be ignored');
+			assert.strictEqual(result, false, 'Expected URL to be ignored');
 		});
 
 		test('handleUrl opens a new connection if a server name is passed', async () => {
@@ -463,7 +463,7 @@ suite('commandLineService tests', () => {
 			let result = await contribution.handleURL(uri);
 
 			// Then I expect connection management service to have been called
-			assert.equal(result, true, 'Expected URL to be handled');
+			assert.strictEqual(result, true, 'Expected URL to be handled');
 			connectionManagementService.verifyAll();
 		});
 
@@ -495,7 +495,7 @@ suite('commandLineService tests', () => {
 			let result = await contribution.handleURL(uri);
 
 			// Then I expect no connection, but the URL should still be handled
-			assert.equal(result, true, 'Expected URL to be handled');
+			assert.strictEqual(result, true, 'Expected URL to be handled');
 			connectionManagementService.verifyAll();
 		});
 
@@ -522,7 +522,7 @@ suite('commandLineService tests', () => {
 			let result = await contribution.handleURL(uri);
 
 			// Then command service should not have been called, and instead connection should be handled
-			assert.equal(result, true);
+			assert.strictEqual(result, true);
 			commandService.verifyAll();
 			notificationService.verifyAll();
 		});
@@ -559,7 +559,7 @@ suite('commandLineService tests', () => {
 			let result = await contribution.handleURL(uri);
 
 			// Then command service should not have been called, and instead connection should be handled
-			assert.equal(result, true);
+			assert.strictEqual(result, true);
 			commandService.verifyAll();
 			notificationService.verifyAll();
 			connectionManagementService.verifyAll();

--- a/src/sql/workbench/contrib/connection/test/browser/advancedPropertiesDialog.test.ts
+++ b/src/sql/workbench/contrib/connection/test/browser/advancedPropertiesDialog.test.ts
@@ -99,6 +99,6 @@ suite('Advanced properties dialog tests', () => {
 		});
 		advancedController.advancedDialog = advanceDialog.object;
 		advancedController.showDialog(providerOptions, options);
-		assert.equal(isAdvancedDialogCalled, true);
+		assert.strictEqual(isAdvancedDialogCalled, true);
 	});
 });

--- a/src/sql/workbench/contrib/dashboard/test/electron-browser/explorerWidget.component.test.ts
+++ b/src/sql/workbench/contrib/dashboard/test/electron-browser/explorerWidget.component.test.ts
@@ -66,7 +66,7 @@ suite('Explorer Widget Tests', () => {
 
 		// Then the resulting list is sorted by type, with Table > View > Stored Procedures > Function, then by name
 		let expectedList = [testMetadata[1], testMetadata[4], testMetadata[0], testMetadata[2], testMetadata[3]];
-		expectedList.forEach((expectedWrapper, index) => assert.equal(sortedMetadata[index], expectedWrapper));
+		expectedList.forEach((expectedWrapper, index) => assert.strictEqual(sortedMetadata[index], expectedWrapper));
 	});
 
 	test('Filter is only performed on the specified properties', () => {
@@ -83,8 +83,8 @@ suite('Explorer Widget Tests', () => {
 		obj2[prop2] = 'Match';
 		obj2[prop3] = 'cd';
 		const result = filter.filter('ATc', [obj1, obj2]);
-		assert.equal(result.length, 1, 'filtered result set should container 1 item');
-		assert.equal(result[0], obj2, 'filtered result set does not match expectation');
+		assert.strictEqual(result.length, 1, 'filtered result set should container 1 item');
+		assert.strictEqual(result[0], obj2, 'filtered result set does not match expectation');
 	});
 
 	test('object type filter', () => {
@@ -137,41 +137,41 @@ suite('Explorer Widget Tests', () => {
 		].map(o => new ObjectMetadataWrapper(o));
 		const filter = new ExplorerFilter('database', ['name']);
 		let result = filter.filter('t:', testMetadata);
-		assert.equal(result.length, 1, 'table type filter should return only 1 item');
-		assert.equal(result[0]['name'], 'testTable', 'table type filter does not return correct data');
+		assert.strictEqual(result.length, 1, 'table type filter should return only 1 item');
+		assert.strictEqual(result[0]['name'], 'testTable', 'table type filter does not return correct data');
 		result = filter.filter('v:', testMetadata);
-		assert.equal(result.length, 2, 'view type filter should return only 1 item');
-		assert.equal(result[0]['name'], 'testView', 'view type filter does not return correct data');
-		assert.equal(result[1]['name'], 'firstView', 'view type filter does not return correct data');
+		assert.strictEqual(result.length, 2, 'view type filter should return only 1 item');
+		assert.strictEqual(result[0]['name'], 'testView', 'view type filter does not return correct data');
+		assert.strictEqual(result[1]['name'], 'firstView', 'view type filter does not return correct data');
 		result = filter.filter('sp:', testMetadata);
-		assert.equal(result.length, 1, 'stored proc type filter should return only 1 item');
-		assert.equal(result[0]['name'], 'testSProc', 'stored proc type filter does not return correct data');
+		assert.strictEqual(result.length, 1, 'stored proc type filter should return only 1 item');
+		assert.strictEqual(result[0]['name'], 'testSProc', 'stored proc type filter does not return correct data');
 		result = filter.filter('f:', testMetadata);
-		assert.equal(result.length, 1, 'function type filter should return only 1 item');
-		assert.equal(result[0]['name'], 'testFunction', 'function type filter does not return correct data');
+		assert.strictEqual(result.length, 1, 'function type filter should return only 1 item');
+		assert.strictEqual(result[0]['name'], 'testFunction', 'function type filter does not return correct data');
 		result = filter.filter('v:first', testMetadata);
-		assert.equal(result.length, 1, 'view type and name filter should return only 1 item');
-		assert.equal(result[0]['name'], 'firstView', 'view type and name filter does not return correct data');
+		assert.strictEqual(result.length, 1, 'view type and name filter should return only 1 item');
+		assert.strictEqual(result[0]['name'], 'firstView', 'view type and name filter does not return correct data');
 	});
 
 	test('Icon css class test', () => {
 		const serverView = new ExplorerView('server');
 		let icon = serverView.getIconClass({});
-		assert.equal(icon, 'database-colored');
+		assert.strictEqual(icon, 'database-colored');
 		const databaseView = new ExplorerView('database');
 		const obj = {};
 		obj['metadataType'] = MetadataType.Function;
 		icon = databaseView.getIconClass(obj);
-		assert.equal(icon, 'scalarvaluedfunction');
+		assert.strictEqual(icon, 'scalarvaluedfunction');
 		obj['metadataType'] = MetadataType.SProc;
 		icon = databaseView.getIconClass(obj);
-		assert.equal(icon, 'storedprocedure');
+		assert.strictEqual(icon, 'storedprocedure');
 		obj['metadataType'] = MetadataType.Table;
 		icon = databaseView.getIconClass(obj);
-		assert.equal(icon, 'table');
+		assert.strictEqual(icon, 'table');
 		obj['metadataType'] = MetadataType.View;
 		icon = databaseView.getIconClass(obj);
-		assert.equal(icon, 'view');
+		assert.strictEqual(icon, 'view');
 	});
 
 	test('explorer property list', () => {
@@ -201,19 +201,19 @@ suite('Explorer Widget Tests', () => {
 			}]
 		};
 		let propertyList = serverView.getPropertyList(emptyFlavor);
-		assert.equal(propertyList.length, 1, 'default database property list should contain 1 property');
-		assert.equal(propertyList[0].value, 'name', 'default database property list should contain name property');
+		assert.strictEqual(propertyList.length, 1, 'default database property list should contain 1 property');
+		assert.strictEqual(propertyList[0].value, 'name', 'default database property list should contain name property');
 		propertyList = serverView.getPropertyList(flavor);
-		assert.equal(propertyList.length, 1, 'database property list should contain 1 property');
-		assert.equal(propertyList[0].value, 'dbprop1', 'database property list should contain dbprop1 property');
+		assert.strictEqual(propertyList.length, 1, 'database property list should contain 1 property');
+		assert.strictEqual(propertyList[0].value, 'dbprop1', 'database property list should contain dbprop1 property');
 		const databaseView = new ExplorerView('database');
 		propertyList = databaseView.getPropertyList(emptyFlavor);
-		assert.equal(propertyList.length, 3, 'default object property list should contain 3 property');
-		assert.equal(propertyList[0].value, 'name', 'default object property list should contain name property');
-		assert.equal(propertyList[1].value, 'schema', 'default object property list should contain schema property');
-		assert.equal(propertyList[2].value, 'metadataTypeName', 'default object property list should contain metadataTypeName property');
+		assert.strictEqual(propertyList.length, 3, 'default object property list should contain 3 property');
+		assert.strictEqual(propertyList[0].value, 'name', 'default object property list should contain name property');
+		assert.strictEqual(propertyList[1].value, 'schema', 'default object property list should contain schema property');
+		assert.strictEqual(propertyList[2].value, 'metadataTypeName', 'default object property list should contain metadataTypeName property');
 		propertyList = databaseView.getPropertyList(flavor);
-		assert.equal(propertyList.length, 1, 'object property list should contain 1 property');
-		assert.equal(propertyList[0].value, 'objprop1', 'object property list should contain objprop1 property');
+		assert.strictEqual(propertyList.length, 1, 'object property list should contain 1 property');
+		assert.strictEqual(propertyList[0].value, 'objprop1', 'object property list should contain objprop1 property');
 	});
 });

--- a/src/sql/workbench/contrib/dashboard/test/electron-browser/propertiesWidget.component.test.ts
+++ b/src/sql/workbench/contrib/dashboard/test/electron-browser/propertiesWidget.component.test.ts
@@ -107,9 +107,9 @@ suite('Dashboard Properties Widget Tests', () => {
 			// because config parsing is done async we need to put our asserts on the thread stack
 			setImmediate(() => {
 				const propertyItems: PropertyItem[] = (testComponent as any).parseProperties(databaseInfo);
-				assert.equal(propertyItems.length, 1);
-				assert.equal(propertyItems[0].displayName, 'Test');
-				assert.equal(propertyItems[0].value, 'Test Property');
+				assert.strictEqual(propertyItems.length, 1);
+				assert.strictEqual(propertyItems[0].displayName, 'Test');
+				assert.strictEqual(propertyItems[0].value, 'Test Property');
 				resolve();
 			});
 		});

--- a/src/sql/workbench/contrib/dataExplorer/test/browser/dataExplorerViewlet.test.ts
+++ b/src/sql/workbench/contrib/dataExplorer/test/browser/dataExplorerViewlet.test.ts
@@ -54,6 +54,6 @@ suite('Data Explorer Viewlet', () => {
 		let retrieved = Platform.Registry.as<ViewletRegistry>(Extensions.Viewlets).getViewlet('dataExplorer-test-id');
 		assert(d === retrieved);
 		let newCount = Platform.Registry.as<ViewletRegistry>(Extensions.Viewlets).getViewlets().length;
-		assert.equal(oldCount + 1, newCount);
+		assert.strictEqual(oldCount + 1, newCount);
 	});
 });

--- a/src/sql/workbench/contrib/jobManagement/test/browser/jobActions.test.ts
+++ b/src/sql/workbench/contrib/jobManagement/test/browser/jobActions.test.ts
@@ -85,8 +85,8 @@ suite('Job Management Actions', () => {
 		mockRefreshAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => mockJobsViewComponent.object.refreshJobs());
 		mockRefreshAction.setup(s => s.id).returns(() => JobsRefreshAction.ID);
 		mockRefreshAction.setup(s => s.label).returns(() => JobsRefreshAction.LABEL);
-		assert.equal(mockRefreshAction.object.id, JobsRefreshAction.ID);
-		assert.equal(mockRefreshAction.object.label, JobsRefreshAction.LABEL);
+		assert.strictEqual(mockRefreshAction.object.id, JobsRefreshAction.ID);
+		assert.strictEqual(mockRefreshAction.object.label, JobsRefreshAction.LABEL);
 
 		// Job Refresh Action from Jobs View should refresh the component
 		await mockRefreshAction.object.run(null);
@@ -98,8 +98,8 @@ suite('Job Management Actions', () => {
 		mockNewJobAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => mockJobsViewComponent.object.openCreateJobDialog());
 		mockNewJobAction.setup(s => s.id).returns(() => NewJobAction.ID);
 		mockNewJobAction.setup(s => s.label).returns(() => NewJobAction.LABEL);
-		assert.equal(mockNewJobAction.object.id, NewJobAction.ID);
-		assert.equal(mockNewJobAction.object.label, NewJobAction.LABEL);
+		assert.strictEqual(mockNewJobAction.object.id, NewJobAction.ID);
+		assert.strictEqual(mockNewJobAction.object.label, NewJobAction.LABEL);
 
 		// New Job Action from Jobs View should open a dialog
 		await mockNewJobAction.object.run(null);
@@ -111,8 +111,8 @@ suite('Job Management Actions', () => {
 		mockEditJobAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockEditJobAction.setup(s => s.id).returns(() => EditJobAction.ID);
 		mockEditJobAction.setup(s => s.label).returns(() => EditJobAction.LABEL);
-		assert.equal(mockEditJobAction.object.id, EditJobAction.ID);
-		assert.equal(mockEditJobAction.object.label, EditJobAction.LABEL);
+		assert.strictEqual(mockEditJobAction.object.id, EditJobAction.ID);
+		assert.strictEqual(mockEditJobAction.object.label, EditJobAction.LABEL);
 
 		// Edit Job Action from Jobs View should open a dialog
 		await mockEditJobAction.object.run(null);
@@ -127,8 +127,8 @@ suite('Job Management Actions', () => {
 
 		mockRunJobAction.setup(s => s.id).returns(() => RunJobAction.ID);
 		mockRunJobAction.setup(s => s.label).returns(() => RunJobAction.LABEL);
-		assert.equal(mockRunJobAction.object.id, RunJobAction.ID);
-		assert.equal(mockRunJobAction.object.label, RunJobAction.LABEL);
+		assert.strictEqual(mockRunJobAction.object.id, RunJobAction.ID);
+		assert.strictEqual(mockRunJobAction.object.label, RunJobAction.LABEL);
 
 		// Run Job Action should make the Job Management service call job action
 		await mockRunJobAction.object.run(null);
@@ -143,8 +143,8 @@ suite('Job Management Actions', () => {
 
 		mockStopJobAction.setup(s => s.id).returns(() => RunJobAction.ID);
 		mockStopJobAction.setup(s => s.label).returns(() => RunJobAction.LABEL);
-		assert.equal(mockStopJobAction.object.id, RunJobAction.ID);
-		assert.equal(mockStopJobAction.object.label, RunJobAction.LABEL);
+		assert.strictEqual(mockStopJobAction.object.id, RunJobAction.ID);
+		assert.strictEqual(mockStopJobAction.object.label, RunJobAction.LABEL);
 
 		// Run Job Action should make the Job Management service call job action
 		await mockStopJobAction.object.run(null);
@@ -159,8 +159,8 @@ suite('Job Management Actions', () => {
 
 		mockDeleteJobAction.setup(s => s.id).returns(() => DeleteJobAction.ID);
 		mockDeleteJobAction.setup(s => s.label).returns(() => DeleteJobAction.LABEL);
-		assert.equal(mockDeleteJobAction.object.id, DeleteJobAction.ID);
-		assert.equal(mockDeleteJobAction.object.label, DeleteJobAction.LABEL);
+		assert.strictEqual(mockDeleteJobAction.object.id, DeleteJobAction.ID);
+		assert.strictEqual(mockDeleteJobAction.object.label, DeleteJobAction.LABEL);
 
 		// Run Job Action should make the Job Management service call job action
 		await mockDeleteJobAction.object.run(null);
@@ -173,8 +173,8 @@ suite('Job Management Actions', () => {
 		mockNewStepAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockNewStepAction.setup(s => s.id).returns(() => NewJobAction.ID);
 		mockNewStepAction.setup(s => s.label).returns(() => NewJobAction.LABEL);
-		assert.equal(mockNewStepAction.object.id, NewJobAction.ID);
-		assert.equal(mockNewStepAction.object.label, NewJobAction.LABEL);
+		assert.strictEqual(mockNewStepAction.object.id, NewJobAction.ID);
+		assert.strictEqual(mockNewStepAction.object.label, NewJobAction.LABEL);
 
 		// New Step Action should called command service
 		await mockNewStepAction.object.run(null);
@@ -188,8 +188,8 @@ suite('Job Management Actions', () => {
 		});
 		mockDeleteStepAction.setup(s => s.id).returns(() => DeleteStepAction.ID);
 		mockDeleteStepAction.setup(s => s.label).returns(() => DeleteStepAction.LABEL);
-		assert.equal(mockDeleteStepAction.object.id, DeleteStepAction.ID);
-		assert.equal(mockDeleteStepAction.object.label, DeleteStepAction.LABEL);
+		assert.strictEqual(mockDeleteStepAction.object.id, DeleteStepAction.ID);
+		assert.strictEqual(mockDeleteStepAction.object.label, DeleteStepAction.LABEL);
 
 		// Delete Step Action should called command service
 		await mockDeleteStepAction.object.run(null);
@@ -202,8 +202,8 @@ suite('Job Management Actions', () => {
 		mockNewAlertAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => mockAlertsViewComponent.object.openCreateAlertDialog());
 		mockNewAlertAction.setup(s => s.id).returns(() => NewJobAction.ID);
 		mockNewAlertAction.setup(s => s.label).returns(() => NewJobAction.LABEL);
-		assert.equal(mockNewAlertAction.object.id, NewJobAction.ID);
-		assert.equal(mockNewAlertAction.object.label, NewJobAction.LABEL);
+		assert.strictEqual(mockNewAlertAction.object.id, NewJobAction.ID);
+		assert.strictEqual(mockNewAlertAction.object.label, NewJobAction.LABEL);
 
 		// New Alert Action from Alerts View should open a dialog
 		await mockNewAlertAction.object.run(null);
@@ -215,8 +215,8 @@ suite('Job Management Actions', () => {
 		mockEditAlertAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockEditAlertAction.setup(s => s.id).returns(() => EditAlertAction.ID);
 		mockEditAlertAction.setup(s => s.label).returns(() => EditAlertAction.LABEL);
-		assert.equal(mockEditAlertAction.object.id, EditAlertAction.ID);
-		assert.equal(mockEditAlertAction.object.label, EditAlertAction.LABEL);
+		assert.strictEqual(mockEditAlertAction.object.id, EditAlertAction.ID);
+		assert.strictEqual(mockEditAlertAction.object.label, EditAlertAction.LABEL);
 
 		// Edit Alert Action from Jobs View should open a dialog
 		await mockEditAlertAction.object.run(null);
@@ -230,8 +230,8 @@ suite('Job Management Actions', () => {
 		});
 		mockDeleteAlertAction.setup(s => s.id).returns(() => DeleteAlertAction.ID);
 		mockDeleteAlertAction.setup(s => s.label).returns(() => DeleteAlertAction.LABEL);
-		assert.equal(mockDeleteAlertAction.object.id, DeleteAlertAction.ID);
-		assert.equal(mockDeleteAlertAction.object.label, DeleteAlertAction.LABEL);
+		assert.strictEqual(mockDeleteAlertAction.object.id, DeleteAlertAction.ID);
+		assert.strictEqual(mockDeleteAlertAction.object.label, DeleteAlertAction.LABEL);
 
 		// Delete Alert Action should call job management service
 		await mockDeleteAlertAction.object.run(null);
@@ -244,8 +244,8 @@ suite('Job Management Actions', () => {
 		mockNewOperatorAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => mockOperatorsViewComponent.object.openCreateOperatorDialog());
 		mockNewOperatorAction.setup(s => s.id).returns(() => NewOperatorAction.ID);
 		mockNewOperatorAction.setup(s => s.label).returns(() => NewOperatorAction.LABEL);
-		assert.equal(mockNewOperatorAction.object.id, NewOperatorAction.ID);
-		assert.equal(mockNewOperatorAction.object.label, NewOperatorAction.LABEL);
+		assert.strictEqual(mockNewOperatorAction.object.id, NewOperatorAction.ID);
+		assert.strictEqual(mockNewOperatorAction.object.label, NewOperatorAction.LABEL);
 
 		// New Operator Action from Operators View should open a dialog
 		await mockNewOperatorAction.object.run(null);
@@ -257,8 +257,8 @@ suite('Job Management Actions', () => {
 		mockEditOperatorAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockEditOperatorAction.setup(s => s.id).returns(() => EditOperatorAction.ID);
 		mockEditOperatorAction.setup(s => s.label).returns(() => EditOperatorAction.LABEL);
-		assert.equal(mockEditOperatorAction.object.id, EditOperatorAction.ID);
-		assert.equal(mockEditOperatorAction.object.label, EditOperatorAction.LABEL);
+		assert.strictEqual(mockEditOperatorAction.object.id, EditOperatorAction.ID);
+		assert.strictEqual(mockEditOperatorAction.object.label, EditOperatorAction.LABEL);
 
 		// Edit Operator Action from Jobs View should open a dialog
 		await mockEditOperatorAction.object.run(null);
@@ -272,8 +272,8 @@ suite('Job Management Actions', () => {
 		});
 		mockDeleteOperatorAction.setup(s => s.id).returns(() => DeleteOperatorAction.ID);
 		mockDeleteOperatorAction.setup(s => s.label).returns(() => DeleteOperatorAction.LABEL);
-		assert.equal(mockDeleteOperatorAction.object.id, DeleteOperatorAction.ID);
-		assert.equal(mockDeleteOperatorAction.object.label, DeleteOperatorAction.LABEL);
+		assert.strictEqual(mockDeleteOperatorAction.object.id, DeleteOperatorAction.ID);
+		assert.strictEqual(mockDeleteOperatorAction.object.label, DeleteOperatorAction.LABEL);
 
 		// Delete Operator Action should call job management service
 		await mockDeleteOperatorAction.object.run(null);
@@ -286,8 +286,8 @@ suite('Job Management Actions', () => {
 		mockNewProxyAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => mockProxiesViewComponent.object.openCreateProxyDialog());
 		mockNewProxyAction.setup(s => s.id).returns(() => NewProxyAction.ID);
 		mockNewProxyAction.setup(s => s.label).returns(() => NewProxyAction.LABEL);
-		assert.equal(mockNewProxyAction.object.id, NewProxyAction.ID);
-		assert.equal(mockNewProxyAction.object.label, NewProxyAction.LABEL);
+		assert.strictEqual(mockNewProxyAction.object.id, NewProxyAction.ID);
+		assert.strictEqual(mockNewProxyAction.object.label, NewProxyAction.LABEL);
 
 		// New Proxy Action from Alerts View should open a dialog
 		await mockNewProxyAction.object.run(null);
@@ -299,8 +299,8 @@ suite('Job Management Actions', () => {
 		mockEditProxyAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockEditProxyAction.setup(s => s.id).returns(() => EditProxyAction.ID);
 		mockEditProxyAction.setup(s => s.label).returns(() => EditProxyAction.LABEL);
-		assert.equal(mockEditProxyAction.object.id, EditProxyAction.ID);
-		assert.equal(mockEditProxyAction.object.label, EditProxyAction.LABEL);
+		assert.strictEqual(mockEditProxyAction.object.id, EditProxyAction.ID);
+		assert.strictEqual(mockEditProxyAction.object.label, EditProxyAction.LABEL);
 
 		// Edit Proxy Action from Proxies View should open a dialog
 		await mockEditProxyAction.object.run(null);
@@ -314,8 +314,8 @@ suite('Job Management Actions', () => {
 		});
 		mockDeleteProxyAction.setup(s => s.id).returns(() => DeleteProxyAction.ID);
 		mockDeleteProxyAction.setup(s => s.label).returns(() => DeleteProxyAction.LABEL);
-		assert.equal(mockDeleteProxyAction.object.id, DeleteProxyAction.ID);
-		assert.equal(mockDeleteProxyAction.object.label, DeleteProxyAction.LABEL);
+		assert.strictEqual(mockDeleteProxyAction.object.id, DeleteProxyAction.ID);
+		assert.strictEqual(mockDeleteProxyAction.object.label, DeleteProxyAction.LABEL);
 
 		// Delete Proxy Action should call job management service
 		await mockDeleteProxyAction.object.run(null);

--- a/src/sql/workbench/contrib/notebook/test/browser/cellMagicMapper.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/cellMagicMapper.test.ts
@@ -44,10 +44,10 @@ suite('Cell Magic Mapper', function (): void {
 	test('Should find magic when magic is passed into constructor', () => {
 		cellMagicMapper = new CellMagicMapper([sampleLanguageMagicWithKernel]);
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic', 'kernel1');
-		assert.deepEqual(magic, sampleLanguageMagicWithKernel, 'cell magic should match sample magic when looking for first kernel');
+		assert.deepStrictEqual(magic, sampleLanguageMagicWithKernel, 'cell magic should match sample magic when looking for first kernel');
 
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic', 'kernel2');
-		assert.deepEqual(magic, sampleLanguageMagicWithKernel, 'cell magic should match sample magic when looking for second kernel');
+		assert.deepStrictEqual(magic, sampleLanguageMagicWithKernel, 'cell magic should match sample magic when looking for second kernel');
 	});
 
 	test('Should not find magic when kernel does not match', () => {
@@ -77,7 +77,7 @@ suite('Cell Magic Mapper', function (): void {
 	test('Should find magic when kernel is not passed in', () => {
 		cellMagicMapper = new CellMagicMapper([sampleLanguageMagicWithoutKernel]);
 		magic = cellMagicMapper.toLanguageMagic('sampleMagicAllKernels', 'kernel1');
-		assert.deepEqual(magic, sampleLanguageMagicWithoutKernel, 'magic should have been found when no kernel was passed in');
+		assert.deepStrictEqual(magic, sampleLanguageMagicWithoutKernel, 'magic should have been found when no kernel was passed in');
 
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic1', 'kernel1');
 		assert.strictEqual(magic, undefined, 'magic should not be found, since magic name does not match');
@@ -86,12 +86,12 @@ suite('Cell Magic Mapper', function (): void {
 	test('Should find magic multiple magics exist for same kernel', () => {
 		cellMagicMapper = new CellMagicMapper([sampleLanguageMagicWithoutKernel, sampleLanguageMagicWithKernel, otherLanguageMagicWithKernel]);
 		magic = cellMagicMapper.toLanguageMagic('sampleMagicAllKernels', 'kernel2');
-		assert.deepEqual(magic, sampleLanguageMagicWithoutKernel, 'magic should have been found when no kernel was passed in');
+		assert.deepStrictEqual(magic, sampleLanguageMagicWithoutKernel, 'magic should have been found when no kernel was passed in');
 
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic', 'kernel2');
-		assert.deepEqual(magic, sampleLanguageMagicWithKernel, 'magic should have been found when kernel was passed in');
+		assert.deepStrictEqual(magic, sampleLanguageMagicWithKernel, 'magic should have been found when kernel was passed in');
 
 		magic = cellMagicMapper.toLanguageMagic('otherMagic', 'kernel2');
-		assert.deepEqual(magic, otherLanguageMagicWithKernel, 'magic should have been found for second magic with kernel passed in');
+		assert.deepStrictEqual(magic, otherLanguageMagicWithKernel, 'magic should have been found for second magic with kernel passed in');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/cellMagicMapper.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/cellMagicMapper.test.ts
@@ -32,13 +32,13 @@ suite('Cell Magic Mapper', function (): void {
 	test('Should find no magics when empty array passed into constructor', () => {
 		cellMagicMapper = new CellMagicMapper([]);
 		magic = cellMagicMapper.toLanguageMagic('', '');
-		assert.equal(magic, undefined, 'cell magic should not exist when magic name and kernel is empty string');
+		assert.strictEqual(magic, undefined, 'cell magic should not exist when magic name and kernel is empty string');
 
 		magic = cellMagicMapper.toLanguageMagic('magicName', 'kernel1');
-		assert.equal(magic, undefined, 'cell magic should not exist when magic name and kernel strings are not empty');
+		assert.strictEqual(magic, undefined, 'cell magic should not exist when magic name and kernel strings are not empty');
 
 		magic = cellMagicMapper.toLanguageMagic(undefined, undefined);
-		assert.equal(magic, undefined, 'cell magic should not exist when magic name and kernel strings are undefined');
+		assert.strictEqual(magic, undefined, 'cell magic should not exist when magic name and kernel strings are undefined');
 	});
 
 	test('Should find magic when magic is passed into constructor', () => {
@@ -53,25 +53,25 @@ suite('Cell Magic Mapper', function (): void {
 	test('Should not find magic when kernel does not match', () => {
 		cellMagicMapper = new CellMagicMapper([sampleLanguageMagicWithKernel]);
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic', 'kernel3');
-		assert.equal(magic, undefined, 'cell magic be undefined when kernel name does not match');
+		assert.strictEqual(magic, undefined, 'cell magic be undefined when kernel name does not match');
 
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic', '');
-		assert.equal(magic, undefined, 'cell magic be undefined when kernel name is empty string');
+		assert.strictEqual(magic, undefined, 'cell magic be undefined when kernel name is empty string');
 
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic', undefined);
-		assert.equal(magic, undefined, 'cell magic be undefined when kernel name is undefined');
+		assert.strictEqual(magic, undefined, 'cell magic be undefined when kernel name is undefined');
 	});
 
 	test('Should not find magic when magic name does not match', () => {
 		cellMagicMapper = new CellMagicMapper([sampleLanguageMagicWithKernel]);
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic1', 'kernel1');
-		assert.equal(magic, undefined, 'cell magic be undefined when magic name does not match');
+		assert.strictEqual(magic, undefined, 'cell magic be undefined when magic name does not match');
 
 		magic = cellMagicMapper.toLanguageMagic('', 'kernel1');
-		assert.equal(magic, undefined, 'cell magic be undefined when magic name is empty string');
+		assert.strictEqual(magic, undefined, 'cell magic be undefined when magic name is empty string');
 
 		magic = cellMagicMapper.toLanguageMagic(undefined, 'kernel1');
-		assert.equal(magic, undefined, 'cell magic be undefined when magic name is undefined');
+		assert.strictEqual(magic, undefined, 'cell magic be undefined when magic name is undefined');
 	});
 
 	test('Should find magic when kernel is not passed in', () => {
@@ -80,7 +80,7 @@ suite('Cell Magic Mapper', function (): void {
 		assert.deepEqual(magic, sampleLanguageMagicWithoutKernel, 'magic should have been found when no kernel was passed in');
 
 		magic = cellMagicMapper.toLanguageMagic('sampleMagic1', 'kernel1');
-		assert.equal(magic, undefined, 'magic should not be found, since magic name does not match');
+		assert.strictEqual(magic, undefined, 'magic should not be found, since magic name does not match');
 	});
 
 	test('Should find magic multiple magics exist for same kernel', () => {

--- a/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
@@ -129,7 +129,7 @@ suite('CellToolbarActions', function (): void {
 			cellModelMock.setup(x => x.cellType).returns(() => 'code');
 			const action = new CellToggleMoreActions(instantiationService);
 			action.onInit(testContainer, contextMock.object);
-			assert.equal(action['_moreActions']['viewItems'][0]['_action']['_actions'].length, 18, 'Unexpected number of valid elements');
+			assert.strictEqual(action['_moreActions']['viewItems'][0]['_action']['_actions'].length, 18, 'Unexpected number of valid elements');
 		});
 
 		test('CellToggleMoreActions with Markdown CellType', function (): void {
@@ -138,7 +138,7 @@ suite('CellToolbarActions', function (): void {
 			const action = new CellToggleMoreActions(instantiationService);
 			action.onInit(testContainer, contextMock.object);
 			// Markdown elements don't show the code-cell related actions such as Run Cell
-			assert.equal(action['_moreActions']['viewItems'][0]['_action']['_actions'].length, 7, 'Unexpected number of valid elements');
+			assert.strictEqual(action['_moreActions']['viewItems'][0]['_action']['_actions'].length, 7, 'Unexpected number of valid elements');
 		});
 	});
 
@@ -154,29 +154,29 @@ suite('CellToolbarActions', function (): void {
 		test('No notebook model passed in', async function (): Promise<void> {
 			let cellModel = new CellModel({ cell_type: 'code', source: '' }, { isTrusted: true, notebook: undefined });
 			await convertCellAction.doRun({ cell: cellModel, model: undefined });
-			assert.equal(cellModel.cellType, 'code', 'Cell type should not be affected');
+			assert.strictEqual(cellModel.cellType, 'code', 'Cell type should not be affected');
 		});
 
 		test('Convert to code cell', async function (): Promise<void> {
 			await notebookModel.loadContents();
 			await convertCellAction.doRun({ model: notebookModel, cell: notebookModel.cells[0] });
-			assert.equal(notebookModel.cells[0].cellType, 'markdown', 'Cell was not converted correctly');
+			assert.strictEqual(notebookModel.cells[0].cellType, 'markdown', 'Cell was not converted correctly');
 		});
 
 		test('Convert to markdown cell', async function (): Promise<void> {
 			await notebookModel.loadContents();
 			notebookModel.cells[0].cellType = 'markdown';
 			await convertCellAction.doRun({ model: notebookModel, cell: notebookModel.cells[0] });
-			assert.equal(notebookModel.cells[0].cellType, 'code', 'Cell was not converted correctly');
+			assert.strictEqual(notebookModel.cells[0].cellType, 'code', 'Cell was not converted correctly');
 		});
 
 		test('Convert to code cell and back', async function (): Promise<void> {
 			await notebookModel.loadContents();
 			notebookModel.cells[0].cellType = 'markdown';
 			await convertCellAction.doRun({ model: notebookModel, cell: notebookModel.cells[0] });
-			assert.equal(notebookModel.cells[0].cellType, 'code', 'Cell was not converted correctly');
+			assert.strictEqual(notebookModel.cells[0].cellType, 'code', 'Cell was not converted correctly');
 			await convertCellAction.doRun({ model: notebookModel, cell: notebookModel.cells[0] });
-			assert.equal(notebookModel.cells[0].cellType, 'markdown', 'Cell was not converted correctly second time');
+			assert.strictEqual(notebookModel.cells[0].cellType, 'markdown', 'Cell was not converted correctly second time');
 		});
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -123,9 +123,9 @@ suite('Data Resource Data Provider', function () {
 		serializerStub.restore();
 
 		const noHeadersResult = await fs.readFile(noHeadersFile.fsPath);
-		assert.equal(noHeadersResult.toString(), '1 2 \n3 4 \n', 'result data should not include headers');
+		assert.strictEqual(noHeadersResult.toString(), '1 2 \n3 4 \n', 'result data should not include headers');
 
 		const withHeadersResult = await fs.readFile(withHeadersFile.fsPath);
-		assert.equal(withHeadersResult.toString(), 'col1 col2 \n1 2 \n3 4 \n', 'result data should include headers');
+		assert.strictEqual(withHeadersResult.toString(), 'col1 col2 \n1 2 \n3 4 \n', 'result data should include headers');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/markdownTextTransformer.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/markdownTextTransformer.test.ts
@@ -152,7 +152,7 @@ suite('MarkdownTextTransformer', () => {
 	});
 
 	test('Ensure notebook editor returns expected object', async () => {
-		assert.deepEqual(notebookEditor, markdownTextTransformer.notebookEditor, 'Notebook editor does not match expected value');
+		assert.deepStrictEqual(notebookEditor, markdownTextTransformer.notebookEditor, 'Notebook editor does not match expected value');
 		// Set markdown text transformer to not have a notebook editor passed in
 		markdownTextTransformer = new MarkdownTextTransformer(mockNotebookService.object, cellModel);
 		assert.strictEqual(markdownTextTransformer.notebookEditor, undefined, 'No notebook editor should be returned');

--- a/src/sql/workbench/contrib/notebook/test/browser/markdownTextTransformer.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/markdownTextTransformer.test.ts
@@ -192,7 +192,7 @@ suite('MarkdownTextTransformer', () => {
 
 		// Test undo (removing text)
 		const valueRange = getValueRange(textModel, value);
-		assert.notEqual(valueRange, undefined, 'Could not find value in model after transformation');
+		assert.notStrictEqual(valueRange, undefined, 'Could not find value in model after transformation');
 		widget.setSelection(valueRange);
 		await markdownTextTransformer.transformText(type);
 		assert.strictEqual(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with single word selection failed`);
@@ -220,7 +220,7 @@ suite('MarkdownTextTransformer', () => {
 
 		// Test undo (removing text)
 		const valueRange = getValueRange(textModel, value);
-		assert.notEqual(valueRange, undefined, 'Could not find value in model after transformation');
+		assert.notStrictEqual(valueRange, undefined, 'Could not find value in model after transformation');
 		widget.setSelection(valueRange);
 		await markdownTextTransformer.transformText(type);
 		assert.strictEqual(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with multiple word selection failed`);
@@ -238,7 +238,7 @@ suite('MarkdownTextTransformer', () => {
 		let valueRange = getValueRange(textModel, 'Multi');
 		// Modify the range to include all the lines
 		valueRange = new Range(valueRange.startLineNumber, valueRange.startColumn, valueRange.endLineNumber + 2, 9);
-		assert.notEqual(valueRange, undefined, 'Could not find value in model after transformation');
+		assert.notStrictEqual(valueRange, undefined, 'Could not find value in model after transformation');
 		widget.setSelection(valueRange);
 		await markdownTextTransformer.transformText(type);
 		assert.strictEqual(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with multiple line selection failed`);

--- a/src/sql/workbench/contrib/notebook/test/browser/markdownTextTransformer.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/markdownTextTransformer.test.ts
@@ -155,11 +155,11 @@ suite('MarkdownTextTransformer', () => {
 		assert.deepEqual(notebookEditor, markdownTextTransformer.notebookEditor, 'Notebook editor does not match expected value');
 		// Set markdown text transformer to not have a notebook editor passed in
 		markdownTextTransformer = new MarkdownTextTransformer(mockNotebookService.object, cellModel);
-		assert.equal(markdownTextTransformer.notebookEditor, undefined, 'No notebook editor should be returned');
+		assert.strictEqual(markdownTextTransformer.notebookEditor, undefined, 'No notebook editor should be returned');
 		// Even after text is attempted to be transformed, there should be no editor, and therefore nothing on the text model
 		await markdownTextTransformer.transformText(MarkdownButtonType.BOLD);
-		assert.equal(markdownTextTransformer.notebookEditor, undefined, 'Notebook model does not have a valid uri, so no editor should be returned');
-		assert.equal(textModel.getValue(), '', 'No text should exist on the textModel');
+		assert.strictEqual(markdownTextTransformer.notebookEditor, undefined, 'Notebook model does not have a valid uri, so no editor should be returned');
+		assert.strictEqual(textModel.getValue(), '', 'No text should exist on the textModel');
 	});
 
 	async function testWithNoSelection(type: MarkdownButtonType, expectedValue: string, setValue = false): Promise<void> {
@@ -167,7 +167,7 @@ suite('MarkdownTextTransformer', () => {
 			textModel.setValue('');
 		}
 		await markdownTextTransformer.transformText(type);
-		assert.equal(textModel.getValue(), expectedValue, `${MarkdownButtonType[type]} with no selection failed (setValue ${setValue})`);
+		assert.strictEqual(textModel.getValue(), expectedValue, `${MarkdownButtonType[type]} with no selection failed (setValue ${setValue})`);
 	}
 
 
@@ -176,7 +176,7 @@ suite('MarkdownTextTransformer', () => {
 			textModel.setValue('');
 		}
 		await insertFormattedMarkdown('[test](./URL)', widget);
-		assert.equal(textModel.getValue(), expectedValue, `${MarkdownButtonType[type]} with no selection and previously transformed md failed (setValue ${setValue})`);
+		assert.strictEqual(textModel.getValue(), expectedValue, `${MarkdownButtonType[type]} with no selection and previously transformed md failed (setValue ${setValue})`);
 	}
 
 	async function testWithSingleWordSelected(type: MarkdownButtonType, expectedValue: string): Promise<void> {
@@ -185,17 +185,17 @@ suite('MarkdownTextTransformer', () => {
 
 		// Test transformation (adding text)
 		widget.setSelection({ startColumn: 1, startLineNumber: 1, endColumn: value.length + 1, endLineNumber: 1 });
-		assert.equal(textModel.getValueInRange(widget.getSelection()), value, 'Expected selection is not found');
+		assert.strictEqual(textModel.getValueInRange(widget.getSelection()), value, 'Expected selection is not found');
 		await markdownTextTransformer.transformText(type);
 		const textModelValue = textModel.getValue();
-		assert.equal(textModelValue, expectedValue, `${MarkdownButtonType[type]} with single word selection failed`);
+		assert.strictEqual(textModelValue, expectedValue, `${MarkdownButtonType[type]} with single word selection failed`);
 
 		// Test undo (removing text)
 		const valueRange = getValueRange(textModel, value);
 		assert.notEqual(valueRange, undefined, 'Could not find value in model after transformation');
 		widget.setSelection(valueRange);
 		await markdownTextTransformer.transformText(type);
-		assert.equal(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with single word selection failed`);
+		assert.strictEqual(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with single word selection failed`);
 	}
 
 	async function testPreviouslyTransformedWithSingleWordSelected(type: MarkdownButtonType, expectedValue: string): Promise<void> {
@@ -204,35 +204,35 @@ suite('MarkdownTextTransformer', () => {
 
 		// Test transformation (adding text)
 		widget.setSelection({ startColumn: 1, startLineNumber: 1, endColumn: value.length + 1, endLineNumber: 1 });
-		assert.equal(textModel.getValueInRange(widget.getSelection()), value, 'Expected selection is not found');
+		assert.strictEqual(textModel.getValueInRange(widget.getSelection()), value, 'Expected selection is not found');
 		await insertFormattedMarkdown('[SampleURL](https://aka.ms)', widget);
 		const textModelValue = textModel.getValue();
-		assert.equal(textModelValue, expectedValue, `${MarkdownButtonType[type]} with single word selection and previously transformed md failed`);
+		assert.strictEqual(textModelValue, expectedValue, `${MarkdownButtonType[type]} with single word selection and previously transformed md failed`);
 	}
 
 	async function testWithMultipleWordsSelected(type: MarkdownButtonType, expectedValue: string): Promise<void> {
 		let value = 'Multi Words';
 		textModel.setValue(value);
 		widget.setSelection({ startColumn: 1, startLineNumber: 1, endColumn: 12, endLineNumber: 1 });
-		assert.equal(textModel.getValueInRange(widget.getSelection()), value, 'Expected multi-word selection is not found');
+		assert.strictEqual(textModel.getValueInRange(widget.getSelection()), value, 'Expected multi-word selection is not found');
 		await markdownTextTransformer.transformText(type);
-		assert.equal(textModel.getValue(), expectedValue, `${MarkdownButtonType[type]} with multiple word selection failed`);
+		assert.strictEqual(textModel.getValue(), expectedValue, `${MarkdownButtonType[type]} with multiple word selection failed`);
 
 		// Test undo (removing text)
 		const valueRange = getValueRange(textModel, value);
 		assert.notEqual(valueRange, undefined, 'Could not find value in model after transformation');
 		widget.setSelection(valueRange);
 		await markdownTextTransformer.transformText(type);
-		assert.equal(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with multiple word selection failed`);
+		assert.strictEqual(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with multiple word selection failed`);
 	}
 
 	async function testWithMultipleLinesSelected(type: MarkdownButtonType, expectedValue: string): Promise<void> {
 		let value = 'Multi\nLines\nSelected';
 		textModel.setValue(value);
 		widget.setSelection({ startColumn: 1, startLineNumber: 1, endColumn: 9, endLineNumber: 3 });
-		assert.equal(textModel.getValueInRange(widget.getSelection()), value, 'Expected multi-line selection is not found');
+		assert.strictEqual(textModel.getValueInRange(widget.getSelection()), value, 'Expected multi-line selection is not found');
 		await markdownTextTransformer.transformText(type);
-		assert.equal(textModel.getValue(), expectedValue, `${MarkdownButtonType[type]} with multiple line selection failed`);
+		assert.strictEqual(textModel.getValue(), expectedValue, `${MarkdownButtonType[type]} with multiple line selection failed`);
 
 		// Test undo (removing text)
 		let valueRange = getValueRange(textModel, 'Multi');
@@ -241,7 +241,7 @@ suite('MarkdownTextTransformer', () => {
 		assert.notEqual(valueRange, undefined, 'Could not find value in model after transformation');
 		widget.setSelection(valueRange);
 		await markdownTextTransformer.transformText(type);
-		assert.equal(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with multiple line selection failed`);
+		assert.strictEqual(textModel.getValue(), value, `Undo operation for ${MarkdownButtonType[type]} with multiple line selection failed`);
 	}
 });
 

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
@@ -263,7 +263,7 @@ suite('Test class NotebookEditor:', () => {
 			changeDecorationsCalled = true;
 			return returnObject;
 		});
-		assert.notEqual(changeDecorationsCalled, true, `changeDecorations callback should not have been called`);
+		assert.notStrictEqual(changeDecorationsCalled, true, `changeDecorations callback should not have been called`);
 		assert.notStrictEqual(result, returnObject, 'object returned by the callback given to changeDecorations() call must not be returned by it');
 		assert.strictEqual(result, null, 'return value of changeDecorations() call must be null when no input is set on notebookEditor object');
 	});

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookExplorerViewlet.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookExplorerViewlet.test.ts
@@ -60,7 +60,7 @@ suite('Notebook Explorer Views', () => {
 		let retrieved = Platform.Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).getView('notebookView-test-1');
 		assert(d === retrieved, 'Could not register view :' + d.id + 'Retrieved: ' + retrieved);
 		let newCount = Platform.Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).getViews(NOTEBOOK_VIEW_CONTAINER).length;
-		assert.equal(oldcount + 1, newCount, 'View registration failed');
+		assert.strictEqual(oldcount + 1, newCount, 'View registration failed');
 
 
 	});
@@ -89,7 +89,7 @@ suite('Notebook Explorer Views', () => {
 		Platform.Registry.as<ViewletRegistry>(Extensions.Viewlets).registerViewlet(v1Duplicate);
 
 		let newCount = Platform.Registry.as<ViewletRegistry>(Extensions.Viewlets).getViewlets().length;
-		assert.equal(oldCount, newCount, 'Duplicate registration of views.');
+		assert.strictEqual(oldCount, newCount, 'Duplicate registration of views.');
 
 	});
 

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookService.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookService.test.ts
@@ -186,17 +186,17 @@ suite.skip('NotebookService:', function (): void {
 		assert.strictEqual(notebookService.languageMagics.length, 0, 'No language magics should exist after creation');
 		assert.strictEqual(notebookService.listNotebookEditors().length, 0, 'No notebook editors should be listed');
 		assert.strictEqual(notebookService.getMimeRegistry().mimeTypes.length, 15, 'MIME Types need to have appropriate tests when added or removed');
-		assert.deepEqual(notebookService.getProvidersForFileType('ipynb'), ['sql'], 'sql provider should be registered for ipynb extension');
+		assert.deepStrictEqual(notebookService.getProvidersForFileType('ipynb'), ['sql'], 'sql provider should be registered for ipynb extension');
 		assert.strictEqual(notebookService.getStandardKernelsForProvider('sql').length, 1, 'SQL kernel should be provided by default');
 		assert.strictEqual(notebookService.getStandardKernelsForProvider('otherProvider'), undefined, 'Other provider should not have kernels since it has not been added as a provider');
-		assert.deepEqual(notebookService.getSupportedFileExtensions(), ['IPYNB'], 'IPYNB file extension should be supported by default');
+		assert.deepStrictEqual(notebookService.getSupportedFileExtensions(), ['IPYNB'], 'IPYNB file extension should be supported by default');
 		await notebookService.registrationComplete;
 		assert.ok(notebookService.isRegistrationComplete, `notebookService.isRegistrationComplete should be true once its registrationComplete promise is resolved`);
 	});
 
 	test('Validate another provider added successfully', async function (): Promise<void> {
 		await notebookService.registrationComplete;
-		assert.deepEqual(notebookService.getProvidersForFileType('ipynb'), ['sql'], 'sql provider should be registered for ipynb extension');
+		assert.deepStrictEqual(notebookService.getProvidersForFileType('ipynb'), ['sql'], 'sql provider should be registered for ipynb extension');
 
 		const otherProviderRegistration: NotebookProviderRegistration = {
 			fileExtensions: 'ipynb',
@@ -211,10 +211,10 @@ suite.skip('NotebookService:', function (): void {
 		const notebookRegistry = Registry.as<INotebookProviderRegistry>(Extensions.NotebookProviderContribution);
 		notebookRegistry.registerNotebookProvider(otherProviderRegistration);
 
-		assert.deepEqual(notebookService.getProvidersForFileType('ipynb'), ['sql', 'otherProvider'], 'otherProvider should also be registered for ipynb extension');
-		assert.deepEqual(notebookService.getSupportedFileExtensions(), ['IPYNB'], 'Only IPYNB should be registered as supported file extension');
+		assert.deepStrictEqual(notebookService.getProvidersForFileType('ipynb'), ['sql', 'otherProvider'], 'otherProvider should also be registered for ipynb extension');
+		assert.deepStrictEqual(notebookService.getSupportedFileExtensions(), ['IPYNB'], 'Only IPYNB should be registered as supported file extension');
 		assert.strictEqual(notebookService.getStandardKernelsForProvider('otherProvider').length, 1, 'otherProvider kernel info could not be found');
-		assert.deepEqual(notebookService.getStandardKernelsForProvider('otherProvider')[0], otherProviderRegistration.standardKernels, 'otherProviderRegistration standard kernels does not match');
+		assert.deepStrictEqual(notebookService.getStandardKernelsForProvider('otherProvider')[0], otherProviderRegistration.standardKernels, 'otherProviderRegistration standard kernels does not match');
 	});
 
 	test('tests that dispose() method calls dispose on underlying disposable objects exactly once', async () => {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookService.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookService.test.ts
@@ -183,12 +183,12 @@ suite.skip('NotebookService:', function (): void {
 	});
 
 	test('Validate default properties on create', async function (): Promise<void> {
-		assert.equal(notebookService.languageMagics.length, 0, 'No language magics should exist after creation');
-		assert.equal(notebookService.listNotebookEditors().length, 0, 'No notebook editors should be listed');
-		assert.equal(notebookService.getMimeRegistry().mimeTypes.length, 15, 'MIME Types need to have appropriate tests when added or removed');
+		assert.strictEqual(notebookService.languageMagics.length, 0, 'No language magics should exist after creation');
+		assert.strictEqual(notebookService.listNotebookEditors().length, 0, 'No notebook editors should be listed');
+		assert.strictEqual(notebookService.getMimeRegistry().mimeTypes.length, 15, 'MIME Types need to have appropriate tests when added or removed');
 		assert.deepEqual(notebookService.getProvidersForFileType('ipynb'), ['sql'], 'sql provider should be registered for ipynb extension');
-		assert.equal(notebookService.getStandardKernelsForProvider('sql').length, 1, 'SQL kernel should be provided by default');
-		assert.equal(notebookService.getStandardKernelsForProvider('otherProvider'), undefined, 'Other provider should not have kernels since it has not been added as a provider');
+		assert.strictEqual(notebookService.getStandardKernelsForProvider('sql').length, 1, 'SQL kernel should be provided by default');
+		assert.strictEqual(notebookService.getStandardKernelsForProvider('otherProvider'), undefined, 'Other provider should not have kernels since it has not been added as a provider');
 		assert.deepEqual(notebookService.getSupportedFileExtensions(), ['IPYNB'], 'IPYNB file extension should be supported by default');
 		await notebookService.registrationComplete;
 		assert.ok(notebookService.isRegistrationComplete, `notebookService.isRegistrationComplete should be true once its registrationComplete promise is resolved`);
@@ -213,7 +213,7 @@ suite.skip('NotebookService:', function (): void {
 
 		assert.deepEqual(notebookService.getProvidersForFileType('ipynb'), ['sql', 'otherProvider'], 'otherProvider should also be registered for ipynb extension');
 		assert.deepEqual(notebookService.getSupportedFileExtensions(), ['IPYNB'], 'Only IPYNB should be registered as supported file extension');
-		assert.equal(notebookService.getStandardKernelsForProvider('otherProvider').length, 1, 'otherProvider kernel info could not be found');
+		assert.strictEqual(notebookService.getStandardKernelsForProvider('otherProvider').length, 1, 'otherProvider kernel info could not be found');
 		assert.deepEqual(notebookService.getStandardKernelsForProvider('otherProvider')[0], otherProviderRegistration.standardKernels, 'otherProviderRegistration standard kernels does not match');
 	});
 
@@ -570,7 +570,7 @@ suite.skip('NotebookService:', function (): void {
 		let getUntitledUriPathSpy = sinon.spy(notebookService, 'getUntitledUriPath');
 		notebookService.getUntitledUriPath('title.ipynb');
 		sinon.assert.calledOnce(getUntitledUriPathSpy);
-		assert.equal(getUntitledUriPathSpy, 'title-0.ipynb');
+		assert.strictEqual(getUntitledUriPathSpy, 'title-0.ipynb');
 	});
 
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookViewModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookViewModel.test.ts
@@ -96,9 +96,9 @@ suite('NotebookViewModel', function (): void {
 
 		let cellsWithNewView = notebookViews.getCells().filter(cell => cell.views.find(v => v.guid === viewModel.guid));
 
-		assert.equal(cellsWithNewView.length, 2);
-		assert.equal(viewModel.cells.length, 2);
-		assert.equal(viewModel.name, defaultViewName);
+		assert.strictEqual(cellsWithNewView.length, 2);
+		assert.strictEqual(viewModel.cells.length, 2);
+		assert.strictEqual(viewModel.name, defaultViewName);
 	});
 
 	test('initialize notebook with no metadata', async function (): Promise<void> {
@@ -108,9 +108,9 @@ suite('NotebookViewModel', function (): void {
 
 		let cellsWithNewView = notebookViews.getCells().filter(cell => cell.views.find(v => v.guid === viewModel.guid));
 
-		assert.equal(cellsWithNewView.length, 2);
-		assert.equal(viewModel.cells.length, 2);
-		assert.equal(viewModel.name, defaultViewName);
+		assert.strictEqual(cellsWithNewView.length, 2);
+		assert.strictEqual(viewModel.cells.length, 2);
+		assert.strictEqual(viewModel.name, defaultViewName);
 	});
 
 	test('rename', async function (): Promise<void> {
@@ -125,7 +125,7 @@ suite('NotebookViewModel', function (): void {
 			exceptionThrown = true;
 		}
 
-		assert.equal(view.name, `${defaultViewName} 1`);
+		assert.strictEqual(view.name, `${defaultViewName} 1`);
 		assert(!exceptionThrown);
 	});
 
@@ -155,7 +155,7 @@ suite('NotebookViewModel', function (): void {
 
 		viewModel.hideCell(cellToHide);
 
-		assert.equal(viewModel.hiddenCells.length, 1);
+		assert.strictEqual(viewModel.hiddenCells.length, 1);
 		assert(viewModel.hiddenCells.includes(cellToHide));
 	});
 
@@ -183,8 +183,8 @@ suite('NotebookViewModel', function (): void {
 		viewModel.moveCell(cellToMove, 98, 99);
 		let cellMeta = viewModel.getCellMetadata(cellToMove);
 
-		assert.equal(cellMeta.x, 98);
-		assert.equal(cellMeta.y, 99);
+		assert.strictEqual(cellMeta.x, 98);
+		assert.strictEqual(cellMeta.y, 99);
 	});
 
 	test('resize cell', async function (): Promise<void> {
@@ -197,8 +197,8 @@ suite('NotebookViewModel', function (): void {
 		viewModel.resizeCell(cellToResize, 3, 4);
 		let cellMeta = viewModel.getCellMetadata(cellToResize);
 
-		assert.equal(cellMeta.width, 3);
-		assert.equal(cellMeta.height, 4);
+		assert.strictEqual(cellMeta.width, 3);
+		assert.strictEqual(cellMeta.height, 4);
 	});
 
 	test('get cell metadata', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookViewModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookViewModel.test.ts
@@ -210,7 +210,7 @@ suite('NotebookViewModel', function (): void {
 		let cellMeta = notebookViews.getCellMetadata(cell);
 
 		assert(!isUndefinedOrNull(cellMeta.views.find(v => v.guid === viewModel.guid)));
-		assert.deepEqual(viewModel.getCellMetadata(cell), cellMeta.views.find(v => v.guid === viewModel.guid));
+		assert.deepStrictEqual(viewModel.getCellMetadata(cell), cellMeta.views.find(v => v.guid === viewModel.guid));
 	});
 
 	test('delete', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookViewsExtension.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookViewsExtension.test.ts
@@ -76,14 +76,14 @@ suite('NotebookViews', function (): void {
 	});
 
 	test('create new view', async function (): Promise<void> {
-		assert.equal(notebookViews.getViews().length, 0, 'notebook should not initially generate any views');
+		assert.strictEqual(notebookViews.getViews().length, 0, 'notebook should not initially generate any views');
 
 		let newView = notebookViews.createNewView(defaultViewName);
 		let cellsWithMatchingGuid = newView.cells.filter(cell => newView.getCellMetadata(cell).guid === newView.guid);
 
-		assert.equal(newView.name, defaultViewName, 'view was not created with its given name');
-		assert.equal(newView.cells.length, 2, 'view did not contain the same number of cells as the notebook used to create it');
-		assert.equal(cellsWithMatchingGuid.length, newView.cells.length, 'cell metadata was not created for all cells in view');
+		assert.strictEqual(newView.name, defaultViewName, 'view was not created with its given name');
+		assert.strictEqual(newView.cells.length, 2, 'view did not contain the same number of cells as the notebook used to create it');
+		assert.strictEqual(cellsWithMatchingGuid.length, newView.cells.length, 'cell metadata was not created for all cells in view');
 	});
 
 	test('remove view', async function (): Promise<void> {
@@ -93,23 +93,23 @@ suite('NotebookViews', function (): void {
 
 		let cellsWithNewView = notebookViews.getCells().filter(cell => cell.views.find(v => v.guid === newView.guid));
 
-		assert.equal(notebookViews.getViews().length, 0, 'view not removed from notebook metadata');
-		assert.equal(cellsWithNewView.length, 0, 'view not removed from cells');
+		assert.strictEqual(notebookViews.getViews().length, 0, 'view not removed from notebook metadata');
+		assert.strictEqual(cellsWithNewView.length, 0, 'view not removed from cells');
 	});
 
 	test('default view name', async function (): Promise<void> {
 		let newView = notebookViews.createNewView();
-		assert.equal(newView.name, NotebookViewsExtension.defaultViewName);
+		assert.strictEqual(newView.name, NotebookViewsExtension.defaultViewName);
 
 		let newView1 = notebookViews.createNewView();
-		assert.equal(newView1.name, `${NotebookViewsExtension.defaultViewName} 1`);
+		assert.strictEqual(newView1.name, `${NotebookViewsExtension.defaultViewName} 1`);
 	});
 
 	test('active view', async function (): Promise<void> {
 		let newView = notebookViews.createNewView();
 		notebookViews.setActiveView(newView);
 
-		assert.equal(notebookViews.getActiveView(), newView);
+		assert.strictEqual(notebookViews.getActiveView(), newView);
 	});
 
 	test('update cell', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/calloutDialog/imageCalloutDialog.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/calloutDialog/imageCalloutDialog.test.ts
@@ -48,9 +48,9 @@ suite('Image Callout Dialog', function (): void {
 		imageCalloutDialog.cancel();
 		let result = await deferred.promise;
 
-		assert.equal(result.imagePath, undefined, 'ImagePath must be undefined');
-		assert.equal(result.embedImage, undefined, 'EmbedImage must be undefined');
-		assert.equal(result.insertEscapedMarkdown, '', 'Markdown not returned correctly');
+		assert.strictEqual(result.imagePath, undefined, 'ImagePath must be undefined');
+		assert.strictEqual(result.embedImage, undefined, 'EmbedImage must be undefined');
+		assert.strictEqual(result.insertEscapedMarkdown, '', 'Markdown not returned correctly');
 	});
 
 	test('Should return expected values on insert', async function (): Promise<void> {
@@ -69,9 +69,9 @@ suite('Image Callout Dialog', function (): void {
 		// And insert the dialog
 		imageCalloutDialog.insert();
 		let result = await deferred.promise;
-		assert.equal(result.imagePath, sampleImageFileUrl.fsPath, 'ImagePath not returned correctly');
-		assert.equal(result.embedImage, false, 'EmbedImage not returned correctly');
-		assert.equal(result.insertEscapedMarkdown, `![](${result.imagePath})`, 'Markdown not returned correctly');
+		assert.strictEqual(result.imagePath, sampleImageFileUrl.fsPath, 'ImagePath not returned correctly');
+		assert.strictEqual(result.embedImage, false, 'EmbedImage not returned correctly');
+		assert.strictEqual(result.insertEscapedMarkdown, `![](${result.imagePath})`, 'Markdown not returned correctly');
 	});
 
 	test('Should return expected values on insert when imageName has space', async function (): Promise<void> {
@@ -91,9 +91,9 @@ suite('Image Callout Dialog', function (): void {
 		// And insert the dialog
 		imageCalloutDialog.insert();
 		let result = await deferred.promise;
-		assert.equal(result.imagePath, sampleImageFileUrl.fsPath, 'imagePath not returned correctly');
-		assert.equal(result.embedImage, false, 'embedImage not returned correctly');
-		assert.equal(result.insertEscapedMarkdown, `![](${result.imagePath.replace(' ', '&#32;')})`, 'Markdown not returned correctly');
+		assert.strictEqual(result.imagePath, sampleImageFileUrl.fsPath, 'imagePath not returned correctly');
+		assert.strictEqual(result.embedImage, false, 'embedImage not returned correctly');
+		assert.strictEqual(result.insertEscapedMarkdown, `![](${result.imagePath.replace(' ', '&#32;')})`, 'Markdown not returned correctly');
 	});
 
 	test('Should return expected values on insert when add as attachment is set', async function (): Promise<void> {
@@ -115,9 +115,9 @@ suite('Image Callout Dialog', function (): void {
 		// And insert the dialog
 		imageCalloutDialog.insert();
 		let result = await deferred.promise;
-		assert.equal(result.imagePath, sampleImageFileUrl.fsPath, 'imagePath not returned correctly');
-		assert.equal(result.embedImage, true, 'embedImage not returned correctly');
-		assert.equal(result.insertEscapedMarkdown, `![${imageName}](attachment:${imageName})`, 'Markdown not returned correctly');
+		assert.strictEqual(result.imagePath, sampleImageFileUrl.fsPath, 'imagePath not returned correctly');
+		assert.strictEqual(result.embedImage, true, 'embedImage not returned correctly');
+		assert.strictEqual(result.insertEscapedMarkdown, `![${imageName}](attachment:${imageName})`, 'Markdown not returned correctly');
 	});
 
 	test('Should return expected values on insert when imageName has space and add attachment is set', async function (): Promise<void> {
@@ -139,9 +139,9 @@ suite('Image Callout Dialog', function (): void {
 		// And insert the dialog
 		imageCalloutDialog.insert();
 		let result = await deferred.promise;
-		assert.equal(result.imagePath, sampleImageFileUrl.fsPath, 'imagePath not returned correctly');
-		assert.equal(result.embedImage, true, 'embedImage not returned correctly');
-		assert.equal(result.insertEscapedMarkdown, `![${imageName}](attachment:${imageName.replace(' ', '')})`, 'Markdown not returned correctly');
+		assert.strictEqual(result.imagePath, sampleImageFileUrl.fsPath, 'imagePath not returned correctly');
+		assert.strictEqual(result.embedImage, true, 'embedImage not returned correctly');
+		assert.strictEqual(result.insertEscapedMarkdown, `![${imageName}](attachment:${imageName.replace(' ', '')})`, 'Markdown not returned correctly');
 	});
 
 });

--- a/src/sql/workbench/contrib/notebook/test/common/jsonext.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/common/jsonext.test.ts
@@ -9,34 +9,34 @@ import { isPrimitive } from 'sql/workbench/services/notebook/common/jsonext';
 suite('jsonext', function (): void {
 	test('Validate null object is primitive', async function (): Promise<void> {
 		let object = null;
-		assert.equal(isPrimitive(object), true, 'null object should be primitive');
+		assert.strictEqual(isPrimitive(object), true, 'null object should be primitive');
 		object = undefined;
-		assert.equal(isPrimitive(object), false, 'undefined object should not be primitive');
+		assert.strictEqual(isPrimitive(object), false, 'undefined object should not be primitive');
 	});
 	test('Validate boolean types are primitive', async function (): Promise<void> {
 		let object: boolean = false;
-		assert.equal(isPrimitive(object), true, 'false boolean object should be primitive');
+		assert.strictEqual(isPrimitive(object), true, 'false boolean object should be primitive');
 		object = true;
-		assert.equal(isPrimitive(object), true, 'true boolean object should be primitive');
+		assert.strictEqual(isPrimitive(object), true, 'true boolean object should be primitive');
 	});
 	test('Validate number types are primitive', async function (): Promise<void> {
 		let object: number = 0;
-		assert.equal(isPrimitive(object), true, 'number with value 0 should be primitive');
+		assert.strictEqual(isPrimitive(object), true, 'number with value 0 should be primitive');
 		object = 1;
-		assert.equal(isPrimitive(object), true, 'number with value 1 should be primitive');
+		assert.strictEqual(isPrimitive(object), true, 'number with value 1 should be primitive');
 	});
 	test('Validate string types are primitive', async function (): Promise<void> {
 		let object: string = '';
-		assert.equal(isPrimitive(object), true, 'empty strings should be primitive');
+		assert.strictEqual(isPrimitive(object), true, 'empty strings should be primitive');
 		object = 'nonempty string';
-		assert.equal(isPrimitive(object), true, 'non-empty strings should be primitive');
+		assert.strictEqual(isPrimitive(object), true, 'non-empty strings should be primitive');
 	});
 	test('custom object is not primitive', async function (): Promise<void> {
 		let object = {
 			prop1: 'val1'
 		};
-		assert.equal(isPrimitive(object), false, 'custom object should not be primitive');
+		assert.strictEqual(isPrimitive(object), false, 'custom object should not be primitive');
 		object = undefined;
-		assert.equal(isPrimitive(object), false, 'undefined object should not be primitive');
+		assert.strictEqual(isPrimitive(object), false, 'undefined object should not be primitive');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/common/nbformat.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/common/nbformat.test.ts
@@ -17,42 +17,42 @@ suite('nbformat', function (): void {
 	};
 	test('Validate display_data Output Type', async function (): Promise<void> {
 		sampleOutput.output_type = 'display_data';
-		assert.equal(nbformat.isDisplayData(sampleOutput), true, 'display_data output type not recognized correctly');
-		assert.equal(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
-		assert.equal(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
-		assert.equal(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
-		assert.equal(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
+		assert.strictEqual(nbformat.isDisplayData(sampleOutput), true, 'display_data output type not recognized correctly');
+		assert.strictEqual(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
+		assert.strictEqual(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
+		assert.strictEqual(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
+		assert.strictEqual(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
 	});
 	test('Validate update_display_data Output Type', async function (): Promise<void> {
 		sampleOutput.output_type = 'update_display_data';
-		assert.equal(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
-		assert.equal(nbformat.isDisplayUpdate(sampleOutput), true, 'update_display_data output type not recognized correctly');
-		assert.equal(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
-		assert.equal(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
-		assert.equal(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
+		assert.strictEqual(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
+		assert.strictEqual(nbformat.isDisplayUpdate(sampleOutput), true, 'update_display_data output type not recognized correctly');
+		assert.strictEqual(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
+		assert.strictEqual(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
+		assert.strictEqual(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
 	});
 	test('Validate error Output Type', async function (): Promise<void> {
 		sampleOutput.output_type = 'error';
-		assert.equal(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
-		assert.equal(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
-		assert.equal(nbformat.isError(sampleOutput), true, 'error output type not recognized correctly');
-		assert.equal(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
-		assert.equal(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
+		assert.strictEqual(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
+		assert.strictEqual(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
+		assert.strictEqual(nbformat.isError(sampleOutput), true, 'error output type not recognized correctly');
+		assert.strictEqual(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
+		assert.strictEqual(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
 	});
 	test('Validate execute_result Output Type', async function (): Promise<void> {
 		sampleOutput.output_type = 'execute_result';
-		assert.equal(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
-		assert.equal(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
-		assert.equal(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
-		assert.equal(nbformat.isExecuteResult(sampleOutput), true, 'execute_result output type not recognized correctly');
-		assert.equal(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
+		assert.strictEqual(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
+		assert.strictEqual(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
+		assert.strictEqual(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
+		assert.strictEqual(nbformat.isExecuteResult(sampleOutput), true, 'execute_result output type not recognized correctly');
+		assert.strictEqual(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
 	});
 	test('Validate stream Output Type', async function (): Promise<void> {
 		sampleOutput.output_type = 'stream';
-		assert.equal(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
-		assert.equal(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
-		assert.equal(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
-		assert.equal(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
-		assert.equal(nbformat.isStream(sampleOutput), true, 'stream output type not recognized correctly');
+		assert.strictEqual(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
+		assert.strictEqual(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
+		assert.strictEqual(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
+		assert.strictEqual(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
+		assert.strictEqual(nbformat.isStream(sampleOutput), true, 'stream output type not recognized correctly');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -36,16 +36,16 @@ suite('Cell Model', function (): void {
 	let factory = new ModelFactory(instantiationService);
 	test('Should set default values if none defined', async function (): Promise<void> {
 		let cell = factory.createCell(undefined, undefined);
-		assert.equal(cell.cellType, CellTypes.Code);
-		assert.equal(cell.source, '');
+		assert.strictEqual(cell.cellType, CellTypes.Code);
+		assert.strictEqual(cell.source, '');
 	});
 
 	test('Should update values', async function (): Promise<void> {
 		let cell = factory.createCell(undefined, undefined);
 		cell.setOverrideLanguage('sql');
-		assert.equal(cell.language, 'sql');
+		assert.strictEqual(cell.language, 'sql');
 		cell.source = 'abcd';
-		assert.equal(JSON.stringify(cell.source), JSON.stringify(['abcd']));
+		assert.strictEqual(JSON.stringify(cell.source), JSON.stringify(['abcd']));
 	});
 
 	test('Should match ICell values if defined', async function (): Promise<void> {
@@ -62,11 +62,11 @@ suite('Cell Model', function (): void {
 			execution_count: 1
 		};
 		let cell = factory.createCell(cellData, undefined);
-		assert.equal(cell.cellType, cellData.cell_type);
-		assert.equal(JSON.stringify(cell.source), JSON.stringify([cellData.source]));
-		assert.equal(cell.outputs.length, 1);
-		assert.equal(cell.outputs[0].output_type, 'stream');
-		assert.equal((<nb.IStreamResult>cell.outputs[0]).text, 'Some output');
+		assert.strictEqual(cell.cellType, cellData.cell_type);
+		assert.strictEqual(JSON.stringify(cell.source), JSON.stringify([cellData.source]));
+		assert.strictEqual(cell.outputs.length, 1);
+		assert.strictEqual(cell.outputs[0].output_type, 'stream');
+		assert.strictEqual((<nb.IStreamResult>cell.outputs[0]).text, 'Some output');
 	});
 
 
@@ -84,7 +84,7 @@ suite('Cell Model', function (): void {
 			mimetype: ''
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
-		assert.equal(cell.language, 'python');
+		assert.strictEqual(cell.language, 'python');
 	});
 
 	test('Should set cell language to python if defined as pyspark in languageInfo', async function (): Promise<void> {
@@ -101,7 +101,7 @@ suite('Cell Model', function (): void {
 			mimetype: ''
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
-		assert.equal(cell.language, 'python');
+		assert.strictEqual(cell.language, 'python');
 	});
 
 	test('Should keep cell language as python if cell has language override', async function (): Promise<void> {
@@ -118,7 +118,7 @@ suite('Cell Model', function (): void {
 			mimetype: ''
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
-		assert.equal(cell.language, 'python');
+		assert.strictEqual(cell.language, 'python');
 	});
 
 	test('Should set cell language to python if no language defined', async function (): Promise<void> {
@@ -135,7 +135,7 @@ suite('Cell Model', function (): void {
 			mimetype: ''
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
-		assert.equal(cell.language, 'python');
+		assert.strictEqual(cell.language, 'python');
 	});
 
 	test('Should allow source of type string[] with length 1', async function (): Promise<void> {
@@ -153,8 +153,8 @@ suite('Cell Model', function (): void {
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
 		assert(Array.isArray(cell.source));
-		assert.equal(cell.source.length, 1);
-		assert.equal(cell.source[0], 'print(1)');
+		assert.strictEqual(cell.source.length, 1);
+		assert.strictEqual(cell.source[0], 'print(1)');
 	});
 
 	test('Should allow source of type string', async function (): Promise<void> {
@@ -172,7 +172,7 @@ suite('Cell Model', function (): void {
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
 		assert(Array.isArray(cell.source));
-		assert.equal(JSON.stringify(cell.source), JSON.stringify(['print(1)']));
+		assert.strictEqual(JSON.stringify(cell.source), JSON.stringify(['print(1)']));
 	});
 
 	test('Should allow source of type string with newline and split it', async function (): Promise<void> {
@@ -190,9 +190,9 @@ suite('Cell Model', function (): void {
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
 		assert(Array.isArray(cell.source));
-		assert.equal(cell.source.length, 2);
-		assert.equal(cell.source[0], 'print(1)\n');
-		assert.equal(cell.source[1], 'print(2)');
+		assert.strictEqual(cell.source.length, 2);
+		assert.strictEqual(cell.source[0], 'print(1)\n');
+		assert.strictEqual(cell.source[1], 'print(2)');
 	});
 
 	test('Should allow source of type string with Windows style newline and split it', async function (): Promise<void> {
@@ -210,9 +210,9 @@ suite('Cell Model', function (): void {
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
 		assert(Array.isArray(cell.source));
-		assert.equal(cell.source.length, 2);
-		assert.equal(cell.source[0], 'print(1)\r\n');
-		assert.equal(cell.source[1], 'print(2)');
+		assert.strictEqual(cell.source.length, 2);
+		assert.strictEqual(cell.source[0], 'print(1)\r\n');
+		assert.strictEqual(cell.source[1], 'print(2)');
 	});
 
 	test('Should allow source of type string[] with length 2', async function (): Promise<void> {
@@ -230,9 +230,9 @@ suite('Cell Model', function (): void {
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
 		assert(Array.isArray(cell.source));
-		assert.equal(cell.source.length, 2);
-		assert.equal(cell.source[0], 'print(1)\n');
-		assert.equal(cell.source[1], 'print(2)');
+		assert.strictEqual(cell.source.length, 2);
+		assert.strictEqual(cell.source[0], 'print(1)\n');
+		assert.strictEqual(cell.source[1], 'print(2)');
 	});
 
 	test('Should allow empty string source', async function (): Promise<void> {
@@ -250,7 +250,7 @@ suite('Cell Model', function (): void {
 		});
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
 		assert(Array.isArray(cell.source));
-		assert.equal(JSON.stringify(cell.source), JSON.stringify(['']));
+		assert.strictEqual(JSON.stringify(cell.source), JSON.stringify(['']));
 	});
 
 	test('Should parse metadata\'s hide_input tag correctly', async function (): Promise<void> {
@@ -571,7 +571,7 @@ suite('Cell Model', function (): void {
 			cell.setFuture(future.object);
 
 			// Then I expect outputs to have been cleared
-			assert.equal(outputs.length, 0);
+			assert.strictEqual(outputs.length, 0);
 			assert(!isUndefinedOrNull(onReply));
 			// ... And when I send an IoPub message
 			let message: nb.IIOPubMessage = {
@@ -588,13 +588,13 @@ suite('Cell Model', function (): void {
 			};
 			onIopub.handle(message);
 			// Then I expect an output to be added
-			assert.equal(outputs.length, 1);
-			assert.equal(outputs[0].output_type, 'stream');
+			assert.strictEqual(outputs.length, 1);
+			assert.strictEqual(outputs[0].output_type, 'stream');
 
 			message = objects.deepClone(message);
 			message.header.msg_type = 'display_data';
 			onIopub.handle(message);
-			assert.equal(outputs[1].output_type, 'display_data');
+			assert.strictEqual(outputs[1].output_type, 'display_data');
 		});
 
 		test('stdin should return void if no handler registered', async () => {
@@ -636,8 +636,8 @@ suite('Cell Model', function (): void {
 			await result;
 			// And I expect message to have been passed upstream and no message sent from the cell
 			assert(!isUndefinedOrNull(stdInMessage));
-			assert.equal(stdInMessage.content.prompt, stdInDefaultMessage.content.prompt);
-			assert.equal(stdInMessage.content.password, stdInDefaultMessage.content.password);
+			assert.strictEqual(stdInMessage.content.prompt, stdInDefaultMessage.content.prompt);
+			assert.strictEqual(stdInMessage.content.password, stdInDefaultMessage.content.password);
 			future.verify(f => f.sendInputReply(TypeMoq.It.isAny()), TypeMoq.Times.never());
 		});
 		test('stdin should send default response if there is upstream error', async () => {
@@ -688,7 +688,7 @@ suite('Cell Model', function (): void {
 			onIopub.handle(message);
 			//Output array's length should be 1
 			//'transient' tag should no longer exist in the output
-			assert.equal(outputs.length, 1);
+			assert.strictEqual(outputs.length, 1);
 			assert(isUndefinedOrNull(outputs[0]['transient']));
 		});
 
@@ -710,7 +710,7 @@ suite('Cell Model', function (): void {
 
 			let cell = factory.createCell(undefined, { notebook: notebookModel, isTrusted: false });
 			assert(!isUndefinedOrNull(cell.cellGuid));
-			assert.equal(cell.cellGuid.length, 36);
+			assert.strictEqual(cell.cellGuid.length, 36);
 			let cellJson = cell.toJSON();
 			assert(!isUndefinedOrNull(cellJson.metadata.azdata_cell_guid));
 		});
@@ -739,7 +739,7 @@ suite('Cell Model', function (): void {
 			let cell = factory.createCell(undefined, { notebook: notebookModel, isTrusted: false });
 			let content = JSON.stringify(cell.toJSON(), undefined, '    ');
 			let contentSplit = content.split('\n');
-			assert.equal(contentSplit.length, 9);
+			assert.strictEqual(contentSplit.length, 9);
 			assert(contentSplit[0].trim().startsWith('{'));
 			assert(contentSplit[1].trim().startsWith('"cell_type": "code",'));
 			assert(contentSplit[2].trim().startsWith('"source": ""'));
@@ -1038,7 +1038,7 @@ suite('Cell Model', function (): void {
 			metadata: { connection_name: connectionName }
 		};
 		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
-		assert.equal(model.savedConnectionName, connectionName);
+		assert.strictEqual(model.savedConnectionName, connectionName);
 	});
 
 	test('Should read attachments name from notebook attachments', async function () {
@@ -1167,7 +1167,7 @@ suite('Cell Model', function (): void {
 			attachments: attachments
 		};
 		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
-		assert.equal(model.attachments, attachments);
+		assert.strictEqual(model.attachments, attachments);
 	});
 
 	test('addAttachment should add a valid attachment to cell', async function () {
@@ -1207,7 +1207,7 @@ suite('Cell Model', function (): void {
 		};
 		let cellModel = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
 		cellModel.addAttachment('image/png', imageFilebase64Value, 'test.png');
-		assert.equal(cellModel.attachments, undefined);
+		assert.strictEqual(cellModel.attachments, undefined);
 	});
 
 	test('addAttachment should not add a duplicate attachment to cell', async function () {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -1054,10 +1054,10 @@ suite('Cell Model', function (): void {
 			attachments: cellAttachment
 		};
 		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
-		assert.deepEqual(model.attachments, contents.attachments, 'Attachments do not match in cellModel');
+		assert.deepStrictEqual(model.attachments, contents.attachments, 'Attachments do not match in cellModel');
 
 		let serializedCell = model.toJSON();
-		assert.deepEqual(serializedCell.attachments, cellAttachment, 'Cell attachment from JSON is incorrect');
+		assert.deepStrictEqual(serializedCell.attachments, cellAttachment, 'Cell attachment from JSON is incorrect');
 	});
 
 	test('Should not include attachments in notebook json if no attachments exist', async function () {
@@ -1071,10 +1071,10 @@ suite('Cell Model', function (): void {
 			source: ''
 		};
 		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
-		assert.deepEqual(model.attachments, undefined, 'Cell model attachments should return undefined if they do not exist');
+		assert.deepStrictEqual(model.attachments, undefined, 'Cell model attachments should return undefined if they do not exist');
 
 		let serializedCell = model.toJSON();
-		assert.deepEqual(serializedCell.attachments, undefined, 'JSON should not include attachments if attachments do not exist');
+		assert.deepStrictEqual(serializedCell.attachments, undefined, 'JSON should not include attachments if attachments do not exist');
 	});
 
 	test('Should not have cache chart data after new cell created', async function () {
@@ -1088,7 +1088,7 @@ suite('Cell Model', function (): void {
 			source: ''
 		};
 		let cellModel = factory.createCell(contents, { notebook: notebookModel, isTrusted: false }) as CellModel;
-		assert.deepEqual(cellModel.previousChartState, [], 'New cell should have no previous chart state');
+		assert.deepStrictEqual(cellModel.previousChartState, [], 'New cell should have no previous chart state');
 	});
 
 	test('Should not cache chart data after clear output', async function () {
@@ -1122,15 +1122,15 @@ suite('Cell Model', function (): void {
 
 		// When I create a cell
 		let cellModel = factory.createCell(contents, { notebook: notebookModel, isTrusted: false }) as CellModel;
-		assert.deepEqual(cellModel.previousChartState, [], 'New cell should have no previous chart state');
+		assert.deepStrictEqual(cellModel.previousChartState, [], 'New cell should have no previous chart state');
 
 		// When previous chart state exists
 		cellModel[<any>'_previousChartState'] = contents.outputs[0].metadata.azdata_chartOptions;
-		assert.deepEqual(cellModel.previousChartState, contents.outputs[0].metadata.azdata_chartOptions, 'Previous chart state should be returned as is');
+		assert.deepStrictEqual(cellModel.previousChartState, contents.outputs[0].metadata.azdata_chartOptions, 'Previous chart state should be returned as is');
 
 		// When cell outputs are cleared
 		cellModel.clearOutputs();
-		assert.deepEqual(cellModel.previousChartState, [], 'Previous chart state should be erased after clearing outputs');
+		assert.deepStrictEqual(cellModel.previousChartState, [], 'Previous chart state should be erased after clearing outputs');
 
 		// Put previous chart state back
 		cellModel[<any>'_previousChartState'] = contents.outputs[0].metadata.azdata_chartOptions;
@@ -1141,7 +1141,7 @@ suite('Cell Model', function (): void {
 		// When output is generated
 		cellModel.setFuture(future.object);
 		await onIopub.handle({ channel: 'iopub', content: { data: 'Hello' }, type: 'execute_reply', metadata: contents.outputs[0].metadata, header: { msg_type: 'execute_result' } });
-		assert.deepEqual(cellModel.previousChartState, [], 'Previous chart state should not exist after cell source change');
+		assert.deepStrictEqual(cellModel.previousChartState, [], 'Previous chart state should not exist after cell source change');
 
 		// Put previous chart state back
 		cellModel[<any>'_previousChartState'] = contents.outputs[0].metadata.azdata_chartOptions;
@@ -1149,7 +1149,7 @@ suite('Cell Model', function (): void {
 		// When output is generated
 		cellModel.setFuture(future.object);
 		await onIopub.handle({ channel: 'iopub', content: { data: 'Hello' }, type: 'execute_reply', metadata: contents.outputs[0].metadata, header: { msg_type: 'execute_result' } });
-		assert.deepEqual(cellModel.previousChartState, contents.outputs[0].metadata.azdata_chartOptions, 'Previous chart state should exist after output is generated');
+		assert.deepStrictEqual(cellModel.previousChartState, contents.outputs[0].metadata.azdata_chartOptions, 'Previous chart state should exist after output is generated');
 	});
 
 	test('Should read attachments from cell contents', async function () {
@@ -1187,10 +1187,10 @@ suite('Cell Model', function (): void {
 		};
 		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
 		model.addAttachment('image/png', imageFilebase64Value, 'test.png');
-		assert.deepEqual(model.attachments, attachments);
+		assert.deepStrictEqual(model.attachments, attachments);
 		attachments = { 'test.png': testImageAttachment, 'test1.png': testImageAttachment };
 		model.addAttachment('image/png', imageFilebase64Value, 'test1.png');
-		assert.deepEqual(model.attachments, attachments, 'addAttachment should add unique images');
+		assert.deepStrictEqual(model.attachments, attachments, 'addAttachment should add unique images');
 	});
 
 	test('addAttachment should not add an invalid attachment to cell', async function () {
@@ -1227,8 +1227,8 @@ suite('Cell Model', function (): void {
 		};
 		let cellModel = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
 		cellModel.addAttachment('image/png', imageFilebase64Value, 'test.png');
-		assert.deepEqual(cellModel.attachments, attachments);
+		assert.deepStrictEqual(cellModel.attachments, attachments);
 		cellModel.addAttachment('image/png', imageFilebase64Value, 'test.png');
-		assert.deepEqual(cellModel.attachments, attachments, 'addAttachment should not add duplicate images');
+		assert.deepStrictEqual(cellModel.attachments, attachments, 'addAttachment should not add duplicate images');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/clientSession.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/clientSession.test.ts
@@ -44,12 +44,12 @@ suite('Client Session', function (): void {
 	});
 
 	test('Should set path, isReady and ready on construction', function (): void {
-		assert.equal(session.notebookUri, path);
+		assert.strictEqual(session.notebookUri, path);
 		assert(!isUndefinedOrNull(session.ready));
 		assert(!session.isReady);
-		assert.equal(session.status, 'starting');
+		assert.strictEqual(session.status, 'starting');
 		assert(!session.isInErrorState);
-		assert.equal(session.errorMessage, '');
+		assert.strictEqual(session.errorMessage, '');
 	});
 
 	test('Should call on serverManager startup if set', async function (): Promise<void> {
@@ -79,7 +79,7 @@ suite('Client Session', function (): void {
 		assert(session.isReady);
 		assert(serverManager.calledStart);
 		assert(session.isInErrorState);
-		assert.equal(session.errorMessage, 'error');
+		assert.strictEqual(session.errorMessage, 'error');
 	});
 
 	test('Should be ready when session manager is ready', async function (): Promise<void> {
@@ -130,7 +130,7 @@ suite('Client Session', function (): void {
 		// Then
 		assert(session.isReady);
 		assert(session.isInErrorState);
-		assert.equal(session.errorMessage, 'error');
+		assert.strictEqual(session.errorMessage, 'error');
 	});
 
 	test('Should start session automatically if kernel preference requests it', async function (): Promise<void> {
@@ -145,10 +145,10 @@ suite('Client Session', function (): void {
 		await session.initialize();
 
 		// Then
-		assert.equal(session.isReady, true, 'Session is not ready');
-		assert.equal(session.isInErrorState, false, 'Session should not be in error state');
-		assert.equal(startOptions.kernelName, 'python', 'Session not started with python by default');
-		assert.equal(startOptions.path, path.fsPath, 'Session start path is incorrect');
+		assert.strictEqual(session.isReady, true, 'Session is not ready');
+		assert.strictEqual(session.isInErrorState, false, 'Session should not be in error state');
+		assert.strictEqual(startOptions.kernelName, 'python', 'Session not started with python by default');
+		assert.strictEqual(startOptions.path, path.fsPath, 'Session start path is incorrect');
 	});
 
 	test('Should shutdown session even if no serverManager is set', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/contentManagers.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/contentManagers.test.ts
@@ -41,12 +41,12 @@ let expectedNotebookContent: nb.INotebookContents = {
 let notebookContentString = JSON.stringify(expectedNotebookContent);
 
 function verifyMatchesExpectedNotebook(notebook: nb.INotebookContents): void {
-	assert.equal(notebook.cells.length, 1, 'Expected 1 cell');
-	assert.equal(notebook.cells[0].cell_type, CellTypes.Code);
-	assert.equal(notebook.cells[0].source, expectedNotebookContent.cells[0].source);
-	assert.equal(notebook.metadata.kernelspec.name, expectedNotebookContent.metadata.kernelspec.name);
-	assert.equal(notebook.nbformat, expectedNotebookContent.nbformat);
-	assert.equal(notebook.nbformat_minor, expectedNotebookContent.nbformat_minor);
+	assert.strictEqual(notebook.cells.length, 1, 'Expected 1 cell');
+	assert.strictEqual(notebook.cells[0].cell_type, CellTypes.Code);
+	assert.strictEqual(notebook.cells[0].source, expectedNotebookContent.cells[0].source);
+	assert.strictEqual(notebook.metadata.kernelspec.name, expectedNotebookContent.metadata.kernelspec.name);
+	assert.strictEqual(notebook.nbformat, expectedNotebookContent.nbformat);
+	assert.strictEqual(notebook.nbformat_minor, expectedNotebookContent.nbformat_minor);
 }
 
 suite('Local Content Manager', function (): void {
@@ -136,23 +136,23 @@ suite('Local Content Manager', function (): void {
 		let notebook = await contentManager.getNotebookContents(URI.file(localFile));
 		// then I expect output to have been normalized into a single string
 		let displayOutput = <nb.IDisplayData>notebook.cells[0].outputs[0];
-		assert.equal(displayOutput.data['text/html'], '<div></div>');
+		assert.strictEqual(displayOutput.data['text/html'], '<div></div>');
 	});
 
 	test('Should create a new empty notebook if content is undefined', async function (): Promise<void> {
 		// verify that when loading content from an empty string, a new notebook is created.
 		let content = await contentManager.loadFromContentString(undefined);
-		assert.equal(content.metadata, undefined, 'Verify that metadata is undefined');
+		assert.strictEqual(content.metadata, undefined, 'Verify that metadata is undefined');
 		// verify that the notebook is empty
-		assert.equal(content.cells.length, 0, 'Notebook should be empty, so the number of cells should be 0');
+		assert.strictEqual(content.cells.length, 0, 'Notebook should be empty, so the number of cells should be 0');
 	});
 
 	test('Should create a new empty notebook if content is an empty string', async function (): Promise<void> {
 		// verify that when loading content from an empty string, a new notebook is created.
 		let content = await contentManager.loadFromContentString('');
-		assert.equal(content.metadata, undefined, 'Verify that metadata is undefined');
+		assert.strictEqual(content.metadata, undefined, 'Verify that metadata is undefined');
 		// verify that the notebook is empty
-		assert.equal(content.cells.length, 0, 'Notebook should be empty, so the number of cells should be 0');
+		assert.strictEqual(content.cells.length, 0, 'Notebook should be empty, so the number of cells should be 0');
 	});
 
 	test('Should create a markdown cell', async function (): Promise<void> {
@@ -176,9 +176,9 @@ suite('Local Content Manager', function (): void {
 		let notebook = await contentManager.loadFromContentString(markdownNotebookContent);
 		// assert that markdown cell is supported by
 		// verifying the notebook matches the expectedNotebookMarkdownContent format
-		assert.equal(notebook.cells.length, 1, 'The number of cells should be equal to 1');
-		assert.equal(notebook.cells[0].cell_type, CellTypes.Markdown, 'The cell type should be markdown');
-		assert.equal(notebook.cells[0].source, expectedNotebookMarkdownContent.cells[0].source, 'The content of the cell must match the expectedNotebookMarkdownContent');
+		assert.strictEqual(notebook.cells.length, 1, 'The number of cells should be equal to 1');
+		assert.strictEqual(notebook.cells[0].cell_type, CellTypes.Markdown, 'The cell type should be markdown');
+		assert.strictEqual(notebook.cells[0].source, expectedNotebookMarkdownContent.cells[0].source, 'The content of the cell must match the expectedNotebookMarkdownContent');
 	});
 
 	test('Should allow stream for output types', async function (): Promise<void> {
@@ -208,7 +208,7 @@ suite('Local Content Manager', function (): void {
 		let streamOutputContent = JSON.stringify(expectedNotebookStreamOutputContent);
 		// Verify that the stream output type is supported
 		let notebook = await contentManager.loadFromContentString(streamOutputContent);
-		assert.equal(notebook.cells[0].outputs[0].output_type, 'stream', 'Cell output from notebook should be stream');
-		assert.equal(notebook.cells[0].cell_type, expectedNotebookStreamOutputContent.cells[0].cell_type, 'Cell type of notebook should match the expectedNotebookStreamOutputContent');
+		assert.strictEqual(notebook.cells[0].outputs[0].output_type, 'stream', 'Cell output from notebook should be stream');
+		assert.strictEqual(notebook.cells[0].cell_type, expectedNotebookStreamOutputContent.cells[0].cell_type, 'Cell type of notebook should match the expectedNotebookStreamOutputContent');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
@@ -179,9 +179,9 @@ suite('Notebook Editor Model', function (): void {
 		let notebookEditorModel = await createTextEditorModel(this);
 		notebookEditorModel.replaceEntireTextEditorModel(notebookModel, undefined);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineCount(), 6);
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(5), '    "cells": []');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(2), '    "metadata": {},');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineCount(), 6);
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(5), '    "cells": []');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(2), '    "metadata": {},');
 	});
 
 	test('should replace entire text model for add cell (0 -> 1 cells)', async function (): Promise<void> {
@@ -200,11 +200,11 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(notebookEditorModel.lastEditFullReplacement);
 	});
@@ -224,7 +224,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
 
 		newCell.executionCount = 1;
 		contentChange = {
@@ -235,11 +235,11 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellExecuted);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 1');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 1');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 
@@ -251,7 +251,7 @@ suite('Notebook Editor Model', function (): void {
 		};
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellExecuted);
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 10');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 10');
 		assert(!notebookEditorModel.lastEditFullReplacement);
 
 		newCell.executionCount = 15;
@@ -262,7 +262,7 @@ suite('Notebook Editor Model', function (): void {
 		};
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellExecuted);
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 15');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 15');
 		assert(!notebookEditorModel.lastEditFullReplacement);
 
 		newCell.executionCount = 105;
@@ -273,7 +273,7 @@ suite('Notebook Editor Model', function (): void {
 		};
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellExecuted);
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 105');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 105');
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
 
@@ -292,7 +292,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		contentChange = {
 			changeType: NotebookChangeType.CellOutputCleared,
@@ -302,11 +302,11 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellOutputCleared);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
@@ -326,7 +326,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		contentChange = {
 			changeType: NotebookChangeType.CellSourceUpdated,
@@ -344,15 +344,15 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellSourceUpdated);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test\\n",');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "Line 2 test\\n",');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '                "Line 3 test"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test\\n",');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "Line 2 test\\n",');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '                "Line 3 test"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
@@ -372,7 +372,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		contentChange = {
 			changeType: NotebookChangeType.CellSourceUpdated,
@@ -390,13 +390,13 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellSourceUpdated);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
@@ -416,7 +416,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		newCell.source = 'This is a test';
 
@@ -431,13 +431,13 @@ suite('Notebook Editor Model', function (): void {
 
 		assert(!notebookEditorModel.lastEditFullReplacement, 'should not do a full replacement for a source update');
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 	});
 
@@ -456,7 +456,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		newCell.source = 'This is a test' + os.EOL + 'Line 2 test' + os.EOL + 'Line 3 test';
 
@@ -471,15 +471,15 @@ suite('Notebook Editor Model', function (): void {
 
 		assert(!notebookEditorModel.lastEditFullReplacement, 'should not do a full replacement for a source update');
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test\\n",');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "Line 2 test\\n",');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '                "Line 3 test"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test\\n",');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "Line 2 test\\n",');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '                "Line 3 test"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '        }');
 	});
 
 	test('should not replace entire text model for single line source change then delete', async function (): Promise<void> {
@@ -497,10 +497,10 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                ""');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                ""');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		contentChange = {
 			changeType: NotebookChangeType.CellSourceUpdated,
@@ -535,13 +535,13 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellSourceUpdated);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                ""');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                ""');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
@@ -560,7 +560,7 @@ suite('Notebook Editor Model', function (): void {
 		};
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		contentChange = {
 			changeType: NotebookChangeType.CellSourceUpdated,
@@ -579,12 +579,12 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellSourceUpdated);
 		assert(!notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test\\n",');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "Line 2 test\\n",');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '                "Line 3 test"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test\\n",');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "Line 2 test\\n",');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '                "Line 3 test"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 
 		contentChange = {
 			changeType: NotebookChangeType.CellSourceUpdated,
@@ -603,10 +603,10 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellSourceUpdated);
 		assert(!notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "Tt"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "Tt"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 	});
 
 	test('should not replace entire text model and affect only edited cell', async function (): Promise<void> {
@@ -651,16 +651,16 @@ suite('Notebook Editor Model', function (): void {
 		assert(!notebookEditorModel.lastEditFullReplacement);
 
 		for (let i = 0; i < 10; i++) {
-			assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8 + i * 21), '            "source": [');
+			assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8 + i * 21), '            "source": [');
 			if (i === 7) {
-				assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9 + i * 21), '                "This is a test"');
-				assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12 + i * 21), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+				assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9 + i * 21), '                "This is a test"');
+				assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12 + i * 21), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 			} else {
-				assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9 + i * 21), '                ""');
+				assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9 + i * 21), '                ""');
 			}
-			assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10 + i * 21), '            ],');
-			assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14 + i * 21), '            "outputs": [');
-			assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25 + i * 21), '            "execution_count": null');
+			assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10 + i * 21), '            ],');
+			assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14 + i * 21), '            "outputs": [');
+			assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25 + i * 21), '            "execution_count": null');
 			assert(notebookEditorModel.editorModel.textEditorModel.getLineContent(26 + i * 21).startsWith('        }'));
 		}
 	});
@@ -680,7 +680,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		newCell[<any>'_outputs'] = newCell.outputs.concat(newCell.outputs);
 
@@ -691,14 +691,14 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellOutputUpdated);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(23), '}, {');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(31), '}');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(32), '],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(33), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(34), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(23), '}, {');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(31), '}');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(32), '],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(33), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(34), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
@@ -717,7 +717,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 
 		// First update the model with unmatched brackets
 		let newUnmatchedBracketOutput: nb.IStreamResult = { output_type: 'stream', name: 'stdout', text: '[0em' };
@@ -730,14 +730,14 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellOutputUpdated);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '    "text": "[0em"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '}');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(29), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(30), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '    "text": "[0em"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '}');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(29), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(30), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 
@@ -752,13 +752,13 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellOutputUpdated);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(32), '                    "text": "test test test"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(33), '                }');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(34), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(35), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(36), '        }');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(37), '    ]');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(38), '}');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(32), '                    "text": "test test test"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(33), '                }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(34), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(35), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(36), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(37), '    ]');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(38), '}');
 
 		assert(notebookEditorModel.lastEditFullReplacement);
 	});
@@ -782,7 +782,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
 
 		// add output
 		newCell[<any>'_outputs'] = previousOutputs;
@@ -794,12 +794,12 @@ suite('Notebook Editor Model', function (): void {
 
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellOutputUpdated);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(23), '}');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(23), '}');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
@@ -813,7 +813,7 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '"This text is in quotes"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\"This text is in quotes\\""');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\"This text is in quotes\\""');
 
 		ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel, newCell);
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -828,7 +828,7 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '""""""""""');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\"\\"\\"\\"\\"\\"\\"\\"\\"\\""');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\"\\"\\"\\"\\"\\"\\"\\"\\"\\""');
 
 		ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel, newCell);
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -843,7 +843,7 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '\\\\\\\\\\');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\\\\\\\\\\\\\\\\\\\\"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\\\\\\\\\\\\\\\\\\\\"');
 
 		ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel, newCell);
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -858,7 +858,7 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '\"\"\"\"\"\"\"\"\"\"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\""');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\""');
 
 		ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel, newCell);
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -873,7 +873,7 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, 'this is a long line in a cell test. Everything should serialize correctly! # Comments here: adding more tests is fun?');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "this is a long line in a cell test. Everything should serialize correctly! # Comments here: adding more tests is fun?"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "this is a long line in a cell test. Everything should serialize correctly! # Comments here: adding more tests is fun?"');
 
 		ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel, newCell);
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -888,7 +888,7 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '`~1!2@3#4$5%6^7&8*9(0)-_=+[{]}\\|;:",<.>/?\'');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "`~1!2@3#4$5%6^7&8*9(0)-_=+[{]}\\\\|;:\\",<.>/?\'"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "`~1!2@3#4$5%6^7&8*9(0)-_=+[{]}\\\\|;:\\",<.>/?\'"');
 
 		ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel, newCell);
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -903,7 +903,7 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '\'\'\'\'');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\'\'\'\'"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\'\'\'\'"');
 
 		ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel, newCell);
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -918,7 +918,7 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                ""');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                ""');
 
 		ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel, newCell);
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -933,15 +933,15 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '"test"' + os.EOL + 'test""');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\"test\\"\\n",');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\"test\\"\\n",');
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "test\\"\\""');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(13), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "outputs": [],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(17), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "test\\"\\""');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(13), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "outputs": [],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(17), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
@@ -955,15 +955,15 @@ suite('Notebook Editor Model', function (): void {
 		setupTextEditorModelWithEmptyOutputs(notebookEditorModel, newCell);
 
 		addTextToBeginningOfTextEditorModel(notebookEditorModel, newCell, '"""""test"' + os.EOL + '"""""""test\\""');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\"\\"\\"\\"\\"test\\"\\n",');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "\\"\\"\\"\\"\\"test\\"\\n",');
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "\\"\\"\\"\\"\\"\\"\\"test\\\\\\"\\""');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(13), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "outputs": [],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(17), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "\\"\\"\\"\\"\\"\\"\\"test\\\\\\"\\""');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(13), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "outputs": [],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(17), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
@@ -996,7 +996,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
 	}
 
 	function addTextToBeginningOfTextEditorModel(notebookEditorModel: NotebookEditorModel, newCell: ICellModel, textToAdd: string) {
@@ -1018,11 +1018,11 @@ suite('Notebook Editor Model', function (): void {
 	}
 
 	function ensureStaticContentInOneLineCellIsCorrect(notebookEditorModel: NotebookEditorModel, newCell: ICellModel) {
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "execution_count": null');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '        }');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "execution_count": null');
+		assert.strictEqual(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '        }');
 	}
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookFindModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookFindModel.test.ts
@@ -119,15 +119,15 @@ suite('Notebook Find Model', function (): void {
 	test('Should set notebook model on initialize', async function (): Promise<void> {
 		//initialize find
 		let notebookFindModel = new NotebookFindModel(model);
-		assert.equal(notebookFindModel.notebookModel, model, 'Failed to set notebook model');
+		assert.strictEqual(notebookFindModel.notebookModel, model, 'Failed to set notebook model');
 	});
 
 	test('Should have no decorations on initialize', async function (): Promise<void> {
 		//initialize find
 		let notebookFindModel = new NotebookFindModel(model);
-		assert.equal(notebookFindModel.findDecorations, undefined, 'findDecorations should be undefined on initialize');
-		assert.equal(notebookFindModel.getPosition(), undefined, 'currentMatch should be undefined on initialize');
-		assert.equal(notebookFindModel.getLastPosition(), undefined, 'previousMatch should be undefined on initialize');
+		assert.strictEqual(notebookFindModel.findDecorations, undefined, 'findDecorations should be undefined on initialize');
+		assert.strictEqual(notebookFindModel.getPosition(), undefined, 'currentMatch should be undefined on initialize');
+		assert.strictEqual(notebookFindModel.getLastPosition(), undefined, 'previousMatch should be undefined on initialize');
 	});
 
 	test('Should find results in the notebook', async function (): Promise<void> {
@@ -139,9 +139,9 @@ suite('Notebook Find Model', function (): void {
 		await notebookFindModel.find('markdown', false, false, max_find_count);
 
 		assert(notebookFindModel.findMatches, 'Find in notebook failed.');
-		assert.equal(notebookFindModel.findMatches.length, 2, 'Find could not find all occurrences');
-		assert.equal(notebookFindModel.findArray.length, 2, 'Find could not find all occurrences');
-		assert.equal(notebookFindModel.getFindCount(), 2, 'Find count do not match find results');
+		assert.strictEqual(notebookFindModel.findMatches.length, 2, 'Find could not find all occurrences');
+		assert.strictEqual(notebookFindModel.findArray.length, 2, 'Find could not find all occurrences');
+		assert.strictEqual(notebookFindModel.getFindCount(), 2, 'Find count do not match find results');
 	});
 
 	test('Should not find results in the notebook', async function (): Promise<void> {
@@ -149,7 +149,7 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 		await notebookFindModel.find('notFound', false, false, max_find_count);
 
-		assert.equal(notebookFindModel.findMatches.length, 0, 'Find failed');
+		assert.strictEqual(notebookFindModel.findMatches.length, 0, 'Find failed');
 	});
 
 	test('Should match find result ranges', async function (): Promise<void> {
@@ -205,7 +205,7 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 		await notebookFindModel.find('best', false, false, max_find_count);
 
-		assert.equal(notebookFindModel.findMatches.length, 1, 'Find failed on markdown link');
+		assert.strictEqual(notebookFindModel.findMatches.length, 1, 'Find failed on markdown link');
 
 		let expectedFindRange1 = new NotebookRange(model.cells[0], 1, 21, 1, 25);
 		assert.deepEqual(notebookFindModel.findMatches[0].range, expectedFindRange1, 'Find in markdown range is wrong :\n' + JSON.stringify(expectedFindRange1) + '\n ' + JSON.stringify(notebookFindModel.findMatches[0].range));
@@ -235,7 +235,7 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 		await notebookFindModel.find('x', false, false, max_find_count);
 
-		assert.equal(notebookFindModel.findMatches.length, 3, 'Find failed');
+		assert.strictEqual(notebookFindModel.findMatches.length, 3, 'Find failed');
 	});
 
 	test('Should match find results for multiple results on same line', async function (): Promise<void> {
@@ -262,7 +262,7 @@ suite('Notebook Find Model', function (): void {
 		// Intentionally not using max_find_count here, as 7 items should be found
 		await notebookFindModel.find('abc', false, false, 10);
 
-		assert.equal(notebookFindModel.findMatches.length, 7, 'Find failed to find number of matches correctly');
+		assert.strictEqual(notebookFindModel.findMatches.length, 7, 'Find failed to find number of matches correctly');
 
 		assert.deepEqual(notebookFindModel.findMatches[0].range, new NotebookRange(model.cells[0], 1, 1, 1, 4));
 		assert.deepEqual(notebookFindModel.findMatches[1].range, new NotebookRange(model.cells[0], 1, 5, 1, 8));
@@ -283,10 +283,10 @@ suite('Notebook Find Model', function (): void {
 		await notebookFindModel.find('insert', false, false, max_find_count);
 
 		assert(notebookFindModel.findMatches, 'Find in notebook failed.');
-		assert.equal(notebookFindModel.findMatches.length, 3, 'Find couldn\'t find all occurrences');
+		assert.strictEqual(notebookFindModel.findMatches.length, 3, 'Find couldn\'t find all occurrences');
 
 		await notebookFindModel.find('insert', true, false, max_find_count);
-		assert.equal(notebookFindModel.findMatches.length, 2, 'Find failed to apply match case while searching');
+		assert.strictEqual(notebookFindModel.findMatches.length, 2, 'Find failed to apply match case while searching');
 
 	});
 
@@ -295,7 +295,7 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 
 		await notebookFindModel.find('insert', true, true, max_find_count);
-		assert.equal(notebookFindModel.findMatches.length, 1, 'Find failed to apply whole word filter while searching');
+		assert.strictEqual(notebookFindModel.findMatches.length, 1, 'Find failed to apply whole word filter while searching');
 
 	});
 
@@ -322,14 +322,14 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 		// test for string with special character
 		await notebookFindModel.find('{special}', true, true, max_find_count);
-		assert.equal(notebookFindModel.findMatches.length, 1, 'Find failed for search term with special character');
+		assert.strictEqual(notebookFindModel.findMatches.length, 1, 'Find failed for search term with special character');
 		// test for only special character !!
 		await notebookFindModel.find('!!', false, false, max_find_count);
-		assert.equal(notebookFindModel.findMatches.length, 2, 'Find failed for special character');
+		assert.strictEqual(notebookFindModel.findMatches.length, 2, 'Find failed for special character');
 
 		// test for only special character combination
 		await notebookFindModel.find('!!!$}', false, false, max_find_count);
-		assert.equal(notebookFindModel.findMatches.length, 1, 'Find failed for special character combination');
+		assert.strictEqual(notebookFindModel.findMatches.length, 1, 'Find failed for special character combination');
 	});
 
 	test('Should find // characters in the search term correctly', async function (): Promise<void> {
@@ -355,13 +355,13 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 
 		await notebookFindModel.find('/', true, false, max_find_count);
-		assert.equal(notebookFindModel.findMatches.length, 2, 'Find failed to find number of / occurrences');
+		assert.strictEqual(notebookFindModel.findMatches.length, 2, 'Find failed to find number of / occurrences');
 
 		await notebookFindModel.find('//', true, false, max_find_count);
-		assert.equal(notebookFindModel.findMatches.length, 1, 'Find failed to find number of // occurrences');
+		assert.strictEqual(notebookFindModel.findMatches.length, 1, 'Find failed to find number of // occurrences');
 
 		await notebookFindModel.find('//', true, true, max_find_count);
-		assert.equal(notebookFindModel.findMatches.length, 0, 'Find failed to apply match whole word for //');
+		assert.strictEqual(notebookFindModel.findMatches.length, 0, 'Find failed to apply match whole word for //');
 	});
 
 	test('Should find results in the code cell on markdown edit', async function (): Promise<void> {
@@ -390,14 +390,14 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 		await notebookFindModel.find('SOP', false, false, max_find_count);
 
-		assert.equal(notebookFindModel.findMatches.length, 1, 'Find failed on markdown');
+		assert.strictEqual(notebookFindModel.findMatches.length, 1, 'Find failed on markdown');
 
 		// fire the edit mode on cell
 		model.cells[0].isEditMode = true;
 		notebookFindModel = new NotebookFindModel(model);
 		await notebookFindModel.find('SOP', false, false, max_find_count);
 
-		assert.equal(notebookFindModel.findMatches.length, 2, 'Find failed on markdown edit');
+		assert.strictEqual(notebookFindModel.findMatches.length, 2, 'Find failed on markdown edit');
 	});
 
 	test('Find next/previous should return the correct find index', async function (): Promise<void> {
@@ -408,13 +408,13 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 		await notebookFindModel.find('insert', false, false, max_find_count);
 
-		assert.equal(notebookFindModel.getFindIndex(), 1, 'Failed to get the correct find index');
+		assert.strictEqual(notebookFindModel.getFindIndex(), 1, 'Failed to get the correct find index');
 
 		notebookFindModel.findNext();
-		assert.equal(notebookFindModel.getFindIndex(), 2, 'Failed to get the correct find index');
+		assert.strictEqual(notebookFindModel.getFindIndex(), 2, 'Failed to get the correct find index');
 
 		notebookFindModel.findPrevious();
-		assert.equal(notebookFindModel.getFindIndex(), 1, 'Failed to get the correct find index');
+		assert.strictEqual(notebookFindModel.getFindIndex(), 1, 'Failed to get the correct find index');
 	});
 
 	test('Should clear results on clear', async function (): Promise<void> {
@@ -425,11 +425,11 @@ suite('Notebook Find Model', function (): void {
 		let notebookFindModel = new NotebookFindModel(model);
 		await notebookFindModel.find('insert', false, false, max_find_count);
 
-		assert.equal(notebookFindModel.findMatches.length, 3, 'Failed to find all occurrences');
+		assert.strictEqual(notebookFindModel.findMatches.length, 3, 'Failed to find all occurrences');
 
 		notebookFindModel.clearFind();
-		assert.equal(notebookFindModel.findMatches.length, 0, 'Failed to clear find results');
-		assert.equal(notebookFindModel.findDecorations, undefined, 'Failed to clear find decorations on clear');
+		assert.strictEqual(notebookFindModel.findMatches.length, 0, 'Failed to clear find results');
+		assert.strictEqual(notebookFindModel.findDecorations, undefined, 'Failed to clear find decorations on clear');
 	});
 
 

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookFindModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookFindModel.test.ts
@@ -160,10 +160,10 @@ suite('Notebook Find Model', function (): void {
 		await notebookFindModel.find('markdown', false, false, max_find_count);
 
 		let expectedFindRange1 = new NotebookRange(model.cells[0], 2, 13, 2, 21);
-		assert.deepEqual(notebookFindModel.findMatches[0].range, expectedFindRange1, 'Find in markdown range is wrong :\n' + JSON.stringify(expectedFindRange1) + '\n ' + JSON.stringify(notebookFindModel.findMatches[0].range));
+		assert.deepStrictEqual(notebookFindModel.findMatches[0].range, expectedFindRange1, 'Find in markdown range is wrong :\n' + JSON.stringify(expectedFindRange1) + '\n ' + JSON.stringify(notebookFindModel.findMatches[0].range));
 
 		let expectedFindRange2 = new NotebookRange(model.cells[1], 1, 6, 1, 14);
-		assert.deepEqual(notebookFindModel.findMatches[1].range, expectedFindRange2, 'Find in markdown range is wrong :\n' + JSON.stringify(expectedFindRange2) + '\n ' + JSON.stringify(notebookFindModel.findMatches[1].range));
+		assert.deepStrictEqual(notebookFindModel.findMatches[1].range, expectedFindRange2, 'Find in markdown range is wrong :\n' + JSON.stringify(expectedFindRange2) + '\n ' + JSON.stringify(notebookFindModel.findMatches[1].range));
 	});
 
 	test('Should set selection when find matches results', async function (): Promise<void> {
@@ -176,7 +176,7 @@ suite('Notebook Find Model', function (): void {
 
 		notebookFindModel.setSelection(notebookFindModel.findMatches[0].range);
 		let expectedFindRange1 = new NotebookRange(model.cells[0], 2, 13, 2, 21);
-		assert.deepEqual(notebookFindModel.currentMatch, expectedFindRange1, 'Find failed to set selection on finding results');
+		assert.deepStrictEqual(notebookFindModel.currentMatch, expectedFindRange1, 'Find failed to set selection on finding results');
 	});
 
 	test('Should ignore hyperlink markdown data and find correctly', async function (): Promise<void> {
@@ -208,7 +208,7 @@ suite('Notebook Find Model', function (): void {
 		assert.strictEqual(notebookFindModel.findMatches.length, 1, 'Find failed on markdown link');
 
 		let expectedFindRange1 = new NotebookRange(model.cells[0], 1, 21, 1, 25);
-		assert.deepEqual(notebookFindModel.findMatches[0].range, expectedFindRange1, 'Find in markdown range is wrong :\n' + JSON.stringify(expectedFindRange1) + '\n ' + JSON.stringify(notebookFindModel.findMatches[0].range));
+		assert.deepStrictEqual(notebookFindModel.findMatches[0].range, expectedFindRange1, 'Find in markdown range is wrong :\n' + JSON.stringify(expectedFindRange1) + '\n ' + JSON.stringify(notebookFindModel.findMatches[0].range));
 
 	});
 
@@ -264,13 +264,13 @@ suite('Notebook Find Model', function (): void {
 
 		assert.strictEqual(notebookFindModel.findMatches.length, 7, 'Find failed to find number of matches correctly');
 
-		assert.deepEqual(notebookFindModel.findMatches[0].range, new NotebookRange(model.cells[0], 1, 1, 1, 4));
-		assert.deepEqual(notebookFindModel.findMatches[1].range, new NotebookRange(model.cells[0], 1, 5, 1, 8));
-		assert.deepEqual(notebookFindModel.findMatches[2].range, new NotebookRange(model.cells[0], 1, 9, 1, 12));
-		assert.deepEqual(notebookFindModel.findMatches[3].range, new NotebookRange(model.cells[0], 1, 13, 1, 16));
-		assert.deepEqual(notebookFindModel.findMatches[4].range, new NotebookRange(model.cells[0], 1, 17, 1, 20));
-		assert.deepEqual(notebookFindModel.findMatches[5].range, new NotebookRange(model.cells[0], 1, 21, 1, 24));
-		assert.deepEqual(notebookFindModel.findMatches[6].range, new NotebookRange(model.cells[0], 1, 24, 1, 27));
+		assert.deepStrictEqual(notebookFindModel.findMatches[0].range, new NotebookRange(model.cells[0], 1, 1, 1, 4));
+		assert.deepStrictEqual(notebookFindModel.findMatches[1].range, new NotebookRange(model.cells[0], 1, 5, 1, 8));
+		assert.deepStrictEqual(notebookFindModel.findMatches[2].range, new NotebookRange(model.cells[0], 1, 9, 1, 12));
+		assert.deepStrictEqual(notebookFindModel.findMatches[3].range, new NotebookRange(model.cells[0], 1, 13, 1, 16));
+		assert.deepStrictEqual(notebookFindModel.findMatches[4].range, new NotebookRange(model.cells[0], 1, 17, 1, 20));
+		assert.deepStrictEqual(notebookFindModel.findMatches[5].range, new NotebookRange(model.cells[0], 1, 21, 1, 24));
+		assert.deepStrictEqual(notebookFindModel.findMatches[6].range, new NotebookRange(model.cells[0], 1, 24, 1, 27));
 	});
 
 

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -255,8 +255,8 @@ suite('notebook model', function (): void {
 
 		// Then I expect all cells to be in the model
 		assert.strictEqual(model.cells.length, 2);
-		assert.deepEqual(model.cells[0].source, expectedNotebookContent.cells[0].source);
-		assert.deepEqual(model.cells[1].source, expectedNotebookContent.cells[1].source);
+		assert.deepStrictEqual(model.cells[0].source, expectedNotebookContent.cells[0].source);
+		assert.deepStrictEqual(model.cells[1].source, expectedNotebookContent.cells[1].source);
 	});
 
 	test('Should handle multiple notebook managers', async function (): Promise<void> {
@@ -332,34 +332,34 @@ suite('notebook model', function (): void {
 
 		// Set the first cell as active
 		model.updateActiveCell(model.cells[0]);
-		assert.deepEqual(model.activeCell, model.cells[0], 'Active cell does not match the first cell');
-		assert.deepEqual(model.activeCell, activeCellFromEvent, 'Active cell returned from the event does not match');
+		assert.deepStrictEqual(model.activeCell, model.cells[0], 'Active cell does not match the first cell');
+		assert.deepStrictEqual(model.activeCell, activeCellFromEvent, 'Active cell returned from the event does not match');
 		assert.strictEqual(activeCellChangeCount, 1, 'Active cell change count is incorrect');
 		assert(isUndefinedOrNull(notebookContentChange), 'Content change should be undefined');
 
 
 		// Set the second cell as active
 		model.updateActiveCell(model.cells[1]);
-		assert.deepEqual(model.activeCell, model.cells[1], 'Active cell does not match expected value');
-		assert.deepEqual(model.activeCell, activeCellFromEvent, 'Active cell returned from the event does not match (2nd)');
+		assert.deepStrictEqual(model.activeCell, model.cells[1], 'Active cell does not match expected value');
+		assert.deepStrictEqual(model.activeCell, activeCellFromEvent, 'Active cell returned from the event does not match (2nd)');
 		assert.strictEqual(activeCellChangeCount, 2, 'Active cell change count is incorrect; should be 2');
 
 		// Delete the active cell
 		model.deleteCell(model.cells[1]);
 		assert(isUndefinedOrNull(model.activeCell), 'Active cell should be undefined after active cell is deleted');
-		assert.deepEqual(model.activeCell, activeCellFromEvent, 'Active cell should match value from event');
+		assert.deepStrictEqual(model.activeCell, activeCellFromEvent, 'Active cell should match value from event');
 		assert.strictEqual(activeCellChangeCount, 3, 'Active cell change count is incorrect; should be 3');
 
 		// Set the remaining cell as active
 		model.updateActiveCell(model.cells[0]);
-		assert.deepEqual(model.activeCell, activeCellFromEvent, 'Active cell should match value from event');
+		assert.deepStrictEqual(model.activeCell, activeCellFromEvent, 'Active cell should match value from event');
 		assert.strictEqual(activeCellChangeCount, 4, 'Active cell change count is incorrect; should be 4');
 
 		// Add new cell
 		let newCell = model.addCell(CellTypes.Code, 0);
 
 		// Ensure new cell is active cell
-		assert.deepEqual(model.activeCell, newCell, 'Active cell does not match newly created cell');
+		assert.deepStrictEqual(model.activeCell, newCell, 'Active cell does not match newly created cell');
 		assert.strictEqual(activeCellChangeCount, 5, 'Active cell change count is incorrect; should be 5');
 	});
 
@@ -520,7 +520,7 @@ suite('notebook model', function (): void {
 		// Delete the first cell
 		model.deleteCell(model.cells[0]);
 		assert.strictEqual(model.cells.length, 1, 'Cell model length should be 1 after cell deletion');
-		assert.deepEqual(model.cells[0].source, expectedNotebookContent.cells[1].source, 'Expected cell source is incorrect');
+		assert.deepStrictEqual(model.cells[0].source, expectedNotebookContent.cells[1].source, 'Expected cell source is incorrect');
 		assert.strictEqual(model.findCellIndex(model.cells[0]), 0, 'findCellIndex returned wrong cell info for only remaining cell');
 		assert.strictEqual(notebookContentChange.changeType, NotebookChangeType.CellsModified, 'notebookContentChange changeType is incorrect');
 		assert.strictEqual(notebookContentChange.isDirty, true, 'notebookContentChange should set dirty flag');
@@ -585,12 +585,12 @@ suite('notebook model', function (): void {
 		model.convertCellType(firstCell);
 		assert.strictEqual(firstCell.cellType, CellTypes.Markdown, 'Failed to convert cell type after conversion');
 		assert.strictEqual(firstCell.language, 'markdown', 'Language should be markdown for text cells');
-		assert.deepEqual(newCell, firstCell);
+		assert.deepStrictEqual(newCell, firstCell);
 
 		model.convertCellType(secondCell);
 		assert.strictEqual(secondCell.cellType, CellTypes.Code, 'Failed to convert second cell type');
 		assert.strictEqual(secondCell.language, 'sql', 'Language should be sql again for second cell');
-		assert.deepEqual(newCell, secondCell);
+		assert.deepStrictEqual(newCell, secondCell);
 	});
 
 	test('Should load contents but then go to error state if client session startup fails', async function (): Promise<void> {
@@ -624,7 +624,7 @@ suite('notebook model', function (): void {
 
 		assert.strictEqual(model.inErrorState, false);
 		assert.strictEqual(model.notebookManagers.length, 1);
-		assert.deepEqual(model.clientSession, mockClientSession);
+		assert.deepStrictEqual(model.clientSession, mockClientSession);
 	});
 
 	test('Should notify on trust set', async function () {
@@ -926,7 +926,7 @@ suite('notebook model', function (): void {
 		// Then I expect load to succeed
 		assert(!isUndefinedOrNull(model.clientSession), 'clientSession should exist after session is started');
 
-		assert.deepEqual(actualSession, mockClientSession, 'session returned is not the expected object');
+		assert.deepStrictEqual(actualSession, mockClientSession, 'session returned is not the expected object');
 
 		// but on server load completion I expect error state to be set
 		// Note: do not expect serverLoad event to throw even if failed

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -208,7 +208,7 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		// Then I expect to have 0 code cell as the contents
-		assert.equal(model.cells.length, 0);
+		assert.strictEqual(model.cells.length, 0);
 
 		// And Trust should be true by default if there are no cells
 		assert(model.trustedMode);
@@ -238,9 +238,9 @@ suite('notebook model', function (): void {
 		// When I initalize the model
 		// Then it should throw
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
-		assert.equal(model.inErrorState, false);
+		assert.strictEqual(model.inErrorState, false);
 		await assert.rejects(async () => { await model.loadContents(); });
-		assert.equal(model.inErrorState, true);
+		assert.strictEqual(model.inErrorState, true);
 	});
 
 	test('Should convert cell info to CellModels', async function (): Promise<void> {
@@ -254,7 +254,7 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		// Then I expect all cells to be in the model
-		assert.equal(model.cells.length, 2);
+		assert.strictEqual(model.cells.length, 2);
 		assert.deepEqual(model.cells[0].source, expectedNotebookContent.cells[0].source);
 		assert.deepEqual(model.cells[1].source, expectedNotebookContent.cells[1].source);
 	});
@@ -282,7 +282,7 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		// I expect the default provider to be jupyter
-		assert.equal(model.notebookManager.providerId, 'jupyter', 'Notebook manager provider id incorrect');
+		assert.strictEqual(model.notebookManager.providerId, 'jupyter', 'Notebook manager provider id incorrect');
 
 		// Similarly, change default notebook provider id to SQL
 		defaultModelOptions.providerId = 'SQL';
@@ -292,18 +292,18 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		// I expect the default provider to be SQL
-		assert.equal(model.notebookManager.providerId, 'SQL', 'Notebook manager provider id incorrect after 2nd model load');
+		assert.strictEqual(model.notebookManager.providerId, 'SQL', 'Notebook manager provider id incorrect after 2nd model load');
 
 		// Check that the getters return  the correct values
-		assert.equal(model.notebookManagers.length, 2, 'There should be 2 notebook managers');
+		assert.strictEqual(model.notebookManagers.length, 2, 'There should be 2 notebook managers');
 		assert(!isUndefinedOrNull(model.getNotebookManager('SQL')), 'SQL notebook manager is not defined');
 		assert(!isUndefinedOrNull(model.getNotebookManager('jupyter')), 'Jupyter notebook manager is not defined');
 		assert(isUndefinedOrNull(model.getNotebookManager('foo')), 'foo notebook manager is incorrectly defined');
 
 		// Check other properties to ensure that they're returning as expected
 		// No server manager was passed into the notebook manager stub, so expect hasServerManager to return false
-		assert.equal(model.hasServerManager, false, 'Notebook model should not have a server manager');
-		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.strictEqual(model.hasServerManager, false, 'Notebook model should not have a server manager');
+		assert.strictEqual(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
 	});
 
 	test('Should set active cell correctly', async function (): Promise<void> {
@@ -328,13 +328,13 @@ suite('notebook model', function (): void {
 		model.contentChanged(c => notebookContentChange = c);
 
 		// Then I expect all cells to be in the model
-		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
+		assert.strictEqual(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		// Set the first cell as active
 		model.updateActiveCell(model.cells[0]);
 		assert.deepEqual(model.activeCell, model.cells[0], 'Active cell does not match the first cell');
 		assert.deepEqual(model.activeCell, activeCellFromEvent, 'Active cell returned from the event does not match');
-		assert.equal(activeCellChangeCount, 1, 'Active cell change count is incorrect');
+		assert.strictEqual(activeCellChangeCount, 1, 'Active cell change count is incorrect');
 		assert(isUndefinedOrNull(notebookContentChange), 'Content change should be undefined');
 
 
@@ -342,25 +342,25 @@ suite('notebook model', function (): void {
 		model.updateActiveCell(model.cells[1]);
 		assert.deepEqual(model.activeCell, model.cells[1], 'Active cell does not match expected value');
 		assert.deepEqual(model.activeCell, activeCellFromEvent, 'Active cell returned from the event does not match (2nd)');
-		assert.equal(activeCellChangeCount, 2, 'Active cell change count is incorrect; should be 2');
+		assert.strictEqual(activeCellChangeCount, 2, 'Active cell change count is incorrect; should be 2');
 
 		// Delete the active cell
 		model.deleteCell(model.cells[1]);
 		assert(isUndefinedOrNull(model.activeCell), 'Active cell should be undefined after active cell is deleted');
 		assert.deepEqual(model.activeCell, activeCellFromEvent, 'Active cell should match value from event');
-		assert.equal(activeCellChangeCount, 3, 'Active cell change count is incorrect; should be 3');
+		assert.strictEqual(activeCellChangeCount, 3, 'Active cell change count is incorrect; should be 3');
 
 		// Set the remaining cell as active
 		model.updateActiveCell(model.cells[0]);
 		assert.deepEqual(model.activeCell, activeCellFromEvent, 'Active cell should match value from event');
-		assert.equal(activeCellChangeCount, 4, 'Active cell change count is incorrect; should be 4');
+		assert.strictEqual(activeCellChangeCount, 4, 'Active cell change count is incorrect; should be 4');
 
 		// Add new cell
 		let newCell = model.addCell(CellTypes.Code, 0);
 
 		// Ensure new cell is active cell
 		assert.deepEqual(model.activeCell, newCell, 'Active cell does not match newly created cell');
-		assert.equal(activeCellChangeCount, 5, 'Active cell change count is incorrect; should be 5');
+		assert.strictEqual(activeCellChangeCount, 5, 'Active cell change count is incorrect; should be 5');
 	});
 
 	test('Should set notebook parameter and injected parameter cell correctly', async function (): Promise<void> {
@@ -373,22 +373,22 @@ suite('notebook model', function (): void {
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
-		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
+		assert.strictEqual(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.strictEqual(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		// Set parameter cell and injected parameters cell
 		let notebookParamsCell = model.cells[0];
 		let notebookInjectedParamsCell = model.cells[1];
 
 		// Parameters Cell Validation
-		assert.equal(model.cells.indexOf(notebookParamsCell), 0, 'Notebook parameters cell should be first cell in notebook');
-		assert.equal(notebookParamsCell.isParameter, true, 'Notebook parameters cell should be tagged parameter');
-		assert.equal(notebookParamsCell.isInjectedParameter, false, 'Notebook parameters cell should not be tagged injected parameter');
+		assert.strictEqual(model.cells.indexOf(notebookParamsCell), 0, 'Notebook parameters cell should be first cell in notebook');
+		assert.strictEqual(notebookParamsCell.isParameter, true, 'Notebook parameters cell should be tagged parameter');
+		assert.strictEqual(notebookParamsCell.isInjectedParameter, false, 'Notebook parameters cell should not be tagged injected parameter');
 
 		// Injected Parameters Cell Validation
-		assert.equal(model.cells.indexOf(notebookInjectedParamsCell), 1, 'Notebook injected parameters cell should be second cell in notebook');
-		assert.equal(notebookInjectedParamsCell.isParameter, false, 'Notebook injected parameters cell should not be tagged parameter cell');
-		assert.equal(notebookInjectedParamsCell.isInjectedParameter, true, 'Notebook injected parameters cell should be tagged injected parameter');
+		assert.strictEqual(model.cells.indexOf(notebookInjectedParamsCell), 1, 'Notebook injected parameters cell should be second cell in notebook');
+		assert.strictEqual(notebookInjectedParamsCell.isParameter, false, 'Notebook injected parameters cell should not be tagged parameter cell');
+		assert.strictEqual(notebookInjectedParamsCell.isInjectedParameter, true, 'Notebook injected parameters cell should be tagged injected parameter');
 	});
 
 	test('Should set notebookUri parameters to new cell correctly', async function (): Promise<void> {
@@ -401,14 +401,14 @@ suite('notebook model', function (): void {
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
-		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
+		assert.strictEqual(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.strictEqual(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		// Validate notebookUri parameter cell is set as the only parameter cell
 		let notebookUriParamsCell = model.cells[0];
-		assert.equal(model.cells.indexOf(notebookUriParamsCell), 0, 'NotebookURI parameters cell should be first cell in notebook');
-		assert.equal(notebookUriParamsCell.isParameter, true, 'NotebookURI parameters cell should be tagged parameter');
-		assert.equal(notebookUriParamsCell.isInjectedParameter, false, 'NotebookURI parameters Cell should not be injected parameter');
+		assert.strictEqual(model.cells.indexOf(notebookUriParamsCell), 0, 'NotebookURI parameters cell should be first cell in notebook');
+		assert.strictEqual(notebookUriParamsCell.isParameter, true, 'NotebookURI parameters cell should be tagged parameter');
+		assert.strictEqual(notebookUriParamsCell.isInjectedParameter, false, 'NotebookURI parameters Cell should not be injected parameter');
 	});
 
 	test('Should set notebookUri parameters to new cell after parameters cell correctly', async function (): Promise<void> {
@@ -425,14 +425,14 @@ suite('notebook model', function (): void {
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
-		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
+		assert.strictEqual(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.strictEqual(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		// Validate notebookUri parameter cell is set as injected parameter
 		let notebookUriParamsCell = model.cells[1];
-		assert.equal(model.cells.indexOf(notebookUriParamsCell), 1, 'NotebookURI parameters cell should be second cell in notebook');
-		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged parameter cell');
-		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected parameter');
+		assert.strictEqual(model.cells.indexOf(notebookUriParamsCell), 1, 'NotebookURI parameters cell should be second cell in notebook');
+		assert.strictEqual(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged parameter cell');
+		assert.strictEqual(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected parameter');
 	});
 
 	test('Should set notebookUri parameters to new cell after injected parameters cell correctly', async function (): Promise<void> {
@@ -446,14 +446,14 @@ suite('notebook model', function (): void {
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
-		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 3, 'Cell count in notebook model is not correct');
+		assert.strictEqual(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.strictEqual(model.cells.length, 3, 'Cell count in notebook model is not correct');
 
 		// Validate notebookUri parameter cell is set as an injected parameter after parameter and injected parameter cells
 		let notebookUriParamsCell = model.cells[2];
-		assert.equal(model.cells.indexOf(notebookUriParamsCell), 2, 'NotebookURI parameters cell should be third cell in notebook');
-		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged parameter cell');
-		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected parameter');
+		assert.strictEqual(model.cells.indexOf(notebookUriParamsCell), 2, 'NotebookURI parameters cell should be third cell in notebook');
+		assert.strictEqual(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged parameter cell');
+		assert.strictEqual(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected parameter');
 	});
 
 	test('Should move first cell below second cell correctly', async function (): Promise<void> {
@@ -465,15 +465,15 @@ suite('notebook model', function (): void {
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
-		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
+		assert.strictEqual(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.strictEqual(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		let firstCell = model.cells[0];
 		let secondCell = model.cells[1];
 		// Move First Cell down
 		model.moveCell(firstCell, 1);
-		assert.equal(model.cells.indexOf(firstCell), 1, 'First Cell did not move down correctly');
-		assert.equal(model.cells.indexOf(secondCell), 0, 'Second Cell did not move up correctly');
+		assert.strictEqual(model.cells.indexOf(firstCell), 1, 'First Cell did not move down correctly');
+		assert.strictEqual(model.cells.indexOf(secondCell), 0, 'Second Cell did not move up correctly');
 	});
 
 	test('Should move second cell up above the first cell correctly', async function (): Promise<void> {
@@ -485,15 +485,15 @@ suite('notebook model', function (): void {
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
-		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
+		assert.strictEqual(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.strictEqual(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		let firstCell = model.cells[0];
 		let secondCell = model.cells[1];
 		// Move Second Cell up
 		model.moveCell(secondCell, 0);
-		assert.equal(model.cells.indexOf(firstCell), 1, 'First Cell did not move down correctly');
-		assert.equal(model.cells.indexOf(secondCell), 0, 'Second Cell did not move up correctly');
+		assert.strictEqual(model.cells.indexOf(firstCell), 1, 'First Cell did not move down correctly');
+		assert.strictEqual(model.cells.indexOf(secondCell), 0, 'Second Cell did not move up correctly');
 	});
 
 	test('Should delete cells correctly', async function (): Promise<void> {
@@ -513,38 +513,38 @@ suite('notebook model', function (): void {
 		model.contentChanged(c => notebookContentChange = c);
 
 		// Then I expect all cells to be in the model
-		assert.equal(model.cells.length, 2, 'Cell count in model is incorrect');
+		assert.strictEqual(model.cells.length, 2, 'Cell count in model is incorrect');
 
-		assert.equal(model.findCellIndex(model.cells[0]), 0, 'findCellIndex returned wrong cell info for first cell');
-		assert.equal(model.findCellIndex(model.cells[1]), 1, 'findCellIndex returned wrong cell info for second cell');
+		assert.strictEqual(model.findCellIndex(model.cells[0]), 0, 'findCellIndex returned wrong cell info for first cell');
+		assert.strictEqual(model.findCellIndex(model.cells[1]), 1, 'findCellIndex returned wrong cell info for second cell');
 		// Delete the first cell
 		model.deleteCell(model.cells[0]);
-		assert.equal(model.cells.length, 1, 'Cell model length should be 1 after cell deletion');
+		assert.strictEqual(model.cells.length, 1, 'Cell model length should be 1 after cell deletion');
 		assert.deepEqual(model.cells[0].source, expectedNotebookContent.cells[1].source, 'Expected cell source is incorrect');
-		assert.equal(model.findCellIndex(model.cells[0]), 0, 'findCellIndex returned wrong cell info for only remaining cell');
-		assert.equal(notebookContentChange.changeType, NotebookChangeType.CellsModified, 'notebookContentChange changeType is incorrect');
-		assert.equal(notebookContentChange.isDirty, true, 'notebookContentChange should set dirty flag');
-		assert.equal(model.activeCell, undefined, 'active cell is not undefined');
+		assert.strictEqual(model.findCellIndex(model.cells[0]), 0, 'findCellIndex returned wrong cell info for only remaining cell');
+		assert.strictEqual(notebookContentChange.changeType, NotebookChangeType.CellsModified, 'notebookContentChange changeType is incorrect');
+		assert.strictEqual(notebookContentChange.isDirty, true, 'notebookContentChange should set dirty flag');
+		assert.strictEqual(model.activeCell, undefined, 'active cell is not undefined');
 
 		// Delete the remaining cell
 		notebookContentChange = undefined;
 		model.deleteCell(model.cells[0]);
-		assert.equal(model.cells.length, 0, 'There should be no cells tracked in the notebook model');
-		assert.equal(model.findCellIndex(model.cells[0]), -1, 'findCellIndex is incorrectly finding a deleted cell');
-		assert.equal(errorCount, 0, 'There should be no errors after deleting a cell that exists');
-		assert.equal(notebookContentChange.changeType, NotebookChangeType.CellsModified, 'notebookContentChange changeType should indicate CellsModified');
-		assert.equal(model.activeCell, undefined, 'Active cell should be undefined');
+		assert.strictEqual(model.cells.length, 0, 'There should be no cells tracked in the notebook model');
+		assert.strictEqual(model.findCellIndex(model.cells[0]), -1, 'findCellIndex is incorrectly finding a deleted cell');
+		assert.strictEqual(errorCount, 0, 'There should be no errors after deleting a cell that exists');
+		assert.strictEqual(notebookContentChange.changeType, NotebookChangeType.CellsModified, 'notebookContentChange changeType should indicate CellsModified');
+		assert.strictEqual(model.activeCell, undefined, 'Active cell should be undefined');
 
 		// Try deleting the cell again
 		notebookContentChange = undefined;
 		model.deleteCell(model.cells[0]);
-		assert.equal(errorCount, 1, 'The model should record an error after trying to delete a cell that does not exist');
+		assert.strictEqual(errorCount, 1, 'The model should record an error after trying to delete a cell that does not exist');
 		assert(isUndefinedOrNull(notebookContentChange), 'There should be no content change after an error is recorded');
 
 		// Try deleting as notebook model is in error state
 		notebookContentChange = undefined;
 		model.deleteCell(model.cells[0]);
-		assert.equal(errorCount, 2, 'Error count should be 2 after trying to delete a cell that does not exist a second time');
+		assert.strictEqual(errorCount, 2, 'Error count should be 2 after trying to delete a cell that does not exist a second time');
 		assert(isUndefinedOrNull(notebookContentChange), 'There still should be no content change after an error is recorded');
 	});
 
@@ -562,7 +562,7 @@ suite('notebook model', function (): void {
 
 		model.cells[0].metadata = { 'test-field': 'test-value' };
 		assert(!isUndefinedOrNull(notebookContentChange));
-		assert.equal(notebookContentChange.changeType, NotebookChangeType.CellMetadataUpdated, 'notebookContentChange changeType should indicate ');
+		assert.strictEqual(notebookContentChange.changeType, NotebookChangeType.CellMetadataUpdated, 'notebookContentChange changeType should indicate ');
 	});
 
 	test('Should set cell language correctly after cell type conversion', async function (): Promise<void> {
@@ -579,17 +579,17 @@ suite('notebook model', function (): void {
 		let firstCell = model.cells[0];
 		let secondCell = model.cells[1];
 
-		assert.equal(firstCell.cellType, CellTypes.Code, 'Initial cell type for first cell should be code');
-		assert.equal(firstCell.language, 'sql', 'Initial language should be sql for first cell');
+		assert.strictEqual(firstCell.cellType, CellTypes.Code, 'Initial cell type for first cell should be code');
+		assert.strictEqual(firstCell.language, 'sql', 'Initial language should be sql for first cell');
 
 		model.convertCellType(firstCell);
-		assert.equal(firstCell.cellType, CellTypes.Markdown, 'Failed to convert cell type after conversion');
-		assert.equal(firstCell.language, 'markdown', 'Language should be markdown for text cells');
+		assert.strictEqual(firstCell.cellType, CellTypes.Markdown, 'Failed to convert cell type after conversion');
+		assert.strictEqual(firstCell.language, 'markdown', 'Language should be markdown for text cells');
 		assert.deepEqual(newCell, firstCell);
 
 		model.convertCellType(secondCell);
-		assert.equal(secondCell.cellType, CellTypes.Code, 'Failed to convert second cell type');
-		assert.equal(secondCell.language, 'sql', 'Language should be sql again for second cell');
+		assert.strictEqual(secondCell.cellType, CellTypes.Code, 'Failed to convert second cell type');
+		assert.strictEqual(secondCell.language, 'sql', 'Language should be sql again for second cell');
 		assert.deepEqual(newCell, secondCell);
 	});
 
@@ -610,20 +610,20 @@ suite('notebook model', function (): void {
 		// Cannot set property 'defaultKernelLoaded' of undefined
 		await assert.rejects(async () => { await model.startSession(notebookManagers[0]); });
 		// Then I expect load to succeed
-		assert.equal(model.cells.length, 1);
+		assert.strictEqual(model.cells.length, 1);
 		assert(model.clientSession);
 		// but on server load completion I expect error state to be set
 		// Note: do not expect serverLoad event to throw even if failed
 		await model.sessionLoadFinished;
-		assert.equal(model.inErrorState, false);
-		assert.equal(sessionFired, false);
+		assert.strictEqual(model.inErrorState, false);
+		assert.strictEqual(sessionFired, false);
 	});
 
 	test('Should not be in error state if client session initialization succeeds', async function (): Promise<void> {
 		let model = await loadModelAndStartClientSession(expectedNotebookContent);
 
-		assert.equal(model.inErrorState, false);
-		assert.equal(model.notebookManagers.length, 1);
+		assert.strictEqual(model.inErrorState, false);
+		assert.strictEqual(model.notebookManagers.length, 1);
 		assert.deepEqual(model.clientSession, mockClientSession);
 	});
 
@@ -643,7 +643,7 @@ suite('notebook model', function (): void {
 		// Then content changed notification should be sent
 		assert(model.trustedMode);
 		assert(!isUndefinedOrNull(actualChanged));
-		assert.equal(actualChanged.changeType, NotebookChangeType.TrustChanged);
+		assert.strictEqual(actualChanged.changeType, NotebookChangeType.TrustChanged);
 	});
 
 	test('Should close active session when closed', async function () {
@@ -656,7 +656,7 @@ suite('notebook model', function (): void {
 		// Ensure client session is cleaned up
 		assert(isUndefinedOrNull(model.clientSession), 'clientSession is not cleaned up properly');
 		// Ensure session is no longer ready
-		assert.equal(model.isSessionReady, false, 'session is incorrectly showing as ready');
+		assert.strictEqual(model.isSessionReady, false, 'session is incorrectly showing as ready');
 	});
 
 	test('Should disconnect when connection profile created by notebook', async function () {
@@ -722,7 +722,7 @@ suite('notebook model', function (): void {
 		let expectedAlias = ['fakeAlias'];
 		let kernelAliases = model.kernelAliases;
 
-		assert.equal(kernelAliases.length, 1);
+		assert.strictEqual(kernelAliases.length, 1);
 		assert(kernelAliases.includes(expectedAlias[0]));
 
 		// // After client session is started, ensure context isn't null/undefined
@@ -748,8 +748,8 @@ suite('notebook model', function (): void {
 		let doChangeKernelStub = sinon.spy(model, 'doChangeKernel' as keyof NotebookModel);
 
 		model.changeKernel(notebookKernelAlias);
-		assert.equal(model.selectedKernelDisplayName, notebookKernelAlias);
-		assert.equal(model.currentKernelAlias, notebookKernelAlias);
+		assert.strictEqual(model.selectedKernelDisplayName, notebookKernelAlias);
+		assert.strictEqual(model.currentKernelAlias, notebookKernelAlias);
 		sinon.assert.calledWith(doChangeKernelStub, model.kernelAliases[0]);
 		doChangeKernelStub.restore();
 
@@ -776,8 +776,8 @@ suite('notebook model', function (): void {
 
 		// Change kernel first to alias kernel and then connect to SQL connection
 		model.changeKernel(notebookKernelAlias);
-		assert.equal(model.selectedKernelDisplayName, notebookKernelAlias);
-		assert.equal(model.currentKernelAlias, notebookKernelAlias);
+		assert.strictEqual(model.selectedKernelDisplayName, notebookKernelAlias);
+		assert.strictEqual(model.currentKernelAlias, notebookKernelAlias);
 		sinon.assert.called(doChangeKernelStub);
 		doChangeKernelStub.restore();
 
@@ -785,8 +785,8 @@ suite('notebook model', function (): void {
 		await changeContextWithConnectionProfile(model);
 		let expectedKernel = 'SQL';
 		model.changeKernel(expectedKernel);
-		assert.equal(model.selectedKernelDisplayName, expectedKernel);
-		assert.equal(model.currentKernelAlias, undefined);
+		assert.strictEqual(model.selectedKernelDisplayName, expectedKernel);
+		assert.strictEqual(model.currentKernelAlias, undefined);
 		sinon.assert.called(doChangeKernelStub);
 		doChangeKernelStub.restore();
 
@@ -838,7 +838,7 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		// I expect the saved connection name to be read
-		assert.equal(model.savedConnectionName, connectionName);
+		assert.strictEqual(model.savedConnectionName, connectionName);
 
 		// When I request a connection
 		let spy = sinon.stub(model, 'changeContext').returns(Promise.resolve());
@@ -867,21 +867,21 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		// I expect multiConnectionMode to be set to true
-		assert.equal(model.multiConnectionMode, true, 'multi_connection_mode not read correctly from notebook metadata');
+		assert.strictEqual(model.multiConnectionMode, true, 'multi_connection_mode not read correctly from notebook metadata');
 
 		// When I change multiConnectionMode to false
 		model.multiConnectionMode = false;
 
 		// I expect multi_connection_mode to not be in the notebook metadata
 		let output: nb.INotebookContents = model.toJSON();
-		assert.equal(output.metadata['multi_connection_mode'], undefined, 'multi_connection_mode saved in notebook metadata when it should not be');
+		assert.strictEqual(output.metadata['multi_connection_mode'], undefined, 'multi_connection_mode saved in notebook metadata when it should not be');
 
 		// When I change multiConnectionMode to true
 		model.multiConnectionMode = true;
 
 		// I expect multi_connection_mode to be in the notebook metadata
 		output = model.toJSON();
-		assert.equal(output.metadata['multi_connection_mode'], true, 'multi_connection_mode not saved correctly to notebook metadata');
+		assert.strictEqual(output.metadata['multi_connection_mode'], true, 'multi_connection_mode not saved correctly to notebook metadata');
 	});
 
 	test('Should keep kernel alias as language info kernel alias name even if kernel spec is seralized as SQL', async function () {
@@ -900,7 +900,7 @@ suite('notebook model', function (): void {
 		await model.requestModelLoad();
 
 		// Check to see if language info is set to kernel alias
-		assert.equal(model.languageInfo.name, 'fake', 'Notebook language info is not set properly');
+		assert.strictEqual(model.languageInfo.name, 'fake', 'Notebook language info is not set properly');
 	});
 
 	async function loadModelAndStartClientSession(notebookContent: nb.INotebookContents): Promise<NotebookModel> {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
@@ -151,20 +151,20 @@ suite('notebookUtils', function (): void {
 		assert.strictEqual(result, undefined);
 
 		result = extractCellMagicCommandPlusArgs('%%magic command', 'magic');
-		assert.equal(result.commandId, 'command');
-		assert.equal(result.args, '');
+		assert.strictEqual(result.commandId, 'command');
+		assert.strictEqual(result.args, '');
 
 		result = extractCellMagicCommandPlusArgs('%%magic command arg1', 'magic');
-		assert.equal(result.commandId, 'command');
-		assert.equal(result.args, 'arg1');
+		assert.strictEqual(result.commandId, 'command');
+		assert.strictEqual(result.args, 'arg1');
 
 		result = extractCellMagicCommandPlusArgs('%%magic command arg1 arg2', 'magic');
-		assert.equal(result.commandId, 'command');
-		assert.equal(result.args, 'arg1 arg2');
+		assert.strictEqual(result.commandId, 'command');
+		assert.strictEqual(result.args, 'arg1 arg2');
 
 		result = extractCellMagicCommandPlusArgs('%%magic command.id arg1 arg2 arg3', 'magic');
-		assert.equal(result.commandId, 'command.id');
-		assert.equal(result.args, 'arg1 arg2 arg3');
+		assert.strictEqual(result.commandId, 'command.id');
+		assert.strictEqual(result.args, 'arg1 arg2 arg3');
 	});
 
 	test('asyncForEach Test', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
@@ -364,7 +364,7 @@ suite('SQL Connection Tree Action tests', () => {
 			connection,
 			connectionManagementService.object);
 
-		assert.equal(connectionAction.enabled, false, 'delete action should be disabled.');
+		assert.strictEqual(connectionAction.enabled, false, 'delete action should be disabled.');
 	});
 
 	test('RefreshConnectionAction - refresh should be called if connection status is connect', () => {

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
@@ -84,8 +84,8 @@ suite('ServerTreeView onAddConnectionProfile handler tests', () => {
 
 	test('isObjectExplorerConnectionUri', async () => {
 		let connectionUriFalse = serverTreeView.isObjectExplorerConnectionUri('123');
-		assert.equal(false, connectionUriFalse);
-		assert.equal(true, serverTreeView.isObjectExplorerConnectionUri('connection:123'));
+		assert.strictEqual(false, connectionUriFalse);
+		assert.strictEqual(true, serverTreeView.isObjectExplorerConnectionUri('connection:123'));
 	});
 
 	test('setExpandedState', async () => {

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/utils.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/utils.test.ts
@@ -33,15 +33,15 @@ suite('Connection Utilities tests', () => {
 		let conProfGroupChild = new ConnectionProfileGroup('testGroupChild', conProfGroup, 'testGroupChild', undefined, undefined);
 		conProfGroup.addGroups([conProfGroupChild]);
 		conProfGroupChild.addConnections([connection]);
-		assert.equal(connection, ConnectionUtils.findProfileInGroup(connection, [conProfGroup]));
+		assert.strictEqual(connection, ConnectionUtils.findProfileInGroup(connection, [conProfGroup]));
 	});
 
 	test('getUriPrefix - test if getUriPrefix finds the correct prefix from fake uri name', () => {
 		let testUri = 'test://testpath';
-		assert.equal('test://', ConnectionUtils.getUriPrefix(testUri));
+		assert.strictEqual('test://', ConnectionUtils.getUriPrefix(testUri));
 		let badTestUri = '://>test#%</';
-		assert.equal(ConnectionUtils.uriPrefixes.default, ConnectionUtils.getUriPrefix(badTestUri));
-		assert.equal('', ConnectionUtils.getUriPrefix(undefined));
+		assert.strictEqual(ConnectionUtils.uriPrefixes.default, ConnectionUtils.getUriPrefix(badTestUri));
+		assert.strictEqual('', ConnectionUtils.getUriPrefix(undefined));
 
 	});
 
@@ -61,6 +61,6 @@ suite('Connection Utilities tests', () => {
 		let testTime = '28:06:42.12';
 		let testTimeInMS = 101202012;
 		//should properly return the time in milliseconds.
-		assert.equal(testTimeInMS, ConnectionUtils.parseTimeString(testTime));
+		assert.strictEqual(testTimeInMS, ConnectionUtils.parseTimeString(testTime));
 	});
 });

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -87,7 +87,7 @@ suite('SQL QueryAction Tests', () => {
 
 		// "class should automatically get set to include the base class and the RunQueryAction class
 		let className = RunQueryAction.EnabledClass;
-		assert.equal(queryAction.class, className, 'CSS class not properly set');
+		assert.strictEqual(queryAction.class, className, 'CSS class not properly set');
 	});
 
 	test('getConnectedQueryEditorUri returns connected URI only if connected', () => {
@@ -146,24 +146,24 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// runQuery should not be run
-		assert.equal(calledRunQueryOnInput, false, 'run should not call runQuery');
+		assert.strictEqual(calledRunQueryOnInput, false, 'run should not call runQuery');
 		testQueryInput.verify(x => x.runQuery(undefined), TypeMoq.Times.never());
 
 		// and the connection dialog should open with the correct parameter details
-		assert.equal(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
-		assert.equal(connectionParams.runQueryOnCompletion, RunQueryOnConnectionMode.executeQuery, 'runQueryOnCompletion should be true`');
-		assert.equal(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
-		assert.equal(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
+		assert.strictEqual(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
+		assert.strictEqual(connectionParams.runQueryOnCompletion, RunQueryOnConnectionMode.executeQuery, 'runQueryOnCompletion should be true`');
+		assert.strictEqual(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
+		assert.strictEqual(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
 
 		// If I call run on RunQueryAction when I am connected
 		isConnected = true;
 		await queryAction.run();
 
 		//runQuery should be run, and the conneciton dialog should not open
-		assert.equal(calledRunQueryOnInput, true, 'run should call runQuery');
+		assert.strictEqual(calledRunQueryOnInput, true, 'run should call runQuery');
 		testQueryInput.verify(x => x.runQuery(undefined), TypeMoq.Times.once());
 
-		assert.equal(countCalledShowDialog, 1, 'run should not call showDialog');
+		assert.strictEqual(countCalledShowDialog, 1, 'run should not call showDialog');
 	});
 
 	test('Queries are only run if the QueryEditor selection is not empty', async () => {
@@ -205,14 +205,14 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		//runQuery should be run
-		assert.equal(countCalledRunQuery, 1, 'runQuery should be called');
+		assert.strictEqual(countCalledRunQuery, 1, 'runQuery should be called');
 
 		// If I call run on RunQueryAction when I have an empty selection
 		isSelectionEmpty = true;
 		await queryAction.run();
 
 		//runQuery should not be run again
-		assert.equal(countCalledRunQuery, 1, 'runQuery should not be called again');
+		assert.strictEqual(countCalledRunQuery, 1, 'runQuery should not be called again');
 	});
 
 	test('ISelectionData is properly passed when queries are run', async () => {
@@ -276,10 +276,10 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// The conneciton dialog should open with an undefined seleciton
-		assert.equal(countCalledShowDialog, 1, 'run should call showDialog');
-		assert.equal(countCalledRunQuery, 0, 'run should not call runQuery');
-		assert.equal(showDialogConnectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
-		assert.equal(showDialogConnectionParams.queryRange, undefined, 'querySelection should be undefined');
+		assert.strictEqual(countCalledShowDialog, 1, 'run should call showDialog');
+		assert.strictEqual(countCalledRunQuery, 0, 'run should not call runQuery');
+		assert.strictEqual(showDialogConnectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
+		assert.strictEqual(showDialogConnectionParams.queryRange, undefined, 'querySelection should be undefined');
 
 		////// If I call run on RunQueryAction while disconnected and with a defined selection
 		isConnected = false;
@@ -287,14 +287,14 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// The conneciton dialog should open with the correct seleciton
-		assert.equal(countCalledShowDialog, 2, 'run should call showDialog again');
-		assert.equal(countCalledRunQuery, 0, 'run should not call runQuery');
-		assert.equal(showDialogConnectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
+		assert.strictEqual(countCalledShowDialog, 2, 'run should call showDialog again');
+		assert.strictEqual(countCalledRunQuery, 0, 'run should not call runQuery');
+		assert.strictEqual(showDialogConnectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
 		assert.notEqual(showDialogConnectionParams.queryRange, undefined, 'There should not be an undefined selection in runQuery');
-		assert.equal(showDialogConnectionParams.queryRange.startLineNumber, selectionToReturnInGetSelection.startLineNumber, 'startLine should match');
-		assert.equal(showDialogConnectionParams.queryRange.startColumn, selectionToReturnInGetSelection.startColumn, 'startColumn should match');
-		assert.equal(showDialogConnectionParams.queryRange.endLineNumber, selectionToReturnInGetSelection.endLineNumber, 'endLine should match');
-		assert.equal(showDialogConnectionParams.queryRange.endColumn, selectionToReturnInGetSelection.endColumn, 'endColumn should match');
+		assert.strictEqual(showDialogConnectionParams.queryRange.startLineNumber, selectionToReturnInGetSelection.startLineNumber, 'startLine should match');
+		assert.strictEqual(showDialogConnectionParams.queryRange.startColumn, selectionToReturnInGetSelection.startColumn, 'startColumn should match');
+		assert.strictEqual(showDialogConnectionParams.queryRange.endLineNumber, selectionToReturnInGetSelection.endLineNumber, 'endLine should match');
+		assert.strictEqual(showDialogConnectionParams.queryRange.endColumn, selectionToReturnInGetSelection.endColumn, 'endColumn should match');
 
 		////// If I call run on RunQueryAction while connected and with an undefined selection
 		isConnected = true;
@@ -302,9 +302,9 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// The query should run with an undefined selection
-		assert.equal(countCalledShowDialog, 2, 'run should not call showDialog');
-		assert.equal(countCalledRunQuery, 1, 'run should call runQuery');
-		assert.equal(runQuerySelection, undefined, 'There should be an undefined selection in runQuery');
+		assert.strictEqual(countCalledShowDialog, 2, 'run should not call showDialog');
+		assert.strictEqual(countCalledRunQuery, 1, 'run should call runQuery');
+		assert.strictEqual(runQuerySelection, undefined, 'There should be an undefined selection in runQuery');
 
 		////// If I call run on RunQueryAction while connected and with a defined selection
 		isConnected = true;
@@ -312,13 +312,13 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// The query should run with the given seleciton
-		assert.equal(countCalledShowDialog, 2, 'run should not call showDialog');
-		assert.equal(countCalledRunQuery, 2, 'run should call runQuery again');
+		assert.strictEqual(countCalledShowDialog, 2, 'run should not call showDialog');
+		assert.strictEqual(countCalledRunQuery, 2, 'run should call runQuery again');
 		assert.notEqual(runQuerySelection, undefined, 'There should not be an undefined selection in runQuery');
-		assert.equal(runQuerySelection.startLineNumber, selectionToReturnInGetSelection.startLineNumber, 'startLine should match');
-		assert.equal(runQuerySelection.startColumn, selectionToReturnInGetSelection.startColumn, 'startColumn should match');
-		assert.equal(runQuerySelection.endLineNumber, selectionToReturnInGetSelection.endLineNumber, 'endLine should match');
-		assert.equal(runQuerySelection.endColumn, selectionToReturnInGetSelection.endColumn, 'endColumn should match');
+		assert.strictEqual(runQuerySelection.startLineNumber, selectionToReturnInGetSelection.startLineNumber, 'startLine should match');
+		assert.strictEqual(runQuerySelection.startColumn, selectionToReturnInGetSelection.startColumn, 'startColumn should match');
+		assert.strictEqual(runQuerySelection.endLineNumber, selectionToReturnInGetSelection.endLineNumber, 'endLine should match');
+		assert.strictEqual(runQuerySelection.endColumn, selectionToReturnInGetSelection.endColumn, 'endColumn should match');
 	});
 
 	test('CancelQueryAction calls cancelQuery() only if URI is connected', async () => {
@@ -341,14 +341,14 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// cancelQuery should not be run
-		assert.equal(calledCancelQuery, false, 'run should not call cancelQuery');
+		assert.strictEqual(calledCancelQuery, false, 'run should not call cancelQuery');
 
 		// If I call run on CancelQueryAction when I am connected
 		isConnected = true;
 		await queryAction.run();
 
 		// cancelQuery should be run
-		assert.equal(calledCancelQuery, true, 'run should call cancelQuery');
+		assert.strictEqual(calledCancelQuery, true, 'run should call cancelQuery');
 	});
 
 	// We want to call disconnectEditor regardless of connection to be able to cancel in-progress connections
@@ -369,14 +369,14 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// disconnectEditor should be run
-		assert.equal(countCalledDisconnectEditor, 1, 'disconnectEditor should be called when URI is not connected');
+		assert.strictEqual(countCalledDisconnectEditor, 1, 'disconnectEditor should be called when URI is not connected');
 
 		// If I call run on DisconnectDatabaseAction when I am connected
 		isConnected = true;
 		await queryAction.run();
 
 		// disconnectEditor should be run again
-		assert.equal(countCalledDisconnectEditor, 2, 'disconnectEditor should be called when URI is connected');
+		assert.strictEqual(countCalledDisconnectEditor, 2, 'disconnectEditor should be called when URI is connected');
 	});
 
 	test('ConnectDatabaseAction opens dialog regardless of URI connection state', async () => {
@@ -400,22 +400,22 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// The conneciton dialog should open with the correct parameter details
-		assert.equal(countCalledShowDialog, 1, 'run should call showDialog');
-		assert.equal(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
-		assert.equal(connectionParams.runQueryOnCompletion, false, 'runQueryOnCompletion should be false`');
-		assert.equal(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
-		assert.equal(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
+		assert.strictEqual(countCalledShowDialog, 1, 'run should call showDialog');
+		assert.strictEqual(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
+		assert.strictEqual(connectionParams.runQueryOnCompletion, 0, 'runQueryOnCompletion should be false`');
+		assert.strictEqual(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
+		assert.strictEqual(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
 
 		// If I call run on ConnectDatabaseAction when I am connected
 		isConnected = true;
 		await queryAction.run();
 
 		// The conneciton dialog should open again with the correct parameter details
-		assert.equal(countCalledShowDialog, 2, 'run should call showDialog');
-		assert.equal(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
-		assert.equal(connectionParams.runQueryOnCompletion, false, 'runQueryOnCompletion should be false`');
-		assert.equal(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
-		assert.equal(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
+		assert.strictEqual(countCalledShowDialog, 2, 'run should call showDialog');
+		assert.strictEqual(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
+		assert.strictEqual(connectionParams.runQueryOnCompletion, 0, 'runQueryOnCompletion should be false`');
+		assert.strictEqual(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
+		assert.strictEqual(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
 	});
 
 	test('ChangeConnectionAction connects regardless of URI being connected', async () => {
@@ -439,21 +439,21 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.run();
 
 		// The connection dialog should open with the params set as below
-		assert.equal(calledShowDialog, 1, 'showDialog should be called when URI is connected');
-		assert.equal(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
-		assert.equal(connectionParams.runQueryOnCompletion, false, 'runQueryOnCompletion should be false`');
-		assert.equal(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
-		assert.equal(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
+		assert.strictEqual(calledShowDialog, 1, 'showDialog should be called when URI is connected');
+		assert.strictEqual(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
+		assert.strictEqual(connectionParams.runQueryOnCompletion, 0, 'runQueryOnCompletion should be false`');
+		assert.strictEqual(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
+		assert.strictEqual(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
 		// Then if I call run on ChangeConnectionAction when I am connected
 		isConnected = true;
 		await queryAction.run();
 
 		// The conneciton dialog should open with the params set as below
-		assert.equal(calledShowDialog, 2, 'showDialog should be called when URI is connected');
-		assert.equal(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
-		assert.equal(connectionParams.runQueryOnCompletion, false, 'runQueryOnCompletion should be false`');
-		assert.equal(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
-		assert.equal(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
+		assert.strictEqual(calledShowDialog, 2, 'showDialog should be called when URI is connected');
+		assert.strictEqual(connectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
+		assert.strictEqual(connectionParams.runQueryOnCompletion, 0, 'runQueryOnCompletion should be false`');
+		assert.strictEqual(connectionParams.input.uri, testUri, 'URI should be set to the test URI');
+		assert.strictEqual(connectionParams.input, editor.object.input, 'Editor should be set to the mock editor');
 	});
 
 	test('ListDatabaseItem shows items as expected', () => {
@@ -474,22 +474,22 @@ suite('SQL QueryAction Tests', () => {
 		// If I query without having initialized anything, state should be clear
 		listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, undefined);
 
-		assert.equal(listItem.isEnabled(), false, 'do not expect dropdown enabled unless connected');
-		assert.equal(listItem.currentDatabaseName, undefined, 'do not expect dropdown to have entries unless connected');
+		assert.strictEqual(listItem.isEnabled(), false, 'do not expect dropdown enabled unless connected');
+		assert.strictEqual(listItem.currentDatabaseName, undefined, 'do not expect dropdown to have entries unless connected');
 
 		// When I connect, database name should be returned in the dropdown and this should be enabled
 		isConnected = true;
 		databaseName = 'master';
 		listItem.onConnected();
-		assert.equal(listItem.isEnabled(), true, 'expect dropdown enabled when connected');
-		assert.equal(listItem.currentDatabaseName, 'master', 'expect dropdown to have current DB name when connected');
+		assert.strictEqual(listItem.isEnabled(), true, 'expect dropdown enabled when connected');
+		assert.strictEqual(listItem.currentDatabaseName, 'master', 'expect dropdown to have current DB name when connected');
 
 		// When I disconnect, state should return to default
 		isConnected = false;
 		databaseName = undefined;
 		listItem.onDisconnect();
-		assert.equal(listItem.isEnabled(), false, 'do not expect dropdown enabled unless connected');
-		assert.equal(listItem.currentDatabaseName, undefined, 'do not expect dropdown to have entries unless connected');
+		assert.strictEqual(listItem.isEnabled(), false, 'do not expect dropdown enabled unless connected');
+		assert.strictEqual(listItem.currentDatabaseName, undefined, 'do not expect dropdown to have entries unless connected');
 	});
 
 	test('ListDatabaseItem - null event params', () => {
@@ -513,7 +513,7 @@ suite('SQL QueryAction Tests', () => {
 		dbChangedEmitter.fire(eventParams);
 
 		// Then: The selected database should not have changed
-		assert.equal(listItem.currentDatabaseName, databaseName);
+		assert.strictEqual(listItem.currentDatabaseName, databaseName);
 	});
 
 	test('ListDatabaseItem - wrong uri', () => {
@@ -542,7 +542,7 @@ suite('SQL QueryAction Tests', () => {
 		dbChangedEmitter.fire(eventParams);
 
 		// Then: The selected database should not have changed
-		assert.equal(listItem.currentDatabaseName, databaseName);
+		assert.strictEqual(listItem.currentDatabaseName, databaseName);
 	});
 
 	test('ListDatabaseItem - updates when connected and uri matches', () => {
@@ -567,7 +567,7 @@ suite('SQL QueryAction Tests', () => {
 
 		// Then:
 		// ... The connection should have changed to the provided database
-		assert.equal(listItem.currentDatabaseName, eventParams.connectionProfile.databaseName);
+		assert.strictEqual(listItem.currentDatabaseName, eventParams.connectionProfile.databaseName);
 	});
 
 	test('runCurrent - opens connection dialog when there are no active connections', async () => {
@@ -599,7 +599,7 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.runCurrent();
 
 		//connection dialog should open and runQueryStatement should not be called
-		assert.equal(calledRunQueryStatementOnInput, false, 'runCurrent should not call runQueryStatement');
+		assert.strictEqual(calledRunQueryStatementOnInput, false, 'runCurrent should not call runQueryStatement');
 		testQueryInput.verify(x => x.runQueryStatement(TypeMoq.It.isAny()), TypeMoq.Times.never());
 		connectionManagementService.verify(x => x.showConnectionDialog(TypeMoq.It.isAny()), TypeMoq.Times.once());
 
@@ -609,7 +609,7 @@ suite('SQL QueryAction Tests', () => {
 		await queryAction.runCurrent();
 
 		//connection dialog should not open and runQueryStatement should be called
-		assert.equal(calledRunQueryStatementOnInput, true, 'runCurrent should call runQueryStatement');
+		assert.strictEqual(calledRunQueryStatementOnInput, true, 'runCurrent should call runQueryStatement');
 		testQueryInput.verify(x => x.runQueryStatement(TypeMoq.It.isAny()), TypeMoq.Times.once());
 		//show Dialog is not called
 		connectionManagementService.verify(x => x.showConnectionDialog(TypeMoq.It.isAny()), TypeMoq.Times.once());
@@ -623,7 +623,7 @@ suite('SQL QueryAction Tests', () => {
 		queryEditor.setup(x => x.isSelectionEmpty()).returns(() => true);
 
 		//connection dialog should not open and runQueryStatement should not be called
-		assert.equal(calledRunQueryStatementOnInput, false, 'runCurrent should not call runQueryStatemet');
+		assert.strictEqual(calledRunQueryStatementOnInput, false, 'runCurrent should not call runQueryStatemet');
 		connectionManagementService.verify(x => x.showConnectionDialog(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
@@ -659,8 +659,8 @@ suite('SQL QueryAction Tests', () => {
 		calledRunQueryStatementOnInput = false;
 		await queryAction.runCurrent();
 
-		assert.equal(calledRunQueryStatementOnInput, true, 'runCurrent should call runQueryStatement');
-		assert.equal(calledRunQueryOnInput, false, 'run should not call runQuery');
+		assert.strictEqual(calledRunQueryStatementOnInput, true, 'runCurrent should call runQueryStatement');
+		assert.strictEqual(calledRunQueryOnInput, false, 'run should not call runQuery');
 
 		// checking if runQuery statement is called with predefinedCursorSelection only
 		testQueryInput.verify(x => x.runQueryStatement(TypeMoq.It.isValue(predefinedCursorSelection)), TypeMoq.Times.once());
@@ -677,8 +677,8 @@ suite('SQL QueryAction Tests', () => {
 		calledRunQueryStatementOnInput = false;
 		await queryAction.runCurrent();
 
-		assert.equal(calledRunQueryStatementOnInput, false, 'runCurrent should not call runQueryStatement');
-		assert.equal(calledRunQueryOnInput, true, 'run should call runQuery');
+		assert.strictEqual(calledRunQueryStatementOnInput, false, 'runCurrent should not call runQueryStatement');
+		assert.strictEqual(calledRunQueryOnInput, true, 'run should call runQuery');
 
 		// checking if runQuery is called with predefinedRangeSelection only
 		testQueryInput.verify(x => x.runQuery(TypeMoq.It.isValue(predefinedRangeSelection)), TypeMoq.Times.once());

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -290,7 +290,7 @@ suite('SQL QueryAction Tests', () => {
 		assert.strictEqual(countCalledShowDialog, 2, 'run should call showDialog again');
 		assert.strictEqual(countCalledRunQuery, 0, 'run should not call runQuery');
 		assert.strictEqual(showDialogConnectionParams.connectionType, ConnectionType.editor, 'connectionType should be queryEditor');
-		assert.notEqual(showDialogConnectionParams.queryRange, undefined, 'There should not be an undefined selection in runQuery');
+		assert.notStrictEqual(showDialogConnectionParams.queryRange, undefined, 'There should not be an undefined selection in runQuery');
 		assert.strictEqual(showDialogConnectionParams.queryRange.startLineNumber, selectionToReturnInGetSelection.startLineNumber, 'startLine should match');
 		assert.strictEqual(showDialogConnectionParams.queryRange.startColumn, selectionToReturnInGetSelection.startColumn, 'startColumn should match');
 		assert.strictEqual(showDialogConnectionParams.queryRange.endLineNumber, selectionToReturnInGetSelection.endLineNumber, 'endLine should match');
@@ -314,7 +314,7 @@ suite('SQL QueryAction Tests', () => {
 		// The query should run with the given seleciton
 		assert.strictEqual(countCalledShowDialog, 2, 'run should not call showDialog');
 		assert.strictEqual(countCalledRunQuery, 2, 'run should call runQuery again');
-		assert.notEqual(runQuerySelection, undefined, 'There should not be an undefined selection in runQuery');
+		assert.notStrictEqual(runQuerySelection, undefined, 'There should not be an undefined selection in runQuery');
 		assert.strictEqual(runQuerySelection.startLineNumber, selectionToReturnInGetSelection.startLineNumber, 'startLine should match');
 		assert.strictEqual(runQuerySelection.startColumn, selectionToReturnInGetSelection.startColumn, 'startColumn should match');
 		assert.strictEqual(runQuerySelection.endLineNumber, selectionToReturnInGetSelection.endLineNumber, 'endLine should match');

--- a/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
@@ -109,17 +109,17 @@ suite('SQL QueryEditor Tests', () => {
 	test('setInput creates SQL components', (done) => {
 		let assertInput = function () {
 			// The taskbar SQL, and parent should be created
-			assert.equal(!!editor.taskbar, true);
-			assert.equal(!!editor.taskbarContainer, true);
-			assert.equal(!!editor.getContainer(), true);
-			assert.equal(!!editor.sqlEditor, true);
-			assert.equal(!!editor.sqlEditorContainer, true);
+			assert.strictEqual(!!editor.taskbar, true);
+			assert.strictEqual(!!editor.taskbarContainer, true);
+			assert.strictEqual(!!editor.getContainer(), true);
+			assert.strictEqual(!!editor.sqlEditor, true);
+			assert.strictEqual(!!editor.sqlEditorContainer, true);
 
 			// But the results componenets should not
-			assert.equal(!!editor.resultsEditor, false);
-			assert.equal(!!editor.resultsEditorContainer, false);
-			assert.equal(!!editor.sash, false);
-			assert.equal(!!editor._isResultsEditorVisible(), false);
+			assert.strictEqual(!!editor.resultsEditor, false);
+			assert.strictEqual(!!editor.resultsEditorContainer, false);
+			assert.strictEqual(!!editor.sash, false);
+			assert.strictEqual(!!editor._isResultsEditorVisible(), false);
 		};
 
 		// If I call create a QueryEditor
@@ -142,15 +142,15 @@ suite('SQL QueryEditor Tests', () => {
 
 		// Make the asserts thenable
 		let assertInput = function () {
-			assert.equal(!!editor.taskbar, true);
-			assert.equal(!!editor.taskbarContainer, true);
-			assert.equal(!!editor.getContainer(), true);
-			assert.equal(!!editor.sqlEditor, true);
-			assert.equal(!!editor.sqlEditorContainer, true);
-			assert.equal(!!editor.resultsEditor, true);
-			assert.equal(!!editor.resultsEditorContainer, true);
-			assert.equal(!!editor.sash, true);
-			assert.equal(!!editor._isResultsEditorVisible(), true);
+			assert.strictEqual(!!editor.taskbar, true);
+			assert.strictEqual(!!editor.taskbarContainer, true);
+			assert.strictEqual(!!editor.getContainer(), true);
+			assert.strictEqual(!!editor.sqlEditor, true);
+			assert.strictEqual(!!editor.sqlEditorContainer, true);
+			assert.strictEqual(!!editor.resultsEditor, true);
+			assert.strictEqual(!!editor.resultsEditorContainer, true);
+			assert.strictEqual(!!editor.sash, true);
+			assert.strictEqual(!!editor._isResultsEditorVisible(), true);
 			editorGroupService.verify(x => x.pinEditor(undefined, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		};
 
@@ -207,11 +207,11 @@ suite('SQL QueryEditor Tests', () => {
 			// The inputs should not match
 			assert.notEqual(firstInput.getName(), secondInput.getName());
 			assert.notEqual(firstContainer.id, secondContainer.id);
-			assert.equal(firstContainer.id, firstContainerId);
+			assert.strictEqual(firstContainer.id, firstContainerId);
 
 			// The first input should be disposed
 			assert.notEqual(firstContainer.parentElement, secondContainer.parentElement);
-			assert.equal(firstContainer.parentElement, undefined);
+			assert.strictEqual(firstContainer.parentElement, undefined);
 
 			// The second input should be added into the DOM
 			assert.notEqual(secondContainer.parentElement, undefined);
@@ -229,10 +229,10 @@ suite('SQL QueryEditor Tests', () => {
 			// The inputs should not match
 			assert.notEqual(firstInput.getName(), secondInput.getName());
 			assert.notEqual(firstContainer.id, secondContainer.id);
-			assert.equal(secondContainer.id, secondContainerId);
+			assert.strictEqual(secondContainer.id, secondContainerId);
 
 			// The first input should be added into the DOM
-			assert.equal(secondContainer.parentElement, undefined);
+			assert.strictEqual(secondContainer.parentElement, undefined);
 
 			// The second input should be disposed
 			assert.notEqual(firstContainer.parentElement, secondContainer.parentElement);
@@ -322,18 +322,18 @@ suite('SQL QueryEditor Tests', () => {
 			queryModelService.setup(x => x.isRunningQuery(TypeMoq.It.isAny())).returns(() => false);
 			// If I use the created QueryEditor with no changes since creation
 			// Buttons should be set as if disconnected
-			assert.equal(queryInput.state.connected, false, 'query state should be not connected');
-			assert.equal(queryInput.state.executing, false, 'query state should be not executing');
-			assert.equal(queryInput.state.connecting, false, 'query state should be not connecting');
+			assert.strictEqual(queryInput.state.connected, false, 'query state should be not connected');
+			assert.strictEqual(queryInput.state.executing, false, 'query state should be not executing');
+			assert.strictEqual(queryInput.state.connecting, false, 'query state should be not connecting');
 		});
 
 		test('Taskbar buttons are set correctly upon connect', () => {
 			let params: INewConnectionParams = { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none };
 			queryModelService.setup(x => x.isRunningQuery(TypeMoq.It.isAny())).returns(() => false);
 			queryInput.onConnectSuccess(params);
-			assert.equal(queryInput.state.connected, true, 'query state should be not connected');
-			assert.equal(queryInput.state.executing, false, 'query state should be not executing');
-			assert.equal(queryInput.state.connecting, false, 'query state should be not connecting');
+			assert.strictEqual(queryInput.state.connected, true, 'query state should be not connected');
+			assert.strictEqual(queryInput.state.executing, false, 'query state should be not executing');
+			assert.strictEqual(queryInput.state.connecting, false, 'query state should be not connecting');
 		});
 		test('Test that we attempt to dispose query when the queryInput is disposed', () => {
 			let queryResultsInput = new QueryResultsInput('testUri');

--- a/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
@@ -191,7 +191,7 @@ suite('SQL QueryEditor Tests', () => {
 		};
 
 		let assertFirstInputIsSet = function () {
-			assert.notEqual(firstContainer.parentElement, undefined);
+			assert.notStrictEqual(firstContainer.parentElement, undefined);
 		};
 
 		let setSecondInput = function () {
@@ -205,16 +205,16 @@ suite('SQL QueryEditor Tests', () => {
 			secondContainer.id = secondContainerId;
 
 			// The inputs should not match
-			assert.notEqual(firstInput.getName(), secondInput.getName());
-			assert.notEqual(firstContainer.id, secondContainer.id);
+			assert.notStrictEqual(firstInput.getName(), secondInput.getName());
+			assert.notStrictEqual(firstContainer.id, secondContainer.id);
 			assert.strictEqual(firstContainer.id, firstContainerId);
 
 			// The first input should be disposed
-			assert.notEqual(firstContainer.parentElement, secondContainer.parentElement);
+			assert.notStrictEqual(firstContainer.parentElement, secondContainer.parentElement);
 			assert.strictEqual(firstContainer.parentElement, undefined);
 
 			// The second input should be added into the DOM
-			assert.notEqual(secondContainer.parentElement, undefined);
+			assert.notStrictEqual(secondContainer.parentElement, undefined);
 		};
 
 		let setFirstInputAgain = function () {
@@ -227,16 +227,16 @@ suite('SQL QueryEditor Tests', () => {
 			firstContainer = editor.sqlEditorContainer;
 
 			// The inputs should not match
-			assert.notEqual(firstInput.getName(), secondInput.getName());
-			assert.notEqual(firstContainer.id, secondContainer.id);
+			assert.notStrictEqual(firstInput.getName(), secondInput.getName());
+			assert.notStrictEqual(firstContainer.id, secondContainer.id);
 			assert.strictEqual(secondContainer.id, secondContainerId);
 
 			// The first input should be added into the DOM
 			assert.strictEqual(secondContainer.parentElement, undefined);
 
 			// The second input should be disposed
-			assert.notEqual(firstContainer.parentElement, secondContainer.parentElement);
-			assert.notEqual(firstContainer.parentElement, undefined);
+			assert.notStrictEqual(firstContainer.parentElement, secondContainer.parentElement);
+			assert.notStrictEqual(firstContainer.parentElement, undefined);
 		};
 
 		// If I create a QueryEditor

--- a/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
+++ b/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
@@ -120,9 +120,9 @@ suite('Account Management Service Tests:', () => {
 				// ... The account list was updated
 				state.eventVerifierUpdate.assertFiredWithVerify((params: UpdateAccountListEventParams | undefined) => {
 					assert.ok(params);
-					assert.equal(params!.providerId, hasAccountProvider.id);
+					assert.strictEqual(params!.providerId, hasAccountProvider.id);
 					assert.ok(Array.isArray(params!.accountList));
-					assert.equal(params!.accountList.length, 1);
+					assert.strictEqual(params!.accountList.length, 1);
 				});
 			});
 	});
@@ -159,10 +159,10 @@ suite('Account Management Service Tests:', () => {
 				// ... The account list change should have been fired
 				state.eventVerifierUpdate.assertFiredWithVerify(param => {
 					assert.ok(param);
-					assert.equal(param!.providerId, hasAccountProvider.id);
+					assert.strictEqual(param!.providerId, hasAccountProvider.id);
 					assert.ok(Array.isArray(param!.accountList));
-					assert.equal(param!.accountList.length, 1);
-					assert.equal(param!.accountList[0], account);
+					assert.strictEqual(param!.accountList.length, 1);
+					assert.strictEqual(param!.accountList[0], account);
 				});
 			});
 	});
@@ -199,10 +199,10 @@ suite('Account Management Service Tests:', () => {
 				// ... The account list change should have been fired
 				state.eventVerifierUpdate.assertFiredWithVerify(param => {
 					assert.ok(param);
-					assert.equal(param!.providerId, hasAccountProvider.id);
+					assert.strictEqual(param!.providerId, hasAccountProvider.id);
 					assert.ok(Array.isArray(param!.accountList));
-					assert.equal(param!.accountList.length, 1);
-					assert.equal(param!.accountList[0], account);
+					assert.strictEqual(param!.accountList.length, 1);
+					assert.strictEqual(param!.accountList[0], account);
 				});
 			});
 	});
@@ -258,8 +258,8 @@ suite('Account Management Service Tests:', () => {
 			.then(result => {
 				// Then: The list should have the one account provider in it
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 1);
-				assert.equal(result[0], noAccountProvider);
+				assert.strictEqual(result.length, 1);
+				assert.strictEqual(result[0], noAccountProvider);
 			});
 	});
 
@@ -272,7 +272,7 @@ suite('Account Management Service Tests:', () => {
 			.then(result => {
 				// Then: The results should be an empty array
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 0);
+				assert.strictEqual(result.length, 0);
 			});
 	});
 
@@ -302,7 +302,7 @@ suite('Account Management Service Tests:', () => {
 			.then(result => {
 				// Then: I should get back an empty array
 				assert.ok(Array.isArray(result));
-				assert.equal(result.length, 0);
+				assert.strictEqual(result.length, 0);
 			});
 	});
 
@@ -319,7 +319,7 @@ suite('Account Management Service Tests:', () => {
 		return ams.getAccountsForProvider(hasAccountProvider.id)
 			.then(result => {
 				// Then: I should get back the list of accounts
-				assert.equal(result, accountList);
+				assert.strictEqual(result, accountList);
 			});
 	});
 
@@ -355,9 +355,9 @@ suite('Account Management Service Tests:', () => {
 				// ... The updated account list event should have fired
 				state.eventVerifierUpdate.assertFiredWithVerify((params: UpdateAccountListEventParams | undefined) => {
 					assert.ok(params);
-					assert.equal(params!.providerId, hasAccountProvider.id);
+					assert.strictEqual(params!.providerId, hasAccountProvider.id);
 					assert.ok(Array.isArray(params!.accountList));
-					assert.equal(params!.accountList.length, 0);
+					assert.strictEqual(params!.accountList.length, 0);
 				});
 			});
 	});
@@ -490,9 +490,9 @@ suite('Account Management Service Tests:', () => {
 				// ... The provider added event should have fired
 				mocks.eventVerifierProviderAdded.assertFiredWithVerify((param: AccountProviderAddedEventParams | undefined) => {
 					assert.ok(param);
-					assert.equal(param!.addedProvider, noAccountProvider);
+					assert.strictEqual(param!.addedProvider, noAccountProvider);
 					assert.ok(Array.isArray(param!.initialAccounts));
-					assert.equal(param!.initialAccounts.length, 0);
+					assert.strictEqual(param!.initialAccounts.length, 0);
 				});
 			});
 	});

--- a/src/sql/workbench/services/accountManagement/test/browser/accountPickerService.test.ts
+++ b/src/sql/workbench/services/accountManagement/test/browser/accountPickerService.test.ts
@@ -44,10 +44,10 @@ suite('Account picker service tests', () => {
 
 		// Then:
 		// ... All the events for the view models should be properly initialized
-		assert.notEqual(service.addAccountCompleteEvent, undefined);
-		assert.notEqual(service.addAccountErrorEvent, undefined);
-		assert.notEqual(service.addAccountStartEvent, undefined);
-		assert.notEqual(service.onAccountSelectionChangeEvent, undefined);
+		assert.notStrictEqual(service.addAccountCompleteEvent, undefined);
+		assert.notStrictEqual(service.addAccountErrorEvent, undefined);
+		assert.notStrictEqual(service.addAccountStartEvent, undefined);
+		assert.notStrictEqual(service.onAccountSelectionChangeEvent, undefined);
 
 
 		// ... All the events should properly fire

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -281,7 +281,7 @@ suite('ConnectionDialogService tests', () => {
 		Also openDialogAndWait returns the connection profile passed in */
 		(connectionDialogService as any).handleDefaultOnConnect(testConnectionParams, connectionProfile);
 		let result = await connectionPromise;
-		assert.equal(result, connectionProfile);
+		assert.strictEqual(result, connectionProfile);
 	});
 
 	test('handleFillInConnectionInputs calls function on ConnectionController widget', async () => {
@@ -292,7 +292,7 @@ suite('ConnectionDialogService tests', () => {
 		await connectionDialogService.showDialog(mockConnectionManagementService.object, testConnectionParams, connectionProfile);
 		await (connectionDialogService as any).handleFillInConnectionInputs(connectionProfile);
 		let returnedModel = ((connectionDialogService as any)._connectionControllerMap['MSSQL'] as any)._model;
-		assert.equal(returnedModel._groupName, 'testGroup');
+		assert.strictEqual(returnedModel._groupName, 'testGroup');
 		assert(called);
 	});
 

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
@@ -76,8 +76,8 @@ suite('ConnectionDialogWidget tests', () => {
 	});
 
 	test('renderBody should have attached a connection dialog body onto element', () => {
-		assert.equal(element.childElementCount, 1);
-		assert.equal(element.children[0].className, 'connection-dialog');
+		assert.strictEqual(element.childElementCount, 1);
+		assert.strictEqual(element.children[0].className, 'connection-dialog');
 	});
 
 	test('updateConnectionProviders should update connection providers', () => {
@@ -87,7 +87,7 @@ suite('ConnectionDialogWidget tests', () => {
 			return getUniqueConnectionProvidersByNameMap(providerNameToDisplayMap);
 		});
 		connectionDialogWidget.updateConnectionProviders(providerDisplayNames, providerNameToDisplayMap);
-		assert.equal(connectionDialogWidget.getDisplayNameFromProviderName('PGSQL'), providerNameToDisplayMap['PGSQL']);
+		assert.strictEqual(connectionDialogWidget.getDisplayNameFromProviderName('PGSQL'), providerNameToDisplayMap['PGSQL']);
 	});
 
 	test('setting newConnectionParams test for connectionDialogWidget', () => {
@@ -109,7 +109,7 @@ suite('ConnectionDialogWidget tests', () => {
 			return getUniqueConnectionProvidersByNameMap(providerNameToDisplayMap);
 		});
 		connectionDialogWidget.newConnectionParams = params;
-		assert.equal(connectionDialogWidget.newConnectionParams, params);
+		assert.strictEqual(connectionDialogWidget.newConnectionParams, params);
 	});
 
 	test('open should call onInitDialog', async () => {
@@ -176,8 +176,8 @@ suite('ConnectionDialogWidget tests', () => {
 		});
 		let providerDisplayName = 'Mock SQL Server';
 		connectionDialogWidget.updateProvider(providerDisplayName);
-		assert.equal(returnedDisplayName, providerDisplayName);
-		assert.equal(returnedContainer.className, 'connection-provider-info');
+		assert.strictEqual(returnedDisplayName, providerDisplayName);
+		assert.strictEqual(returnedContainer.className, 'connection-provider-info');
 		assert(called);
 	});
 });

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -300,7 +300,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		let saveConnection = connectionManagementService.getConnectionProfile(params.input.uri);
 
 		assert.notEqual(saveConnection, undefined, `profile was not added to the connections`);
-		assert.equal(saveConnection.serverName, connectionProfile.serverName, `Server names are different`);
+		assert.strictEqual(saveConnection.serverName, connectionProfile.serverName, `Server names are different`);
 		await connectionManagementService.showConnectionDialog(params);
 		verifyShowConnectionDialog(connectionProfile, params.connectionType, params.input.uri, false);
 	});
@@ -326,7 +326,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 	test('getDefaultProviderId is MSSQL', () => {
 		let defaultProvider = connectionManagementService.getDefaultProviderId();
-		assert.equal(defaultProvider, 'MSSQL', `Default provider is not equal to MSSQL`);
+		assert.strictEqual(defaultProvider, 'MSSQL', `Default provider is not equal to MSSQL`);
 	});
 
 	/* Andresse  10/5/17 commented this test out since it was only working before my changes by the chance of how Promises work
@@ -373,7 +373,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		await connect(uri, options);
 		verifyOptions(options);
 		assert.notEqual(paramsInOnConnectSuccess, undefined);
-		assert.equal(paramsInOnConnectSuccess.connectionType, options.params.connectionType);
+		assert.strictEqual(paramsInOnConnectSuccess.connectionType, options.params.connectionType);
 	});
 
 	test('connectAndSaveProfile should show not load the password', async () => {
@@ -389,7 +389,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		let options: IConnectionCompletionOptions = undefined;
 
 		await connect(uri, options);
-		assert.equal(connectionManagementService.isProfileConnected(connectionProfile), true);
+		assert.strictEqual(connectionManagementService.isProfileConnected(connectionProfile), true);
 	});
 
 	test('failed connection should open the dialog if connection fails', async () => {
@@ -414,8 +414,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfile, error, errorCode, errorCallStack);
-		assert.equal(result.connected, expectedConnection);
-		assert.equal(result.errorMessage, connectionResult.errorMessage);
+		assert.strictEqual(result.connected, expectedConnection);
+		assert.strictEqual(result.errorMessage, connectionResult.errorMessage);
 		verifyShowFirewallRuleDialog(connectionProfile, false);
 		verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult);
 	});
@@ -442,19 +442,19 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfile, error, errorCode, errorCallStack);
-		assert.equal(result.connected, expectedConnection);
-		assert.equal(result.errorMessage, connectionResult.errorMessage);
+		assert.strictEqual(result.connected, expectedConnection);
+		assert.strictEqual(result.errorMessage, connectionResult.errorMessage);
 		verifyShowFirewallRuleDialog(connectionProfile, false);
 		verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult, false);
 	});
 
 	test('Accessors for event emitters should return emitter function', () => {
 		let onAddConnectionProfile1 = connectionManagementService.onAddConnectionProfile;
-		assert.equal(typeof (onAddConnectionProfile1), 'function');
+		assert.strictEqual(typeof (onAddConnectionProfile1), 'function');
 		let onDeleteConnectionProfile1 = connectionManagementService.onDeleteConnectionProfile;
-		assert.equal(typeof (onDeleteConnectionProfile1), 'function');
+		assert.strictEqual(typeof (onDeleteConnectionProfile1), 'function');
 		let onConnect1 = connectionManagementService.onConnect;
-		assert.equal(typeof (onConnect1), 'function');
+		assert.strictEqual(typeof (onConnect1), 'function');
 	});
 
 	test('onConnectionChangedNotification should call onConnectionChanged event', async () => {
@@ -472,8 +472,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		let changedConnectionInfo: azdata.ChangedConnectionInfo = { connectionUri: uri, connection: saveConnection };
 		let called = false;
 		connectionManagementService.onConnectionChanged((params: IConnectionParams) => {
-			assert.equal(uri, params.connectionUri);
-			assert.equal(saveConnection, params.connectionProfile);
+			assert.strictEqual(uri, params.connectionUri);
+			assert.strictEqual(saveConnection, params.connectionProfile);
 			called = true;
 		});
 		connectionManagementService.onConnectionChangedNotification(0, changedConnectionInfo);
@@ -487,7 +487,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		let newGroupId = 'new_group_id';
 		connectionStore.setup(x => x.changeGroupIdForConnection(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve());
 		await connectionManagementService.changeGroupIdForConnection(profile, newGroupId);
-		assert.equal(profile.groupId, newGroupId);
+		assert.strictEqual(profile.groupId, newGroupId);
 	});
 
 	test('changeGroupIdForConnectionGroup should call changeGroupIdForConnectionGroup in ConnectionStore', async () => {
@@ -530,7 +530,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			+ profile.serverName + '|userName:' + profile.userName;
 		await connect(uri1, options, true, profile);
 		let returnedProfile = connectionManagementService.findExistingConnection(profile);
-		assert.equal(returnedProfile.getConnectionInfoId(), connectionInfoString);
+		assert.strictEqual(returnedProfile.getConnectionInfoId(), connectionInfoString);
 	});
 
 	test('deleteConnection should delete the connection properly', async () => {
@@ -745,7 +745,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		await connect(uri, options);
 		let result = await connectionManagementService.cancelEditorConnection(options.params.input);
-		assert.equal(result, false);
+		assert.strictEqual(result, false);
 		assert(connectionManagementService.isConnected(uri));
 	});
 
@@ -776,10 +776,10 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		await connect(uri, options, true, profile);
 		// invalid uri check.
-		assert.equal(connectionManagementService.getConnection(badString), undefined);
+		assert.strictEqual(connectionManagementService.getConnection(badString), undefined);
 		let returnedProfile = connectionManagementService.getConnection(uri);
-		assert.equal(returnedProfile.groupFullName, profile.groupFullName);
-		assert.equal(returnedProfile.groupId, profile.groupId);
+		assert.strictEqual(returnedProfile.groupFullName, profile.groupFullName);
+		assert.strictEqual(returnedProfile.groupId, profile.groupId);
 	});
 
 	test('connectIfNotConnected should not try to connect with already connected profile', async () => {
@@ -808,12 +808,12 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		await connect(uri, options, true, profile);
 		let result = await connectionManagementService.connectIfNotConnected(profile, undefined, true);
-		assert.equal(result, uri);
+		assert.strictEqual(result, uri);
 	});
 
 	test('getServerInfo should return undefined when given an invalid string', () => {
 		let badString = 'bad_string';
-		assert.equal(connectionManagementService.getServerInfo(badString), undefined);
+		assert.strictEqual(connectionManagementService.getServerInfo(badString), undefined);
 	});
 
 	test('getConnectionString should get connection string of connectionId', async () => {
@@ -843,7 +843,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		let getConnectionResult = await connectionManagementService.getConnectionString(badString);
 		// test for invalid profile id
-		assert.equal(getConnectionResult, undefined);
+		assert.strictEqual(getConnectionResult, undefined);
 		await connect(uri, options, true, profile);
 		let currentConnections = connectionManagementService.getConnections(true);
 		let profileId = currentConnections[0].id;
@@ -923,7 +923,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		});
 		await connect(uri, options, true, profile);
 		let result = await connectionManagementService.buildConnectionInfo(testConnectionString, providerName);
-		assert.equal(result.options, options);
+		assert.strictEqual(result.options, options);
 	});
 
 	test('removeConnectionProfileCredentials should return connection profile without password', () => {
@@ -934,7 +934,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			return <ConnectionProfile>profileWithoutPass;
 		});
 		let clearedProfile = connectionManagementService.removeConnectionProfileCredentials(profile);
-		assert.equal(clearedProfile.password, undefined);
+		assert.strictEqual(clearedProfile.password, undefined);
 	});
 
 	test('getConnectionProfileById should return profile when given profileId', async () => {
@@ -962,13 +962,13 @@ suite('SQL ConnectionManagementService tests', () => {
 			showFirewallRuleOnError: true
 		};
 		let result = await connect(uri, options, true, profile);
-		assert.equal(result.connected, true);
-		assert.equal(connectionManagementService.getConnectionProfileById(badString), undefined);
+		assert.strictEqual(result.connected, true);
+		assert.strictEqual(connectionManagementService.getConnectionProfileById(badString), undefined);
 		let currentConnections = connectionManagementService.getConnections(true);
 		let profileId = currentConnections[0].id;
 		let returnedProfile = connectionManagementService.getConnectionProfileById(profileId);
-		assert.equal(returnedProfile.groupFullName, profile.groupFullName);
-		assert.equal(returnedProfile.groupId, profile.groupId);
+		assert.strictEqual(returnedProfile.groupFullName, profile.groupFullName);
+		assert.strictEqual(returnedProfile.groupId, profile.groupId);
 	});
 
 	test('Edit Connection - Changing connection profile name for same URI should persist after edit', async () => {
@@ -1001,7 +1001,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		newProfile.connectionName = newname;
 		options.params.isEditConnection = true;
 		await connect(uri1, options, true, newProfile);
-		assert.equal(connectionManagementService.getConnectionProfile(uri1).connectionName, newname);
+		assert.strictEqual(connectionManagementService.getConnectionProfile(uri1).connectionName, newname);
 	});
 
 	test('Edit Connection - Connecting a different URI with same profile via edit should not change profile ID.', async () => {
@@ -1035,7 +1035,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		await connect(uri2, options, true, profile);
 		let uri1info = connectionManagementService.getConnectionInfo(uri1);
 		let uri2info = connectionManagementService.getConnectionInfo(uri2);
-		assert.equal(uri1info.connectionProfile.id, uri2info.connectionProfile.id);
+		assert.strictEqual(uri1info.connectionProfile.id, uri2info.connectionProfile.id);
 	});
 
 
@@ -1058,8 +1058,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfile, error, errorCode);
-		assert.equal(result.connected, expectedConnection);
-		assert.equal(result.errorMessage, expectedError);
+		assert.strictEqual(result.connected, expectedConnection);
+		assert.strictEqual(result.errorMessage, expectedError);
 		verifyShowFirewallRuleDialog(connectionProfile, true);
 	});
 
@@ -1089,8 +1089,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfile, error, errorCode, errorCallStack);
-		assert.equal(result.connected, expectedConnection);
-		assert.equal(result.errorMessage, connectionResult.errorMessage);
+		assert.strictEqual(result.connected, expectedConnection);
+		assert.strictEqual(result.errorMessage, connectionResult.errorMessage);
 		verifyShowFirewallRuleDialog(connectionProfile, false);
 		verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult, false);
 	});
@@ -1101,25 +1101,25 @@ suite('SQL ConnectionManagementService tests', () => {
 
 	test('getConnectionIconId should return undefined as there is no mementoObj service', () => {
 		let connectionId = 'connection:connectionId';
-		assert.equal(connectionManagementService.getConnectionIconId(connectionId), undefined);
+		assert.strictEqual(connectionManagementService.getConnectionIconId(connectionId), undefined);
 	});
 
 	test('getAdvancedProperties should return a list of properties for connectionManagementService', () => {
 		let propertyNames = ['connectionName', 'serverName', 'databaseName', 'userName', 'authenticationType', 'password'];
 		let advancedProperties = connectionManagementService.getAdvancedProperties();
-		assert.equal(propertyNames[0], advancedProperties[0].name);
-		assert.equal(propertyNames[1], advancedProperties[1].name);
-		assert.equal(propertyNames[2], advancedProperties[2].name);
-		assert.equal(propertyNames[3], advancedProperties[3].name);
-		assert.equal(propertyNames[4], advancedProperties[4].name);
-		assert.equal(propertyNames[5], advancedProperties[5].name);
+		assert.strictEqual(propertyNames[0], advancedProperties[0].name);
+		assert.strictEqual(propertyNames[1], advancedProperties[1].name);
+		assert.strictEqual(propertyNames[2], advancedProperties[2].name);
+		assert.strictEqual(propertyNames[3], advancedProperties[3].name);
+		assert.strictEqual(propertyNames[4], advancedProperties[4].name);
+		assert.strictEqual(propertyNames[5], advancedProperties[5].name);
 	});
 
 	test('saveProfileGroup should return groupId from connection group', async () => {
 		let newConnectionGroup = createConnectionGroup(connectionProfile.groupId);
 		connectionStore.setup(x => x.saveProfileGroup(TypeMoq.It.isAny())).returns(() => Promise.resolve(connectionProfile.groupId));
 		let result = await connectionManagementService.saveProfileGroup(newConnectionGroup);
-		assert.equal(result, connectionProfile.groupId);
+		assert.strictEqual(result, connectionProfile.groupId);
 	});
 
 	test('editGroup should fire onAddConnectionProfile', async () => {
@@ -1137,10 +1137,10 @@ suite('SQL ConnectionManagementService tests', () => {
 		let testUri = 'connection:';
 		let formattedUri = 'connection:connectionId';
 		let badUri = 'bad_uri';
-		assert.equal(formattedUri, connectionManagementService.getFormattedUri(testUri, connectionProfile));
-		assert.equal(formattedUri, connectionManagementService.getFormattedUri(formattedUri, connectionProfile));
+		assert.strictEqual(formattedUri, connectionManagementService.getFormattedUri(testUri, connectionProfile));
+		assert.strictEqual(formattedUri, connectionManagementService.getFormattedUri(formattedUri, connectionProfile));
 		// test for invalid URI
-		assert.equal(badUri, connectionManagementService.getFormattedUri(badUri, connectionProfile));
+		assert.strictEqual(badUri, connectionManagementService.getFormattedUri(badUri, connectionProfile));
 	});
 
 	test('failed firewall rule connection and failed during open firewall rule should open the firewall rule dialog and connection dialog with error', async () => {
@@ -1169,8 +1169,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfile, error, errorCode, errorCallStack);
-		assert.equal(result.connected, expectedConnection);
-		assert.equal(result.errorMessage, connectionResult.errorMessage);
+		assert.strictEqual(result.connected, expectedConnection);
+		assert.strictEqual(result.errorMessage, connectionResult.errorMessage);
 		verifyShowFirewallRuleDialog(connectionProfile, true);
 		verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult, true);
 	});
@@ -1201,7 +1201,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfile, error, errorCode, errorCallStack);
-		assert.equal(result, undefined);
+		assert.strictEqual(result, undefined);
 		verifyShowFirewallRuleDialog(connectionProfile, true);
 		verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult, false);
 	});
@@ -1225,8 +1225,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfileWithEmptyUnsavedPassword);
-		assert.equal(result.connected, expectedConnection);
-		assert.equal(result.errorMessage, connectionResult.errorMessage);
+		assert.strictEqual(result.connected, expectedConnection);
+		assert.strictEqual(result.errorMessage, connectionResult.errorMessage);
 		verifyShowConnectionDialog(connectionProfileWithEmptyUnsavedPassword, ConnectionType.default, uri, true, connectionResult);
 		verifyShowFirewallRuleDialog(connectionProfile, false);
 	});
@@ -1250,8 +1250,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfileWithEmptySavedPassword);
-		assert.equal(result.connected, expectedConnection);
-		assert.equal(result.errorMessage, connectionResult.errorMessage);
+		assert.strictEqual(result.connected, expectedConnection);
+		assert.strictEqual(result.errorMessage, connectionResult.errorMessage);
 		verifyShowConnectionDialog(connectionProfileWithEmptySavedPassword, ConnectionType.default, uri, true, connectionResult, false);
 	});
 
@@ -1286,8 +1286,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		};
 
 		let result = await connect(uri, options, false, connectionProfileWithEmptySavedPassword);
-		assert.equal(result.connected, expectedConnection);
-		assert.equal(result.errorMessage, connectionResult.errorMessage);
+		assert.strictEqual(result.connected, expectedConnection);
+		assert.strictEqual(result.errorMessage, connectionResult.errorMessage);
 		verifyShowConnectionDialog(connectionProfileWithEmptySavedPassword, ConnectionType.editor, uri, true, connectionResult, false);
 	});
 
@@ -1383,8 +1383,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		let pgsqlId = 'PGSQL';
 		let mssqlProperties = connectionManagementService.getProviderProperties('MSSQL');
 		let pgsqlProperties = connectionManagementService.getProviderProperties('PGSQL');
-		assert.equal(mssqlProperties.providerId, mssqlId);
-		assert.equal(pgsqlProperties.providerId, pgsqlId);
+		assert.strictEqual(mssqlProperties.providerId, mssqlId);
+		assert.strictEqual(pgsqlProperties.providerId, pgsqlId);
 	});
 
 	test('doChangeLanguageFlavor should throw on unknown provider', () => {
@@ -1404,9 +1404,9 @@ suite('SQL ConnectionManagementService tests', () => {
 		let called = false;
 		connectionManagementService.onLanguageFlavorChanged((changeParams: azdata.DidChangeLanguageFlavorParams) => {
 			called = true;
-			assert.equal(changeParams.uri, uri);
-			assert.equal(changeParams.language, language);
-			assert.equal(changeParams.flavor, flavor);
+			assert.strictEqual(changeParams.uri, uri);
+			assert.strictEqual(changeParams.language, language);
+			assert.strictEqual(changeParams.flavor, flavor);
 		});
 		connectionManagementService.doChangeLanguageFlavor(uri, language, flavor);
 		assert.ok(called, 'expected onLanguageFlavorChanged event to be sent');
@@ -1416,17 +1416,17 @@ suite('SQL ConnectionManagementService tests', () => {
 	test('getUniqueConnectionProvidersByNameMap should return non CMS providers', () => {
 		let nameToDisplayNameMap: { [providerDisplayName: string]: string } = { 'MSSQL': 'SQL Server', 'MSSQL-CMS': 'SQL Server' };
 		let providerNames = Object.keys(connectionManagementService.getUniqueConnectionProvidersByNameMap(nameToDisplayNameMap));
-		assert.equal(providerNames.length, 1);
-		assert.equal(providerNames[0], 'MSSQL');
+		assert.strictEqual(providerNames.length, 1);
+		assert.strictEqual(providerNames[0], 'MSSQL');
 	});
 
 	test('providerNameToDisplayNameMap should return all providers', () => {
 		let expectedNames = ['MSSQL', 'PGSQL', 'FAKE'];
 		let providerNames = Object.keys(connectionManagementService.providerNameToDisplayNameMap);
-		assert.equal(providerNames.length, 3);
-		assert.equal(providerNames[0], expectedNames[0]);
-		assert.equal(providerNames[1], expectedNames[1]);
-		assert.equal(providerNames[2], expectedNames[2]);
+		assert.strictEqual(providerNames.length, 3);
+		assert.strictEqual(providerNames[0], expectedNames[0]);
+		assert.strictEqual(providerNames[1], expectedNames[1]);
+		assert.strictEqual(providerNames[2], expectedNames[2]);
 	});
 
 	test('ensureDefaultLanguageFlavor should send event if uri is not connected', () => {
@@ -1455,7 +1455,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		await connect(uri, options);
 		called = false; //onLanguageFlavorChanged is called when connecting, must set back to false.
 		connectionManagementService.ensureDefaultLanguageFlavor(uri);
-		assert.equal(called, false, 'do not expect flavor change to be called');
+		assert.strictEqual(called, false, 'do not expect flavor change to be called');
 	});
 
 	test('getConnectionId returns the URI associated with a connection that has had its database filled in', async () => {
@@ -1475,8 +1475,8 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		// Then the retrieved URIs should match the one on the connection
 		let expectedUri = Utils.generateUri(connectionProfileWithoutDb);
-		assert.equal(actualUriWithDb, expectedUri);
-		assert.equal(actualUriWithoutDb, expectedUri);
+		assert.strictEqual(actualUriWithDb, expectedUri);
+		assert.strictEqual(actualUriWithoutDb, expectedUri);
 	});
 
 	test('list and change database tests', async () => {
@@ -1508,11 +1508,11 @@ suite('SQL ConnectionManagementService tests', () => {
 		mssqlConnectionProvider.setup(x => x.changeDatabase(ownerUri, newDbName)).returns(() => changeDatabasesThenable(ownerUri, newDbName));
 		await connect(ownerUri, undefined, false, connectionProfileWithoutDb);
 		let listDatabasesResult = await connectionManagementService.listDatabases(ownerUri);
-		assert.equal(listDatabasesResult.databaseNames.length, 1);
-		assert.equal(listDatabasesResult.databaseNames[0], dbName);
+		assert.strictEqual(listDatabasesResult.databaseNames.length, 1);
+		assert.strictEqual(listDatabasesResult.databaseNames[0], dbName);
 		let changeDatabaseResults = await connectionManagementService.changeDatabase(ownerUri, newDbName);
 		assert(changeDatabaseResults);
-		assert.equal(newDbName, connectionManagementService.getConnectionProfile(ownerUri).databaseName);
+		assert.strictEqual(newDbName, connectionManagementService.getConnectionProfile(ownerUri).databaseName);
 	});
 
 	test('list and change database tests for invalid uris', async () => {
@@ -1527,7 +1527,7 @@ suite('SQL ConnectionManagementService tests', () => {
 	test('getTabColorForUri returns undefined when there is no connection for the given URI', () => {
 		let connectionManagementService = createConnectionManagementService();
 		let color = connectionManagementService.getTabColorForUri('invalidUri');
-		assert.equal(color, undefined);
+		assert.strictEqual(color, undefined);
 	});
 
 	test('getTabColorForUri returns the group color corresponding to the connection for a URI', async () => {
@@ -1540,7 +1540,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		let uri = 'testUri';
 		await connect(uri);
 		let tabColor = connectionManagementService.getTabColorForUri(uri);
-		assert.equal(tabColor, expectedColor);
+		assert.strictEqual(tabColor, expectedColor);
 	});
 
 	test('getConnectionCredentials returns the credentials dictionary for an active connection profile', async () => {
@@ -1550,7 +1550,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		connectionStatusManager.addConnection(profile, 'test_uri');
 		(connectionManagementService as any)._connectionStatusManager = connectionStatusManager;
 		let credentials = await connectionManagementService.getConnectionCredentials(profile.id);
-		assert.equal(credentials['password'], profile.options['password']);
+		assert.strictEqual(credentials['password'], profile.options['password']);
 	});
 
 	test('getConnectionCredentials returns the credentials dictionary for a recently used connection profile', async () => {
@@ -1569,13 +1569,13 @@ suite('SQL ConnectionManagementService tests', () => {
 		testInstantiationService.stub(IStorageService, new TestStorageService());
 		testInstantiationService.stubCreateInstance(ConnectionStore, connectionStoreMock.object);
 		const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService());
-		assert.equal(profile.password, '', 'Profile should not have password initially');
-		assert.equal(profile.options['password'], '', 'Profile options should not have password initially');
+		assert.strictEqual(profile.password, '', 'Profile should not have password initially');
+		assert.strictEqual(profile.options['password'], '', 'Profile options should not have password initially');
 		// Check for invalid profile id
 		let badCredentials = await connectionManagementService.getConnectionCredentials(badString);
-		assert.equal(badCredentials, undefined);
+		assert.strictEqual(badCredentials, undefined);
 		let credentials = await connectionManagementService.getConnectionCredentials(profile.id);
-		assert.equal(credentials['password'], test_password);
+		assert.strictEqual(credentials['password'], test_password);
 	});
 
 	test('getConnectionCredentials returns the credentials dictionary for a saved connection profile', async () => {
@@ -1599,10 +1599,10 @@ suite('SQL ConnectionManagementService tests', () => {
 		testInstantiationService.stubCreateInstance(ConnectionStore, connectionStoreMock.object);
 
 		const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService());
-		assert.equal(profile.password, '', 'Profile should not have password initially');
-		assert.equal(profile.options['password'], '', 'Profile options should not have password initially');
+		assert.strictEqual(profile.password, '', 'Profile should not have password initially');
+		assert.strictEqual(profile.options['password'], '', 'Profile options should not have password initially');
 		let credentials = await connectionManagementService.getConnectionCredentials(profile.id);
-		assert.equal(credentials['password'], test_password);
+		assert.strictEqual(credentials['password'], test_password);
 	});
 
 	test('getConnectionUriFromId returns a URI of an active connection with the given id', () => {
@@ -1617,11 +1617,11 @@ suite('SQL ConnectionManagementService tests', () => {
 		let foundUri = connectionManagementService.getConnectionUriFromId(profile.id);
 
 		// Then the returned URI matches the connection's original URI
-		assert.equal(foundUri, uri);
+		assert.strictEqual(foundUri, uri);
 	});
 
 	test('provider is registered and working', () => {
-		assert.equal(connectionManagementService.providerRegistered('MSSQL'), true);
+		assert.strictEqual(connectionManagementService.providerRegistered('MSSQL'), true);
 	});
 
 	test('getConectionUriFromId returns undefined if the given connection is not active', () => {
@@ -1635,7 +1635,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		let foundUri = connectionManagementService.getConnectionUriFromId('different_id');
 
 		// Then undefined is returned
-		assert.equal(foundUri, undefined);
+		assert.strictEqual(foundUri, undefined);
 	});
 
 	test('addSavedPassword fills in Azure access tokens for Azure accounts', async () => {
@@ -1689,8 +1689,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		let profileWithCredentials = await connectionManagementService.addSavedPassword(azureConnectionProfile);
 
 		// Then the returned profile has the account token set
-		assert.equal(profileWithCredentials.userName, azureConnectionProfile.userName);
-		assert.equal(profileWithCredentials.options['azureAccountToken'], testToken);
+		assert.strictEqual(profileWithCredentials.userName, azureConnectionProfile.userName);
+		assert.strictEqual(profileWithCredentials.options['azureAccountToken'], testToken);
 	});
 
 	test('addSavedPassword fills in Azure access token for selected tenant', async () => {
@@ -1743,8 +1743,8 @@ suite('SQL ConnectionManagementService tests', () => {
 		let profileWithCredentials = await connectionManagementService.addSavedPassword(azureConnectionProfile);
 
 		// Then the returned profile has the account token set corresponding to the requested tenant
-		assert.equal(profileWithCredentials.userName, azureConnectionProfile.userName);
-		assert.equal(profileWithCredentials.options['azureAccountToken'], returnedToken.token);
+		assert.strictEqual(profileWithCredentials.userName, azureConnectionProfile.userName);
+		assert.strictEqual(profileWithCredentials.options['azureAccountToken'], returnedToken.token);
 	});
 
 	test('getConnections test', () => {
@@ -1776,7 +1776,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		// dupe connections have been seeded the numbers below already reflected the de-duped results
 
 		const verifyConnections = (actualConnections: ConnectionProfile[], expectedConnectionIds: string[], scenario: string) => {
-			assert.equal(actualConnections.length, expectedConnectionIds.length, 'incorrect number of connections returned, ' + scenario);
+			assert.strictEqual(actualConnections.length, expectedConnectionIds.length, 'incorrect number of connections returned, ' + scenario);
 			assert.deepEqual(actualConnections.map(conn => conn.id).sort(), expectedConnectionIds.sort(), 'connections do not match expectation, ' + scenario);
 		};
 

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -1777,7 +1777,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		const verifyConnections = (actualConnections: ConnectionProfile[], expectedConnectionIds: string[], scenario: string) => {
 			assert.strictEqual(actualConnections.length, expectedConnectionIds.length, 'incorrect number of connections returned, ' + scenario);
-			assert.deepEqual(actualConnections.map(conn => conn.id).sort(), expectedConnectionIds.sort(), 'connections do not match expectation, ' + scenario);
+			assert.deepStrictEqual(actualConnections.map(conn => conn.id).sort(), expectedConnectionIds.sort(), 'connections do not match expectation, ' + scenario);
 		};
 
 		// no parameter - default to false

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -299,7 +299,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		await connect(params.input.uri);
 		let saveConnection = connectionManagementService.getConnectionProfile(params.input.uri);
 
-		assert.notEqual(saveConnection, undefined, `profile was not added to the connections`);
+		assert.notStrictEqual(saveConnection, undefined, `profile was not added to the connections`);
 		assert.strictEqual(saveConnection.serverName, connectionProfile.serverName, `Server names are different`);
 		await connectionManagementService.showConnectionDialog(params);
 		verifyShowConnectionDialog(connectionProfile, params.connectionType, params.input.uri, false);
@@ -372,7 +372,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		await connect(uri, options);
 		verifyOptions(options);
-		assert.notEqual(paramsInOnConnectSuccess, undefined);
+		assert.notStrictEqual(paramsInOnConnectSuccess, undefined);
 		assert.strictEqual(paramsInOnConnectSuccess.connectionType, options.params.connectionType);
 	});
 

--- a/src/sql/workbench/services/dialog/test/electron-browser/dialogPane.test.ts
+++ b/src/sql/workbench/services/dialog/test/electron-browser/dialogPane.test.ts
@@ -37,14 +37,14 @@ suite('Dialog Pane Tests', () => {
 		let modelViewId = 'test_content';
 		let bootstrapCalls = 0;
 		setupBootstrap((collection, moduleType, container, selectorString, params: DialogComponentParams, input, callbackSetModule) => {
-			assert.equal(params.modelViewId, modelViewId);
+			assert.strictEqual(params.modelViewId, modelViewId);
 			bootstrapCalls++;
 		});
 		dialog.content = modelViewId;
 		const themeService = new TestThemeService();
 		let dialogPane = new DialogPane(dialog.title, dialog.content, () => undefined, workbenchInstantiationService(), themeService, undefined);
 		dialogPane.createBody(container);
-		assert.equal(bootstrapCalls, 1);
+		assert.strictEqual(bootstrapCalls, 1);
 	});
 
 	test('Creating a pane from content with a single tab initializes without showing tabs', () => {
@@ -52,14 +52,14 @@ suite('Dialog Pane Tests', () => {
 		let modelViewId = 'test_content';
 		let bootstrapCalls = 0;
 		setupBootstrap((collection, moduleType, container, selectorString, params: DialogComponentParams, input, callbackSetModule) => {
-			assert.equal(params.modelViewId, modelViewId);
+			assert.strictEqual(params.modelViewId, modelViewId);
 			bootstrapCalls++;
 		});
 		dialog.content = [new DialogTab('', modelViewId)];
 		const themeService = new TestThemeService();
 		let dialogPane = new DialogPane(dialog.title, dialog.content, () => undefined, workbenchInstantiationService(), themeService, false);
 		dialogPane.createBody(container);
-		assert.equal(bootstrapCalls, 1);
+		assert.strictEqual(bootstrapCalls, 1);
 	});
 
 	test('Dialog validation gets set based on the validity of the model view content', () => {
@@ -83,21 +83,21 @@ suite('Dialog Pane Tests', () => {
 		// If I set tab 2's validation to false
 		validationCallbacks[1](false);
 		// Then the whole dialog's validation is false
-		assert.equal(dialog.valid, false);
-		assert.equal(validityChanges.length, 1);
-		assert.equal(validityChanges[0], false);
+		assert.strictEqual(dialog.valid, false);
+		assert.strictEqual(validityChanges.length, 1);
+		assert.strictEqual(validityChanges[0], false);
 		// If I then set it back to true
 		validationCallbacks[1](true);
 		// Then the whole dialog's validation is true
-		assert.equal(dialog.valid, true);
-		assert.equal(validityChanges.length, 2);
-		assert.equal(validityChanges[1], true);
+		assert.strictEqual(dialog.valid, true);
+		assert.strictEqual(validityChanges.length, 2);
+		assert.strictEqual(validityChanges[1], true);
 		// If I set tab 1's validation to false
 		validationCallbacks[0](false);
 		// Then the whole dialog's validation is false
-		assert.equal(dialog.valid, false);
-		assert.equal(validityChanges.length, 3);
-		assert.equal(validityChanges[2], false);
+		assert.strictEqual(dialog.valid, false);
+		assert.strictEqual(validityChanges.length, 3);
+		assert.strictEqual(validityChanges[2], false);
 	});
 
 	teardown(() => {

--- a/src/sql/workbench/services/insights/test/browser/insightsDialogModel.test.ts
+++ b/src/sql/workbench/services/insights/test/browser/insightsDialogModel.test.ts
@@ -32,7 +32,7 @@ suite('Insights Dialog Model Tests', () => {
 		];
 		let result = insightsDialogModel.getListResources(0, 1);
 		for (let resource of result) {
-			assert.equal(resource.stateColor, 'green', 'always Condition did not return val as expected');
+			assert.strictEqual(resource.stateColor, 'green', 'always Condition did not return val as expected');
 		}
 
 		label.state = [
@@ -52,9 +52,9 @@ suite('Insights Dialog Model Tests', () => {
 			['label3', 'value3']
 		];
 		result = insightsDialogModel.getListResources(0, 1);
-		assert.equal(result[0].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(isUndefinedOrNull(result[1].stateColor), true, 'always Condition did not return val as expected');
-		assert.equal(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
+		assert.strictEqual(result[0].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(isUndefinedOrNull(result[1].stateColor), true, 'always Condition did not return val as expected');
+		assert.strictEqual(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
 
 		label.state = [
 			{
@@ -80,9 +80,9 @@ suite('Insights Dialog Model Tests', () => {
 			['label3', 'value3']
 		];
 		result = insightsDialogModel.getListResources(0, 1);
-		assert.equal(result[0].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(result[1].stateColor, 'red', 'always Condition did not return val as expected');
-		assert.equal(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
+		assert.strictEqual(result[0].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[1].stateColor, 'red', 'always Condition did not return val as expected');
+		assert.strictEqual(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
 
 		label.state = [
 			{
@@ -108,9 +108,9 @@ suite('Insights Dialog Model Tests', () => {
 			['label3', 'value3']
 		];
 		result = insightsDialogModel.getListResources(0, 1);
-		assert.equal(result[0].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(result[1].stateColor, 'red', 'always Condition did not return val as expected');
-		assert.equal(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
+		assert.strictEqual(result[0].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[1].stateColor, 'red', 'always Condition did not return val as expected');
+		assert.strictEqual(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
 
 		label.state = [
 			{
@@ -136,9 +136,9 @@ suite('Insights Dialog Model Tests', () => {
 			['label3', 'value3']
 		];
 		result = insightsDialogModel.getListResources(0, 1);
-		assert.equal(result[0].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(result[1].stateColor, 'red', 'always Condition did not return val as expected');
-		assert.equal(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
+		assert.strictEqual(result[0].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[1].stateColor, 'red', 'always Condition did not return val as expected');
+		assert.strictEqual(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
 
 		label.state = [
 			{
@@ -164,9 +164,9 @@ suite('Insights Dialog Model Tests', () => {
 			['label3', 'value3']
 		];
 		result = insightsDialogModel.getListResources(0, 1);
-		assert.equal(result[0].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(result[1].stateColor, 'red', 'always Condition did not return val as expected');
-		assert.equal(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
+		assert.strictEqual(result[0].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[1].stateColor, 'red', 'always Condition did not return val as expected');
+		assert.strictEqual(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
 
 		label.state = [
 			{
@@ -192,9 +192,9 @@ suite('Insights Dialog Model Tests', () => {
 			['label3', 'value3']
 		];
 		result = insightsDialogModel.getListResources(0, 1);
-		assert.equal(result[0].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(result[1].stateColor, 'red', 'always Condition did not return val as expected');
-		assert.equal(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
+		assert.strictEqual(result[0].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[1].stateColor, 'red', 'always Condition did not return val as expected');
+		assert.strictEqual(isUndefinedOrNull(result[2].stateColor), true, 'always Condition did not return val as expected');
 
 		label.state = [
 			{
@@ -220,9 +220,9 @@ suite('Insights Dialog Model Tests', () => {
 			['label3', 'value3']
 		];
 		result = insightsDialogModel.getListResources(0, 1);
-		assert.equal(result[0].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(isUndefinedOrNull(result[1].stateColor), true, 'always Condition did not return val as expected');
-		assert.equal(result[2].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[0].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(isUndefinedOrNull(result[1].stateColor), true, 'always Condition did not return val as expected');
+		assert.strictEqual(result[2].stateColor, 'green', 'always Condition did not return val as expected');
 
 		label.state = [
 			{
@@ -247,8 +247,8 @@ suite('Insights Dialog Model Tests', () => {
 			['label3', 'value3']
 		];
 		result = insightsDialogModel.getListResources(0, 1);
-		assert.equal(result[0].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(result[1].stateColor, 'green', 'always Condition did not return val as expected');
-		assert.equal(result[2].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[0].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[1].stateColor, 'green', 'always Condition did not return val as expected');
+		assert.strictEqual(result[2].stateColor, 'green', 'always Condition did not return val as expected');
 	});
 });

--- a/src/sql/workbench/services/objectExplorer/test/browser/asyncServerTreeDragAndDrop.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/asyncServerTreeDragAndDrop.test.ts
@@ -70,33 +70,33 @@ suite('AsyncServerTreeDragAndDrop', () => {
 
 	test('create new serverTreeDragAndDrop object should create serverTreeDragAndDrop object successfully', async () => {
 
-		assert.equal(serverTreeDragAndDrop !== null || serverTreeDragAndDrop !== undefined, true);
+		assert.strictEqual(serverTreeDragAndDrop !== null || serverTreeDragAndDrop !== undefined, true);
 	});
 
 	test('able to get DragURI', async () => {
 		let uri = serverTreeDragAndDrop.getDragURI(connectionProfile);
-		assert.equal(connectionProfile.id, uri);
+		assert.strictEqual(connectionProfile.id, uri);
 
 		let uriGroup = serverTreeDragAndDrop.getDragURI(connectionProfileGroupId);
-		assert.equal(connectionProfileGroupId.id, uriGroup);
+		assert.strictEqual(connectionProfileGroupId.id, uriGroup);
 
 		let uriUndefined = serverTreeDragAndDrop.getDragURI(undefined);
-		assert.equal(null, uriUndefined);
+		assert.strictEqual(null, uriUndefined);
 
 	});
 
 	test('able to get DragLabel', async () => {
 		let label = serverTreeDragAndDrop.getDragLabel(connectionProfileArray);
-		assert.equal(connectionProfileArray[0].serverName, label);
+		assert.strictEqual(connectionProfileArray[0].serverName, label);
 
 		let labelGroup = serverTreeDragAndDrop.getDragLabel(connectionProfileGroupArray);
-		assert.equal(connectionProfileGroupArray[0].name, labelGroup);
+		assert.strictEqual(connectionProfileGroupArray[0].name, labelGroup);
 
 		let labelTreeNode = serverTreeDragAndDrop.getDragLabel(treeNodeArray);
-		assert.equal(treeNodeArray[0].label, labelTreeNode);
+		assert.strictEqual(treeNodeArray[0].label, labelTreeNode);
 
 		let labelUndefined = serverTreeDragAndDrop.getDragLabel(undefined);
-		assert.equal('', labelUndefined);
+		assert.strictEqual('', labelUndefined);
 
 	});
 

--- a/src/sql/workbench/services/objectExplorer/test/browser/dragAndDropController.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/dragAndDropController.test.ts
@@ -95,35 +95,35 @@ suite('SQL Drag And Drop Controller tests', () => {
 
 	test('create new serverTreeDragAndDrop object should create serverTreeDragAndDrop object successfully', async () => {
 
-		assert.equal(serverTreeDragAndDrop !== null || serverTreeDragAndDrop !== undefined, true);
+		assert.strictEqual(serverTreeDragAndDrop !== null || serverTreeDragAndDrop !== undefined, true);
 	});
 
 	test('able to get DragURI', async () => {
 		connectionProfileArray.forEach(connectionProfile => {
 			let uri = serverTreeDragAndDrop.getDragURI(testTree, connectionProfile);
-			assert.equal(connectionProfile.id, uri);
+			assert.strictEqual(connectionProfile.id, uri);
 		});
 
 		let uriGroup = serverTreeDragAndDrop.getDragURI(testTree, connectionProfileGroupId);
-		assert.equal(connectionProfileGroupId.id, uriGroup);
+		assert.strictEqual(connectionProfileGroupId.id, uriGroup);
 
 		let uriUndefined = serverTreeDragAndDrop.getDragURI(testTree, null);
-		assert.equal(null, uriUndefined);
+		assert.strictEqual(null, uriUndefined);
 
 	});
 
 	test('able to get DragLabel', async () => {
 		let label = serverTreeDragAndDrop.getDragLabel(testTree, connectionProfileArray);
-		assert.equal(connectionProfileArray[0].serverName, label);
+		assert.strictEqual(connectionProfileArray[0].serverName, label);
 
 		let labelGroup = serverTreeDragAndDrop.getDragLabel(testTree, connectionProfileGroupArray);
-		assert.equal(connectionProfileGroupArray[0].name, labelGroup);
+		assert.strictEqual(connectionProfileGroupArray[0].name, labelGroup);
 
 		let labelTreeNode = serverTreeDragAndDrop.getDragLabel(testTree, treeNodeArray);
-		assert.equal(treeNodeArray[0].label, labelTreeNode);
+		assert.strictEqual(treeNodeArray[0].label, labelTreeNode);
 
 		let labelUndefined = serverTreeDragAndDrop.getDragLabel(testTree, null);
-		assert.equal('', labelUndefined);
+		assert.strictEqual('', labelUndefined);
 
 	});
 

--- a/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
@@ -298,54 +298,54 @@ suite('SQL Object Explorer Service tests', () => {
 
 	test('create new session should create session successfully', async () => {
 		const session = await objectExplorerService.createNewSession(mssqlProviderName, connection);
-		assert.equal(session !== null || session !== undefined, true);
-		assert.equal(session.sessionId, '1234');
+		assert.strictEqual(session !== null || session !== undefined, true);
+		assert.strictEqual(session.sessionId, '1234');
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		const node = objectExplorerService.getObjectExplorerNode(connection);
 		assert.notEqual(node, undefined);
-		assert.equal(node.session.success, true);
+		assert.strictEqual(node.session.success, true);
 	});
 
 	test('create new session should raise failed event for failed session', async () => {
 		const session = await objectExplorerService.createNewSession(mssqlProviderName, connectionToFail);
-		assert.equal(session !== null || session !== undefined, true);
-		assert.equal(session.sessionId, failedSessionId);
+		assert.strictEqual(session !== null || session !== undefined, true);
+		assert.strictEqual(session.sessionId, failedSessionId);
 		const currentNumberOfSuccessfulSessions = numberOfSuccessfulSessions;
 		objectExplorerService.onSessionCreated(1, objectExplorerFailedSession);
 		const node = objectExplorerService.getObjectExplorerNode(connection);
-		assert.equal(node, undefined);
-		assert.equal(currentNumberOfSuccessfulSessions, numberOfSuccessfulSessions);
+		assert.strictEqual(node, undefined);
+		assert.strictEqual(currentNumberOfSuccessfulSessions, numberOfSuccessfulSessions);
 	});
 
 	test('close session should close session successfully', async () => {
 		const session = await objectExplorerService.closeSession(mssqlProviderName, objectExplorerSession);
-		assert.equal(session !== null || session !== undefined, true);
-		assert.equal(session.success, true);
-		assert.equal(session.sessionId, '1234');
+		assert.strictEqual(session !== null || session !== undefined, true);
+		assert.strictEqual(session.success, true);
+		assert.strictEqual(session.sessionId, '1234');
 	});
 
 	test('expand node should expand node correctly', async () => {
 		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		const expandInfo = await objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, 'testServerName/tables');
-		assert.equal(expandInfo !== null || expandInfo !== undefined, true);
-		assert.equal(expandInfo.sessionId, '1234');
-		assert.equal(expandInfo.nodes.length, 2);
+		assert.strictEqual(expandInfo !== null || expandInfo !== undefined, true);
+		assert.strictEqual(expandInfo.sessionId, '1234');
+		assert.strictEqual(expandInfo.nodes.length, 2);
 		const children = expandInfo.nodes;
-		assert.equal(children[0].label, 'dbo.Table1');
-		assert.equal(children[1].label, 'dbo.Table2');
+		assert.strictEqual(children[0].label, 'dbo.Table1');
+		assert.strictEqual(children[1].label, 'dbo.Table2');
 	});
 
 	test('refresh node should refresh node correctly', async () => {
 		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		const expandInfo = await objectExplorerService.refreshNode(mssqlProviderName, objectExplorerSession, 'testServerName/tables');
-		assert.equal(expandInfo !== null || expandInfo !== undefined, true);
-		assert.equal(expandInfo.sessionId, '1234');
-		assert.equal(expandInfo.nodes.length, 2);
+		assert.strictEqual(expandInfo !== null || expandInfo !== undefined, true);
+		assert.strictEqual(expandInfo.sessionId, '1234');
+		assert.strictEqual(expandInfo.nodes.length, 2);
 		const children = expandInfo.nodes;
-		assert.equal(children[0].label, 'dbo.Table1');
-		assert.equal(children[1].label, 'dbo.Table3');
+		assert.strictEqual(children[0].label, 'dbo.Table1');
+		assert.strictEqual(children[1].label, 'dbo.Table3');
 	});
 
 	test('expand tree node should get correct children', async () => {
@@ -354,13 +354,13 @@ suite('SQL Object Explorer Service tests', () => {
 		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		const children = await objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, tablesNode);
-		assert.equal(children !== null || children !== undefined, true);
-		assert.equal(children[0].label, 'dbo.Table1');
-		assert.equal(children[0].parent, tablesNode);
-		assert.equal(children[0].nodePath, 'testServerName/tables/dbo.Table1');
-		assert.equal(children[1].label, 'dbo.Table2');
-		assert.equal(children[1].parent, tablesNode);
-		assert.equal(children[1].nodePath, 'testServerName/tables/dbo.Table2');
+		assert.strictEqual(children !== null || children !== undefined, true);
+		assert.strictEqual(children[0].label, 'dbo.Table1');
+		assert.strictEqual(children[0].parent, tablesNode);
+		assert.strictEqual(children[0].nodePath, 'testServerName/tables/dbo.Table1');
+		assert.strictEqual(children[1].label, 'dbo.Table2');
+		assert.strictEqual(children[1].parent, tablesNode);
+		assert.strictEqual(children[1].nodePath, 'testServerName/tables/dbo.Table2');
 	});
 
 	test('refresh tree node should children correctly', async () => {
@@ -369,13 +369,13 @@ suite('SQL Object Explorer Service tests', () => {
 		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		const children = await objectExplorerService.refreshTreeNode(objectExplorerSession, tablesNode);
-		assert.equal(children !== null || children !== undefined, true);
-		assert.equal(children[0].label, 'dbo.Table1');
-		assert.equal(children[0].parent, tablesNode);
-		assert.equal(children[0].nodePath, 'testServerName/tables/dbo.Table1');
-		assert.equal(children[1].label, 'dbo.Table3');
-		assert.equal(children[1].parent, tablesNode);
-		assert.equal(children[1].nodePath, 'testServerName/tables/dbo.Table3');
+		assert.strictEqual(children !== null || children !== undefined, true);
+		assert.strictEqual(children[0].label, 'dbo.Table1');
+		assert.strictEqual(children[0].parent, tablesNode);
+		assert.strictEqual(children[0].nodePath, 'testServerName/tables/dbo.Table1');
+		assert.strictEqual(children[1].label, 'dbo.Table3');
+		assert.strictEqual(children[1].parent, tablesNode);
+		assert.strictEqual(children[1].nodePath, 'testServerName/tables/dbo.Table3');
 	});
 
 	test('update object explorer nodes should get active connection, create session, add to the active OE nodes successfully', async () => {
@@ -383,11 +383,11 @@ suite('SQL Object Explorer Service tests', () => {
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		await objectExplorerService.updateObjectExplorerNodes(connection);
 		const treeNode = objectExplorerService.getObjectExplorerNode(connection);
-		assert.equal(treeNode !== null || treeNode !== undefined, true);
-		assert.equal(treeNode.getSession(), objectExplorerSession);
-		assert.equal(treeNode.getConnectionProfile(), connection);
-		assert.equal(treeNode.label, 'Tables');
-		assert.equal(treeNode.nodePath, 'testServerName/tables');
+		assert.strictEqual(treeNode !== null || treeNode !== undefined, true);
+		assert.strictEqual(treeNode.getSession(), objectExplorerSession);
+		assert.strictEqual(treeNode.getConnectionProfile(), connection);
+		assert.strictEqual(treeNode.label, 'Tables');
+		assert.strictEqual(treeNode.nodePath, 'testServerName/tables');
 	});
 
 	test('delete object explorerNode nodes should delete session, delete the root node to the active OE node', async () => {
@@ -395,10 +395,10 @@ suite('SQL Object Explorer Service tests', () => {
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		await objectExplorerService.updateObjectExplorerNodes(connection);
 		let treeNode = objectExplorerService.getObjectExplorerNode(connection);
-		assert.equal(treeNode !== null && treeNode !== undefined, true);
+		assert.strictEqual(treeNode !== null && treeNode !== undefined, true);
 		await objectExplorerService.deleteObjectExplorerNode(connection);
 		treeNode = objectExplorerService.getObjectExplorerNode(connection);
-		assert.equal(treeNode === null || treeNode === undefined, true);
+		assert.strictEqual(treeNode === null || treeNode === undefined, true);
 	});
 
 	test('children tree nodes should return correct object explorer session, connection profile and database name', () => {
@@ -419,9 +419,9 @@ suite('SQL Object Explorer Service tests', () => {
 		const table1Node = new TreeNode(NodeType.Table, 'dbo.Table1', false, 'testServerName\\Db1\\tables\\dbo.Table1', '', '', tablesNode, undefined, undefined, undefined);
 		const table2Node = new TreeNode(NodeType.Table, 'dbo.Table2', false, 'testServerName\\Db1\\tables\\dbo.Table2', '', '', tablesNode, undefined, undefined, undefined);
 		tablesNode.children = [table1Node, table2Node];
-		assert.equal(table1Node.getSession(), objectExplorerSession);
-		assert.equal(table1Node.getConnectionProfile(), connection);
-		assert.equal(table1Node.getDatabaseName(), 'Db1');
+		assert.strictEqual(table1Node.getSession(), objectExplorerSession);
+		assert.strictEqual(table1Node.getConnectionProfile(), connection);
+		assert.strictEqual(table1Node.getDatabaseName(), 'Db1');
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile if it is selected', () => {
@@ -430,8 +430,8 @@ suite('SQL Object Explorer Service tests', () => {
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 
 		const selectedProfileAndDatabase = objectExplorerService.getSelectedProfileAndDatabase();
-		assert.equal(selectedProfileAndDatabase.profile, connection);
-		assert.equal(selectedProfileAndDatabase.databaseName, undefined);
+		assert.strictEqual(selectedProfileAndDatabase.profile, connection);
+		assert.strictEqual(selectedProfileAndDatabase.databaseName, undefined);
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile but no database if children of a server are selected', () => {
@@ -442,8 +442,8 @@ suite('SQL Object Explorer Service tests', () => {
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 
 		const selectedProfileAndDatabase = objectExplorerService.getSelectedProfileAndDatabase();
-		assert.equal(selectedProfileAndDatabase.profile, connection);
-		assert.equal(selectedProfileAndDatabase.databaseName, undefined);
+		assert.strictEqual(selectedProfileAndDatabase.profile, connection);
+		assert.strictEqual(selectedProfileAndDatabase.databaseName, undefined);
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile and database if children of a database node are selected', () => {
@@ -466,8 +466,8 @@ suite('SQL Object Explorer Service tests', () => {
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 
 		const selectedProfileAndDatabase = objectExplorerService.getSelectedProfileAndDatabase();
-		assert.equal(selectedProfileAndDatabase.profile, connection);
-		assert.equal(selectedProfileAndDatabase.databaseName, databaseName);
+		assert.strictEqual(selectedProfileAndDatabase.profile, connection);
+		assert.strictEqual(selectedProfileAndDatabase.databaseName, databaseName);
 	});
 
 	test('getSelectedProfileAndDatabase returns undefined when there is no selection', () => {
@@ -476,7 +476,7 @@ suite('SQL Object Explorer Service tests', () => {
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 
 		const selectedProfileAndDatabase = objectExplorerService.getSelectedProfileAndDatabase();
-		assert.equal(selectedProfileAndDatabase, undefined);
+		assert.strictEqual(selectedProfileAndDatabase, undefined);
 	});
 
 	test('isExpanded returns true when the node and its parents are expanded', async () => {
@@ -501,7 +501,7 @@ suite('SQL Object Explorer Service tests', () => {
 		const tableNode = childNodes.find(node => node.nodePath === table1NodePath);
 		await objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, tableNode);
 		const isExpanded = await tableNode.isExpanded();
-		assert.equal(isExpanded, true, 'Table node was not expanded');
+		assert.strictEqual(isExpanded, true, 'Table node was not expanded');
 	});
 
 	test('isExpanded returns false when the node is not expanded', async () => {
@@ -516,7 +516,7 @@ suite('SQL Object Explorer Service tests', () => {
 		// If I check whether the table is expanded, the answer should be no because only its parent node is expanded
 		const tableNode = childNodes.find(node => node.nodePath === table1NodePath);
 		const isExpanded = await tableNode.isExpanded();
-		assert.equal(isExpanded, false);
+		assert.strictEqual(isExpanded, false);
 	});
 
 	test('isExpanded returns false when the parent of the requested node is not expanded', async () => {
@@ -542,7 +542,7 @@ suite('SQL Object Explorer Service tests', () => {
 		// If I check whether the table is expanded, the answer should be yes
 		const tableNode = childNodes.find(node => node.nodePath === table1NodePath);
 		const isExpanded = await tableNode.isExpanded();
-		assert.equal(isExpanded, false);
+		assert.strictEqual(isExpanded, false);
 	});
 
 	test('setting a node to expanded calls expand on the requested tree node', async () => {
@@ -609,9 +609,9 @@ suite('SQL Object Explorer Service tests', () => {
 		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		const treeNode = await objectExplorerService.getTreeNode(connection.id, table1NodePath);
-		assert.equal(treeNode.nodePath, objectExplorerExpandInfo.nodes[0].nodePath);
-		assert.equal(treeNode.nodeTypeId, objectExplorerExpandInfo.nodes[0].nodeType);
-		assert.equal(treeNode.label, objectExplorerExpandInfo.nodes[0].label);
+		assert.strictEqual(treeNode.nodePath, objectExplorerExpandInfo.nodes[0].nodePath);
+		assert.strictEqual(treeNode.nodeTypeId, objectExplorerExpandInfo.nodes[0].nodeType);
+		assert.strictEqual(treeNode.label, objectExplorerExpandInfo.nodes[0].label);
 	});
 
 	test('findTreeNode returns undefined if the requested node does not exist', async () => {
@@ -619,7 +619,7 @@ suite('SQL Object Explorer Service tests', () => {
 		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		const nodeInfo = await objectExplorerService.getTreeNode(connection.id, invalidNodePath);
-		assert.equal(nodeInfo, undefined);
+		assert.strictEqual(nodeInfo, undefined);
 	});
 
 	test('refreshInView refreshes the node, expands it, and returns the refreshed node', async () => {
@@ -636,7 +636,7 @@ suite('SQL Object Explorer Service tests', () => {
 		// Verify that it was refreshed, expanded, and the refreshed detailed were returned
 		sqlOEProvider.verify(x => x.refreshNode(TypeMoq.It.is(refreshNode => refreshNode.nodePath === nodePath)), TypeMoq.Times.once());
 		refreshedNode.children.forEach((childNode, index) => {
-			assert.equal(childNode.nodePath, objectExplorerExpandInfoRefresh.nodes[index].nodePath);
+			assert.strictEqual(childNode.nodePath, objectExplorerExpandInfoRefresh.nodes[index].nodePath);
 		});
 	});
 
@@ -657,8 +657,8 @@ suite('SQL Object Explorer Service tests', () => {
 
 		// Then the expand request has compconsted and the session is closed
 		const expandResult = await expandPromise;
-		assert.equal(expandResult.nodes.length, 0);
-		assert.equal(closeSessionResult.success, true);
+		assert.strictEqual(expandResult.nodes.length, 0);
+		assert.strictEqual(closeSessionResult.success, true);
 	});
 
 	test('resolveTreeNodeChildren refreshes a node if it currently has an error', async () => {

--- a/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
@@ -302,7 +302,7 @@ suite('SQL Object Explorer Service tests', () => {
 		assert.strictEqual(session.sessionId, '1234');
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		const node = objectExplorerService.getObjectExplorerNode(connection);
-		assert.notEqual(node, undefined);
+		assert.notStrictEqual(node, undefined);
 		assert.strictEqual(node.session.success, true);
 	});
 

--- a/src/sql/workbench/services/profiler/test/browser/profilerFilter.test.ts
+++ b/src/sql/workbench/services/profiler/test/browser/profilerFilter.test.ts
@@ -105,7 +105,7 @@ suite('Profiler filter data tests', () => {
 
 function filterAndVerify(filter: ProfilerFilter, data: TestData[], expectedResult: TestData[], stepName: string) {
 	let actualResult = FilterData(filter, data);
-	assert.equal(actualResult.length, expectedResult.length, `length check for ${stepName}`);
+	assert.strictEqual(actualResult.length, expectedResult.length, `length check for ${stepName}`);
 	for (let i = 0; i < actualResult.length; i++) {
 		let actual = actualResult[i];
 		let expected = expectedResult[i];

--- a/src/sql/workbench/services/query/test/common/queryRunner.test.ts
+++ b/src/sql/workbench/services/query/test/common/queryRunner.test.ts
@@ -36,24 +36,24 @@ suite('Query Runner', () => {
 		// start batch
 		const batch: BatchSummary = { id: 0, hasError: false, range: rangeSelection, resultSetSummaries: [], executionStart: '' };
 		const returnBatch = await trigger(batch, arg => runner.handleBatchStart(arg), runner.onBatchStart);
-		assert.deepEqual(returnBatch, batch);
+		assert.deepStrictEqual(returnBatch, batch);
 		// we expect the query runner to create a message sense we sent a selection
 		assert(runner.messages.length === 1);
 		// start result set
 		const result1: ResultSetSummary = { batchId: 0, id: 0, complete: false, rowCount: 0, columnInfo: [{ columnName: 'column' }] };
 		const returnResult = await trigger(result1, arg => runner.handleResultSetAvailable(arg), runner.onResultSet);
-		assert.deepEqual(returnResult, result1);
-		assert.deepEqual(runner.batchSets[0].resultSetSummaries[0], result1);
+		assert.deepStrictEqual(returnResult, result1);
+		assert.deepStrictEqual(runner.batchSets[0].resultSetSummaries[0], result1);
 		// update result set
 		const result1Update: ResultSetSummary = { batchId: 0, id: 0, complete: true, rowCount: 100, columnInfo: [{ columnName: 'column' }] };
 		const returnResultUpdate = await trigger(result1Update, arg => runner.handleResultSetUpdated(arg), runner.onResultSetUpdate);
-		assert.deepEqual(returnResultUpdate, result1Update);
-		assert.deepEqual(runner.batchSets[0].resultSetSummaries[0], result1Update);
+		assert.deepStrictEqual(returnResultUpdate, result1Update);
+		assert.deepStrictEqual(runner.batchSets[0].resultSetSummaries[0], result1Update);
 		// post message
 		const message: IResultMessage = { message: 'some message', isError: false, batchId: 0 };
 		const messageReturn = await trigger([message], arg => runner.handleMessage(arg), runner.onMessage);
-		assert.deepEqual(messageReturn[0], message);
-		assert.deepEqual(runner.messages[1], message);
+		assert.deepStrictEqual(messageReturn[0], message);
+		assert.deepStrictEqual(runner.messages[1], message);
 		// get query rows
 		const rowResults: ResultSetSubset = { rowCount: 100, rows: range(100).map(r => range(1).map(c => ({ displayValue: `${r}${c}` }))) };
 		const getRowStub = sinon.stub().returns(Promise.resolve(rowResults));

--- a/src/sql/workbench/services/query/test/common/queryRunner.test.ts
+++ b/src/sql/workbench/services/query/test/common/queryRunner.test.ts
@@ -126,7 +126,7 @@ suite('Query Runner', () => {
 		runner.handleResultSetAvailable({ id: 0, batchId: 0, complete: true, rowCount: 1, columnInfo: [{ columnName: 'Microsoft SQL Server 2005 XML Showplan' }] });
 		const plan = await runner.planXml;
 		assert(getRowsStub.calledOnce);
-		assert.equal(plan, xmlPlan);
+		assert.strictEqual(plan, xmlPlan);
 		assert(runner.isQueryPlan);
 	});
 
@@ -147,7 +147,7 @@ suite('Query Runner', () => {
 		runner.handleResultSetUpdated({ id: 0, batchId: 0, complete: true, rowCount: 1, columnInfo: [{ columnName: 'Microsoft SQL Server 2005 XML Showplan' }] });
 		const plan = await runner.planXml;
 		assert(getRowsStub.calledOnce);
-		assert.equal(plan, xmlPlan);
+		assert.strictEqual(plan, xmlPlan);
 		assert(runner.isQueryPlan);
 	});
 

--- a/src/sql/workbench/services/restore/test/browser/restoreViewModel.test.ts
+++ b/src/sql/workbench/services/restore/test/browser/restoreViewModel.test.ts
@@ -120,39 +120,39 @@ suite('Restore Dialog view model tests', () => {
 
 	test('get boolean option type should return correct display value', () => {
 		let falseStringOptionValue = 'False';
-		assert.equal(false, viewModel.getDisplayValue(booleanServiceOption, falseStringOptionValue));
+		assert.strictEqual(false, viewModel.getDisplayValue(booleanServiceOption, falseStringOptionValue));
 
 		let falseBooleanOptionValue = false;
-		assert.equal(false, viewModel.getDisplayValue(booleanServiceOption, falseBooleanOptionValue));
+		assert.strictEqual(false, viewModel.getDisplayValue(booleanServiceOption, falseBooleanOptionValue));
 
 		let trueStringOptionValue = 'true';
-		assert.equal(true, viewModel.getDisplayValue(booleanServiceOption, trueStringOptionValue));
+		assert.strictEqual(true, viewModel.getDisplayValue(booleanServiceOption, trueStringOptionValue));
 
 		let undefinedOptionValue = undefined;
-		assert.equal(false, viewModel.getDisplayValue(booleanServiceOption, undefinedOptionValue));
+		assert.strictEqual(false, viewModel.getDisplayValue(booleanServiceOption, undefinedOptionValue));
 	});
 
 	test('get category option type should return correct display value', () => {
 		let categoryOptionValue = 'catagory2';
-		assert.equal('Catagory 2', viewModel.getDisplayValue(categoryServiceOption, categoryOptionValue));
+		assert.strictEqual('Catagory 2', viewModel.getDisplayValue(categoryServiceOption, categoryOptionValue));
 
 		let undefinedOptionValue = undefined;
-		assert.equal('Catagory 1', viewModel.getDisplayValue(categoryServiceOption, undefinedOptionValue));
+		assert.strictEqual('Catagory 1', viewModel.getDisplayValue(categoryServiceOption, undefinedOptionValue));
 	});
 
 	test('get string option type should return correct display value', () => {
 		let stringOptionValue = 'string1';
-		assert.equal(stringOptionValue, viewModel.getDisplayValue(stringServiceOption, stringOptionValue));
+		assert.strictEqual(stringOptionValue, viewModel.getDisplayValue(stringServiceOption, stringOptionValue));
 
 		let undefinedOptionValue = undefined;
-		assert.equal('', viewModel.getDisplayValue(stringServiceOption, undefinedOptionValue));
+		assert.strictEqual('', viewModel.getDisplayValue(stringServiceOption, undefinedOptionValue));
 	});
 
 	test('get option meta data should return the correct one', () => {
-		assert.equal(stringServiceOption, viewModel.getOptionMetadata(option1String));
-		assert.equal(categoryServiceOption, viewModel.getOptionMetadata(option2Category));
-		assert.equal(booleanServiceOption, viewModel.getOptionMetadata(option3Boolean));
-		assert.equal(undefined, viewModel.getOptionMetadata('option4'));
+		assert.strictEqual(stringServiceOption, viewModel.getOptionMetadata(option1String));
+		assert.strictEqual(categoryServiceOption, viewModel.getOptionMetadata(option2Category));
+		assert.strictEqual(booleanServiceOption, viewModel.getOptionMetadata(option3Boolean));
+		assert.strictEqual(undefined, viewModel.getOptionMetadata('option4'));
 	});
 
 	test('get restore advanced option should return the only the options that have been changed and are different from the default value', () => {
@@ -161,9 +161,9 @@ suite('Restore Dialog view model tests', () => {
 		viewModel.setOptionValue(option3Boolean, false);
 		options = {};
 		viewModel.getRestoreAdvancedOptions(options);
-		assert.equal(undefined, options[option1String]);
-		assert.equal('catagory2', options[option2Category]);
-		assert.equal(false, options[option3Boolean]);
+		assert.strictEqual(undefined, options[option1String]);
+		assert.strictEqual('catagory2', options[option2Category]);
+		assert.strictEqual(false, options[option3Boolean]);
 	});
 
 	test('on restore plan response should update all options from restore plan response correctly', () => {
@@ -179,19 +179,19 @@ suite('Restore Dialog view model tests', () => {
 		viewModel.onRestorePlanResponse(restorePlanResponse);
 
 		// verify that source database, target databasem and last backup get set correctly
-		assert.equal('dbSource', viewModel.sourceDatabaseName);
-		assert.equal('db1', viewModel.targetDatabaseName);
-		assert.equal('8/16/2017', viewModel.lastBackupTaken);
+		assert.strictEqual('dbSource', viewModel.sourceDatabaseName);
+		assert.strictEqual('db1', viewModel.targetDatabaseName);
+		assert.strictEqual('8/16/2017', viewModel.lastBackupTaken);
 
 		// verify that advanced options get set correctly
 		options = {};
 		viewModel.getRestoreAdvancedOptions(options);
-		assert.equal('newOptionValue', options[option1String]);
+		assert.strictEqual('newOptionValue', options[option1String]);
 
 		// verify that selected backup sets get set correctly
 		let selectedBackupSets = viewModel.selectedBackupSets;
-		assert.equal(1, selectedBackupSets!.length);
-		assert.equal('file2', selectedBackupSets![0]);
+		assert.strictEqual(1, selectedBackupSets!.length);
+		assert.strictEqual('file2', selectedBackupSets![0]);
 	});
 
 
@@ -211,20 +211,20 @@ suite('Restore Dialog view model tests', () => {
 		viewModel.resetRestoreOptions('db2');
 
 		// verify that file path, source database, target databasem and last backup get set correctly
-		assert.equal('', viewModel.lastBackupTaken);
-		assert.equal('db2', viewModel.sourceDatabaseName);
-		assert.equal('db2', viewModel.targetDatabaseName);
-		assert.equal('', viewModel.lastBackupTaken);
-		assert.equal(0, viewModel.databaseList!.length);
+		assert.strictEqual('', viewModel.lastBackupTaken);
+		assert.strictEqual('db2', viewModel.sourceDatabaseName);
+		assert.strictEqual('db2', viewModel.targetDatabaseName);
+		assert.strictEqual('', viewModel.lastBackupTaken);
+		assert.strictEqual(0, viewModel.databaseList!.length);
 
 		// verify that advanced options get set correctly
 		options = {};
 		viewModel.getRestoreAdvancedOptions(options);
-		assert.equal(undefined, options[option1String]);
+		assert.strictEqual(undefined, options[option1String]);
 
 		// verify that selected backup sets get set correctly
 		let selectedBackupSets = viewModel.selectedBackupSets;
-		assert.equal(undefined, selectedBackupSets);
+		assert.strictEqual(undefined, selectedBackupSets);
 	});
 
 	test('update options with config info should update option correctly', () => {
@@ -234,16 +234,16 @@ suite('Restore Dialog view model tests', () => {
 		configInfo[option1String] = 'option1 from config info';
 		viewModel.updateOptionWithConfigInfo(configInfo);
 		assert.ok(viewModel.databaseList);
-		assert.equal(3, viewModel.databaseList!.length);
-		assert.equal('', viewModel.databaseList![0]);
-		assert.equal(databaseList[1], viewModel.databaseList![1]);
-		assert.equal(databaseList[2], viewModel.databaseList![2]);
-		assert.equal('option1 from config info', viewModel.getOptionValue(option1String));
+		assert.strictEqual(3, viewModel.databaseList!.length);
+		assert.strictEqual('', viewModel.databaseList![0]);
+		assert.strictEqual(databaseList[1], viewModel.databaseList![1]);
+		assert.strictEqual(databaseList[2], viewModel.databaseList![2]);
+		assert.strictEqual('option1 from config info', viewModel.getOptionValue(option1String));
 
 		// verify that the options from get restore advanced options doesn't contain option1String
 		options = {};
 		viewModel.getRestoreAdvancedOptions(options);
-		assert.equal(undefined, options[option1String]);
+		assert.strictEqual(undefined, options[option1String]);
 	});
 
 	test('on restore from changed should set readHeaderFromMedia and reset the source database names and selected database name correctly', () => {
@@ -252,13 +252,13 @@ suite('Restore Dialog view model tests', () => {
 		viewModel.filePath = 'filepath';
 		viewModel.readHeaderFromMedia = false;
 		viewModel.onRestoreFromChanged(true);
-		assert.equal(true, viewModel.readHeaderFromMedia);
-		assert.equal(undefined, viewModel.sourceDatabaseName);
-		assert.equal('', viewModel.filePath);
+		assert.strictEqual(true, viewModel.readHeaderFromMedia);
+		assert.strictEqual(undefined, viewModel.sourceDatabaseName);
+		assert.strictEqual('', viewModel.filePath);
 
 		viewModel.sourceDatabaseName = 'sourceDatabase2';
 		viewModel.onRestoreFromChanged(false);
-		assert.equal(false, viewModel.readHeaderFromMedia);
-		assert.equal('', viewModel.sourceDatabaseName);
+		assert.strictEqual(false, viewModel.readHeaderFromMedia);
+		assert.strictEqual('', viewModel.sourceDatabaseName);
 	});
 });

--- a/src/sql/workbench/test/browser/modal/optionsDialogHelper.test.ts
+++ b/src/sql/workbench/test/browser/modal/optionsDialogHelper.test.ts
@@ -109,14 +109,14 @@ suite('Advanced options helper tests', () => {
 		categoryOption.isRequired = false;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(categoryOption, options, possibleInputs);
-		assert.equal(optionValue, 'ReadWrite');
-		assert.equal(possibleInputs.length, 3);
-		assert.equal(possibleInputs[0].text, '');
-		assert.equal(possibleInputs[1].text, 'ReadWrite');
-		assert.equal(possibleInputs[2].text, 'ReadOnly');
-		assert.equal(possibleInputs[0].value, '');
-		assert.equal(possibleInputs[1].value, 'RW');
-		assert.equal(possibleInputs[2].value, 'RO');
+		assert.strictEqual(optionValue, 'ReadWrite');
+		assert.strictEqual(possibleInputs.length, 3);
+		assert.strictEqual(possibleInputs[0].text, '');
+		assert.strictEqual(possibleInputs[1].text, 'ReadWrite');
+		assert.strictEqual(possibleInputs[2].text, 'ReadOnly');
+		assert.strictEqual(possibleInputs[0].value, '');
+		assert.strictEqual(possibleInputs[1].value, 'RW');
+		assert.strictEqual(possibleInputs[2].value, 'RO');
 	});
 
 	test('create default and required category options should set the option value and possible inputs correctly', () => {
@@ -124,10 +124,10 @@ suite('Advanced options helper tests', () => {
 		categoryOption.isRequired = true;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(categoryOption, options, possibleInputs);
-		assert.equal(optionValue, 'ReadWrite');
-		assert.equal(possibleInputs.length, 2);
-		assert.equal(possibleInputs[0].text, 'ReadWrite');
-		assert.equal(possibleInputs[1].text, 'ReadOnly');
+		assert.strictEqual(optionValue, 'ReadWrite');
+		assert.strictEqual(possibleInputs.length, 2);
+		assert.strictEqual(possibleInputs[0].text, 'ReadWrite');
+		assert.strictEqual(possibleInputs[1].text, 'ReadOnly');
 	});
 
 	test('create no default and not required category options should set the option value and possible inputs correctly', () => {
@@ -135,11 +135,11 @@ suite('Advanced options helper tests', () => {
 		categoryOption.isRequired = false;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(categoryOption, options, possibleInputs);
-		assert.equal(optionValue, '');
-		assert.equal(possibleInputs.length, 3);
-		assert.equal(possibleInputs[0].text, '');
-		assert.equal(possibleInputs[1].text, 'ReadWrite');
-		assert.equal(possibleInputs[2].text, 'ReadOnly');
+		assert.strictEqual(optionValue, '');
+		assert.strictEqual(possibleInputs.length, 3);
+		assert.strictEqual(possibleInputs[0].text, '');
+		assert.strictEqual(possibleInputs[1].text, 'ReadWrite');
+		assert.strictEqual(possibleInputs[2].text, 'ReadOnly');
 	});
 
 	test('create no default but required category options should set the option value and possible inputs correctly', () => {
@@ -147,10 +147,10 @@ suite('Advanced options helper tests', () => {
 		categoryOption.isRequired = true;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(categoryOption, options, possibleInputs);
-		assert.equal(optionValue, 'ReadWrite');
-		assert.equal(possibleInputs.length, 2);
-		assert.equal(possibleInputs[0].text, 'ReadWrite');
-		assert.equal(possibleInputs[1].text, 'ReadOnly');
+		assert.strictEqual(optionValue, 'ReadWrite');
+		assert.strictEqual(possibleInputs.length, 2);
+		assert.strictEqual(possibleInputs[0].text, 'ReadWrite');
+		assert.strictEqual(possibleInputs[1].text, 'ReadOnly');
 	});
 
 	test('create not required category options with option value should set the option value and possible inputs correctly', () => {
@@ -159,11 +159,11 @@ suite('Advanced options helper tests', () => {
 		possibleInputs = [];
 		options['applicationIntent'] = 'ReadOnly';
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(categoryOption, options, possibleInputs);
-		assert.equal(optionValue, 'ReadOnly');
-		assert.equal(possibleInputs.length, 3);
-		assert.equal(possibleInputs[0].text, '');
-		assert.equal(possibleInputs[1].text, 'ReadWrite');
-		assert.equal(possibleInputs[2].text, 'ReadOnly');
+		assert.strictEqual(optionValue, 'ReadOnly');
+		assert.strictEqual(possibleInputs.length, 3);
+		assert.strictEqual(possibleInputs[0].text, '');
+		assert.strictEqual(possibleInputs[1].text, 'ReadWrite');
+		assert.strictEqual(possibleInputs[2].text, 'ReadOnly');
 	});
 
 	test('create required category options with option value should set the option value and possible inputs correctly', () => {
@@ -172,10 +172,10 @@ suite('Advanced options helper tests', () => {
 		possibleInputs = [];
 		options['applicationIntent'] = 'ReadOnly';
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(categoryOption, options, possibleInputs);
-		assert.equal(optionValue, 'ReadOnly');
-		assert.equal(possibleInputs.length, 2);
-		assert.equal(possibleInputs[0].text, 'ReadWrite');
-		assert.equal(possibleInputs[1].text, 'ReadOnly');
+		assert.strictEqual(optionValue, 'ReadOnly');
+		assert.strictEqual(possibleInputs.length, 2);
+		assert.strictEqual(possibleInputs[0].text, 'ReadWrite');
+		assert.strictEqual(possibleInputs[1].text, 'ReadOnly');
 	});
 
 	test('create default but not required boolean options should set the option value and possible inputs correctly', () => {
@@ -183,11 +183,11 @@ suite('Advanced options helper tests', () => {
 		booleanOption.isRequired = false;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(booleanOption, options, possibleInputs);
-		assert.equal(optionValue, 'False');
-		assert.equal(possibleInputs.length, 3);
-		assert.equal(possibleInputs[0].text, '');
-		assert.equal(possibleInputs[1].text, 'True');
-		assert.equal(possibleInputs[2].text, 'False');
+		assert.strictEqual(optionValue, 'False');
+		assert.strictEqual(possibleInputs.length, 3);
+		assert.strictEqual(possibleInputs[0].text, '');
+		assert.strictEqual(possibleInputs[1].text, 'True');
+		assert.strictEqual(possibleInputs[2].text, 'False');
 	});
 
 	test('create default and required boolean options should set the option value and possible inputs correctly', () => {
@@ -195,10 +195,10 @@ suite('Advanced options helper tests', () => {
 		booleanOption.isRequired = true;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(booleanOption, options, possibleInputs);
-		assert.equal(optionValue, 'False');
-		assert.equal(possibleInputs.length, 2);
-		assert.equal(possibleInputs[0].text, 'True');
-		assert.equal(possibleInputs[1].text, 'False');
+		assert.strictEqual(optionValue, 'False');
+		assert.strictEqual(possibleInputs.length, 2);
+		assert.strictEqual(possibleInputs[0].text, 'True');
+		assert.strictEqual(possibleInputs[1].text, 'False');
 	});
 
 	test('create no default and not required boolean options should set the option value and possible inputs correctly', () => {
@@ -206,11 +206,11 @@ suite('Advanced options helper tests', () => {
 		booleanOption.isRequired = false;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(booleanOption, options, possibleInputs);
-		assert.equal(optionValue, '');
-		assert.equal(possibleInputs.length, 3);
-		assert.equal(possibleInputs[0].text, '');
-		assert.equal(possibleInputs[1].text, 'True');
-		assert.equal(possibleInputs[2].text, 'False');
+		assert.strictEqual(optionValue, '');
+		assert.strictEqual(possibleInputs.length, 3);
+		assert.strictEqual(possibleInputs[0].text, '');
+		assert.strictEqual(possibleInputs[1].text, 'True');
+		assert.strictEqual(possibleInputs[2].text, 'False');
 	});
 
 	test('create no default but required boolean options should set the option value and possible inputs correctly', () => {
@@ -218,10 +218,10 @@ suite('Advanced options helper tests', () => {
 		booleanOption.isRequired = true;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(booleanOption, options, possibleInputs);
-		assert.equal(optionValue, 'True');
-		assert.equal(possibleInputs.length, 2);
-		assert.equal(possibleInputs[0].text, 'True');
-		assert.equal(possibleInputs[1].text, 'False');
+		assert.strictEqual(optionValue, 'True');
+		assert.strictEqual(possibleInputs.length, 2);
+		assert.strictEqual(possibleInputs[0].text, 'True');
+		assert.strictEqual(possibleInputs[1].text, 'False');
 	});
 
 	test('create not required boolean options with option value should set the option value and possible inputs correctly', () => {
@@ -230,11 +230,11 @@ suite('Advanced options helper tests', () => {
 		possibleInputs = [];
 		options['asynchronousProcessing'] = true;
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(booleanOption, options, possibleInputs);
-		assert.equal(optionValue, 'True');
-		assert.equal(possibleInputs.length, 3);
-		assert.equal(possibleInputs[0].text, '');
-		assert.equal(possibleInputs[1].text, 'True');
-		assert.equal(possibleInputs[2].text, 'False');
+		assert.strictEqual(optionValue, 'True');
+		assert.strictEqual(possibleInputs.length, 3);
+		assert.strictEqual(possibleInputs[0].text, '');
+		assert.strictEqual(possibleInputs[1].text, 'True');
+		assert.strictEqual(possibleInputs[2].text, 'False');
 	});
 
 	test('create required boolean options with option value should set the option value and possible inputs correctly', () => {
@@ -243,10 +243,10 @@ suite('Advanced options helper tests', () => {
 		possibleInputs = [];
 		options['asynchronousProcessing'] = 'False';
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(booleanOption, options, possibleInputs);
-		assert.equal(optionValue, 'False');
-		assert.equal(possibleInputs.length, 2);
-		assert.equal(possibleInputs[0].text, 'True');
-		assert.equal(possibleInputs[1].text, 'False');
+		assert.strictEqual(optionValue, 'False');
+		assert.strictEqual(possibleInputs.length, 2);
+		assert.strictEqual(possibleInputs[0].text, 'True');
+		assert.strictEqual(possibleInputs[1].text, 'False');
 	});
 
 	test('create default number options should set the option value and possible inputs correctly', () => {
@@ -254,7 +254,7 @@ suite('Advanced options helper tests', () => {
 		numberOption.isRequired = true;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(numberOption, options, possibleInputs);
-		assert.equal(optionValue, '15');
+		assert.strictEqual(optionValue, '15');
 	});
 
 	test('create number options with option value should set the option value and possible inputs correctly', () => {
@@ -263,7 +263,7 @@ suite('Advanced options helper tests', () => {
 		possibleInputs = [];
 		options['connectTimeout'] = '45';
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(numberOption, options, possibleInputs);
-		assert.equal(optionValue, '45');
+		assert.strictEqual(optionValue, '45');
 	});
 
 	test('create default string options should set the option value and possible inputs correctly', () => {
@@ -271,7 +271,7 @@ suite('Advanced options helper tests', () => {
 		stringOption.isRequired = true;
 		possibleInputs = [];
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(stringOption, options, possibleInputs);
-		assert.equal(optionValue, 'Japanese');
+		assert.strictEqual(optionValue, 'Japanese');
 	});
 
 	test('create string options with option value should set the option value and possible inputs correctly', () => {
@@ -280,7 +280,7 @@ suite('Advanced options helper tests', () => {
 		possibleInputs = [];
 		options['currentLanguage'] = 'Spanish';
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(stringOption, options, possibleInputs);
-		assert.equal(optionValue, 'Spanish');
+		assert.strictEqual(optionValue, 'Spanish');
 	});
 
 	test('validate undefined and optional number input should return no error', () => {
@@ -295,7 +295,7 @@ suite('Advanced options helper tests', () => {
 		};
 
 		let error = OptionsDialogHelper.validateInputs(optionsMap);
-		assert.equal(error, true);
+		assert.strictEqual(error, true);
 	});
 
 	test('validate a valid optional number input should return no error', () => {
@@ -310,7 +310,7 @@ suite('Advanced options helper tests', () => {
 		};
 
 		let error = OptionsDialogHelper.validateInputs(optionsMap);
-		assert.equal(error, true);
+		assert.strictEqual(error, true);
 	});
 
 	test('validate a valid required number input should return no error', () => {
@@ -324,7 +324,7 @@ suite('Advanced options helper tests', () => {
 			optionValue: null
 		};
 		let error = OptionsDialogHelper.validateInputs(optionsMap);
-		assert.equal(error, true);
+		assert.strictEqual(error, true);
 	});
 
 	test('validate invalid optional number option should return an expected error', () => {
@@ -339,7 +339,7 @@ suite('Advanced options helper tests', () => {
 		};
 
 		let error = OptionsDialogHelper.validateInputs(optionsMap);
-		assert.equal(error, false);
+		assert.strictEqual(error, false);
 	});
 
 	test('validate required optional number option should return an expected error', () => {
@@ -354,7 +354,7 @@ suite('Advanced options helper tests', () => {
 		};
 
 		let error = OptionsDialogHelper.validateInputs(optionsMap);
-		assert.equal(error, false);
+		assert.strictEqual(error, false);
 	});
 
 	test('update options should delete option entry if the input value is an empty string', () => {
@@ -369,7 +369,7 @@ suite('Advanced options helper tests', () => {
 		};
 		options['connectTimeout'] = '45';
 		OptionsDialogHelper.updateOptions(options, optionsMap);
-		assert.equal(options['connectTimeout'], undefined);
+		assert.strictEqual(options['connectTimeout'], undefined);
 	});
 
 	test('update options should update correct option value', () => {
@@ -384,7 +384,7 @@ suite('Advanced options helper tests', () => {
 		};
 		options['connectTimeout'] = '45';
 		OptionsDialogHelper.updateOptions(options, optionsMap);
-		assert.equal(options['connectTimeout'], 50);
+		assert.strictEqual(options['connectTimeout'], '50');
 	});
 
 	test('update options should add the option value to options', () => {
@@ -399,18 +399,18 @@ suite('Advanced options helper tests', () => {
 		};
 		options = {};
 		OptionsDialogHelper.updateOptions(options, optionsMap);
-		assert.equal(options['connectTimeout'], 50);
+		assert.strictEqual(options['connectTimeout'], '50');
 	});
 
 	test('groupOptionsByCategory converts a list of options to a map of category names to lists of options', () => {
 		let optionsList = [categoryOption, booleanOption, numberOption, stringOption, defaultGroupOption];
 		let optionsMap = OptionsDialogHelper.groupOptionsByCategory(optionsList);
 		let categoryNames = Object.keys(optionsMap);
-		assert.equal(categoryNames.some(x => x === 'Initialization'), true);
-		assert.equal(categoryNames.some(x => x === 'General'), true);
-		assert.equal(categoryNames.length, 2);
-		assert.equal(optionsMap['Initialization'].length, 4);
-		assert.equal(optionsMap['General'].length, 1);
+		assert.strictEqual(categoryNames.some(x => x === 'Initialization'), true);
+		assert.strictEqual(categoryNames.some(x => x === 'General'), true);
+		assert.strictEqual(categoryNames.length, 2);
+		assert.strictEqual(optionsMap['Initialization'].length, 4);
+		assert.strictEqual(optionsMap['General'].length, 1);
 	});
 
 });

--- a/src/sql/workbench/test/browser/taskUtilities.test.ts
+++ b/src/sql/workbench/test/browser/taskUtilities.test.ts
@@ -46,7 +46,7 @@ suite('TaskUtilities', function () {
 		// If I call getCurrentGlobalConnection, it should return the expected database profile
 		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
 		assert.strictEqual(actualProfile.databaseName, dbName);
-		assert.notEqual(actualProfile.id, serverProfile.id);
+		assert.notStrictEqual(actualProfile.id, serverProfile.id);
 		// Other connection attributes still match
 		assert.strictEqual(actualProfile.authenticationType, serverProfile.authenticationType);
 		assert.strictEqual(actualProfile.password, serverProfile.password);

--- a/src/sql/workbench/test/browser/taskUtilities.test.ts
+++ b/src/sql/workbench/test/browser/taskUtilities.test.ts
@@ -27,7 +27,7 @@ suite('TaskUtilities', function () {
 
 		// If I call getCurrentGlobalConnection, it should return the expected server profile
 		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
-		assert.equal(actualProfile, expectedProfile);
+		assert.strictEqual(actualProfile, expectedProfile);
 	});
 
 	test('getCurrentGlobalConnection returns the selected OE database if a database or its children is selected', () => {
@@ -45,13 +45,13 @@ suite('TaskUtilities', function () {
 
 		// If I call getCurrentGlobalConnection, it should return the expected database profile
 		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
-		assert.equal(actualProfile.databaseName, dbName);
+		assert.strictEqual(actualProfile.databaseName, dbName);
 		assert.notEqual(actualProfile.id, serverProfile.id);
 		// Other connection attributes still match
-		assert.equal(actualProfile.authenticationType, serverProfile.authenticationType);
-		assert.equal(actualProfile.password, serverProfile.password);
-		assert.equal(actualProfile.serverName, serverProfile.serverName);
-		assert.equal(actualProfile.userName, serverProfile.userName);
+		assert.strictEqual(actualProfile.authenticationType, serverProfile.authenticationType);
+		assert.strictEqual(actualProfile.password, serverProfile.password);
+		assert.strictEqual(actualProfile.serverName, serverProfile.serverName);
+		assert.strictEqual(actualProfile.userName, serverProfile.userName);
 	});
 
 	test('getCurrentGlobalConnection returns the connection from the active tab, if there is one and OE is not focused', () => {
@@ -76,11 +76,11 @@ suite('TaskUtilities', function () {
 
 		// If I call getCurrentGlobalConnection, it should return the expected profile from the active tab
 		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
-		assert.equal(actualProfile.databaseName, tabProfile.databaseName);
-		assert.equal(actualProfile.authenticationType, tabProfile.authenticationType);
-		assert.equal(actualProfile.password, tabProfile.password);
-		assert.equal(actualProfile.serverName, tabProfile.serverName);
-		assert.equal(actualProfile.userName, tabProfile.userName);
+		assert.strictEqual(actualProfile.databaseName, tabProfile.databaseName);
+		assert.strictEqual(actualProfile.authenticationType, tabProfile.authenticationType);
+		assert.strictEqual(actualProfile.password, tabProfile.password);
+		assert.strictEqual(actualProfile.serverName, tabProfile.serverName);
+		assert.strictEqual(actualProfile.userName, tabProfile.userName);
 	});
 
 	test('getCurrentGlobalConnection returns the connection from OE if there is no active tab, even if OE is not focused', () => {
@@ -97,6 +97,6 @@ suite('TaskUtilities', function () {
 
 		// If I call getCurrentGlobalConnection, it should return the expected profile from OE
 		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
-		assert.equal(actualProfile, oeProfile);
+		assert.strictEqual(actualProfile, oeProfile);
 	});
 });

--- a/src/sql/workbench/test/common/editor/query/gridTableState.test.ts
+++ b/src/sql/workbench/test/common/editor/query/gridTableState.test.ts
@@ -14,12 +14,12 @@ suite('Grid Table State', () => {
 		const batchId = 0;
 		const state = new GridTableState(resultId, batchId);
 
-		assert.equal(state.resultId, resultId);
-		assert.equal(state.batchId, batchId);
+		assert.strictEqual(state.resultId, resultId);
+		assert.strictEqual(state.batchId, batchId);
 		assert(isUndefined(state.canBeMaximized));
 		assert(isUndefined(state.maximized));
-		assert.equal(state.scrollPositionX, 0);
-		assert.equal(state.scrollPositionY, 0);
+		assert.strictEqual(state.scrollPositionX, 0);
+		assert.strictEqual(state.scrollPositionY, 0);
 		assert(isUndefined(state.columnSizes));
 		assert(isUndefined(state.selection));
 		assert(isUndefined(state.activeCell));
@@ -32,31 +32,31 @@ suite('Grid Table State', () => {
 			state.canBeMaximized = true;
 		});
 
-		assert.equal(event, true);
-		assert.equal(state.canBeMaximized, true);
+		assert.strictEqual(event, true);
+		assert.strictEqual(state.canBeMaximized, true);
 
 		event = await new Promise<boolean>(resolve => {
 			Event.once(state.onCanBeMaximizedChange)(e => resolve(e));
 			state.canBeMaximized = false;
 		});
 
-		assert.equal(event, false);
-		assert.equal(state.canBeMaximized, false);
+		assert.strictEqual(event, false);
+		assert.strictEqual(state.canBeMaximized, false);
 
 		event = await new Promise<boolean>(resolve => {
 			Event.once(state.onMaximizedChange)(e => resolve(e));
 			state.maximized = true;
 		});
 
-		assert.equal(event, true);
-		assert.equal(state.maximized, true);
+		assert.strictEqual(event, true);
+		assert.strictEqual(state.maximized, true);
 
 		event = await new Promise<boolean>(resolve => {
 			Event.once(state.onMaximizedChange)(e => resolve(e));
 			state.maximized = false;
 		});
 
-		assert.equal(event, false);
-		assert.equal(state.maximized, false);
+		assert.strictEqual(event, false);
+		assert.strictEqual(state.maximized, false);
 	});
 });

--- a/src/sql/workbench/test/electron-browser/api/extHostAccountManagement.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostAccountManagement.test.ts
@@ -65,7 +65,7 @@ suite('ExtHostAccountManagement', () => {
 		let extHost = new ExtHostAccountManagement(threadService);
 
 		// Then: There shouldn't be any account providers registered
-		assert.equal(extHost.getProviderCount(), 0);
+		assert.strictEqual(extHost.getProviderCount(), 0);
 	});
 
 	// REGISTER TESTS //////////////////////////////////////////////////////
@@ -78,7 +78,7 @@ suite('ExtHostAccountManagement', () => {
 		extHost.$registerAccountProvider(mockAccountMetadata, mockProvider.object);
 
 		// Then: The account provider should be registered
-		assert.equal(extHost.getProviderCount(), 1);
+		assert.strictEqual(extHost.getProviderCount(), 1);
 	});
 
 	test('Register Account Provider - Account Provider Already Registered', () => {
@@ -95,7 +95,7 @@ suite('ExtHostAccountManagement', () => {
 		});
 
 		// ... There should only be one account provider
-		assert.equal(extHost.getProviderCount(), 1);
+		assert.strictEqual(extHost.getProviderCount(), 1);
 	});
 
 	// TODO: Test for unregistering a provider
@@ -310,7 +310,7 @@ suite('ExtHostAccountManagement', () => {
 				);
 
 				assert.ok(Array.isArray(accounts));
-				assert.equal(accounts.length, expectedAccounts.length);
+				assert.strictEqual(accounts.length, expectedAccounts.length);
 				assert.deepStrictEqual(accounts, expectedAccounts);
 			});
 	});

--- a/src/sql/workbench/test/electron-browser/api/extHostCredentialManagement.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostCredentialManagement.test.ts
@@ -41,7 +41,7 @@ suite('ExtHostCredentialManagement', () => {
 		let extHost = new ExtHostCredentialManagement(threadService);
 
 		// Then: The extension host should not have any providers registered
-		assert.equal(extHost.getProviderCount(), 0);
+		assert.strictEqual(extHost.getProviderCount(), 0);
 	});
 
 	test('Register Credential Provider', () => {
@@ -53,7 +53,7 @@ suite('ExtHostCredentialManagement', () => {
 		extHost.$registerCredentialProvider(mockCredentialProvider);
 
 		// Then: There should be one provider registered
-		assert.equal(extHost.getProviderCount(), 1);
+		assert.strictEqual(extHost.getProviderCount(), 1);
 	});
 
 	test('Get Credential Provider - Success', () => {
@@ -71,7 +71,7 @@ suite('ExtHostCredentialManagement', () => {
 		return extHost.$getCredentialProvider(namespaceId)
 			.then((provider) => {
 				// Then: There should still only be one provider registered
-				assert.equal(extHost.getProviderCount(), 1);
+				assert.strictEqual(extHost.getProviderCount(), 1);
 				credProvider = provider;
 			})
 			.then(() => {
@@ -81,8 +81,8 @@ suite('ExtHostCredentialManagement', () => {
 			.then(() => {
 				// Then: The credential should have been stored with its namespace
 				assert.notStrictEqual(mockCredentialProvider.storedCredentials[expectedCredentialId], undefined);
-				assert.equal(mockCredentialProvider.storedCredentials[expectedCredentialId].credentialId, expectedCredentialId);
-				assert.equal(mockCredentialProvider.storedCredentials[expectedCredentialId].password, credential);
+				assert.strictEqual(mockCredentialProvider.storedCredentials[expectedCredentialId].credentialId, expectedCredentialId);
+				assert.strictEqual(mockCredentialProvider.storedCredentials[expectedCredentialId].password, credential);
 			})
 			.then(() => {
 				// If: I read a credential
@@ -90,8 +90,8 @@ suite('ExtHostCredentialManagement', () => {
 			})
 			.then((returnedCredential: Credential) => {
 				// Then: The credential ID should be namespaced
-				assert.equal(returnedCredential.credentialId, expectedCredentialId);
-				assert.equal(returnedCredential.password, credential);
+				assert.strictEqual(returnedCredential.credentialId, expectedCredentialId);
+				assert.strictEqual(returnedCredential.password, credential);
 			})
 			.then(() => {
 				// If: I delete a credential

--- a/src/sql/workbench/test/electron-browser/api/extHostDataProtocol.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostDataProtocol.test.ts
@@ -52,10 +52,10 @@ suite('ExtHostDataProtocol', () => {
 		let allProviders = extHostDataProtocol.getProvidersByType<azdata.MetadataProvider>(DataProviderType.MetadataProvider);
 
 		// Then each provider was retrieved successfully
-		assert.equal(retrievedProvider1, extension1MetadataMock.object, 'Expected metadata provider was not retrieved for extension 1');
-		assert.equal(retrievedProvider2, extension2MetadataMock.object, 'Expected metadata provider was not retrieved for extension 2');
-		assert.equal(allProviders.length, 2, 'All metadata providers had unexpected length');
-		assert.equal(allProviders.some(provider => provider === extension1MetadataMock.object), true, 'All metadata providers did not include extension 1 metadata provider');
-		assert.equal(allProviders.some(provider => provider === extension2MetadataMock.object), true, 'All metadata providers did not include extension 2 metadata provider');
+		assert.strictEqual(retrievedProvider1, extension1MetadataMock.object, 'Expected metadata provider was not retrieved for extension 1');
+		assert.strictEqual(retrievedProvider2, extension2MetadataMock.object, 'Expected metadata provider was not retrieved for extension 2');
+		assert.strictEqual(allProviders.length, 2, 'All metadata providers had unexpected length');
+		assert.strictEqual(allProviders.some(provider => provider === extension1MetadataMock.object), true, 'All metadata providers did not include extension 1 metadata provider');
+		assert.strictEqual(allProviders.some(provider => provider === extension2MetadataMock.object), true, 'All metadata providers did not include extension 2 metadata provider');
 	});
 });

--- a/src/sql/workbench/test/electron-browser/api/extHostModelView.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostModelView.test.ts
@@ -78,14 +78,14 @@ suite('ExtHostModelView Validation Tests', () => {
 
 		test('The custom validation output of a component gets set when it is initialized', () => {
 			return extHostModelView.$runCustomValidations(handle, inputBox.id).then(valid => {
-				assert.equal(valid, false, 'Empty input box did not validate as false');
+				assert.strictEqual(valid, false, 'Empty input box did not validate as false');
 			});
 		});
 
 		test('The custom validation output of a component changes if its value changes', () => {
 			inputBox.value = validText;
 			return extHostModelView.$runCustomValidations(handle, inputBox.id).then(valid => {
-				assert.equal(valid, true, 'Valid input box did not validate as valid');
+				assert.strictEqual(valid, true, 'Valid input box did not validate as valid');
 			});
 		});
 
@@ -97,22 +97,22 @@ suite('ExtHostModelView Validation Tests', () => {
 				eventType: ComponentEventType.PropertiesChanged
 			} as IComponentEventArgs);
 			return extHostModelView.$runCustomValidations(handle, inputBox.id).then(valid => {
-				assert.equal(valid, true, 'Valid input box did not validate as valid after PropertiesChanged event');
+				assert.strictEqual(valid, true, 'Valid input box did not validate as valid after PropertiesChanged event');
 			});
 		});
 
 		test('The validity of a component is set by main thread validationChanged events', () => {
-			assert.equal(inputBox.valid, true, 'Component validity is true by default');
+			assert.strictEqual(inputBox.valid, true, 'Component validity is true by default');
 			extHostModelView.$handleEvent(handle, inputBox.id, {
 				eventType: ComponentEventType.validityChanged,
 				args: false
 			});
-			assert.equal(inputBox.valid, false, 'Input box did not update validity to false based on the validityChanged event');
+			assert.strictEqual(inputBox.valid, false, 'Input box did not update validity to false based on the validityChanged event');
 			extHostModelView.$handleEvent(handle, inputBox.id, {
 				eventType: ComponentEventType.validityChanged,
 				args: true
 			});
-			assert.equal(inputBox.valid, true, 'Input box did not update validity to true based on the validityChanged event');
+			assert.strictEqual(inputBox.valid, true, 'Input box did not update validity to true based on the validityChanged event');
 		});
 
 		test('Main thread validityChanged events cause component to fire validity changed events', () => {
@@ -122,7 +122,7 @@ suite('ExtHostModelView Validation Tests', () => {
 				eventType: ComponentEventType.validityChanged,
 				args: false
 			});
-			assert.equal(validityFromEvent, false, 'Main thread validityChanged event did not cause component to fire its own event');
+			assert.strictEqual(validityFromEvent, false, 'Main thread validityChanged event did not cause component to fire its own event');
 		});
 
 		test('Setting a form component as required initializes the model with the component required', () => {
@@ -186,26 +186,26 @@ suite('ExtHostModelView Validation Tests', () => {
 			modelView.initializeModel(formContainer);
 
 			// Then all the items plus a group label are added and have the correct layouts
-			assert.equal(rootComponent.itemConfigs.length, 4);
+			assert.strictEqual(rootComponent.itemConfigs.length, 4);
 			let listBoxConfig = rootComponent.itemConfigs[0];
 			let groupLabelConfig = rootComponent.itemConfigs[1];
 			let inputBoxConfig = rootComponent.itemConfigs[2];
 			let dropdownConfig = rootComponent.itemConfigs[3];
 
 			// Verify that the correct items were added
-			assert.equal(listBoxConfig.componentShape.type, ModelComponentTypes.ListBox, `Unexpected ModelComponentType. Expected ListBox but got ${ModelComponentTypes[listBoxConfig.componentShape.type]}`);
-			assert.equal(groupLabelConfig.componentShape.type, ModelComponentTypes.Text, `Unexpected ModelComponentType. Expected Text but got ${ModelComponentTypes[groupLabelConfig.componentShape.type]}`);
-			assert.equal(inputBoxConfig.componentShape.type, ModelComponentTypes.InputBox, `Unexpected ModelComponentType. Expected InputBox but got ${ModelComponentTypes[inputBoxConfig.componentShape.type]}`);
-			assert.equal(dropdownConfig.componentShape.type, ModelComponentTypes.DropDown, `Unexpected ModelComponentType. Expected DropDown but got ${ModelComponentTypes[dropdownConfig.componentShape.type]}`);
+			assert.strictEqual(listBoxConfig.componentShape.type, ModelComponentTypes.ListBox, `Unexpected ModelComponentType. Expected ListBox but got ${ModelComponentTypes[listBoxConfig.componentShape.type]}`);
+			assert.strictEqual(groupLabelConfig.componentShape.type, ModelComponentTypes.Text, `Unexpected ModelComponentType. Expected Text but got ${ModelComponentTypes[groupLabelConfig.componentShape.type]}`);
+			assert.strictEqual(inputBoxConfig.componentShape.type, ModelComponentTypes.InputBox, `Unexpected ModelComponentType. Expected InputBox but got ${ModelComponentTypes[inputBoxConfig.componentShape.type]}`);
+			assert.strictEqual(dropdownConfig.componentShape.type, ModelComponentTypes.DropDown, `Unexpected ModelComponentType. Expected DropDown but got ${ModelComponentTypes[dropdownConfig.componentShape.type]}`);
 
 			// Verify that the group title was set up correctly
-			assert.equal(groupLabelConfig.componentShape.properties['value'], groupTitle, `Unexpected title. Expected ${groupTitle} but got ${groupLabelConfig.componentShape.properties['value']}`);
-			assert.equal((groupLabelConfig.config as TitledFormItemLayout).isGroupLabel, true, `Unexpected value for isGroupLabel. Expected true but got ${(groupLabelConfig.config as TitledFormItemLayout).isGroupLabel}`);
+			assert.strictEqual(groupLabelConfig.componentShape.properties['value'], groupTitle, `Unexpected title. Expected ${groupTitle} but got ${groupLabelConfig.componentShape.properties['value']}`);
+			assert.strictEqual((groupLabelConfig.config as TitledFormItemLayout).isGroupLabel, true, `Unexpected value for isGroupLabel. Expected true but got ${(groupLabelConfig.config as TitledFormItemLayout).isGroupLabel}`);
 
 			// Verify that the components' layouts are correct
-			assert.equal((listBoxConfig.config as azdata.FormItemLayout).horizontal, defaultLayout.horizontal, `Unexpected layout for listBoxConfig. Expected defaultLayout.horizontal but got ${(listBoxConfig.config as azdata.FormItemLayout).horizontal}`);
-			assert.equal((inputBoxConfig.config as azdata.FormItemLayout).horizontal, groupInputLayout.horizontal, `Unexpected layout for inputBoxConfig. Expected groupInputLayout.horizontal but got ${(inputBoxConfig.config as azdata.FormItemLayout).horizontal}`);
-			assert.equal((dropdownConfig.config as azdata.FormItemLayout).horizontal, defaultLayout.horizontal, `Unexpected layout for dropdownConfig. Expected defaultLayout.horizontal but got ${(dropdownConfig.config as azdata.FormItemLayout).horizontal}`);
+			assert.strictEqual((listBoxConfig.config as azdata.FormItemLayout).horizontal, defaultLayout.horizontal, `Unexpected layout for listBoxConfig. Expected defaultLayout.horizontal but got ${(listBoxConfig.config as azdata.FormItemLayout).horizontal}`);
+			assert.strictEqual((inputBoxConfig.config as azdata.FormItemLayout).horizontal, groupInputLayout.horizontal, `Unexpected layout for inputBoxConfig. Expected groupInputLayout.horizontal but got ${(inputBoxConfig.config as azdata.FormItemLayout).horizontal}`);
+			assert.strictEqual((dropdownConfig.config as azdata.FormItemLayout).horizontal, defaultLayout.horizontal, `Unexpected layout for dropdownConfig. Expected defaultLayout.horizontal but got ${(dropdownConfig.config as azdata.FormItemLayout).horizontal}`);
 		});
 
 		test('Inserting and removing components from a container should work correctly', () => {
@@ -221,13 +221,13 @@ suite('ExtHostModelView Validation Tests', () => {
 			modelView.initializeModel(flex);
 
 			const itemConfigs: InternalItemConfig[] = (flex as IWithItemConfig).itemConfigs;
-			assert.equal(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
 			flex.insertItem(dropDown, 1);
-			assert.equal(itemConfigs.length, 3, `Unexpected number of items in list. Expected 3, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
-			assert.equal(itemConfigs[1].toIItemConfig().componentShape.type, ModelComponentTypes.DropDown, `Unexpected ModelComponentType. Expected DropDown but got ${ModelComponentTypes[itemConfigs[1].toIItemConfig().componentShape.type]}`);
+			assert.strictEqual(itemConfigs.length, 3, `Unexpected number of items in list. Expected 3, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs[1].toIItemConfig().componentShape.type, ModelComponentTypes.DropDown, `Unexpected ModelComponentType. Expected DropDown but got ${ModelComponentTypes[itemConfigs[1].toIItemConfig().componentShape.type]}`);
 			flex.removeItem(listBox);
-			assert.equal(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
-			assert.equal(itemConfigs[0].toIItemConfig().componentShape.type, ModelComponentTypes.DropDown, `Unexpected ModelComponentType. Expected DropDown but got ${ModelComponentTypes[itemConfigs[0].toIItemConfig().componentShape.type]}`);
+			assert.strictEqual(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs[0].toIItemConfig().componentShape.type, ModelComponentTypes.DropDown, `Unexpected ModelComponentType. Expected DropDown but got ${ModelComponentTypes[itemConfigs[0].toIItemConfig().componentShape.type]}`);
 		});
 
 		test('Inserting component give negative number fails', () => {
@@ -244,7 +244,7 @@ suite('ExtHostModelView Validation Tests', () => {
 			modelView.initializeModel(flex);
 
 			const itemConfigs: InternalItemConfig[] = (flex as IWithItemConfig).itemConfigs;
-			assert.equal(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
 			assert.throws(() => flex.insertItem(dropDown, -1), `Didn't get expected exception when calling insertItem with invalid index -1`);
 		});
 
@@ -262,7 +262,7 @@ suite('ExtHostModelView Validation Tests', () => {
 			modelView.initializeModel(flex);
 
 			const itemConfigs: InternalItemConfig[] = (flex as IWithItemConfig).itemConfigs;
-			assert.equal(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
 			assert.throws(() => flex.insertItem(dropDown, 10), `Didn't get expected exception when calling insertItem with invalid index 10`);
 		});
 
@@ -280,9 +280,9 @@ suite('ExtHostModelView Validation Tests', () => {
 			modelView.initializeModel(flex);
 
 			const itemConfigs: InternalItemConfig[] = (flex as IWithItemConfig).itemConfigs;
-			assert.equal(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
 			flex.insertItem(dropDown, 2);
-			assert.equal(itemConfigs.length, 3, `Unexpected number of items in list. Expected 3, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs.length, 3, `Unexpected number of items in list. Expected 3, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
 		});
 
 		test('Removing a component that does not exist does not fail', () => {
@@ -300,9 +300,9 @@ suite('ExtHostModelView Validation Tests', () => {
 
 			const itemConfigs: InternalItemConfig[] = (flex as IWithItemConfig).itemConfigs;
 			let result = flex.removeItem(dropDown);
-			assert.equal(result, false);
-			assert.equal(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
-			assert.equal(itemConfigs[0].toIItemConfig().componentShape.type, ModelComponentTypes.ListBox, `Unexpected ModelComponentType. Expected ListBox but got ${ModelComponentTypes[itemConfigs[0].toIItemConfig().componentShape.type]}`);
+			assert.strictEqual(result, false);
+			assert.strictEqual(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs[0].toIItemConfig().componentShape.type, ModelComponentTypes.ListBox, `Unexpected ModelComponentType. Expected ListBox but got ${ModelComponentTypes[itemConfigs[0].toIItemConfig().componentShape.type]}`);
 		});
 
 
@@ -342,19 +342,19 @@ suite('ExtHostModelView Validation Tests', () => {
 			modelView.initializeModel(formBuilder.component());
 
 			const itemConfigs: InternalItemConfig[] = (form as IWithItemConfig).itemConfigs;
-			assert.equal(itemConfigs.length, 1);
+			assert.strictEqual(itemConfigs.length, 1);
 			formBuilder.insertFormItem(inputBoxFormItem, 0);
-			assert.equal(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
-			assert.equal(itemConfigs[0].toIItemConfig().componentShape.type, ModelComponentTypes.InputBox, `Unexpected ModelComponentType. Expected InputBox but got ${ModelComponentTypes[itemConfigs[0].toIItemConfig().componentShape.type]}`);
+			assert.strictEqual(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs[0].toIItemConfig().componentShape.type, ModelComponentTypes.InputBox, `Unexpected ModelComponentType. Expected InputBox but got ${ModelComponentTypes[itemConfigs[0].toIItemConfig().componentShape.type]}`);
 			formBuilder.insertFormItem(groupItems, 0);
-			assert.equal(itemConfigs.length, 5, `Unexpected number of items in list. Expected 5, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs.length, 5, `Unexpected number of items in list. Expected 5, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
 			formBuilder.removeFormItem(listBoxFormItem);
-			assert.equal(itemConfigs.length, 4, `Unexpected number of items in list. Expected 4, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs.length, 4, `Unexpected number of items in list. Expected 4, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
 			formBuilder.removeFormItem(groupItems);
-			assert.equal(itemConfigs.length, 1, `Unexpected number of items in list. Expected 1, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs.length, 1, `Unexpected number of items in list. Expected 1, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
 			formBuilder.addFormItem(listBoxFormItem);
-			assert.equal(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
-			assert.equal(itemConfigs[1].toIItemConfig().componentShape.type, ModelComponentTypes.ListBox, `Unexpected ModelComponentType. Expected ListBox but got ${ModelComponentTypes[itemConfigs[1].toIItemConfig().componentShape.type]}`);
+			assert.strictEqual(itemConfigs.length, 2, `Unexpected number of items in list. Expected 2, got ${itemConfigs.length} ${JSON.stringify(itemConfigs)}`);
+			assert.strictEqual(itemConfigs[1].toIItemConfig().componentShape.type, ModelComponentTypes.ListBox, `Unexpected ModelComponentType. Expected ListBox but got ${ModelComponentTypes[itemConfigs[1].toIItemConfig().componentShape.type]}`);
 		});
 	});
 

--- a/src/sql/workbench/test/electron-browser/api/extHostModelViewDialog.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostModelViewDialog.test.ts
@@ -125,7 +125,7 @@ suite('ExtHostModelViewDialog Tests', () => {
 		extHostModelViewDialog.$onButtonClick(button1Handle);
 
 		// Then the clicks should have been handled by the expected handlers
-		assert.deepEqual(clickEvents, [1, 2, 2, 1]);
+		assert.deepStrictEqual(clickEvents, [1, 2, 2, 1]);
 	});
 
 	test('Creating a wizard returns a wizard with initialized buttons and the given title', () => {
@@ -137,7 +137,7 @@ suite('ExtHostModelViewDialog Tests', () => {
 		assert.strictEqual(wizard.cancelButton.enabled, true);
 		assert.strictEqual(wizard.nextButton.enabled, true);
 		assert.strictEqual(wizard.backButton.enabled, true);
-		assert.deepEqual(wizard.pages, []);
+		assert.deepStrictEqual(wizard.pages, []);
 	});
 
 	test('Opening a wizard updates its pages and buttons on the main thread', () => {

--- a/src/sql/workbench/test/electron-browser/api/extHostModelViewDialog.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostModelViewDialog.test.ts
@@ -286,7 +286,7 @@ suite('ExtHostModelViewDialog Tests', () => {
 			lastPage: lastPage,
 			newPage: newPage
 		});
-		assert.notEqual(validationInfo, undefined);
+		assert.notStrictEqual(validationInfo, undefined);
 		assert.strictEqual(validationInfo.lastPage, lastPage);
 		assert.strictEqual(validationInfo.newPage, newPage);
 	});

--- a/src/sql/workbench/test/electron-browser/api/extHostModelViewDialog.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostModelViewDialog.test.ts
@@ -43,24 +43,24 @@ suite('ExtHostModelViewDialog Tests', () => {
 		let title = 'dialog_title';
 		let dialog = extHostModelViewDialog.createDialog(title);
 
-		assert.equal(dialog.title, title);
-		assert.equal(dialog.okButton.enabled, true);
-		assert.equal(dialog.cancelButton.enabled, true);
+		assert.strictEqual(dialog.title, title);
+		assert.strictEqual(dialog.okButton.enabled, true);
+		assert.strictEqual(dialog.cancelButton.enabled, true);
 	});
 
 	test('Creating a tab returns a tab with the given title', () => {
 		let title = 'tab_title';
 		let tab = extHostModelViewDialog.createTab(title);
 
-		assert.equal(tab.title, title);
+		assert.strictEqual(tab.title, title);
 	});
 
 	test('Creating a button returns an enabled button with the given label', () => {
 		let label = 'button_label';
 		let button = extHostModelViewDialog.createButton(label);
 
-		assert.equal(button.label, label);
-		assert.equal(button.enabled, true);
+		assert.strictEqual(button.label, label);
+		assert.strictEqual(button.enabled, true);
 	});
 
 	test('Opening a dialog updates its tabs and buttons on the main thread', () => {
@@ -132,11 +132,11 @@ suite('ExtHostModelViewDialog Tests', () => {
 		let title = 'wizard_title';
 		let wizard = extHostModelViewDialog.createWizard(title);
 
-		assert.equal(wizard.title, title);
-		assert.equal(wizard.doneButton.enabled, true);
-		assert.equal(wizard.cancelButton.enabled, true);
-		assert.equal(wizard.nextButton.enabled, true);
-		assert.equal(wizard.backButton.enabled, true);
+		assert.strictEqual(wizard.title, title);
+		assert.strictEqual(wizard.doneButton.enabled, true);
+		assert.strictEqual(wizard.cancelButton.enabled, true);
+		assert.strictEqual(wizard.nextButton.enabled, true);
+		assert.strictEqual(wizard.backButton.enabled, true);
 		assert.deepEqual(wizard.pages, []);
 	});
 
@@ -207,9 +207,9 @@ suite('ExtHostModelViewDialog Tests', () => {
 			newPage: 1
 		};
 		extHostModelViewDialog.$onWizardPageChanged(wizardHandle, expectedPageChangeInfo);
-		assert.equal(actualPageChangeInfo.length, 1);
-		assert.equal(actualPageChangeInfo[0], expectedPageChangeInfo);
-		assert.equal(wizard.currentPage, expectedPageChangeInfo.newPage);
+		assert.strictEqual(actualPageChangeInfo.length, 1);
+		assert.strictEqual(actualPageChangeInfo[0], expectedPageChangeInfo);
+		assert.strictEqual(wizard.currentPage, expectedPageChangeInfo.newPage);
 	});
 
 	test('Validity changed events are handled correctly', () => {
@@ -232,11 +232,11 @@ suite('ExtHostModelViewDialog Tests', () => {
 
 		// Call the validity changed event on tab 2 and verify that it was handled but tab 1 is still not valid
 		extHostModelViewDialog.$onPanelValidityChanged(tabHandles[1], false);
-		assert.equal(tab1ValidityChangedEvents.length, 0);
-		assert.equal(tab1.valid, true);
-		assert.equal(tab2ValidityChangedEvents.length, 1);
-		assert.equal(tab2ValidityChangedEvents[0], false);
-		assert.equal(tab2.valid, false);
+		assert.strictEqual(tab1ValidityChangedEvents.length, 0);
+		assert.strictEqual(tab1.valid, true);
+		assert.strictEqual(tab2ValidityChangedEvents.length, 1);
+		assert.strictEqual(tab2ValidityChangedEvents[0], false);
+		assert.strictEqual(tab2.valid, false);
 	});
 
 	test('Verify validity changed events update validity for all panel types', () => {
@@ -258,11 +258,11 @@ suite('ExtHostModelViewDialog Tests', () => {
 
 		// Call the validity changed event on each object and verify that the object's validity was updated
 		extHostModelViewDialog.$onPanelValidityChanged(tabHandle, false);
-		assert.equal(tab.valid, false);
+		assert.strictEqual(tab.valid, false);
 		extHostModelViewDialog.$onPanelValidityChanged(dialogHandle, false);
-		assert.equal(dialog.valid, false);
+		assert.strictEqual(dialog.valid, false);
 		extHostModelViewDialog.$onPanelValidityChanged(pageHandle, false);
-		assert.equal(page.valid, false);
+		assert.strictEqual(page.valid, false);
 	});
 
 	test('Main thread can execute wizard navigation validation', () => {
@@ -287,8 +287,8 @@ suite('ExtHostModelViewDialog Tests', () => {
 			newPage: newPage
 		});
 		assert.notEqual(validationInfo, undefined);
-		assert.equal(validationInfo.lastPage, lastPage);
-		assert.equal(validationInfo.newPage, newPage);
+		assert.strictEqual(validationInfo.lastPage, lastPage);
+		assert.strictEqual(validationInfo.newPage, newPage);
 	});
 
 	test('Changing the wizard message sends the new message to the main thread', () => {
@@ -323,6 +323,6 @@ suite('ExtHostModelViewDialog Tests', () => {
 
 		// If I call the validation from the main thread then it should run
 		extHostModelViewDialog.$validateDialogClose(dialogHandle);
-		assert.equal(callCount, 1);
+		assert.strictEqual(callCount, 1);
 	});
 });

--- a/src/sql/workbench/test/electron-browser/api/extHostObjectExplorer.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostObjectExplorer.test.ts
@@ -84,27 +84,27 @@ suite('ExtHostObjectExplorer Tests', () => {
 		suite('getParent', () => {
 			test('Should return undefined if no parent', async () => {
 				extHostObjectExplorerNode = new ExtHostObjectExplorerNode(nodes['Server1'], 'connectionId', mockProxy.object);
-				assert.equal(await extHostObjectExplorerNode.getParent(), undefined);
+				assert.strictEqual(await extHostObjectExplorerNode.getParent(), undefined);
 			});
 
 			test('should return root with direct descendent of root', async () => {
 				extHostObjectExplorerNode = new ExtHostObjectExplorerNode(nodes['DatabasesFolder'], 'connectionId', mockProxy.object);
-				assert.equal((await extHostObjectExplorerNode.getParent()).nodePath, nodes['Server1'].nodePath);
+				assert.strictEqual((await extHostObjectExplorerNode.getParent()).nodePath, nodes['Server1'].nodePath);
 			});
 
 			test('should return correct parent with further descendent of root', async () => {
 				extHostObjectExplorerNode = new ExtHostObjectExplorerNode(nodes['Database1'], 'connectionId', mockProxy.object);
-				assert.equal((await extHostObjectExplorerNode.getParent()).nodePath, nodes['DatabasesFolder'].nodePath);
+				assert.strictEqual((await extHostObjectExplorerNode.getParent()).nodePath, nodes['DatabasesFolder'].nodePath);
 			});
 
 			test('should return correct parent with node having / in its name', async () => {
 				extHostObjectExplorerNode = new ExtHostObjectExplorerNode(nodes['Database2'], 'connectionId', mockProxy.object);
-				assert.equal((await extHostObjectExplorerNode.getParent()).nodePath, nodes['DatabasesFolder'].nodePath);
+				assert.strictEqual((await extHostObjectExplorerNode.getParent()).nodePath, nodes['DatabasesFolder'].nodePath);
 			});
 
 			test('should return correct parent with parent node having / in its name', async () => {
 				extHostObjectExplorerNode = new ExtHostObjectExplorerNode(nodes['TablesFolder'], 'connectionId', mockProxy.object);
-				assert.equal((await extHostObjectExplorerNode.getParent()).nodePath, nodes['Database2'].nodePath);
+				assert.strictEqual((await extHostObjectExplorerNode.getParent()).nodePath, nodes['Database2'].nodePath);
 			});
 		});
 	});

--- a/src/sql/workbench/test/electron-browser/api/exthostNotebook.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/exthostNotebook.test.ts
@@ -87,7 +87,7 @@ suite('ExtHostNotebook Tests', () => {
 				// This is because we can't easily track identity of the managers, so just track which one is assigned to
 				// a notebook by the handle ID
 				assert.notEqual(originalManagerDetails.handle, differentDetails.handle, 'Should have unique handle for each manager');
-				assert.equal(originalManagerDetails.handle, sameDetails.handle, 'Should have same handle when same URI is passed in');
+				assert.strictEqual(originalManagerDetails.handle, sameDetails.handle, 'Should have same handle when same URI is passed in');
 
 			});
 		});

--- a/src/sql/workbench/test/electron-browser/api/exthostNotebook.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/exthostNotebook.test.ts
@@ -86,7 +86,7 @@ suite('ExtHostNotebook Tests', () => {
 				// Then I expect the 2 different handles in the managers returned.
 				// This is because we can't easily track identity of the managers, so just track which one is assigned to
 				// a notebook by the handle ID
-				assert.notEqual(originalManagerDetails.handle, differentDetails.handle, 'Should have unique handle for each manager');
+				assert.notStrictEqual(originalManagerDetails.handle, differentDetails.handle, 'Should have unique handle for each manager');
 				assert.strictEqual(originalManagerDetails.handle, sameDetails.handle, 'Should have same handle when same URI is passed in');
 
 			});

--- a/src/sql/workbench/test/electron-browser/api/mainThreadModelViewDialog.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/mainThreadModelViewDialog.test.ts
@@ -197,21 +197,21 @@ suite('MainThreadModelViewDialog Tests', () => {
 		// Then the opened dialog's content and buttons match what was set
 		mockDialogService.verify(x => x.showDialog(It.isAny(), undefined, It.isAny()), Times.once());
 		assert.notEqual(openedDialog, undefined);
-		assert.equal(openedDialog.title, dialogDetails.title);
-		assert.equal(openedDialog.okButton.label, okButtonDetails.label);
-		assert.equal(openedDialog.okButton.enabled, okButtonDetails.enabled);
-		assert.equal(openedDialog.cancelButton.label, cancelButtonDetails.label);
-		assert.equal(openedDialog.cancelButton.enabled, cancelButtonDetails.enabled);
-		assert.equal(openedDialog.customButtons.length, 2);
-		assert.equal(openedDialog.customButtons[0].label, button1Details.label);
-		assert.equal(openedDialog.customButtons[0].enabled, button1Details.enabled);
-		assert.equal(openedDialog.customButtons[1].label, button2Details.label);
-		assert.equal(openedDialog.customButtons[1].enabled, button2Details.enabled);
-		assert.equal(openedDialog.content.length, 2);
-		assert.equal((openedDialog.content[0] as DialogTab).content, tab1Details.content);
-		assert.equal((openedDialog.content[0] as DialogTab).title, tab1Details.title);
-		assert.equal((openedDialog.content[1] as DialogTab).content, tab2Details.content);
-		assert.equal((openedDialog.content[1] as DialogTab).title, tab2Details.title);
+		assert.strictEqual(openedDialog.title, dialogDetails.title);
+		assert.strictEqual(openedDialog.okButton.label, okButtonDetails.label);
+		assert.strictEqual(openedDialog.okButton.enabled, okButtonDetails.enabled);
+		assert.strictEqual(openedDialog.cancelButton.label, cancelButtonDetails.label);
+		assert.strictEqual(openedDialog.cancelButton.enabled, cancelButtonDetails.enabled);
+		assert.strictEqual(openedDialog.customButtons.length, 2);
+		assert.strictEqual(openedDialog.customButtons[0].label, button1Details.label);
+		assert.strictEqual(openedDialog.customButtons[0].enabled, button1Details.enabled);
+		assert.strictEqual(openedDialog.customButtons[1].label, button2Details.label);
+		assert.strictEqual(openedDialog.customButtons[1].enabled, button2Details.enabled);
+		assert.strictEqual(openedDialog.content.length, 2);
+		assert.strictEqual((openedDialog.content[0] as DialogTab).content, tab1Details.content);
+		assert.strictEqual((openedDialog.content[0] as DialogTab).title, tab1Details.title);
+		assert.strictEqual((openedDialog.content[1] as DialogTab).content, tab2Details.content);
+		assert.strictEqual((openedDialog.content[1] as DialogTab).title, tab2Details.title);
 	});
 
 	test('Button presses are forwarded to the extension host', () => {
@@ -253,29 +253,29 @@ suite('MainThreadModelViewDialog Tests', () => {
 		// Then the opened wizard's content and buttons match what was set
 		mockDialogService.verify(x => x.showWizard(It.isAny(), It.isAny(), It.isAny()), Times.once());
 		assert.notEqual(openedWizard, undefined);
-		assert.equal(openedWizard.title, wizardDetails.title);
-		assert.equal(openedWizard.doneButton.label, okButtonDetails.label);
-		assert.equal(openedWizard.doneButton.enabled, okButtonDetails.enabled);
-		assert.equal(openedWizard.cancelButton.label, cancelButtonDetails.label);
-		assert.equal(openedWizard.cancelButton.enabled, cancelButtonDetails.enabled);
-		assert.equal(openedWizard.customButtons.length, 0);
-		assert.equal(openedWizard.pages.length, 2);
-		assert.equal(openedWizard.currentPage, 0);
-		assert.equal(openedWizard.displayPageTitles, wizardDetails.displayPageTitles);
+		assert.strictEqual(openedWizard.title, wizardDetails.title);
+		assert.strictEqual(openedWizard.doneButton.label, okButtonDetails.label);
+		assert.strictEqual(openedWizard.doneButton.enabled, okButtonDetails.enabled);
+		assert.strictEqual(openedWizard.cancelButton.label, cancelButtonDetails.label);
+		assert.strictEqual(openedWizard.cancelButton.enabled, cancelButtonDetails.enabled);
+		assert.strictEqual(openedWizard.customButtons.length, 0);
+		assert.strictEqual(openedWizard.pages.length, 2);
+		assert.strictEqual(openedWizard.currentPage, 0);
+		assert.strictEqual(openedWizard.displayPageTitles, wizardDetails.displayPageTitles);
 		let page1 = openedWizard.pages[0];
-		assert.equal(page1.title, page1Details.title);
-		assert.equal(page1.content, page1Details.content);
-		assert.equal(page1.enabled, page1Details.enabled);
-		assert.equal(page1.valid, true);
-		assert.equal(page1.customButtons.length, 0);
-		assert.equal(page1.description, page1Details.description);
+		assert.strictEqual(page1.title, page1Details.title);
+		assert.strictEqual(page1.content, page1Details.content);
+		assert.strictEqual(page1.enabled, page1Details.enabled);
+		assert.strictEqual(page1.valid, true);
+		assert.strictEqual(page1.customButtons.length, 0);
+		assert.strictEqual(page1.description, page1Details.description);
 		let page2 = openedWizard.pages[1];
-		assert.equal(page2.title, page2Details.title);
-		assert.equal(page2.content, page2Details.content);
-		assert.equal(page2.enabled, page2Details.enabled);
-		assert.equal(page2.valid, true);
-		assert.equal(page2.customButtons.length, 2);
-		assert.equal(page2.description, page2Details.description);
+		assert.strictEqual(page2.title, page2Details.title);
+		assert.strictEqual(page2.content, page2Details.content);
+		assert.strictEqual(page2.enabled, page2Details.enabled);
+		assert.strictEqual(page2.valid, true);
+		assert.strictEqual(page2.customButtons.length, 2);
+		assert.strictEqual(page2.description, page2Details.description);
 	});
 
 	test('The extension host gets notified when wizard page change events occur', () => {
@@ -364,8 +364,8 @@ suite('MainThreadModelViewDialog Tests', () => {
 		mainThreadModelViewDialog.$setWizardDetails(wizardHandle, wizardDetails);
 
 		// Then the message gets changed on the wizard
-		assert.equal(newMessage, wizardDetails.message, 'New message was not included in the fired event');
-		assert.equal(openedWizard.message, wizardDetails.message, 'New message was not set on the wizard');
+		assert.strictEqual(newMessage, wizardDetails.message, 'New message was not included in the fired event');
+		assert.strictEqual(openedWizard.message, wizardDetails.message, 'New message was not set on the wizard');
 	});
 
 	test('Creating a dialog adds a close validation that calls the extension host', () => {

--- a/src/sql/workbench/test/electron-browser/api/mainThreadModelViewDialog.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/mainThreadModelViewDialog.test.ts
@@ -243,7 +243,7 @@ suite('MainThreadModelViewDialog Tests', () => {
 		okEmitter.fire();
 
 		// Verify that the correct button click notifications were sent to the proxy
-		assert.deepEqual(pressedHandles, [button1Handle, button2Handle, okButtonHandle, cancelButtonHandle, button2Handle, cancelButtonHandle, button1Handle, okButtonHandle]);
+		assert.deepStrictEqual(pressedHandles, [button1Handle, button2Handle, okButtonHandle, cancelButtonHandle, button2Handle, cancelButtonHandle, button1Handle, okButtonHandle]);
 	});
 
 	test('Creating a wizard and calling open on it causes a wizard with correct pages and buttons to open', () => {

--- a/src/sql/workbench/test/electron-browser/api/mainThreadModelViewDialog.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/mainThreadModelViewDialog.test.ts
@@ -196,7 +196,7 @@ suite('MainThreadModelViewDialog Tests', () => {
 
 		// Then the opened dialog's content and buttons match what was set
 		mockDialogService.verify(x => x.showDialog(It.isAny(), undefined, It.isAny()), Times.once());
-		assert.notEqual(openedDialog, undefined);
+		assert.notStrictEqual(openedDialog, undefined);
 		assert.strictEqual(openedDialog.title, dialogDetails.title);
 		assert.strictEqual(openedDialog.okButton.label, okButtonDetails.label);
 		assert.strictEqual(openedDialog.okButton.enabled, okButtonDetails.enabled);
@@ -252,7 +252,7 @@ suite('MainThreadModelViewDialog Tests', () => {
 
 		// Then the opened wizard's content and buttons match what was set
 		mockDialogService.verify(x => x.showWizard(It.isAny(), It.isAny(), It.isAny()), Times.once());
-		assert.notEqual(openedWizard, undefined);
+		assert.notStrictEqual(openedWizard, undefined);
 		assert.strictEqual(openedWizard.title, wizardDetails.title);
 		assert.strictEqual(openedWizard.doneButton.label, okButtonDetails.label);
 		assert.strictEqual(openedWizard.doneButton.enabled, okButtonDetails.enabled);

--- a/src/sql/workbench/test/electron-browser/api/mainThreadNotebook.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/mainThreadNotebook.test.ts
@@ -131,7 +131,7 @@ suite('MainThreadNotebook Tests', () => {
 
 			// Then it shouldn't have wrappers for the content or server manager
 			assert.ok(!(manager.contentManager instanceof LocalContentManager));
-			assert.notEqual(manager.serverManager, undefined);
+			assert.notStrictEqual(manager.serverManager, undefined);
 		});
 	});
 

--- a/src/sql/workbench/test/electron-browser/api/mainThreadNotebook.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/mainThreadNotebook.test.ts
@@ -70,7 +70,7 @@ suite('MainThreadNotebook Tests', () => {
 			mainThreadNotebook.$registerNotebookProvider(providerId, 1);
 			// Then I expect a provider implementation to be passed to the service
 			mockNotebookService.verify(s => s.registerProvider(TypeMoq.It.isAnyString(), TypeMoq.It.isAny()), TypeMoq.Times.once());
-			assert.equal(provider.providerId, providerId);
+			assert.strictEqual(provider.providerId, providerId);
 		});
 		test('should unregister in service', () => {
 			// Given we have a provider
@@ -118,7 +118,7 @@ suite('MainThreadNotebook Tests', () => {
 			// Then it should use the built-in content manager
 			assert.ok(manager.contentManager instanceof LocalContentManager);
 			// And it should not define a server manager
-			assert.equal(manager.serverManager, undefined);
+			assert.strictEqual(manager.serverManager, undefined);
 		});
 
 		test('should return manager with a content & server manager if extension host has these', async () => {

--- a/src/sql/workbench/test/electron-browser/modalComponents/componentBase.test.ts
+++ b/src/sql/workbench/test/electron-browser/modalComponents/componentBase.test.ts
@@ -67,7 +67,7 @@ suite('ComponentBase Tests', () => {
 	});
 
 	test('Component validation runs external validations stored in the model store', () => {
-		assert.equal(testComponent.valid, true, 'Test component validity did not default to true');
+		assert.strictEqual(testComponent.valid, true, 'Test component validity did not default to true');
 		let validationCalls = 0;
 		modelStore.registerValidationCallback(componentId => {
 			validationCalls += 1;
@@ -75,14 +75,14 @@ suite('ComponentBase Tests', () => {
 		});
 
 		return testComponent.validate().then(valid => {
-			assert.equal(validationCalls, 1, 'External validation was not called once');
-			assert.equal(valid, false, 'Validate call did not return correct value from the external validation');
-			assert.equal(testComponent.valid, false, 'Validate call did not update the component valid property');
+			assert.strictEqual(validationCalls, 1, 'External validation was not called once');
+			assert.strictEqual(valid, false, 'Validate call did not return correct value from the external validation');
+			assert.strictEqual(testComponent.valid, false, 'Validate call did not update the component valid property');
 		});
 	});
 
 	test('Component validation runs default component validations', () => {
-		assert.equal(testComponent.valid, true, 'Test component validity did not default to true');
+		assert.strictEqual(testComponent.valid, true, 'Test component validity did not default to true');
 		let validationCalls = 0;
 		testComponent.addValidation(() => {
 			validationCalls += 1;
@@ -90,20 +90,20 @@ suite('ComponentBase Tests', () => {
 		});
 
 		return testComponent.validate().then(valid => {
-			assert.equal(validationCalls, 1, 'Default validation was not called once');
-			assert.equal(valid, false, 'Validate call did not return correct value from the default validation');
-			assert.equal(testComponent.valid, false, 'Validate call did not update the component valid property');
+			assert.strictEqual(validationCalls, 1, 'Default validation was not called once');
+			assert.strictEqual(valid, false, 'Validate call did not return correct value from the default validation');
+			assert.strictEqual(testComponent.valid, false, 'Validate call did not update the component valid property');
 		});
 	});
 
 	test('Container validation reflects child component validity', () => {
-		assert.equal(testContainer.valid, true, 'Test container validity did not default to true');
+		assert.strictEqual(testContainer.valid, true, 'Test container validity did not default to true');
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined }]);
 		testComponent.addValidation(() => false);
 		return testComponent.validate().then(() => {
 			return testContainer.validate().then(valid => {
-				assert.equal(valid, false, 'Validate call did not return correct value for container child validation');
-				assert.equal(testContainer.valid, false, 'Validate call did not update the container valid property');
+				assert.strictEqual(valid, false, 'Validate call did not return correct value for container child validation');
+				assert.strictEqual(testContainer.valid, false, 'Validate call did not update the container valid property');
 			});
 		});
 	});
@@ -112,8 +112,8 @@ suite('ComponentBase Tests', () => {
 		testContainer.registerEventHandler(event => {
 			try {
 				if (event.eventType === ComponentEventType.validityChanged) {
-					assert.equal(testContainer.valid, false, 'Test container validity did not change to false when child validity changed');
-					assert.equal(event.args, false, 'ValidityChanged event did not contain the updated container validity');
+					assert.strictEqual(testContainer.valid, false, 'Test container validity did not change to false when child validity changed');
+					assert.strictEqual(event.args, false, 'ValidityChanged event did not contain the updated container validity');
 					done();
 				}
 			} catch (err) {
@@ -127,51 +127,51 @@ suite('ComponentBase Tests', () => {
 
 	test('Inserting a component to a container adds the component to the right place', () => {
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined }]);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 		testContainer.addToContainer([{ componentDescriptor: testComponent2.descriptor, config: undefined, index: 0 }]);
-		assert.equal(testContainer.TestItems.length, 2, `Unexpected number of items. Expected 2 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
-		assert.equal(testContainer.TestItems[0].descriptor.id, testComponent2.descriptor.id);
+		assert.strictEqual(testContainer.TestItems.length, 2, `Unexpected number of items. Expected 2 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems[0].descriptor.id, testComponent2.descriptor.id);
 	});
 
 	test('Inserting a component to a container given negative index fails', () => {
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined }]);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 		assert.throws(() => testContainer.addToContainer([{ componentDescriptor: testComponent2.descriptor, config: undefined, index: -1 }]));
 	});
 
 	test('Inserting a component to a container given wrong index fails', () => {
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined }]);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 		assert.throws(() => testContainer.addToContainer([{ componentDescriptor: testComponent2.descriptor, config: undefined, index: 10 }]));
 	});
 
 	test('Inserting a component to a container given end of list succeeds', () => {
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined }]);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 		testContainer.addToContainer([{ componentDescriptor: testComponent2.descriptor, config: undefined, index: 1 }]);
-		assert.equal(testContainer.TestItems.length, 2, `Unexpected number of items. Expected 2 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 2, `Unexpected number of items. Expected 2 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 	});
 
 	test('Removing a component the does not exist does not make change in the items', () => {
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined }]);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 		testContainer.removeFromContainer(testComponent2.descriptor);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 	});
 
 	test('Removing a component removes it from items', () => {
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined }]);
 		testContainer.addToContainer([{ componentDescriptor: testComponent2.descriptor, config: undefined }]);
-		assert.equal(testContainer.TestItems.length, 2, `Unexpected number of items. Expected 2 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 2, `Unexpected number of items. Expected 2 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 		testContainer.removeFromContainer(testComponent.descriptor);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
-		assert.equal(testContainer.TestItems[0].descriptor.id, testComponent2.descriptor.id);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems[0].descriptor.id, testComponent2.descriptor.id);
 	});
 
 	test('Container dost not add same component twice', () => {
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined }]);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 		testContainer.addToContainer([{ componentDescriptor: testComponent.descriptor, config: undefined, index: 0 }]);
-		assert.equal(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
+		assert.strictEqual(testContainer.TestItems.length, 1, `Unexpected number of items. Expected 1 got ${testContainer.TestItems.length} : ${JSON.stringify(testContainer.TestItems)}`);
 	});
 });

--- a/src/sql/workbench/test/electron-browser/modalComponents/table.component.test.ts
+++ b/src/sql/workbench/test/electron-browser/modalComponents/table.component.test.ts
@@ -34,7 +34,7 @@ suite('TableComponent Tests', () => {
 				'c3': '6'
 			}
 		];
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('Table transformData should return empty array given undefined rows', () => {
@@ -43,7 +43,7 @@ suite('TableComponent Tests', () => {
 		let columns = ['c1', 'c2', 'c3'];
 		let actual = tableComponent.transformData(data, columns);
 		let expected: { [key: string]: string }[] = [];
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('Table transformData should return empty array given undefined columns', () => {
@@ -55,7 +55,7 @@ suite('TableComponent Tests', () => {
 		const tableComponent = new TableComponent(undefined, undefined, undefined, new NullLogService(), undefined);
 		let actual = tableComponent.transformData(data, columns);
 		let expected: { [key: string]: string }[] = [];
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 
 	test('Table transformData should return array matched with columns given rows with missing column', () => {
@@ -76,6 +76,6 @@ suite('TableComponent Tests', () => {
 				'c2': '5'
 			}
 		];
-		assert.deepEqual(actual, expected);
+		assert.deepStrictEqual(actual, expected);
 	});
 });

--- a/src/vs/base/parts/tree/test/browser/treeModel.test.ts
+++ b/src/vs/base/parts/tree/test/browser/treeModel.test.ts
@@ -915,7 +915,7 @@ suite('TreeModel - Traits', () => {
 			assert(model.isSelected(SAMPLE.AB.children[2]));
 
 			model.setSelection([]);
-			assert.deepEqual(model.getSelection(), []);
+			assert.deepStrictEqual(model.getSelection(), []);
 			assert.strictEqual(model.getSelection().length, 0);
 			assert(!model.isSelected(SAMPLE.AB.children[0]));
 			assert(!model.isSelected(SAMPLE.AB.children[1]));

--- a/src/vs/base/parts/tree/test/browser/treeModel.test.ts
+++ b/src/vs/base/parts/tree/test/browser/treeModel.test.ts
@@ -196,7 +196,7 @@ suite('TreeModel', () => {
 
 	test('setInput, getInput', () => {
 		model.setInput(SAMPLE.ONE);
-		assert.equal(model.getInput(), SAMPLE.ONE);
+		assert.strictEqual(model.getInput(), SAMPLE.ONE);
 	});
 
 	test('refresh() refreshes all', () => {
@@ -208,7 +208,7 @@ suite('TreeModel', () => {
 			counter.listen(model.onDidRefreshItemChildren); // 1
 			return model.refresh(null);
 		}).then(() => {
-			assert.equal(counter.count, 8);
+			assert.strictEqual(counter.count, 8);
 		});
 	});
 
@@ -221,7 +221,7 @@ suite('TreeModel', () => {
 			counter.listen(model.onDidRefreshItemChildren); // 1
 			return model.refresh(SAMPLE.AB);
 		}).then(() => {
-			assert.equal(counter.count, 8);
+			assert.strictEqual(counter.count, 8);
 		});
 	});
 
@@ -234,7 +234,7 @@ suite('TreeModel', () => {
 			counter.listen(model.onDidRefreshItemChildren); // 1
 			return model.refresh(SAMPLE.AB, false);
 		}).then(() => {
-			assert.equal(counter.count, 5);
+			assert.strictEqual(counter.count, 5);
 		});
 	});
 
@@ -247,7 +247,7 @@ suite('TreeModel', () => {
 			counter.listen(model.onDidRefreshItemChildren); // 0
 			return model.refresh(SAMPLE.AB.children[0]);
 		}).then(() => {
-			assert.equal(counter.count, 3);
+			assert.strictEqual(counter.count, 3);
 		});
 	});
 
@@ -262,7 +262,7 @@ suite('TreeModel', () => {
 				return model.refresh(SAMPLE.AB.children[0]);
 			});
 		}).then(() => {
-			assert.equal(counter.count, 7);
+			assert.strictEqual(counter.count, 7);
 		});
 	});
 
@@ -272,7 +272,7 @@ suite('TreeModel', () => {
 				counter.listen(model.onRefresh); // 1
 				counter.listen(model.onDidRefresh); // 1
 				counter.listen(model.onDidRefreshItem, item => { // 1
-					assert.equal(item.id, 'a');
+					assert.strictEqual(item.id, 'a');
 					counter.up();
 				});
 				counter.listen(model.onRefreshItemChildren); // 1
@@ -280,7 +280,7 @@ suite('TreeModel', () => {
 				return model.refresh(SAMPLE.AB.children[0], false);
 			});
 		}).then(() => {
-			assert.equal(counter.count, 6);
+			assert.strictEqual(counter.count, 6);
 		});
 	});
 
@@ -289,14 +289,14 @@ suite('TreeModel', () => {
 			return model.expandAll(['a', 'c']).then(() => {
 				counter.listen(model.onDidRefreshItem, item => {
 					switch (item.id) {
-						case 'ROOT': assert.equal(item.getDepth(), 0); break;
-						case 'a': assert.equal(item.getDepth(), 1); break;
-						case 'aa': assert.equal(item.getDepth(), 2); break;
-						case 'ab': assert.equal(item.getDepth(), 2); break;
-						case 'b': assert.equal(item.getDepth(), 1); break;
-						case 'c': assert.equal(item.getDepth(), 1); break;
-						case 'ca': assert.equal(item.getDepth(), 2); break;
-						case 'cb': assert.equal(item.getDepth(), 2); break;
+						case 'ROOT': assert.strictEqual(item.getDepth(), 0); break;
+						case 'a': assert.strictEqual(item.getDepth(), 1); break;
+						case 'aa': assert.strictEqual(item.getDepth(), 2); break;
+						case 'ab': assert.strictEqual(item.getDepth(), 2); break;
+						case 'b': assert.strictEqual(item.getDepth(), 1); break;
+						case 'c': assert.strictEqual(item.getDepth(), 1); break;
+						case 'ca': assert.strictEqual(item.getDepth(), 2); break;
+						case 'cb': assert.strictEqual(item.getDepth(), 2); break;
 						default: return;
 					}
 					counter.up();
@@ -305,7 +305,7 @@ suite('TreeModel', () => {
 				return model.refresh();
 			});
 		}).then(() => {
-			assert.equal(counter.count, 16);
+			assert.strictEqual(counter.count, 16);
 		});
 	});
 
@@ -349,10 +349,10 @@ suite('TreeModel - TreeNavigator', () => {
 	test('next()', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			const nav = model.getNavigator();
-			assert.equal(nav.next()!.id, 'a');
-			assert.equal(nav.next()!.id, 'b');
-			assert.equal(nav.next()!.id, 'c');
-			assert.equal(nav.next() && false, null);
+			assert.strictEqual(nav.next()!.id, 'a');
+			assert.strictEqual(nav.next()!.id, 'b');
+			assert.strictEqual(nav.next()!.id, 'c');
+			assert.strictEqual(nav.next() && false, null);
 		});
 	});
 
@@ -363,10 +363,10 @@ suite('TreeModel - TreeNavigator', () => {
 			nav.next();
 			nav.next();
 
-			assert.equal(nav.next()!.id, 'c');
-			assert.equal(nav.previous()!.id, 'b');
-			assert.equal(nav.previous()!.id, 'a');
-			assert.equal(nav.previous() && false, null);
+			assert.strictEqual(nav.next()!.id, 'c');
+			assert.strictEqual(nav.previous()!.id, 'b');
+			assert.strictEqual(nav.previous()!.id, 'a');
+			assert.strictEqual(nav.previous() && false, null);
 		});
 	});
 
@@ -375,22 +375,22 @@ suite('TreeModel - TreeNavigator', () => {
 			return model.expandAll([{ id: 'a' }, { id: 'c' }]).then(() => {
 				const nav = model.getNavigator();
 
-				assert.equal(nav.next()!.id, 'a');
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.parent()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.parent()!.id, 'a');
 
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.parent()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.parent()!.id, 'a');
 
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.next()!.id, 'ca');
-				assert.equal(nav.parent()!.id, 'c');
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.next()!.id, 'ca');
+				assert.strictEqual(nav.parent()!.id, 'c');
 
-				assert.equal(nav.parent() && false, null);
+				assert.strictEqual(nav.parent() && false, null);
 			});
 		});
 	});
@@ -399,9 +399,9 @@ suite('TreeModel - TreeNavigator', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			const nav = model.getNavigator(SAMPLE.AB.children[0]);
 			return model.expand({ id: 'a' }).then(() => {
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.next() && false, null);
 			});
 		});
 	});
@@ -410,10 +410,10 @@ suite('TreeModel - TreeNavigator', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			const nav = model.getNavigator(SAMPLE.AB.children[0]);
 			return model.expand({ id: 'a' }).then(() => {
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.previous()!.id, 'aa');
-				assert.equal(nav.previous() && false, null);
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.previous()!.id, 'aa');
+				assert.strictEqual(nav.previous() && false, null);
 			});
 		});
 	});
@@ -423,9 +423,9 @@ suite('TreeModel - TreeNavigator', () => {
 			return model.expandAll([{ id: 'a' }, { id: 'c' }]).then(() => {
 				const nav = model.getNavigator(SAMPLE.AB.children[0]);
 
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.parent() && false, null);
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.parent() && false, null);
 			});
 		});
 	});
@@ -434,11 +434,11 @@ suite('TreeModel - TreeNavigator', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			const nav = model.getNavigator(SAMPLE.AB.children[0], false);
 			return model.expand({ id: 'a' }).then(() => {
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.next() && false, null);
 			});
 		});
 	});
@@ -447,15 +447,15 @@ suite('TreeModel - TreeNavigator', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			const nav = model.getNavigator(SAMPLE.AB.children[0], false);
 			return model.expand({ id: 'a' }).then(() => {
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.previous()!.id, 'b');
-				assert.equal(nav.previous()!.id, 'ab');
-				assert.equal(nav.previous()!.id, 'aa');
-				assert.equal(nav.previous()!.id, 'a');
-				assert.equal(nav.previous() && false, null);
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.previous()!.id, 'b');
+				assert.strictEqual(nav.previous()!.id, 'ab');
+				assert.strictEqual(nav.previous()!.id, 'aa');
+				assert.strictEqual(nav.previous()!.id, 'a');
+				assert.strictEqual(nav.previous() && false, null);
 			});
 		});
 	});
@@ -465,10 +465,10 @@ suite('TreeModel - TreeNavigator', () => {
 			return model.expandAll([{ id: 'a' }, { id: 'c' }]).then(() => {
 				const nav = model.getNavigator(SAMPLE.AB.children[0], false);
 
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.parent()!.id, 'a');
-				assert.equal(nav.parent() && false, null);
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.parent()!.id, 'a');
+				assert.strictEqual(nav.parent() && false, null);
 			});
 		});
 	});
@@ -478,9 +478,9 @@ suite('TreeModel - TreeNavigator', () => {
 			return model.expand(SAMPLE.DEEP.children[0]).then(() => {
 				return model.expand(SAMPLE.DEEP.children[0].children[0]).then(() => {
 					const nav = model.getNavigator(SAMPLE.DEEP.children[0].children[0]);
-					assert.equal(nav.next()!.id, 'xa');
-					assert.equal(nav.next()!.id, 'xb');
-					assert.equal(nav.next() && false, null);
+					assert.strictEqual(nav.next()!.id, 'xa');
+					assert.strictEqual(nav.next()!.id, 'xb');
+					assert.strictEqual(nav.next() && false, null);
 				});
 			});
 		});
@@ -491,10 +491,10 @@ suite('TreeModel - TreeNavigator', () => {
 			return model.expand(SAMPLE.DEEP.children[0]).then(() => {
 				return model.expand(SAMPLE.DEEP.children[0].children[0]).then(() => {
 					const nav = model.getNavigator(SAMPLE.DEEP.children[0].children[0]);
-					assert.equal(nav.next()!.id, 'xa');
-					assert.equal(nav.next()!.id, 'xb');
-					assert.equal(nav.previous()!.id, 'xa');
-					assert.equal(nav.previous() && false, null);
+					assert.strictEqual(nav.next()!.id, 'xa');
+					assert.strictEqual(nav.next()!.id, 'xb');
+					assert.strictEqual(nav.previous()!.id, 'xa');
+					assert.strictEqual(nav.previous() && false, null);
 				});
 			});
 		});
@@ -504,7 +504,7 @@ suite('TreeModel - TreeNavigator', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			return model.expandAll([{ id: 'a' }, { id: 'c' }]).then(() => {
 				const nav = model.getNavigator();
-				assert.equal(nav.last()!.id, 'cb');
+				assert.strictEqual(nav.last()!.id, 'cb');
 			});
 		});
 	});
@@ -529,45 +529,45 @@ suite('TreeModel - Expansion', () => {
 	test('collapse, expand', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			counter.listen(model.onExpandItem, (e) => {
-				assert.equal(e.item.id, 'a');
+				assert.strictEqual(e.item.id, 'a');
 				const nav = model.getNavigator(e.item);
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next() && false, null);
 			});
 
 			counter.listen(model.onDidExpandItem, (e) => {
-				assert.equal(e.item.id, 'a');
+				assert.strictEqual(e.item.id, 'a');
 				const nav = model.getNavigator(e.item);
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.next() && false, null);
 			});
 
 			assert(!model.isExpanded(SAMPLE.AB.children[0]));
 
 			let nav = model.getNavigator();
-			assert.equal(nav.next()!.id, 'a');
-			assert.equal(nav.next()!.id, 'b');
-			assert.equal(nav.next()!.id, 'c');
-			assert.equal(nav.next() && false, null);
+			assert.strictEqual(nav.next()!.id, 'a');
+			assert.strictEqual(nav.next()!.id, 'b');
+			assert.strictEqual(nav.next()!.id, 'c');
+			assert.strictEqual(nav.next() && false, null);
 
-			assert.equal(model.getExpandedElements().length, 0);
+			assert.strictEqual(model.getExpandedElements().length, 0);
 
 			return model.expand(SAMPLE.AB.children[0]).then(() => {
 				assert(model.isExpanded(SAMPLE.AB.children[0]));
 
 				nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'a');
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.next() && false, null);
 
 				const expandedElements = model.getExpandedElements();
-				assert.equal(expandedElements.length, 1);
-				assert.equal(expandedElements[0].id, 'a');
+				assert.strictEqual(expandedElements.length, 1);
+				assert.strictEqual(expandedElements[0].id, 'a');
 
-				assert.equal(counter.count, 2);
+				assert.strictEqual(counter.count, 2);
 			});
 		});
 	});
@@ -627,18 +627,18 @@ suite('TreeModel - Expansion', () => {
 			assert(!model.isExpanded(SAMPLE.AB.children[0]));
 
 			let nav = model.getNavigator();
-			assert.equal(nav.next()!.id, 'a');
-			assert.equal(nav.next()!.id, 'b');
-			assert.equal(nav.next()!.id, 'c');
-			assert.equal(nav.next() && false, null);
+			assert.strictEqual(nav.next()!.id, 'a');
+			assert.strictEqual(nav.next()!.id, 'b');
+			assert.strictEqual(nav.next()!.id, 'c');
+			assert.strictEqual(nav.next() && false, null);
 
 			const f: () => void = counter.listen(model.onRefreshItemChildren, (e) => {
-				assert.equal(e.item.id, 'a');
+				assert.strictEqual(e.item.id, 'a');
 				f();
 			});
 
 			const g: () => void = counter.listen(model.onDidRefreshItemChildren, (e) => {
-				assert.equal(e.item.id, 'a');
+				assert.strictEqual(e.item.id, 'a');
 				g();
 			});
 
@@ -646,14 +646,14 @@ suite('TreeModel - Expansion', () => {
 				assert(model.isExpanded(SAMPLE.AB.children[0]));
 
 				nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'a');
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.next() && false, null);
 
-				assert.equal(counter.count, 2);
+				assert.strictEqual(counter.count, 2);
 			});
 		});
 	});
@@ -662,12 +662,12 @@ suite('TreeModel - Expansion', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			return model.collapseAll([{ id: 'a' }, { id: 'b' }, { id: 'c' }]).then(() => {
 				const nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'a');
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.previous()!.id, 'b');
-				assert.equal(nav.previous()!.id, 'a');
-				assert.equal(nav.previous() && false, null);
+				assert.strictEqual(nav.next()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.previous()!.id, 'b');
+				assert.strictEqual(nav.previous()!.id, 'a');
+				assert.strictEqual(nav.previous() && false, null);
 			});
 		});
 	});
@@ -735,21 +735,21 @@ suite('TreeModel - Filter', () => {
 
 			return model.expandAll([{ id: 'a' }, { id: 'c' }]).then(() => {
 				const nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'a');
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.next()!.id, 'ca');
-				assert.equal(nav.next()!.id, 'cb');
+				assert.strictEqual(nav.next()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.next()!.id, 'ca');
+				assert.strictEqual(nav.next()!.id, 'cb');
 
-				assert.equal(nav.previous()!.id, 'ca');
-				assert.equal(nav.previous()!.id, 'c');
-				assert.equal(nav.previous()!.id, 'b');
-				assert.equal(nav.previous()!.id, 'ab');
-				assert.equal(nav.previous()!.id, 'aa');
-				assert.equal(nav.previous()!.id, 'a');
-				assert.equal(nav.previous() && false, null);
+				assert.strictEqual(nav.previous()!.id, 'ca');
+				assert.strictEqual(nav.previous()!.id, 'c');
+				assert.strictEqual(nav.previous()!.id, 'b');
+				assert.strictEqual(nav.previous()!.id, 'ab');
+				assert.strictEqual(nav.previous()!.id, 'aa');
+				assert.strictEqual(nav.previous()!.id, 'a');
+				assert.strictEqual(nav.previous() && false, null);
 			});
 		});
 	});
@@ -760,7 +760,7 @@ suite('TreeModel - Filter', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			return model.refresh().then(() => {
 				const nav = model.getNavigator();
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next() && false, null);
 			});
 		});
 	});
@@ -773,12 +773,12 @@ suite('TreeModel - Filter', () => {
 			return model.expand({ id: 'a' }).then(() => {
 
 				const nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'a');
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'ab');
-				assert.equal(nav.previous()!.id, 'aa');
-				assert.equal(nav.previous()!.id, 'a');
-				assert.equal(nav.previous() && false, null);
+				assert.strictEqual(nav.next()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'ab');
+				assert.strictEqual(nav.previous()!.id, 'aa');
+				assert.strictEqual(nav.previous()!.id, 'a');
+				assert.strictEqual(nav.previous() && false, null);
 			});
 		});
 	});
@@ -790,11 +790,11 @@ suite('TreeModel - Filter', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
 			return model.expand({ id: 'a' }).then(() => {
 				const nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'a');
-				assert.equal(nav.next()!.id, 'aa');
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next()!.id, 'a');
+				assert.strictEqual(nav.next()!.id, 'aa');
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.next() && false, null);
 			});
 		});
 	});
@@ -807,14 +807,14 @@ suite('TreeModel - Filter', () => {
 			return model.expand({ id: 'c' }).then(() => {
 
 				const nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.next()!.id, 'ca');
-				assert.equal(nav.next()!.id, 'cb');
-				assert.equal(nav.previous()!.id, 'ca');
-				assert.equal(nav.previous()!.id, 'c');
-				assert.equal(nav.previous()!.id, 'b');
-				assert.equal(nav.previous() && false, null);
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.next()!.id, 'ca');
+				assert.strictEqual(nav.next()!.id, 'cb');
+				assert.strictEqual(nav.previous()!.id, 'ca');
+				assert.strictEqual(nav.previous()!.id, 'c');
+				assert.strictEqual(nav.previous()!.id, 'b');
+				assert.strictEqual(nav.previous() && false, null);
 			});
 		});
 	});
@@ -827,14 +827,14 @@ suite('TreeModel - Filter', () => {
 			return model.expand({ id: 'c' }).then(() => {
 
 				const nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'b');
-				assert.equal(nav.next()!.id, 'c');
-				assert.equal(nav.next()!.id, 'ca');
-				assert.equal(nav.next()!.id, 'cb');
-				assert.equal(nav.previous()!.id, 'ca');
-				assert.equal(nav.previous()!.id, 'c');
-				assert.equal(nav.previous()!.id, 'b');
-				assert.equal(nav.previous() && false, null);
+				assert.strictEqual(nav.next()!.id, 'b');
+				assert.strictEqual(nav.next()!.id, 'c');
+				assert.strictEqual(nav.next()!.id, 'ca');
+				assert.strictEqual(nav.next()!.id, 'cb');
+				assert.strictEqual(nav.previous()!.id, 'ca');
+				assert.strictEqual(nav.previous()!.id, 'c');
+				assert.strictEqual(nav.previous()!.id, 'b');
+				assert.strictEqual(nav.previous() && false, null);
 			});
 		});
 	});
@@ -845,8 +845,8 @@ suite('TreeModel - Filter', () => {
 
 		return model.setInput(SAMPLE.AB).then(() => {
 			const nav = model.getNavigator({ id: 'c' }, false);
-			assert.equal(nav.previous()!.id, 'a');
-			assert.equal(nav.previous() && false, null);
+			assert.strictEqual(nav.previous()!.id, 'a');
+			assert.strictEqual(nav.previous() && false, null);
 		});
 	});
 });
@@ -869,96 +869,96 @@ suite('TreeModel - Traits', () => {
 
 	test('Selection', () => {
 		return model.setInput(SAMPLE.AB).then(() => {
-			assert.equal(model.getSelection().length, 0);
+			assert.strictEqual(model.getSelection().length, 0);
 			model.select(SAMPLE.AB.children[1]);
 			assert(model.isSelected(SAMPLE.AB.children[1]));
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			model.select(SAMPLE.AB.children[0]);
 			assert(model.isSelected(SAMPLE.AB.children[0]));
-			assert.equal(model.getSelection().length, 2);
+			assert.strictEqual(model.getSelection().length, 2);
 			model.select(SAMPLE.AB.children[2]);
 			assert(model.isSelected(SAMPLE.AB.children[2]));
-			assert.equal(model.getSelection().length, 3);
+			assert.strictEqual(model.getSelection().length, 3);
 			model.deselect(SAMPLE.AB.children[0]);
 			assert(!model.isSelected(SAMPLE.AB.children[0]));
-			assert.equal(model.getSelection().length, 2);
+			assert.strictEqual(model.getSelection().length, 2);
 			model.setSelection([]);
 			assert(!model.isSelected(SAMPLE.AB.children[0]));
 			assert(!model.isSelected(SAMPLE.AB.children[1]));
 			assert(!model.isSelected(SAMPLE.AB.children[2]));
-			assert.equal(model.getSelection().length, 0);
+			assert.strictEqual(model.getSelection().length, 0);
 			model.selectAll([SAMPLE.AB.children[0], SAMPLE.AB.children[1], SAMPLE.AB.children[2]]);
-			assert.equal(model.getSelection().length, 3);
+			assert.strictEqual(model.getSelection().length, 3);
 			model.select(SAMPLE.AB.children[0]);
-			assert.equal(model.getSelection().length, 3);
+			assert.strictEqual(model.getSelection().length, 3);
 			model.deselectAll([SAMPLE.AB.children[0], SAMPLE.AB.children[1], SAMPLE.AB.children[2]]);
-			assert.equal(model.getSelection().length, 0);
+			assert.strictEqual(model.getSelection().length, 0);
 			model.deselect(SAMPLE.AB.children[0]);
-			assert.equal(model.getSelection().length, 0);
+			assert.strictEqual(model.getSelection().length, 0);
 
 			model.setSelection([SAMPLE.AB.children[0]]);
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[0]));
 			assert(!model.isSelected(SAMPLE.AB.children[1]));
 			assert(!model.isSelected(SAMPLE.AB.children[2]));
 
 			model.setSelection([SAMPLE.AB.children[0], SAMPLE.AB.children[1], SAMPLE.AB.children[2]]);
-			assert.equal(model.getSelection().length, 3);
+			assert.strictEqual(model.getSelection().length, 3);
 			assert(model.isSelected(SAMPLE.AB.children[0]));
 			assert(model.isSelected(SAMPLE.AB.children[1]));
 			assert(model.isSelected(SAMPLE.AB.children[2]));
 
 			model.setSelection([SAMPLE.AB.children[1], SAMPLE.AB.children[2]]);
-			assert.equal(model.getSelection().length, 2);
+			assert.strictEqual(model.getSelection().length, 2);
 			assert(!model.isSelected(SAMPLE.AB.children[0]));
 			assert(model.isSelected(SAMPLE.AB.children[1]));
 			assert(model.isSelected(SAMPLE.AB.children[2]));
 
 			model.setSelection([]);
 			assert.deepEqual(model.getSelection(), []);
-			assert.equal(model.getSelection().length, 0);
+			assert.strictEqual(model.getSelection().length, 0);
 			assert(!model.isSelected(SAMPLE.AB.children[0]));
 			assert(!model.isSelected(SAMPLE.AB.children[1]));
 			assert(!model.isSelected(SAMPLE.AB.children[2]));
 
 			model.selectNext();
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[0]));
 
 			model.selectNext();
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[1]));
 
 			model.selectNext();
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[2]));
 
 			model.selectNext();
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[2]));
 
 			model.selectPrevious();
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[1]));
 
 			model.selectPrevious();
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[0]));
 
 			model.selectPrevious();
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[0]));
 
 			model.selectNext(2);
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[2]));
 
 			model.selectPrevious(4);
-			assert.equal(model.getSelection().length, 1);
+			assert.strictEqual(model.getSelection().length, 1);
 			assert(model.isSelected(SAMPLE.AB.children[0]));
 
-			assert.equal(model.isSelected(SAMPLE.AB.children[0]), true);
-			assert.equal(model.isSelected(SAMPLE.AB.children[2]), false);
+			assert.strictEqual(model.isSelected(SAMPLE.AB.children[0]), true);
+			assert.strictEqual(model.isSelected(SAMPLE.AB.children[2]), false);
 		});
 	});
 
@@ -1028,8 +1028,8 @@ suite('TreeModel - Traits', () => {
 			assert(model.getFocus());
 			assert(model.isFocused(SAMPLE.AB.children[0]));
 
-			assert.equal(model.isFocused(SAMPLE.AB.children[0]), true);
-			assert.equal(model.isFocused(SAMPLE.AB.children[2]), false);
+			assert.strictEqual(model.isFocused(SAMPLE.AB.children[0]), true);
+			assert.strictEqual(model.isFocused(SAMPLE.AB.children[2]), false);
 
 			model.focusFirst();
 			assert(model.isFocused(SAMPLE.AB.children[0]));
@@ -1064,8 +1064,8 @@ suite('TreeModel - Traits', () => {
 			assert(!model.isHighlighted(SAMPLE.AB.children[1]));
 			assert(!model.isHighlighted(SAMPLE.AB.children[2]));
 
-			assert.equal(model.isHighlighted(SAMPLE.AB.children[0]), true);
-			assert.equal(model.isHighlighted(SAMPLE.AB.children[2]), false);
+			assert.strictEqual(model.isHighlighted(SAMPLE.AB.children[0]), true);
+			assert.strictEqual(model.isHighlighted(SAMPLE.AB.children[2]), false);
 
 			model.setHighlight();
 			assert(!model.getHighlight());
@@ -1170,12 +1170,12 @@ suite('TreeModel - Dynamic data model', () => {
 				const items = ['baby', 'son', 'daughter', 'father'];
 				let times = 0;
 				counter.listen(model.onDidDisposeItem, item => {
-					assert.equal(items[times++], item.id);
+					assert.strictEqual(items[times++], item.id);
 				});
 
 				return model.refresh().then(() => {
-					assert.equal(times, items.length);
-					assert.equal(counter.count, 4);
+					assert.strictEqual(times, items.length);
+					assert.strictEqual(counter.count, 4);
 				});
 			});
 		});
@@ -1188,17 +1188,17 @@ suite('TreeModel - Dynamic data model', () => {
 
 		return model.setInput('root').then(() => {
 			let nav = model.getNavigator();
-			assert.equal(nav.next()!.id, 'super');
-			assert.equal(nav.next()!.id, 'hyper');
-			assert.equal(nav.next()!.id, 'mega');
-			assert.equal(nav.next() && false, null);
+			assert.strictEqual(nav.next()!.id, 'super');
+			assert.strictEqual(nav.next()!.id, 'hyper');
+			assert.strictEqual(nav.next()!.id, 'mega');
+			assert.strictEqual(nav.next() && false, null);
 
 			dataModel.removeChild('root', 'hyper');
 			return model.refresh().then(() => {
 				nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'super');
-				assert.equal(nav.next()!.id, 'mega');
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next()!.id, 'super');
+				assert.strictEqual(nav.next()!.id, 'mega');
+				assert.strictEqual(nav.next() && false, null);
 
 				dataModel.addChild('mega', 'micro');
 				dataModel.addChild('mega', 'nano');
@@ -1207,18 +1207,18 @@ suite('TreeModel - Dynamic data model', () => {
 				return model.refresh().then(() => {
 					return model.expand('mega').then(() => {
 						nav = model.getNavigator();
-						assert.equal(nav.next()!.id, 'super');
-						assert.equal(nav.next()!.id, 'mega');
-						assert.equal(nav.next()!.id, 'micro');
-						assert.equal(nav.next()!.id, 'nano');
-						assert.equal(nav.next()!.id, 'pico');
-						assert.equal(nav.next() && false, null);
+						assert.strictEqual(nav.next()!.id, 'super');
+						assert.strictEqual(nav.next()!.id, 'mega');
+						assert.strictEqual(nav.next()!.id, 'micro');
+						assert.strictEqual(nav.next()!.id, 'nano');
+						assert.strictEqual(nav.next()!.id, 'pico');
+						assert.strictEqual(nav.next() && false, null);
 
 						model.collapse('mega');
 						nav = model.getNavigator();
-						assert.equal(nav.next()!.id, 'super');
-						assert.equal(nav.next()!.id, 'mega');
-						assert.equal(nav.next() && false, null);
+						assert.strictEqual(nav.next()!.id, 'super');
+						assert.strictEqual(nav.next()!.id, 'mega');
+						assert.strictEqual(nav.next() && false, null);
 					});
 				});
 			});
@@ -1238,13 +1238,13 @@ suite('TreeModel - Dynamic data model', () => {
 			return model.expand('super').then(() => {
 
 				let nav = model.getNavigator();
-				assert.equal(nav.next()!.id, 'super');
-				assert.equal(nav.next()!.id, 'apples');
-				assert.equal(nav.next()!.id, 'bananas');
-				assert.equal(nav.next()!.id, 'pears');
-				assert.equal(nav.next()!.id, 'hyper');
-				assert.equal(nav.next()!.id, 'mega');
-				assert.equal(nav.next() && false, null);
+				assert.strictEqual(nav.next()!.id, 'super');
+				assert.strictEqual(nav.next()!.id, 'apples');
+				assert.strictEqual(nav.next()!.id, 'bananas');
+				assert.strictEqual(nav.next()!.id, 'pears');
+				assert.strictEqual(nav.next()!.id, 'hyper');
+				assert.strictEqual(nav.next()!.id, 'mega');
+				assert.strictEqual(nav.next() && false, null);
 
 				dataModel.move('bananas', 'super', 'hyper');
 				dataModel.move('apples', 'super', 'mega');
@@ -1253,13 +1253,13 @@ suite('TreeModel - Dynamic data model', () => {
 
 					return model.expandAll(['hyper', 'mega']).then(() => {
 						nav = model.getNavigator();
-						assert.equal(nav.next()!.id, 'super');
-						assert.equal(nav.next()!.id, 'pears');
-						assert.equal(nav.next()!.id, 'hyper');
-						assert.equal(nav.next()!.id, 'bananas');
-						assert.equal(nav.next()!.id, 'mega');
-						assert.equal(nav.next()!.id, 'apples');
-						assert.equal(nav.next() && false, null);
+						assert.strictEqual(nav.next()!.id, 'super');
+						assert.strictEqual(nav.next()!.id, 'pears');
+						assert.strictEqual(nav.next()!.id, 'hyper');
+						assert.strictEqual(nav.next()!.id, 'bananas');
+						assert.strictEqual(nav.next()!.id, 'mega');
+						assert.strictEqual(nav.next()!.id, 'apples');
+						assert.strictEqual(nav.next() && false, null);
 					});
 				});
 			});
@@ -1277,20 +1277,20 @@ suite('TreeModel - Dynamic data model', () => {
 					let times = 0;
 					let listener = dataModel.onGetChildren((element) => {
 						times++;
-						assert.equal(element, 'grandfather');
+						assert.strictEqual(element, 'grandfather');
 					});
 
 					return model.refresh('grandfather').then(() => {
-						assert.equal(times, 1);
+						assert.strictEqual(times, 1);
 						listener.dispose();
 
 						listener = dataModel.onGetChildren((element) => {
 							times++;
-							assert.equal(element, 'father');
+							assert.strictEqual(element, 'father');
 						});
 
 						return model.expand('father').then(() => {
-							assert.equal(times, 2);
+							assert.strictEqual(times, 2);
 							listener.dispose();
 						});
 					});
@@ -1310,11 +1310,11 @@ suite('TreeModel - Dynamic data model', () => {
 				return model.expand('mother').then(() => {
 
 					let nav = model.getNavigator();
-					assert.equal(nav.next()!.id, 'father');
-					assert.equal(nav.next()!.id, 'son');
-					assert.equal(nav.next()!.id, 'mother');
-					assert.equal(nav.next()!.id, 'daughter');
-					assert.equal(nav.next() && false, null);
+					assert.strictEqual(nav.next()!.id, 'father');
+					assert.strictEqual(nav.next()!.id, 'son');
+					assert.strictEqual(nav.next()!.id, 'mother');
+					assert.strictEqual(nav.next()!.id, 'daughter');
+					assert.strictEqual(nav.next() && false, null);
 
 					dataModel.removeChild('father', 'son');
 					dataModel.removeChild('mother', 'daughter');
@@ -1329,23 +1329,23 @@ suite('TreeModel - Dynamic data model', () => {
 					const gotListener = dataModel.onDidGetChildren((element) => { gotTimes++; });
 
 					const p1 = model.refresh('father');
-					assert.equal(getTimes, 1);
-					assert.equal(gotTimes, 0);
+					assert.strictEqual(getTimes, 1);
+					assert.strictEqual(gotTimes, 0);
 
 					const p2 = model.refresh('mother');
-					assert.equal(getTimes, 2);
-					assert.equal(gotTimes, 0);
+					assert.strictEqual(getTimes, 2);
+					assert.strictEqual(gotTimes, 0);
 
 					return Promise.all([p1, p2]).then(() => {
-						assert.equal(getTimes, 2);
-						assert.equal(gotTimes, 2);
+						assert.strictEqual(getTimes, 2);
+						assert.strictEqual(gotTimes, 2);
 
 						nav = model.getNavigator();
-						assert.equal(nav.next()!.id, 'father');
-						assert.equal(nav.next()!.id, 'brother');
-						assert.equal(nav.next()!.id, 'mother');
-						assert.equal(nav.next()!.id, 'sister');
-						assert.equal(nav.next() && false, null);
+						assert.strictEqual(nav.next()!.id, 'father');
+						assert.strictEqual(nav.next()!.id, 'brother');
+						assert.strictEqual(nav.next()!.id, 'mother');
+						assert.strictEqual(nav.next()!.id, 'sister');
+						assert.strictEqual(nav.next() && false, null);
 
 						getListener.dispose();
 						gotListener.dispose();
@@ -1364,10 +1364,10 @@ suite('TreeModel - Dynamic data model', () => {
 			return model.expand('grandfather').then(() => {
 				return model.expand('father').then(() => {
 					let nav = model.getNavigator();
-					assert.equal(nav.next()!.id, 'grandfather');
-					assert.equal(nav.next()!.id, 'father');
-					assert.equal(nav.next()!.id, 'son');
-					assert.equal(nav.next() && false, null);
+					assert.strictEqual(nav.next()!.id, 'grandfather');
+					assert.strictEqual(nav.next()!.id, 'father');
+					assert.strictEqual(nav.next()!.id, 'son');
+					assert.strictEqual(nav.next() && false, null);
 
 					let refreshTimes = 0;
 					counter.listen(model.onDidRefreshItem, (e) => { refreshTimes++; });
@@ -1383,48 +1383,48 @@ suite('TreeModel - Dynamic data model', () => {
 
 					model.refresh('grandfather').then(() => {
 						// just a single get
-						assert.equal(refreshTimes, 1); // (+1) grandfather
-						assert.equal(getTimes, 1);
-						assert.equal(gotTimes, 0);
+						assert.strictEqual(refreshTimes, 1); // (+1) grandfather
+						assert.strictEqual(getTimes, 1);
+						assert.strictEqual(gotTimes, 0);
 
 						// unblock the first get
 						p1Completes.shift()!();
 
 						// once the first get is unblocked, the second get should appear
-						assert.equal(refreshTimes, 2); // (+1) first father refresh
-						assert.equal(getTimes, 2);
-						assert.equal(gotTimes, 1);
+						assert.strictEqual(refreshTimes, 2); // (+1) first father refresh
+						assert.strictEqual(getTimes, 2);
+						assert.strictEqual(gotTimes, 1);
 
 						let p2Complete: () => void;
 						dataModel.promiseFactory = () => { return new Promise<void>((c) => { p2Complete = c; }); };
 						const p2 = model.refresh('father');
 
 						// same situation still
-						assert.equal(refreshTimes, 3); // (+1) second father refresh
-						assert.equal(getTimes, 2);
-						assert.equal(gotTimes, 1);
+						assert.strictEqual(refreshTimes, 3); // (+1) second father refresh
+						assert.strictEqual(getTimes, 2);
+						assert.strictEqual(gotTimes, 1);
 
 						// unblock the second get
 						p1Completes.shift()!();
 
 						// the third get should have appeared, it should've been waiting for the second one
-						assert.equal(refreshTimes, 4); // (+1) first son request
-						assert.equal(getTimes, 3);
-						assert.equal(gotTimes, 2);
+						assert.strictEqual(refreshTimes, 4); // (+1) first son request
+						assert.strictEqual(getTimes, 3);
+						assert.strictEqual(gotTimes, 2);
 
 						p2Complete!();
 
 						// all good
-						assert.equal(refreshTimes, 5); // (+1) second son request
-						assert.equal(getTimes, 3);
-						assert.equal(gotTimes, 3);
+						assert.strictEqual(refreshTimes, 5); // (+1) second son request
+						assert.strictEqual(getTimes, 3);
+						assert.strictEqual(gotTimes, 3);
 
 						return p2.then(() => {
 							nav = model.getNavigator();
-							assert.equal(nav.next()!.id, 'grandfather');
-							assert.equal(nav.next()!.id, 'father');
-							assert.equal(nav.next()!.id, 'son');
-							assert.equal(nav.next() && false, null);
+							assert.strictEqual(nav.next()!.id, 'grandfather');
+							assert.strictEqual(nav.next()!.id, 'father');
+							assert.strictEqual(nav.next()!.id, 'son');
+							assert.strictEqual(nav.next() && false, null);
 
 							getListener.dispose();
 							gotListener.dispose();
@@ -1618,7 +1618,7 @@ suite('TreeModel - bugs', () => {
 			listeners = null;
 			model.dispose();
 
-			assert.equal(counter.count, 0);
+			assert.strictEqual(counter.count, 0);
 		});
 	});
 
@@ -1642,9 +1642,9 @@ suite('TreeModel - bugs', () => {
 		await model.expand('father');
 
 		let nav = model.getNavigator();
-		assert.equal(nav.next()!.id, 'father');
-		assert.equal(nav.next()!.id, 'son');
-		assert.equal(nav.next(), null);
+		assert.strictEqual(nav.next()!.id, 'father');
+		assert.strictEqual(nav.next()!.id, 'son');
+		assert.strictEqual(nav.next(), null);
 
 		await model.collapse('father');
 		isSonVisible = false;
@@ -1653,8 +1653,8 @@ suite('TreeModel - bugs', () => {
 		await model.expand('father');
 
 		nav = model.getNavigator();
-		assert.equal(nav.next()!.id, 'father');
-		assert.equal(nav.next(), null);
+		assert.strictEqual(nav.next()!.id, 'father');
+		assert.strictEqual(nav.next(), null);
 
 		counter.dispose();
 		model.dispose();

--- a/src/vs/base/parts/tree/test/browser/treeViewModel.test.ts
+++ b/src/vs/base/parts/tree/test/browser/treeViewModel.test.ts
@@ -63,15 +63,15 @@ suite('TreeView - HeightMap', () => {
 	});
 
 	test('simple', () => {
-		assert.equal(rangeMap.itemAt(0), 'a');
-		assert.equal(rangeMap.itemAt(2), 'a');
-		assert.equal(rangeMap.itemAt(3), 'b');
-		assert.equal(rangeMap.itemAt(32), 'b');
-		assert.equal(rangeMap.itemAt(33), 'c');
-		assert.equal(rangeMap.itemAt(40), 'c');
-		assert.equal(rangeMap.itemAt(57), 'c');
-		assert.equal(rangeMap.itemAt(58), 'd');
-		assert.equal(rangeMap.itemAt(59), 'd');
+		assert.strictEqual(rangeMap.itemAt(0), 'a');
+		assert.strictEqual(rangeMap.itemAt(2), 'a');
+		assert.strictEqual(rangeMap.itemAt(3), 'b');
+		assert.strictEqual(rangeMap.itemAt(32), 'b');
+		assert.strictEqual(rangeMap.itemAt(33), 'c');
+		assert.strictEqual(rangeMap.itemAt(40), 'c');
+		assert.strictEqual(rangeMap.itemAt(57), 'c');
+		assert.strictEqual(rangeMap.itemAt(58), 'd');
+		assert.strictEqual(rangeMap.itemAt(59), 'd');
 		assert.throws(() => rangeMap.itemAt(60));
 	});
 
@@ -79,20 +79,20 @@ suite('TreeView - HeightMap', () => {
 		let navigator = makeNavigator('x', 4, 'y', 20, 'z', 8);
 		rangeMap.onInsertItems(navigator);
 
-		assert.equal(rangeMap.itemAt(0), 'x');
-		assert.equal(rangeMap.itemAt(3), 'x');
-		assert.equal(rangeMap.itemAt(4), 'y');
-		assert.equal(rangeMap.itemAt(23), 'y');
-		assert.equal(rangeMap.itemAt(24), 'z');
-		assert.equal(rangeMap.itemAt(31), 'z');
-		assert.equal(rangeMap.itemAt(32), 'a');
-		assert.equal(rangeMap.itemAt(34), 'a');
-		assert.equal(rangeMap.itemAt(35), 'b');
-		assert.equal(rangeMap.itemAt(64), 'b');
-		assert.equal(rangeMap.itemAt(65), 'c');
-		assert.equal(rangeMap.itemAt(89), 'c');
-		assert.equal(rangeMap.itemAt(90), 'd');
-		assert.equal(rangeMap.itemAt(91), 'd');
+		assert.strictEqual(rangeMap.itemAt(0), 'x');
+		assert.strictEqual(rangeMap.itemAt(3), 'x');
+		assert.strictEqual(rangeMap.itemAt(4), 'y');
+		assert.strictEqual(rangeMap.itemAt(23), 'y');
+		assert.strictEqual(rangeMap.itemAt(24), 'z');
+		assert.strictEqual(rangeMap.itemAt(31), 'z');
+		assert.strictEqual(rangeMap.itemAt(32), 'a');
+		assert.strictEqual(rangeMap.itemAt(34), 'a');
+		assert.strictEqual(rangeMap.itemAt(35), 'b');
+		assert.strictEqual(rangeMap.itemAt(64), 'b');
+		assert.strictEqual(rangeMap.itemAt(65), 'c');
+		assert.strictEqual(rangeMap.itemAt(89), 'c');
+		assert.strictEqual(rangeMap.itemAt(90), 'd');
+		assert.strictEqual(rangeMap.itemAt(91), 'd');
 		assert.throws(() => rangeMap.itemAt(92));
 	});
 
@@ -100,20 +100,20 @@ suite('TreeView - HeightMap', () => {
 		let navigator = makeNavigator('x', 4, 'y', 20, 'z', 8);
 		rangeMap.onInsertItems(navigator, 'a');
 
-		assert.equal(rangeMap.itemAt(0), 'a');
-		assert.equal(rangeMap.itemAt(2), 'a');
-		assert.equal(rangeMap.itemAt(3), 'x');
-		assert.equal(rangeMap.itemAt(6), 'x');
-		assert.equal(rangeMap.itemAt(7), 'y');
-		assert.equal(rangeMap.itemAt(26), 'y');
-		assert.equal(rangeMap.itemAt(27), 'z');
-		assert.equal(rangeMap.itemAt(34), 'z');
-		assert.equal(rangeMap.itemAt(35), 'b');
-		assert.equal(rangeMap.itemAt(64), 'b');
-		assert.equal(rangeMap.itemAt(65), 'c');
-		assert.equal(rangeMap.itemAt(89), 'c');
-		assert.equal(rangeMap.itemAt(90), 'd');
-		assert.equal(rangeMap.itemAt(91), 'd');
+		assert.strictEqual(rangeMap.itemAt(0), 'a');
+		assert.strictEqual(rangeMap.itemAt(2), 'a');
+		assert.strictEqual(rangeMap.itemAt(3), 'x');
+		assert.strictEqual(rangeMap.itemAt(6), 'x');
+		assert.strictEqual(rangeMap.itemAt(7), 'y');
+		assert.strictEqual(rangeMap.itemAt(26), 'y');
+		assert.strictEqual(rangeMap.itemAt(27), 'z');
+		assert.strictEqual(rangeMap.itemAt(34), 'z');
+		assert.strictEqual(rangeMap.itemAt(35), 'b');
+		assert.strictEqual(rangeMap.itemAt(64), 'b');
+		assert.strictEqual(rangeMap.itemAt(65), 'c');
+		assert.strictEqual(rangeMap.itemAt(89), 'c');
+		assert.strictEqual(rangeMap.itemAt(90), 'd');
+		assert.strictEqual(rangeMap.itemAt(91), 'd');
 		assert.throws(() => rangeMap.itemAt(92));
 	});
 
@@ -121,52 +121,52 @@ suite('TreeView - HeightMap', () => {
 		let navigator = makeNavigator('x', 4, 'y', 20, 'z', 8);
 		rangeMap.onInsertItems(navigator, 'd');
 
-		assert.equal(rangeMap.itemAt(0), 'a');
-		assert.equal(rangeMap.itemAt(2), 'a');
-		assert.equal(rangeMap.itemAt(3), 'b');
-		assert.equal(rangeMap.itemAt(32), 'b');
-		assert.equal(rangeMap.itemAt(33), 'c');
-		assert.equal(rangeMap.itemAt(57), 'c');
-		assert.equal(rangeMap.itemAt(58), 'd');
-		assert.equal(rangeMap.itemAt(59), 'd');
-		assert.equal(rangeMap.itemAt(60), 'x');
-		assert.equal(rangeMap.itemAt(63), 'x');
-		assert.equal(rangeMap.itemAt(64), 'y');
-		assert.equal(rangeMap.itemAt(83), 'y');
-		assert.equal(rangeMap.itemAt(84), 'z');
-		assert.equal(rangeMap.itemAt(91), 'z');
+		assert.strictEqual(rangeMap.itemAt(0), 'a');
+		assert.strictEqual(rangeMap.itemAt(2), 'a');
+		assert.strictEqual(rangeMap.itemAt(3), 'b');
+		assert.strictEqual(rangeMap.itemAt(32), 'b');
+		assert.strictEqual(rangeMap.itemAt(33), 'c');
+		assert.strictEqual(rangeMap.itemAt(57), 'c');
+		assert.strictEqual(rangeMap.itemAt(58), 'd');
+		assert.strictEqual(rangeMap.itemAt(59), 'd');
+		assert.strictEqual(rangeMap.itemAt(60), 'x');
+		assert.strictEqual(rangeMap.itemAt(63), 'x');
+		assert.strictEqual(rangeMap.itemAt(64), 'y');
+		assert.strictEqual(rangeMap.itemAt(83), 'y');
+		assert.strictEqual(rangeMap.itemAt(84), 'z');
+		assert.strictEqual(rangeMap.itemAt(91), 'z');
 		assert.throws(() => rangeMap.itemAt(92));
 	});
 
 	test('onRemoveItems at beginning', () => {
 		rangeMap.onRemoveItems(new ArrayNavigator(['a', 'b']));
 
-		assert.equal(rangeMap.itemAt(0), 'c');
-		assert.equal(rangeMap.itemAt(24), 'c');
-		assert.equal(rangeMap.itemAt(25), 'd');
-		assert.equal(rangeMap.itemAt(26), 'd');
+		assert.strictEqual(rangeMap.itemAt(0), 'c');
+		assert.strictEqual(rangeMap.itemAt(24), 'c');
+		assert.strictEqual(rangeMap.itemAt(25), 'd');
+		assert.strictEqual(rangeMap.itemAt(26), 'd');
 		assert.throws(() => rangeMap.itemAt(27));
 	});
 
 	test('onRemoveItems in middle', () => {
 		rangeMap.onRemoveItems(new ArrayNavigator(['c']));
 
-		assert.equal(rangeMap.itemAt(0), 'a');
-		assert.equal(rangeMap.itemAt(2), 'a');
-		assert.equal(rangeMap.itemAt(3), 'b');
-		assert.equal(rangeMap.itemAt(32), 'b');
-		assert.equal(rangeMap.itemAt(33), 'd');
-		assert.equal(rangeMap.itemAt(34), 'd');
+		assert.strictEqual(rangeMap.itemAt(0), 'a');
+		assert.strictEqual(rangeMap.itemAt(2), 'a');
+		assert.strictEqual(rangeMap.itemAt(3), 'b');
+		assert.strictEqual(rangeMap.itemAt(32), 'b');
+		assert.strictEqual(rangeMap.itemAt(33), 'd');
+		assert.strictEqual(rangeMap.itemAt(34), 'd');
 		assert.throws(() => rangeMap.itemAt(35));
 	});
 
 	test('onRemoveItems at end', () => {
 		rangeMap.onRemoveItems(new ArrayNavigator(['c', 'd']));
 
-		assert.equal(rangeMap.itemAt(0), 'a');
-		assert.equal(rangeMap.itemAt(2), 'a');
-		assert.equal(rangeMap.itemAt(3), 'b');
-		assert.equal(rangeMap.itemAt(32), 'b');
+		assert.strictEqual(rangeMap.itemAt(0), 'a');
+		assert.strictEqual(rangeMap.itemAt(2), 'a');
+		assert.strictEqual(rangeMap.itemAt(3), 'b');
+		assert.strictEqual(rangeMap.itemAt(32), 'b');
 		assert.throws(() => rangeMap.itemAt(33));
 	});
 
@@ -174,12 +174,12 @@ suite('TreeView - HeightMap', () => {
 		let navigator = makeNavigator('a', 1, 'b', 1);
 		rangeMap.onRefreshItems(navigator);
 
-		assert.equal(rangeMap.itemAt(0), 'a');
-		assert.equal(rangeMap.itemAt(1), 'b');
-		assert.equal(rangeMap.itemAt(2), 'c');
-		assert.equal(rangeMap.itemAt(26), 'c');
-		assert.equal(rangeMap.itemAt(27), 'd');
-		assert.equal(rangeMap.itemAt(28), 'd');
+		assert.strictEqual(rangeMap.itemAt(0), 'a');
+		assert.strictEqual(rangeMap.itemAt(1), 'b');
+		assert.strictEqual(rangeMap.itemAt(2), 'c');
+		assert.strictEqual(rangeMap.itemAt(26), 'c');
+		assert.strictEqual(rangeMap.itemAt(27), 'd');
+		assert.strictEqual(rangeMap.itemAt(28), 'd');
 		assert.throws(() => rangeMap.itemAt(29));
 	});
 
@@ -187,14 +187,14 @@ suite('TreeView - HeightMap', () => {
 		let navigator = makeNavigator('b', 40, 'c', 4);
 		rangeMap.onRefreshItems(navigator);
 
-		assert.equal(rangeMap.itemAt(0), 'a');
-		assert.equal(rangeMap.itemAt(2), 'a');
-		assert.equal(rangeMap.itemAt(3), 'b');
-		assert.equal(rangeMap.itemAt(42), 'b');
-		assert.equal(rangeMap.itemAt(43), 'c');
-		assert.equal(rangeMap.itemAt(46), 'c');
-		assert.equal(rangeMap.itemAt(47), 'd');
-		assert.equal(rangeMap.itemAt(48), 'd');
+		assert.strictEqual(rangeMap.itemAt(0), 'a');
+		assert.strictEqual(rangeMap.itemAt(2), 'a');
+		assert.strictEqual(rangeMap.itemAt(3), 'b');
+		assert.strictEqual(rangeMap.itemAt(42), 'b');
+		assert.strictEqual(rangeMap.itemAt(43), 'c');
+		assert.strictEqual(rangeMap.itemAt(46), 'c');
+		assert.strictEqual(rangeMap.itemAt(47), 'd');
+		assert.strictEqual(rangeMap.itemAt(48), 'd');
 		assert.throws(() => rangeMap.itemAt(49));
 	});
 
@@ -202,51 +202,51 @@ suite('TreeView - HeightMap', () => {
 		let navigator = makeNavigator('d', 22);
 		rangeMap.onRefreshItems(navigator);
 
-		assert.equal(rangeMap.itemAt(0), 'a');
-		assert.equal(rangeMap.itemAt(2), 'a');
-		assert.equal(rangeMap.itemAt(3), 'b');
-		assert.equal(rangeMap.itemAt(32), 'b');
-		assert.equal(rangeMap.itemAt(33), 'c');
-		assert.equal(rangeMap.itemAt(57), 'c');
-		assert.equal(rangeMap.itemAt(58), 'd');
-		assert.equal(rangeMap.itemAt(79), 'd');
+		assert.strictEqual(rangeMap.itemAt(0), 'a');
+		assert.strictEqual(rangeMap.itemAt(2), 'a');
+		assert.strictEqual(rangeMap.itemAt(3), 'b');
+		assert.strictEqual(rangeMap.itemAt(32), 'b');
+		assert.strictEqual(rangeMap.itemAt(33), 'c');
+		assert.strictEqual(rangeMap.itemAt(57), 'c');
+		assert.strictEqual(rangeMap.itemAt(58), 'd');
+		assert.strictEqual(rangeMap.itemAt(79), 'd');
 		assert.throws(() => rangeMap.itemAt(80));
 	});
 
 	test('withItemsInRange', () => {
 		let i = 0;
 		let itemsInRange = ['a', 'b'];
-		rangeMap.withItemsInRange(2, 27, function (item) { assert.equal(item, itemsInRange[i++]); });
-		assert.equal(i, itemsInRange.length);
+		rangeMap.withItemsInRange(2, 27, function (item) { assert.strictEqual(item, itemsInRange[i++]); });
+		assert.strictEqual(i, itemsInRange.length);
 
 		i = 0;
 		itemsInRange = ['a', 'b'];
-		rangeMap.withItemsInRange(0, 3, function (item) { assert.equal(item, itemsInRange[i++]); });
-		assert.equal(i, itemsInRange.length);
+		rangeMap.withItemsInRange(0, 3, function (item) { assert.strictEqual(item, itemsInRange[i++]); });
+		assert.strictEqual(i, itemsInRange.length);
 
 		i = 0;
 		itemsInRange = ['a'];
-		rangeMap.withItemsInRange(0, 2, function (item) { assert.equal(item, itemsInRange[i++]); });
-		assert.equal(i, itemsInRange.length);
+		rangeMap.withItemsInRange(0, 2, function (item) { assert.strictEqual(item, itemsInRange[i++]); });
+		assert.strictEqual(i, itemsInRange.length);
 
 		i = 0;
 		itemsInRange = ['a'];
-		rangeMap.withItemsInRange(0, 2, function (item) { assert.equal(item, itemsInRange[i++]); });
-		assert.equal(i, itemsInRange.length);
+		rangeMap.withItemsInRange(0, 2, function (item) { assert.strictEqual(item, itemsInRange[i++]); });
+		assert.strictEqual(i, itemsInRange.length);
 
 		i = 0;
 		itemsInRange = ['b', 'c'];
-		rangeMap.withItemsInRange(15, 39, function (item) { assert.equal(item, itemsInRange[i++]); });
-		assert.equal(i, itemsInRange.length);
+		rangeMap.withItemsInRange(15, 39, function (item) { assert.strictEqual(item, itemsInRange[i++]); });
+		assert.strictEqual(i, itemsInRange.length);
 
 		i = 0;
 		itemsInRange = ['a', 'b', 'c', 'd'];
-		rangeMap.withItemsInRange(1, 58, function (item) { assert.equal(item, itemsInRange[i++]); });
-		assert.equal(i, itemsInRange.length);
+		rangeMap.withItemsInRange(1, 58, function (item) { assert.strictEqual(item, itemsInRange[i++]); });
+		assert.strictEqual(i, itemsInRange.length);
 
 		i = 0;
 		itemsInRange = ['c', 'd'];
-		rangeMap.withItemsInRange(45, 58, function (item) { assert.equal(item, itemsInRange[i++]); });
-		assert.equal(i, itemsInRange.length);
+		rangeMap.withItemsInRange(45, 58, function (item) { assert.strictEqual(item, itemsInRange[i++]); });
+		assert.strictEqual(i, itemsInRange.length);
 	});
 });


### PR DESCRIPTION
Several of the assert functions we've been using in our tests are technically marked as deprecated, so I went ahead and updated those to the supported functions so that the build won't randomly break once those assert functions are finally removed. The asserts were updated in the following ways:

assert.equal -> assert.strictEqual
assert.notEqual -> assert.notStrictEqual
assert.deepEqual -> assert.deepStrictEqual
assert.notDeepEqual -> assert.notDeepStrictEqual

I also update the usage of a deprecated overload of assert.fail.

Since these asserts are now strict versions, I had to update some tests to be more specific about their expected data values. The only test where this proved to be a little annoying was with outputProcessor.test.ts, since the actual results in those tests have a null object prototype, so all our expected data objects had to be updated to be created with a null prototype as well in order to pass assert.deepStrictEqual.