### PR TITLE
adding configuration var

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -980,6 +980,7 @@ declare module 'azdata' {
 	export interface ExecutionPlanOptions {
 		displayEstimatedQueryPlan?: boolean | undefined;
 		displayActualQueryPlan?: boolean | undefined;
+		maxCharsToStore?: number | undefined;
 	}
 
 	export interface SimpleExecuteParams {

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -402,6 +402,11 @@ const queryEditorConfiguration: IConfigurationNode = {
 			'description': localize('queryEditor.results.openAfterSave', "Whether to open the file in Azure Data Studio after the result is saved."),
 			'default': true
 		},
+		'queryEditor.results.maxCharsToStore': {
+			'type': 'number',
+			'default': 65535,
+			'description': localize('queryEditor.results.maxCharsToStore', "Maximum characters to store when running a query")
+		},
 		'queryEditor.messages.showBatchTime': {
 			'type': 'boolean',
 			'description': localize('queryEditor.messages.showBatchTime', "Should execution time be shown for individual batches"),


### PR DESCRIPTION
This PR fixes #392 
Adds a configuration variable called MaxCharsToStore which will call STS with the modified maxchars. This execution setting cannot be sent with a Save As Request because STS saves the query in a temporary file before the SaveRequest is even made. The MaxCharsToStore is only checked when the RunQuery is initially performed.  