### PR TITLE
Apply Changes From Remote Database to Local SQL Database Project

### DIFF
--- a/extensions/integration-tests/src/test/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/test/schemaCompare.test.ts
@@ -54,6 +54,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			serverName: '',
 			databaseName: '',
 			ownerUri: '',
+			projectFilePath: '',
+			folderStructure: '',
+			targetScripts: [],
+			dsp: '',
 			connectionDetails: undefined
 		};
 		let target: mssql.SchemaCompareEndpointInfo = {
@@ -63,6 +67,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			serverName: '',
 			databaseName: '',
 			ownerUri: '',
+			projectFilePath: '',
+			folderStructure: '',
+			targetScripts: [],
+			dsp: '',
 			connectionDetails: undefined
 		};
 
@@ -114,6 +122,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: server.serverName,
 				databaseName: sourceDB,
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 			let target: mssql.SchemaCompareEndpointInfo = {
@@ -123,6 +135,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: server.serverName,
 				databaseName: targetDB,
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 
@@ -179,6 +195,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: '',
 				databaseName: '',
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 			let target: mssql.SchemaCompareEndpointInfo = {
@@ -188,6 +208,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: server.serverName,
 				databaseName: targetDB,
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 
@@ -231,6 +255,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			serverName: '',
 			databaseName: '',
 			ownerUri: '',
+			projectFilePath: '',
+			folderStructure: '',
+			targetScripts: [],
+			dsp: '',
 			connectionDetails: undefined
 		};
 		let target: mssql.SchemaCompareEndpointInfo = {
@@ -240,6 +268,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			serverName: '',
 			databaseName: '',
 			ownerUri: '',
+			projectFilePath: '',
+			folderStructure: '',
+			targetScripts: [],
+			dsp: '',
 			connectionDetails: undefined
 		};
 
@@ -297,6 +329,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: '',
 				databaseName: '',
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 			const target: mssql.SchemaCompareEndpointInfo = {
@@ -306,6 +342,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: server.serverName,
 				databaseName: targetDB,
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 
@@ -323,7 +363,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			assertIncludeExcludeResult(includeResult, true, 0, 0);
 
 			//publish the updated changes. Function1 should not be added to the target database
-			const publishChangesResult = await schemaCompareService.schemaComparePublishChanges(schemaCompareResult.operationId, server.serverName, targetDB, azdata.TaskExecutionMode.execute);
+			const publishChangesResult = await schemaCompareService.schemaComparePublishDatabaseChanges(schemaCompareResult.operationId, server.serverName, targetDB, azdata.TaskExecutionMode.execute);
 			assert(publishChangesResult.success === true, `Publish changes should complete successfully. But it failed with error : ${publishChangesResult.errorMessage}`);
 
 			//verify table Table3 is added
@@ -372,6 +412,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: '',
 				databaseName: '',
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 			const target: mssql.SchemaCompareEndpointInfo = {
@@ -381,6 +425,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: server.serverName,
 				databaseName: targetDB,
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 
@@ -390,7 +438,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			assertSchemaCompareResult(schemaCompareResult, operationId, 4);
 
 			//publish all the changes
-			const publishChangesResult = await schemaCompareService.schemaComparePublishChanges(schemaCompareResult.operationId, server.serverName, targetDB, azdata.TaskExecutionMode.execute);
+			const publishChangesResult = await schemaCompareService.schemaComparePublishDatabaseChanges(schemaCompareResult.operationId, server.serverName, targetDB, azdata.TaskExecutionMode.execute);
 			assert(publishChangesResult.success === true, `Publish changes should complete successfully. But it failed with error : ${publishChangesResult.errorMessage}`);
 
 			//verify table Table3 is added
@@ -435,6 +483,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: '',
 				databaseName: '',
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 			const target: mssql.SchemaCompareEndpointInfo = {
@@ -444,6 +496,10 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				serverName: server.serverName,
 				databaseName: targetDB,
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
 				connectionDetails: undefined
 			};
 

--- a/extensions/integration-tests/src/test/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/test/schemaCompare.test.ts
@@ -57,7 +57,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			projectFilePath: '',
 			folderStructure: '',
 			targetScripts: [],
-			dsp: '',
+			dataSchemaProvider: '',
 			connectionDetails: undefined
 		};
 		let target: mssql.SchemaCompareEndpointInfo = {
@@ -70,7 +70,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			projectFilePath: '',
 			folderStructure: '',
 			targetScripts: [],
-			dsp: '',
+			dataSchemaProvider: '',
 			connectionDetails: undefined
 		};
 
@@ -125,7 +125,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 			let target: mssql.SchemaCompareEndpointInfo = {
@@ -138,7 +138,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 
@@ -198,7 +198,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 			let target: mssql.SchemaCompareEndpointInfo = {
@@ -211,7 +211,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 
@@ -258,7 +258,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			projectFilePath: '',
 			folderStructure: '',
 			targetScripts: [],
-			dsp: '',
+			dataSchemaProvider: '',
 			connectionDetails: undefined
 		};
 		let target: mssql.SchemaCompareEndpointInfo = {
@@ -271,7 +271,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 			projectFilePath: '',
 			folderStructure: '',
 			targetScripts: [],
-			dsp: '',
+			dataSchemaProvider: '',
 			connectionDetails: undefined
 		};
 
@@ -332,7 +332,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 			const target: mssql.SchemaCompareEndpointInfo = {
@@ -345,7 +345,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 
@@ -415,7 +415,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 			const target: mssql.SchemaCompareEndpointInfo = {
@@ -428,7 +428,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 
@@ -486,7 +486,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 			const target: mssql.SchemaCompareEndpointInfo = {
@@ -499,7 +499,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined
 			};
 

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -612,6 +612,15 @@ export namespace LanguageExtensibilityUpdateRequest {
 }
 
 // ------------------------------- <Schema Compare> -----------------------------
+export enum DacExtractTarget {
+	dacpac,
+	file,
+	flat,
+	objectType,
+	schema,
+	schemaObjectType
+}
+
 export interface SchemaCompareParams {
 	operationId: string;
 	sourceEndpointInfo: mssql.SchemaCompareEndpointInfo;
@@ -637,7 +646,7 @@ export interface SchemaComparePublishDatabaseChangesParams {
 export interface SchemaComparePublishProjectChangesParams {
 	operationId: string;
 	targetProjectPath: string;
-	targetFolderStructure: string;
+	targetFolderStructure: DacExtractTarget;
 	taskExecutionMode: TaskExecutionMode;
 }
 

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -436,7 +436,6 @@ export interface ImportParams {
 	taskExecutionMode: TaskExecutionMode;
 }
 
-
 export interface ExtractParams {
 	databaseName: string;
 	packageFilePath: string;
@@ -628,10 +627,17 @@ export interface SchemaCompareGenerateScriptParams {
 	taskExecutionMode: TaskExecutionMode;
 }
 
-export interface SchemaComparePublishChangesParams {
+export interface SchemaComparePublishDatabaseChangesParams {
 	operationId: string;
 	targetServerName: string;
 	targetDatabaseName: string;
+	taskExecutionMode: TaskExecutionMode;
+}
+
+export interface SchemaComparePublishProjectChangesParams {
+	operationId: string;
+	targetProjectPath: string;
+	targetFolderStructure: string;
 	taskExecutionMode: TaskExecutionMode;
 }
 
@@ -672,8 +678,12 @@ export namespace SchemaCompareGenerateScriptRequest {
 	export const type = new RequestType<SchemaCompareGenerateScriptParams, azdata.ResultStatus, void, void>('schemaCompare/generateScript');
 }
 
-export namespace SchemaComparePublishChangesRequest {
-	export const type = new RequestType<SchemaComparePublishChangesParams, azdata.ResultStatus, void, void>('schemaCompare/publish');
+export namespace SchemaComparePublishDatabaseChangesRequest {
+	export const type = new RequestType<SchemaComparePublishDatabaseChangesParams, azdata.ResultStatus, void, void>('schemaCompare/publishDatabase');
+}
+
+export namespace SchemaComparePublishProjectChangesRequest {
+	export const type = new RequestType<SchemaComparePublishProjectChangesParams, mssql.SchemaComparePublishProjectResult, void, void>('schemaCompare/publishProject');
 }
 
 export namespace SchemaCompareGetDefaultOptionsRequest {

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -122,7 +122,8 @@ export const enum SchemaDifferenceType {
 
 export const enum SchemaCompareEndpointType {
 	Database = 0,
-	Dacpac = 1
+	Project = 1,
+	Dacpac = 2
 }
 
 export interface SchemaCompareEndpointInfo {
@@ -134,6 +135,10 @@ export interface SchemaCompareEndpointInfo {
 	ownerUri: string;
 	connectionDetails: azdata.ConnectionInfo;
 	connectionName?: string;
+	projectFilePath: string;
+	targetScripts: string[];
+	folderStructure: string;
+	dsp: string;
 }
 
 export interface SchemaCompareObjectId {
@@ -310,7 +315,8 @@ export interface ISchemaCompareService {
 
 	schemaCompare(operationId: string, sourceEndpointInfo: SchemaCompareEndpointInfo, targetEndpointInfo: SchemaCompareEndpointInfo, taskExecutionMode: azdata.TaskExecutionMode, deploymentOptions: DeploymentOptions): Thenable<SchemaCompareResult>;
 	schemaCompareGenerateScript(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
-	schemaComparePublishChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
+	schemaComparePublishDatabaseChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
+	schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<SchemaComparePublishProjectResult>;
 	schemaCompareGetDefaultOptions(): Thenable<SchemaCompareOptionsResult>;
 	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<SchemaCompareIncludeExcludeResult>;
 	schemaCompareOpenScmp(filePath: string): Thenable<SchemaCompareOpenScmpResult>;
@@ -326,6 +332,12 @@ export interface SchemaCompareOpenScmpResult extends azdata.ResultStatus {
 	deploymentOptions: DeploymentOptions;
 	excludedSourceElements: SchemaCompareObjectId[];
 	excludedTargetElements: SchemaCompareObjectId[];
+}
+
+export interface SchemaComparePublishProjectResult extends azdata.ResultStatus {
+	changedFiles: string[];
+	addedFiles: string[];
+	deletedFiles: string[];
 }
 
 //#endregion

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -7,6 +7,7 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
+import { DacExtractTarget } from './contracts';
 
 /**
  * Covers defining what the mssql extension exports to other extensions
@@ -138,7 +139,7 @@ export interface SchemaCompareEndpointInfo {
 	projectFilePath: string;
 	targetScripts: string[];
 	folderStructure: string;
-	dsp: string;
+	dataSchemaProvider: string;
 }
 
 export interface SchemaCompareObjectId {
@@ -316,7 +317,7 @@ export interface ISchemaCompareService {
 	schemaCompare(operationId: string, sourceEndpointInfo: SchemaCompareEndpointInfo, targetEndpointInfo: SchemaCompareEndpointInfo, taskExecutionMode: azdata.TaskExecutionMode, deploymentOptions: DeploymentOptions): Thenable<SchemaCompareResult>;
 	schemaCompareGenerateScript(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
 	schemaComparePublishDatabaseChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
-	schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<SchemaComparePublishProjectResult>;
+	schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: DacExtractTarget, taskExecutionMode: azdata.TaskExecutionMode): Thenable<SchemaComparePublishProjectResult>;
 	schemaCompareGetDefaultOptions(): Thenable<SchemaCompareOptionsResult>;
 	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<SchemaCompareIncludeExcludeResult>;
 	schemaCompareOpenScmp(filePath: string): Thenable<SchemaCompareOpenScmpResult>;

--- a/extensions/mssql/src/schemaCompare/schemaCompareService.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareService.ts
@@ -65,7 +65,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		);
 	}
 
-	public schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
+	public schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: contracts.DacExtractTarget, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
 		const params: contracts.SchemaComparePublishProjectChangesParams = { operationId: operationId, targetProjectPath: targetProjectPath, targetFolderStructure: targetFolderStructure, taskExecutionMode: taskExecutionMode };
 		return this.client.sendRequest(contracts.SchemaComparePublishProjectChangesRequest.type, params).then(
 			undefined,

--- a/extensions/mssql/src/schemaCompare/schemaCompareService.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareService.ts
@@ -36,7 +36,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		const params: contracts.SchemaCompareParams = { operationId: operationId, sourceEndpointInfo: sourceEndpointInfo, targetEndpointInfo: targetEndpointInfo, taskExecutionMode: taskExecutionMode, deploymentOptions: deploymentOptions };
 		return this.client.sendRequest(contracts.SchemaCompareRequest.type, params).then(
 			undefined,
-			e => {
+			(e: any) => {
 				this.client.logFailedRequest(contracts.SchemaCompareRequest.type, e);
 				return Promise.resolve(undefined);
 			}
@@ -47,19 +47,30 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		const params: contracts.SchemaCompareGenerateScriptParams = { operationId: operationId, targetServerName: targetServerName, targetDatabaseName: targetDatabaseName, taskExecutionMode: taskExecutionMode };
 		return this.client.sendRequest(contracts.SchemaCompareGenerateScriptRequest.type, params).then(
 			undefined,
-			e => {
+			(e: any) => {
 				this.client.logFailedRequest(contracts.SchemaCompareGenerateScriptRequest.type, e);
 				return Promise.resolve(undefined);
 			}
 		);
 	}
 
-	public schemaComparePublishChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
-		const params: contracts.SchemaComparePublishChangesParams = { operationId: operationId, targetServerName: targetServerName, targetDatabaseName: targetDatabaseName, taskExecutionMode: taskExecutionMode };
-		return this.client.sendRequest(contracts.SchemaComparePublishChangesRequest.type, params).then(
+	public schemaComparePublishDatabaseChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+		const params: contracts.SchemaComparePublishDatabaseChangesParams = { operationId: operationId, targetServerName: targetServerName, targetDatabaseName: targetDatabaseName, taskExecutionMode: taskExecutionMode };
+		return this.client.sendRequest(contracts.SchemaComparePublishDatabaseChangesRequest.type, params).then(
 			undefined,
-			e => {
-				this.client.logFailedRequest(contracts.SchemaComparePublishChangesRequest.type, e);
+			(e: any) => {
+				this.client.logFailedRequest(contracts.SchemaComparePublishDatabaseChangesRequest.type, e);
+				return Promise.resolve(undefined);
+			}
+		);
+	}
+
+	public schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
+		const params: contracts.SchemaComparePublishProjectChangesParams = { operationId: operationId, targetProjectPath: targetProjectPath, targetFolderStructure: targetFolderStructure, taskExecutionMode: taskExecutionMode };
+		return this.client.sendRequest(contracts.SchemaComparePublishProjectChangesRequest.type, params).then(
+			undefined,
+			(e: any) => {
+				this.client.logFailedRequest(contracts.SchemaComparePublishProjectChangesRequest.type, e);
 				return Promise.resolve(undefined);
 			}
 		);
@@ -69,7 +80,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		const params: contracts.SchemaCompareGetOptionsParams = {};
 		return this.client.sendRequest(contracts.SchemaCompareGetDefaultOptionsRequest.type, params).then(
 			undefined,
-			e => {
+			(e: any) => {
 				this.client.logFailedRequest(contracts.SchemaCompareGetDefaultOptionsRequest.type, e);
 				return Promise.resolve(undefined);
 			}
@@ -80,7 +91,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		const params: contracts.SchemaCompareNodeParams = { operationId: operationId, diffEntry, includeRequest, taskExecutionMode: taskExecutionMode };
 		return this.client.sendRequest(contracts.SchemaCompareIncludeExcludeNodeRequest.type, params).then(
 			undefined,
-			e => {
+			(e: any) => {
 				this.client.logFailedRequest(contracts.SchemaCompareIncludeExcludeNodeRequest.type, e);
 				return Promise.resolve(undefined);
 			}
@@ -91,7 +102,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		const params: contracts.SchemaCompareOpenScmpParams = { filePath: filePath };
 		return this.client.sendRequest(contracts.SchemaCompareOpenScmpRequest.type, params).then(
 			undefined,
-			e => {
+			(e: any) => {
 				this.client.logFailedRequest(contracts.SchemaCompareOpenScmpRequest.type, e);
 				return Promise.resolve(undefined);
 			}
@@ -102,7 +113,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		const params: contracts.SchemaCompareSaveScmpParams = { sourceEndpointInfo: sourceEndpointInfo, targetEndpointInfo: targetEndpointInfo, taskExecutionMode: taskExecutionMode, deploymentOptions: deploymentOptions, scmpFilePath: scmpFilePath, excludedSourceObjects: excludedSourceObjects, excludedTargetObjects: excludedTargetObjects };
 		return this.client.sendRequest(contracts.SchemaCompareSaveScmpRequest.type, params).then(
 			undefined,
-			e => {
+			(e: any) => {
 				this.client.logFailedRequest(contracts.SchemaCompareSaveScmpRequest.type, e);
 				return Promise.resolve(undefined);
 			}
@@ -113,7 +124,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		const params: contracts.SchemaCompareCancelParams = { operationId: operationId };
 		return this.client.sendRequest(contracts.SchemaCompareCancellationRequest.type, params).then(
 			undefined,
-			e => {
+			(e: any) => {
 				this.client.logFailedRequest(contracts.SchemaCompareCancellationRequest.type, e);
 				return Promise.resolve(undefined);
 			}

--- a/extensions/schema-compare/package-lock.json
+++ b/extensions/schema-compare/package-lock.json
@@ -1,0 +1,14 @@
+{
+	"name": "schema-compare",
+	"version": "1.12.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@types/node": {
+			"version": "12.20.23",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.23.tgz",
+			"integrity": "sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw==",
+			"dev": true
+		}
+	}
+}

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -87,15 +87,15 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",
+    "@types/node": "^12.20.23",
     "@types/sinon": "^9.0.4",
-    "@types/node": "^12.11.7",
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
     "should": "^13.2.1",
+    "sinon": "^9.0.2",
     "typemoq": "^2.1.0",
-    "vscodetestcover": "^1.1.0",
-    "sinon": "^9.0.2"
+    "vscodetestcover": "^1.1.0"
   },
   "__metadata": {
     "id": "37",

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -277,7 +277,7 @@ export class SchemaCompareDialog {
 				targetScripts: [],
 				folderStructure: '',
 				packageFilePath: '',
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined,
 				connectionName: sourceServerDropdownValue.connection.options.connectionName
 			};
@@ -291,7 +291,7 @@ export class SchemaCompareDialog {
 				projectFilePath: '',
 				targetScripts: [],
 				folderStructure: '',
-				dsp: '',
+				dataSchemaProvider: '',
 				packageFilePath: this.sourceTextBox.value,
 				connectionDetails: undefined
 			};
@@ -300,7 +300,7 @@ export class SchemaCompareDialog {
 				endpointType: mssql.SchemaCompareEndpointType.Project,
 				projectFilePath: this.sourceTextBox.value,
 				targetScripts: await this.getTargetScripts(true),
-				dsp: await this.getDsp(true),
+				dataSchemaProvider: await this.getDsp(true),
 				folderStructure: '',
 				serverDisplayName: '',
 				serverName: '',
@@ -325,7 +325,7 @@ export class SchemaCompareDialog {
 				folderStructure: '',
 				targetScripts: [],
 				packageFilePath: '',
-				dsp: '',
+				dataSchemaProvider: '',
 				connectionDetails: undefined,
 				connectionName: targetServerDropdownValue.connection.options.connectionName
 			};
@@ -339,7 +339,7 @@ export class SchemaCompareDialog {
 				projectFilePath: '',
 				folderStructure: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				packageFilePath: this.targetTextBox.value,
 				connectionDetails: undefined
 			};
@@ -349,7 +349,7 @@ export class SchemaCompareDialog {
 				projectFilePath: this.targetTextBox.value,
 				folderStructure: this.targetStructureDropdown!.value as string,
 				targetScripts: await this.getTargetScripts(false),
-				dsp: await this.getDsp(false),
+				dataSchemaProvider: await this.getDsp(false),
 				serverDisplayName: '',
 				serverName: '',
 				databaseName: '',

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -9,7 +9,7 @@ import * as loc from '../localizedConstants';
 import * as path from 'path';
 import { SchemaCompareMainWindow } from '../schemaCompareMainWindow';
 import { TelemetryReporter, TelemetryViews } from '../telemetry';
-import { getEndpointName, getRootPath, exists } from '../utils';
+import { getEndpointName, getRootPath, exists, getAzdataApi } from '../utils';
 import * as mssql from '../../../mssql';
 
 const titleFontSize: number = 13;
@@ -18,13 +18,18 @@ interface Deferred<T> {
 	resolve: (result: T | Promise<T>) => void;
 	reject: (reason: any) => void;
 }
+
 export class SchemaCompareDialog {
-	public dialog: azdata.window.Dialog;
 	public dialogName: string;
+	public dialog: azdata.window.Dialog;
+	private initDialogComplete: Deferred<void>;
+	private initDialogPromise: Promise<void> = new Promise<void>((resolve, reject) => this.initDialogComplete = { resolve, reject });
+	private schemaCompareTab: azdata.window.DialogTab;
 	private sourceDacpacRadioButton: azdata.RadioButtonComponent;
 	private sourceDatabaseRadioButton: azdata.RadioButtonComponent;
-	private schemaCompareTab: azdata.window.DialogTab;
+	private sourceProjectRadioButton: azdata.RadioButtonComponent;
 	private sourceDacpacComponent: azdata.FormComponent;
+	private sourceProjectFilePathComponent: azdata.FormComponent;
 	private sourceTextBox: azdata.InputBoxComponent;
 	private sourceFileButton: azdata.ButtonComponent;
 	private sourceServerComponent: azdata.FormComponent;
@@ -32,25 +37,34 @@ export class SchemaCompareDialog {
 	private sourceConnectionButton: azdata.ButtonComponent;
 	private sourceDatabaseComponent: azdata.FormComponent;
 	private sourceDatabaseDropdown: azdata.DropDownComponent;
+	private sourceIsDacpac: boolean;
+	private sourceIsProject: boolean;
+	private sourceIsDatabase: boolean;
+	private sourceDbEditable: string;
+	private sourceDacpacPath: string;
+	private sourceProjectFilePath: string;
 	private targetDacpacComponent: azdata.FormComponent;
+	private targetProjectFilePathComponent: azdata.FormComponent;
+	private targetProjectStructureComponent: azdata.FormComponent;
 	private targetTextBox: azdata.InputBoxComponent;
 	private targetFileButton: azdata.ButtonComponent;
+	private targetStructureDropdown: azdata.DropDownComponent;
 	private targetServerComponent: azdata.FormComponent;
 	protected targetServerDropdown: azdata.DropDownComponent;
 	private targetConnectionButton: azdata.ButtonComponent;
 	private targetDatabaseComponent: azdata.FormComponent;
 	private targetDatabaseDropdown: azdata.DropDownComponent;
-	private formBuilder: azdata.FormBuilder;
-	private sourceIsDacpac: boolean;
 	private targetIsDacpac: boolean;
-	private connectionId: string;
-	private sourceDbEditable: string;
+	private targetIsDatabase: boolean;
+	private targetIsProject: boolean;
 	private targetDbEditable: string;
+	private targetDacpacPath: string;
+	private targetProjectFilePath: string;
 	private previousSource: mssql.SchemaCompareEndpointInfo;
 	private previousTarget: mssql.SchemaCompareEndpointInfo;
-	private initDialogComplete: Deferred<void>;
-	private initDialogPromise: Promise<void> = new Promise<void>((resolve, reject) => this.initDialogComplete = { resolve, reject });
-
+	private formBuilder: azdata.FormBuilder;
+	private toDispose: vscode.Disposable[] = [];
+	private connectionId: string;
 	private textBoxWidth: number = 280;
 
 	public promise;
@@ -59,6 +73,11 @@ export class SchemaCompareDialog {
 	constructor(private schemaCompareMainWindow: SchemaCompareMainWindow, private view?: azdata.ModelView, private extensionContext?: vscode.ExtensionContext) {
 		this.previousSource = schemaCompareMainWindow.sourceEndpointInfo;
 		this.previousTarget = schemaCompareMainWindow.targetEndpointInfo;
+
+		this.dialog = azdata.window.createModelViewDialog(loc.SchemaCompareLabel);
+		this.dialog.registerCloseValidator(async () => {
+			return this.validate();
+		});
 	}
 
 	protected async initializeDialog(): Promise<void> {
@@ -74,12 +93,11 @@ export class SchemaCompareDialog {
 			this.connectionId = connection.connectionId;
 		}
 
-		this.dialog = azdata.window.createModelViewDialog(loc.SchemaCompareLabel);
 		await this.initializeDialog();
 
 		this.dialog.okButton.label = loc.OkButtonText;
 		this.dialog.okButton.enabled = false;
-		this.dialog.okButton.onClick(async () => await this.execute());
+		this.toDispose.push(this.dialog.okButton.onClick(async () => await this.handleOkButtonClick()));
 
 		this.dialog.cancelButton.label = loc.CancelButtonText;
 		this.dialog.cancelButton.onClick(async () => await this.cancel());
@@ -88,18 +106,164 @@ export class SchemaCompareDialog {
 		await this.initDialogPromise;
 	}
 
+	private async initializeSchemaCompareTab(): Promise<void> {
+		this.schemaCompareTab.registerContent(async view => {
+			if (isNullOrUndefined(this.view)) {
+				this.view = view;
+			}
+
+			let sourceValue = '';
+
+			if (this.schemaCompareMainWindow.sourceEndpointInfo && this.schemaCompareMainWindow.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Dacpac) {
+				sourceValue = this.schemaCompareMainWindow.sourceEndpointInfo.packageFilePath;
+			} else if (this.schemaCompareMainWindow.sourceEndpointInfo && this.schemaCompareMainWindow.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+				sourceValue = this.schemaCompareMainWindow.sourceEndpointInfo.projectFilePath;
+			}
+
+			this.sourceTextBox = this.view.modelBuilder.inputBox().withProps({
+				value: sourceValue,
+				width: this.textBoxWidth,
+				ariaLabel: loc.sourceFile
+			}).component();
+
+			this.sourceTextBox.onTextChanged(async (e) => {
+				this.dialog.okButton.enabled = await this.shouldEnableOkayButton();
+
+				if (this.sourceIsDacpac) {
+					this.sourceDacpacPath = e;
+				} else if (this.sourceIsProject) {
+					this.sourceProjectFilePath = e;
+				}
+			});
+
+
+			let targetValue = '';
+
+			if (this.schemaCompareMainWindow.targetEndpointInfo && this.schemaCompareMainWindow.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Dacpac) {
+				targetValue = this.schemaCompareMainWindow.targetEndpointInfo.packageFilePath;
+			} else if (this.schemaCompareMainWindow.targetEndpointInfo && this.schemaCompareMainWindow.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+				targetValue = this.schemaCompareMainWindow.targetEndpointInfo.projectFilePath;
+			}
+
+			this.targetTextBox = this.view.modelBuilder.inputBox().withProps({
+				value: targetValue,
+				width: this.textBoxWidth,
+				ariaLabel: loc.targetFile
+			}).component();
+
+			this.targetTextBox.onTextChanged(async (e) => {
+				this.dialog.okButton.enabled = await this.shouldEnableOkayButton();
+
+				if (this.targetIsDacpac) {
+					this.targetDacpacPath = e;
+				} else if (this.targetIsProject) {
+					this.targetProjectFilePath = e;
+				}
+			});
+
+			this.sourceServerComponent = this.createSourceServerDropdown();
+
+			this.sourceDatabaseComponent = this.createSourceDatabaseDropdown();
+
+			this.targetServerComponent = this.createTargetServerDropdown();
+
+			this.targetDatabaseComponent = this.createTargetDatabaseDropdown();
+
+			this.sourceDacpacComponent = this.createFileBrowser(false, true, this.schemaCompareMainWindow.sourceEndpointInfo);
+			this.targetDacpacComponent = this.createFileBrowser(true, true, this.schemaCompareMainWindow.targetEndpointInfo);
+
+			this.sourceProjectFilePathComponent = this.createFileBrowser(false, false, this.schemaCompareMainWindow.sourceEndpointInfo);
+			this.targetProjectFilePathComponent = this.createFileBrowser(true, false, this.schemaCompareMainWindow.targetEndpointInfo);
+
+			this.targetProjectStructureComponent = this.createStructureDropdown();
+
+			let sourceRadioButtons = this.createSourceRadioButtons();
+			let targetRadioButtons = this.createTargetRadioButtons();
+
+			let sourceComponents = [];
+			let targetComponents = [];
+
+			// start source and target with either dacpac, database, or project selection based on what the previous value was
+			if (this.schemaCompareMainWindow.sourceEndpointInfo && this.schemaCompareMainWindow.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
+				sourceComponents = [
+					sourceRadioButtons,
+					this.sourceServerComponent,
+					this.sourceDatabaseComponent
+				];
+			} else if (this.schemaCompareMainWindow.sourceEndpointInfo && this.schemaCompareMainWindow.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Dacpac) {
+				sourceComponents = [
+					sourceRadioButtons,
+					this.sourceDacpacComponent,
+				];
+			} else if (this.schemaCompareMainWindow.sourceEndpointInfo && this.schemaCompareMainWindow.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+				sourceComponents = [
+					sourceRadioButtons,
+					this.sourceProjectFilePathComponent,
+				];
+			} else {
+				sourceComponents = [
+					sourceRadioButtons,
+				];
+			}
+
+			if (this.schemaCompareMainWindow.targetEndpointInfo && this.schemaCompareMainWindow.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
+				targetComponents = [
+					targetRadioButtons,
+					this.targetServerComponent,
+					this.targetDatabaseComponent
+				];
+			} else if (this.schemaCompareMainWindow.targetEndpointInfo && this.schemaCompareMainWindow.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Dacpac) {
+				targetComponents = [
+					targetRadioButtons,
+					this.targetDacpacComponent,
+				];
+			} else if (this.schemaCompareMainWindow.targetEndpointInfo && this.schemaCompareMainWindow.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+				targetComponents = [
+					targetRadioButtons,
+					this.targetProjectFilePathComponent,
+					this.targetProjectStructureComponent
+				];
+			} else {
+				targetComponents = [
+					targetRadioButtons,
+				];
+			}
+
+			this.formBuilder = <azdata.FormBuilder>this.view.modelBuilder.formContainer()
+				.withFormItems([
+					{
+						title: loc.SourceTitle,
+						components: sourceComponents
+					}, {
+						title: loc.TargetTitle,
+						components: targetComponents
+					}
+				], {
+					horizontal: true,
+					titleFontSize: titleFontSize
+				})
+				.withLayout({
+					width: '100%',
+					padding: '10px 10px 0 30px'
+				});
+
+			let formModel = this.formBuilder.component();
+			await this.view.initializeModel(formModel);
+
+			if (this.sourceIsDacpac) {
+				await this.sourceDacpacRadioButton.focus();
+			} else if (this.sourceIsDatabase) {
+				await this.sourceDatabaseRadioButton.focus();
+			} else if (this.sourceIsProject) {
+				await this.sourceProjectRadioButton.focus();
+			}
+
+			this.initDialogComplete.resolve();
+		});
+	}
+
 	public async execute(): Promise<void> {
-		if (this.sourceIsDacpac) {
-			this.schemaCompareMainWindow.sourceEndpointInfo = {
-				endpointType: mssql.SchemaCompareEndpointType.Dacpac,
-				serverDisplayName: '',
-				serverName: '',
-				databaseName: '',
-				ownerUri: '',
-				packageFilePath: this.sourceTextBox.value,
-				connectionDetails: undefined
-			};
-		} else {
+		if (this.sourceIsDatabase) {
 			const sourceServerDropdownValue = this.sourceServerDropdown.value as ConnectionDropdownValue;
 			const ownerUri = await azdata.connection.getUriForConnection(sourceServerDropdownValue.connection.connectionId);
 
@@ -109,23 +273,45 @@ export class SchemaCompareDialog {
 				serverName: sourceServerDropdownValue.name,
 				databaseName: this.sourceDatabaseDropdown.value.toString(),
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				targetScripts: [],
+				folderStructure: '',
 				packageFilePath: '',
+				dsp: '',
 				connectionDetails: undefined,
 				connectionName: sourceServerDropdownValue.connection.options.connectionName
 			};
-		}
-
-		if (this.targetIsDacpac) {
-			this.schemaCompareMainWindow.targetEndpointInfo = {
+		} else if (this.sourceIsDacpac) {
+			this.schemaCompareMainWindow.sourceEndpointInfo = {
 				endpointType: mssql.SchemaCompareEndpointType.Dacpac,
 				serverDisplayName: '',
 				serverName: '',
 				databaseName: '',
 				ownerUri: '',
-				packageFilePath: this.targetTextBox.value,
+				projectFilePath: '',
+				targetScripts: [],
+				folderStructure: '',
+				dsp: '',
+				packageFilePath: this.sourceTextBox.value,
 				connectionDetails: undefined
 			};
 		} else {
+			this.schemaCompareMainWindow.sourceEndpointInfo = {
+				endpointType: mssql.SchemaCompareEndpointType.Project,
+				projectFilePath: this.sourceTextBox.value,
+				targetScripts: await this.getTargetScripts(true),
+				dsp: await this.getDsp(true),
+				folderStructure: '',
+				serverDisplayName: '',
+				serverName: '',
+				databaseName: '',
+				ownerUri: '',
+				packageFilePath: '',
+				connectionDetails: undefined
+			};
+		}
+
+		if (this.targetIsDatabase) {
 			const targetServerDropdownValue = this.targetServerDropdown.value as ConnectionDropdownValue;
 			const ownerUri = await azdata.connection.getUriForConnection(targetServerDropdownValue.connection.connectionId);
 
@@ -135,16 +321,52 @@ export class SchemaCompareDialog {
 				serverName: targetServerDropdownValue.name,
 				databaseName: this.targetDatabaseDropdown.value.toString(),
 				ownerUri: ownerUri,
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
 				packageFilePath: '',
+				dsp: '',
 				connectionDetails: undefined,
 				connectionName: targetServerDropdownValue.connection.options.connectionName
+			};
+		} else if (this.targetIsDacpac) {
+			this.schemaCompareMainWindow.targetEndpointInfo = {
+				endpointType: mssql.SchemaCompareEndpointType.Dacpac,
+				serverDisplayName: '',
+				serverName: '',
+				databaseName: '',
+				ownerUri: '',
+				projectFilePath: '',
+				folderStructure: '',
+				targetScripts: [],
+				dsp: '',
+				packageFilePath: this.targetTextBox.value,
+				connectionDetails: undefined
+			};
+		} else {
+			this.schemaCompareMainWindow.targetEndpointInfo = {
+				endpointType: mssql.SchemaCompareEndpointType.Project,
+				projectFilePath: this.targetTextBox.value,
+				folderStructure: this.targetStructureDropdown!.value as string,
+				targetScripts: await this.getTargetScripts(false),
+				dsp: await this.getDsp(false),
+				serverDisplayName: '',
+				serverName: '',
+				databaseName: '',
+				ownerUri: '',
+				packageFilePath: '',
+				connectionDetails: undefined
 			};
 		}
 
 		TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareDialog, 'SchemaCompareStart')
 			.withAdditionalProperties({
 				sourceIsDacpac: this.sourceIsDacpac.toString(),
-				targetIsDacpac: this.targetIsDacpac.toString()
+				targetIsDacpac: this.targetIsDacpac.toString(),
+				sourceIsDatabase: this.sourceIsDatabase.toString(),
+				targetIsDatabase: this.targetIsDatabase.toString(),
+				sourceIsProject: this.sourceIsProject.toString(),
+				targetIsProject: this.targetIsProject.toString()
 			}).send();
 
 		// update source and target values that are displayed
@@ -173,118 +395,9 @@ export class SchemaCompareDialog {
 		}
 	}
 
-	private endpointChanged(previousEndpoint: mssql.SchemaCompareEndpointInfo, updatedEndpoint: mssql.SchemaCompareEndpointInfo): boolean {
-		if (previousEndpoint && updatedEndpoint) {
-			return getEndpointName(previousEndpoint).toLowerCase() !== getEndpointName(updatedEndpoint).toLowerCase()
-				|| (previousEndpoint.serverDisplayName && updatedEndpoint.serverDisplayName && previousEndpoint.serverDisplayName.toLowerCase() !== updatedEndpoint.serverDisplayName.toLowerCase());
-		}
-		return false;
-	}
-
-	protected async cancel(): Promise<void> {
-	}
-
-	private async initializeSchemaCompareTab(): Promise<void> {
-		this.schemaCompareTab.registerContent(async view => {
-			if (isNullOrUndefined(this.view)) {
-				this.view = view;
-			}
-
-			this.sourceTextBox = this.view.modelBuilder.inputBox().withProps({
-				value: this.schemaCompareMainWindow.sourceEndpointInfo ? this.schemaCompareMainWindow.sourceEndpointInfo.packageFilePath : '',
-				width: this.textBoxWidth,
-				ariaLabel: loc.sourceFile
-			}).component();
-
-			this.sourceTextBox.onTextChanged(async (e) => {
-				this.dialog.okButton.enabled = await this.shouldEnableOkayButton();
-			});
-
-			this.targetTextBox = this.view.modelBuilder.inputBox().withProps({
-				value: this.schemaCompareMainWindow.targetEndpointInfo ? this.schemaCompareMainWindow.targetEndpointInfo.packageFilePath : '',
-				width: this.textBoxWidth,
-				ariaLabel: loc.targetFile
-			}).component();
-
-			this.targetTextBox.onTextChanged(async () => {
-				this.dialog.okButton.enabled = await this.shouldEnableOkayButton();
-			});
-
-			this.sourceServerComponent = this.createSourceServerDropdown();
-
-			this.sourceDatabaseComponent = this.createSourceDatabaseDropdown();
-
-			this.targetServerComponent = this.createTargetServerDropdown();
-
-			this.targetDatabaseComponent = this.createTargetDatabaseDropdown();
-
-			this.sourceDacpacComponent = this.createFileBrowser(false, this.schemaCompareMainWindow.sourceEndpointInfo);
-			this.targetDacpacComponent = this.createFileBrowser(true, this.schemaCompareMainWindow.targetEndpointInfo);
-
-			let sourceRadioButtons = this.createSourceRadioButtons();
-			let targetRadioButtons = this.createTargetRadioButtons();
-
-			let sourceComponents = [];
-			let targetComponents = [];
-
-			// start source and target with either dacpac or database selection based on what the previous value was
-			if (this.schemaCompareMainWindow.sourceEndpointInfo && this.schemaCompareMainWindow.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
-				sourceComponents = [
-					sourceRadioButtons,
-					this.sourceServerComponent,
-					this.sourceDatabaseComponent
-				];
-			} else {
-				sourceComponents = [
-					sourceRadioButtons,
-					this.sourceDacpacComponent,
-				];
-			}
-
-			if (this.schemaCompareMainWindow.targetEndpointInfo && this.schemaCompareMainWindow.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
-				targetComponents = [
-					targetRadioButtons,
-					this.targetServerComponent,
-					this.targetDatabaseComponent
-				];
-			} else {
-				targetComponents = [
-					targetRadioButtons,
-					this.targetDacpacComponent,
-				];
-			}
-
-			this.formBuilder = <azdata.FormBuilder>this.view.modelBuilder.formContainer()
-				.withFormItems([
-					{
-						title: loc.SourceTitle,
-						components: sourceComponents
-					}, {
-						title: loc.TargetTitle,
-						components: targetComponents
-					}
-				], {
-					horizontal: true,
-					titleFontSize: titleFontSize
-				})
-				.withLayout({
-					width: '100%',
-					padding: '10px 10px 0 30px'
-				});
-
-			let formModel = this.formBuilder.component();
-			await this.view.initializeModel(formModel);
-			if (this.sourceIsDacpac) {
-				await this.sourceDacpacRadioButton.focus();
-			} else {
-				await this.sourceDatabaseRadioButton.focus();
-			}
-			this.initDialogComplete.resolve();
-		});
-	}
-
-	private createFileBrowser(isTarget: boolean, endpoint: mssql.SchemaCompareEndpointInfo): azdata.FormComponent {
+	private createFileBrowser(isTarget: boolean, dacpac: boolean, endpoint: mssql.SchemaCompareEndpointInfo): azdata.FormComponent {
 		let currentTextbox = isTarget ? this.targetTextBox : this.sourceTextBox;
+
 		if (isTarget) {
 			this.targetFileButton = this.view.modelBuilder.button().withProps({
 				title: loc.selectTargetFile,
@@ -303,7 +416,9 @@ export class SchemaCompareDialog {
 
 		let currentButton = isTarget ? this.targetFileButton : this.sourceFileButton;
 
-		currentButton.onDidClick(async (click) => {
+		const filter = dacpac ? 'dacpac' : 'sqlproj';
+
+		currentButton.onDidClick(async () => {
 			// file browser should open where the current dacpac is or the appropriate default folder
 			let rootPath = getRootPath();
 			let defaultUri = endpoint && endpoint.packageFilePath && await exists(endpoint.packageFilePath) ? endpoint.packageFilePath : rootPath;
@@ -316,7 +431,7 @@ export class SchemaCompareDialog {
 					defaultUri: vscode.Uri.file(defaultUri),
 					openLabel: loc.open,
 					filters: {
-						'dacpac Files': ['dacpac'],
+						'Files': [filter]
 					}
 				}
 			);
@@ -336,6 +451,22 @@ export class SchemaCompareDialog {
 		};
 	}
 
+	private createStructureDropdown(): azdata.FormComponent {
+		this.targetStructureDropdown = this.view.modelBuilder.dropDown().withProps({
+			editable: true,
+			fireOnTextChange: true,
+			ariaLabel: loc.targetStructure,
+			width: this.textBoxWidth,
+			values: [loc.file, loc.flat, loc.objectType, loc.schema, loc.schemaObjectType],
+			value: loc.schemaObjectType,
+		}).component();
+
+		return {
+			component: this.targetStructureDropdown,
+			title: loc.StructureDropdownLabel,
+		};
+	}
+
 	private createSourceRadioButtons(): azdata.FormComponent {
 		this.sourceDacpacRadioButton = this.view.modelBuilder.radioButton()
 			.withProps({
@@ -349,11 +480,21 @@ export class SchemaCompareDialog {
 				label: loc.DatabaseRadioButtonLabel
 			}).component();
 
+		this.sourceProjectRadioButton = this.view.modelBuilder.radioButton()
+			.withProps({
+				name: 'source',
+				label: loc.ProjectRadioButtonLabel
+			}).component();
+
 		// show dacpac file browser
 		this.sourceDacpacRadioButton.onDidClick(async () => {
 			this.sourceIsDacpac = true;
+			this.sourceIsDatabase = false;
+			this.sourceIsProject = false;
+			this.sourceTextBox.value = this.sourceDacpacPath;
 			this.formBuilder.removeFormItem(this.sourceServerComponent);
 			this.formBuilder.removeFormItem(this.sourceDatabaseComponent);
+			this.formBuilder.removeFormItem(this.sourceProjectFilePathComponent);
 			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 2, { horizontal: true, titleFontSize: titleFontSize });
 			this.dialog.okButton.enabled = await this.shouldEnableOkayButton();
 		});
@@ -361,24 +502,50 @@ export class SchemaCompareDialog {
 		// show server and db dropdowns
 		this.sourceDatabaseRadioButton.onDidClick(async () => {
 			this.sourceIsDacpac = false;
+			this.sourceIsDatabase = true;
+			this.sourceIsProject = false;
 			this.formBuilder.insertFormItem(this.sourceServerComponent, 2, { horizontal: true, titleFontSize: titleFontSize });
 			this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 3, { horizontal: true, titleFontSize: titleFontSize });
 			this.formBuilder.removeFormItem(this.sourceDacpacComponent);
+			this.formBuilder.removeFormItem(this.sourceProjectFilePathComponent);
 
 			await this.populateServerDropdown(false);
+		});
+
+		// show project directory browser
+		this.sourceProjectRadioButton.onDidClick(async () => {
+			this.sourceIsDacpac = false;
+			this.sourceIsDatabase = false;
+			this.sourceIsProject = true;
+			this.sourceTextBox.value = this.sourceProjectFilePath;
+			this.formBuilder.removeFormItem(this.sourceServerComponent);
+			this.formBuilder.removeFormItem(this.sourceDatabaseComponent);
+			this.formBuilder.removeFormItem(this.sourceDacpacComponent);
+			this.formBuilder.insertFormItem(this.sourceProjectFilePathComponent, 2, { horizontal: true, titleFontSize: titleFontSize });
+			this.dialog.okButton.enabled = await this.shouldEnableOkayButton();
 		});
 
 		// if source is currently a db, show it in the server and db dropdowns
 		if (this.schemaCompareMainWindow.sourceEndpointInfo && this.schemaCompareMainWindow.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
 			this.sourceDatabaseRadioButton.checked = true;
 			this.sourceIsDacpac = false;
-		} else {
+			this.sourceIsDatabase = true;
+			this.sourceIsProject = false;
+		} else if (this.schemaCompareMainWindow.sourceEndpointInfo && this.schemaCompareMainWindow.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Dacpac) {
 			this.sourceDacpacRadioButton.checked = true;
 			this.sourceIsDacpac = true;
+			this.sourceIsDatabase = false;
+			this.sourceIsProject = false;
+		} else if (this.schemaCompareMainWindow.sourceEndpointInfo) {
+			this.sourceProjectRadioButton.checked = true;
+			this.sourceIsDacpac = false;
+			this.sourceIsDatabase = false;
+			this.sourceIsProject = true;
 		}
+
 		let flexRadioButtonsModel = this.view.modelBuilder.flexContainer()
 			.withLayout({ flexFlow: 'column' })
-			.withItems([this.sourceDacpacRadioButton, this.sourceDatabaseRadioButton])
+			.withItems([this.sourceDacpacRadioButton, this.sourceProjectRadioButton, this.sourceDatabaseRadioButton])
 			.withProps({ ariaRole: 'radiogroup' })
 			.component();
 
@@ -401,11 +568,22 @@ export class SchemaCompareDialog {
 				label: loc.DatabaseRadioButtonLabel
 			}).component();
 
+		let projectRadioButton = this.view.modelBuilder.radioButton()
+			.withProps({
+				name: 'target',
+				label: loc.ProjectRadioButtonLabel
+			}).component();
+
 		// show dacpac file browser
 		dacpacRadioButton.onDidClick(async () => {
 			this.targetIsDacpac = true;
+			this.targetIsDatabase = false;
+			this.targetIsProject = false;
+			this.targetTextBox.value = this.targetDacpacPath;
 			this.formBuilder.removeFormItem(this.targetServerComponent);
 			this.formBuilder.removeFormItem(this.targetDatabaseComponent);
+			this.formBuilder.removeFormItem(this.targetProjectFilePathComponent);
+			this.formBuilder.removeFormItem(this.targetProjectStructureComponent);
 			this.formBuilder.addFormItem(this.targetDacpacComponent, { horizontal: true, titleFontSize: titleFontSize });
 			this.dialog.okButton.enabled = await this.shouldEnableOkayButton();
 		});
@@ -413,25 +591,52 @@ export class SchemaCompareDialog {
 		// show server and db dropdowns
 		databaseRadioButton.onDidClick(async () => {
 			this.targetIsDacpac = false;
+			this.targetIsDatabase = true;
+			this.targetIsProject = false;
 			this.formBuilder.removeFormItem(this.targetDacpacComponent);
+			this.formBuilder.removeFormItem(this.targetProjectFilePathComponent);
+			this.formBuilder.removeFormItem(this.targetProjectStructureComponent);
 			this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, titleFontSize: titleFontSize });
 			this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, titleFontSize: titleFontSize });
 
 			await this.populateServerDropdown(true);
 		});
 
+		// show project directory browser
+		projectRadioButton.onDidClick(async () => {
+			this.targetIsDacpac = false;
+			this.targetIsDatabase = false;
+			this.targetIsProject = true;
+			this.targetTextBox.value = this.targetProjectFilePath;
+			this.formBuilder.removeFormItem(this.targetServerComponent);
+			this.formBuilder.removeFormItem(this.targetDatabaseComponent);
+			this.formBuilder.removeFormItem(this.targetDacpacComponent);
+			this.formBuilder.addFormItem(this.targetProjectFilePathComponent, { horizontal: true, titleFontSize: titleFontSize });
+			this.formBuilder.addFormItem(this.targetProjectStructureComponent, { horizontal: true, titleFontSize: titleFontSize });
+			this.dialog.okButton.enabled = await this.shouldEnableOkayButton();
+		});
+
 		// if target is currently a db, show it in the server and db dropdowns
 		if (this.schemaCompareMainWindow.targetEndpointInfo && this.schemaCompareMainWindow.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
 			databaseRadioButton.checked = true;
 			this.targetIsDacpac = false;
-		} else {
+			this.targetIsDatabase = true;
+			this.targetIsProject = false;
+		} else if (this.schemaCompareMainWindow.targetEndpointInfo && this.schemaCompareMainWindow.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Dacpac) {
 			dacpacRadioButton.checked = true;
 			this.targetIsDacpac = true;
+			this.targetIsDatabase = false;
+			this.targetIsProject = false;
+		} else if (this.schemaCompareMainWindow.targetEndpointInfo) {
+			projectRadioButton.checked = true;
+			this.targetIsDacpac = false;
+			this.targetIsDatabase = false;
+			this.targetIsProject = true;
 		}
 
 		let flexRadioButtonsModel = this.view.modelBuilder.flexContainer()
 			.withLayout({ flexFlow: 'column' })
-			.withItems([dacpacRadioButton, databaseRadioButton]
+			.withItems([dacpacRadioButton, projectRadioButton, databaseRadioButton]
 			)
 			.withProps({ ariaRole: 'radiogroup' })
 			.component();
@@ -440,19 +645,6 @@ export class SchemaCompareDialog {
 			component: flexRadioButtonsModel,
 			title: loc.RadioButtonsLabel
 		};
-	}
-
-	private async shouldEnableOkayButton(): Promise<boolean> {
-		let sourcefilled = (this.sourceIsDacpac && await this.existsDacpac(this.sourceTextBox.value))
-			|| (!this.sourceIsDacpac && !isNullOrUndefined(this.sourceDatabaseDropdown.value) && this.sourceDatabaseDropdown.values.findIndex(x => this.matchesValue(x, this.sourceDbEditable)) !== -1);
-		let targetfilled = (this.targetIsDacpac && await this.existsDacpac(this.targetTextBox.value))
-			|| (!this.targetIsDacpac && !isNullOrUndefined(this.targetDatabaseDropdown.value) && this.targetDatabaseDropdown.values.findIndex(x => this.matchesValue(x, this.targetDbEditable)) !== -1);
-
-		return sourcefilled && targetfilled;
-	}
-
-	private async existsDacpac(filename: string): Promise<boolean> {
-		return !isNullOrUndefined(filename) && await exists(filename) && (filename.toLocaleLowerCase().endsWith('.dacpac'));
 	}
 
 	protected createSourceServerDropdown(): azdata.FormComponent {
@@ -488,31 +680,6 @@ export class SchemaCompareDialog {
 			title: loc.ServerDropdownLabel,
 			actions: [this.sourceConnectionButton]
 		};
-	}
-
-	private createConnectionButton(isTarget: boolean): azdata.ButtonComponent {
-		const selectConnectionButton = this.view.modelBuilder.button().withProps({
-			ariaLabel: loc.selectConnection,
-			iconPath: path.join(this.extensionContext.extensionPath, 'media', 'selectConnection.svg'),
-			height: '20px',
-			width: '20px'
-		}).component();
-
-		selectConnectionButton.onDidClick(async () => {
-			await this.connectionButtonClick(isTarget);
-			selectConnectionButton.iconPath = path.join(this.extensionContext.extensionPath, 'media', 'connect.svg');
-		});
-
-		return selectConnectionButton;
-	}
-
-	public async connectionButtonClick(isTarget: boolean): Promise<void> {
-		let connection = await azdata.connection.openConnectionDialog();
-		if (connection) {
-			this.connectionId = connection.connectionId;
-			this.promise = this.populateServerDropdown(isTarget);
-			this.promise2 = this.populateServerDropdown(!isTarget, true);		// passively populate the other server dropdown as well to add the new connections
-		}
 	}
 
 	protected createTargetServerDropdown(): azdata.FormComponent {
@@ -690,10 +857,6 @@ export class SchemaCompareDialog {
 		};
 	}
 
-	private matchesValue(listValue: any, value: string): boolean {
-		return listValue.displayName === value || listValue === value;
-	}
-
 	protected async populateDatabaseDropdown(connectionProfile: azdata.connection.ConnectionProfile, isTarget: boolean): Promise<void> {
 		const currentDropdown = isTarget ? this.targetDatabaseDropdown : this.sourceDatabaseDropdown;
 		currentDropdown.loading = true;
@@ -745,6 +908,144 @@ export class SchemaCompareDialog {
 		}
 		return values;
 	}
+
+	private createConnectionButton(isTarget: boolean): azdata.ButtonComponent {
+		const selectConnectionButton = this.view.modelBuilder.button().withProps({
+			ariaLabel: loc.selectConnection,
+			iconPath: path.join(this.extensionContext.extensionPath, 'media', 'selectConnection.svg'),
+			height: '20px',
+			width: '20px'
+		}).component();
+
+		selectConnectionButton.onDidClick(async () => {
+			await this.connectionButtonClick(isTarget);
+			selectConnectionButton.iconPath = path.join(this.extensionContext.extensionPath, 'media', 'connect.svg');
+		});
+
+		return selectConnectionButton;
+	}
+
+	public async connectionButtonClick(isTarget: boolean): Promise<void> {
+		let connection = await azdata.connection.openConnectionDialog();
+		if (connection) {
+			this.connectionId = connection.connectionId;
+			this.promise = this.populateServerDropdown(isTarget);
+			this.promise2 = this.populateServerDropdown(!isTarget, true);		// passively populate the other server dropdown as well to add the new connections
+		}
+	}
+
+	private endpointChanged(previousEndpoint: mssql.SchemaCompareEndpointInfo, updatedEndpoint: mssql.SchemaCompareEndpointInfo): boolean {
+		if (previousEndpoint && updatedEndpoint) {
+			return getEndpointName(previousEndpoint).toLowerCase() !== getEndpointName(updatedEndpoint).toLowerCase()
+				|| (previousEndpoint.serverDisplayName && updatedEndpoint.serverDisplayName && previousEndpoint.serverDisplayName.toLowerCase() !== updatedEndpoint.serverDisplayName.toLowerCase());
+		}
+		return false;
+	}
+
+	private async existsDacpac(filename: string): Promise<boolean> {
+		return !isNullOrUndefined(filename) && await exists(filename) && (filename.toLocaleLowerCase().endsWith('.dacpac'));
+	}
+
+	private async existsProjectFile(filename: string): Promise<boolean> {
+		return !isNullOrUndefined(filename) && await exists(filename) && (filename.toLocaleLowerCase().endsWith('.sqlproj'));
+	}
+
+	private async getTargetScripts(source: boolean): Promise<string[]> {
+		const projectFilePath = source ? this.sourceTextBox.value : this.targetTextBox.value;
+		return await vscode.commands.executeCommand(loc.sqlDatabaseProjectsGetTargetScripts, projectFilePath);
+	}
+
+	private async getDsp(source: boolean): Promise<string> {
+		try {
+			const projectFilePath = source ? this.sourceTextBox.value : this.targetTextBox.value;
+			return await vscode.commands.executeCommand(loc.sqlDatabaseProjectsGetDsp, projectFilePath);
+		} catch (e) {
+			throw e;
+		}
+	}
+
+	private matchesValue(listValue: any, value: string): boolean {
+		return listValue.displayName === value || listValue === value;
+	}
+
+	private async shouldEnableOkayButton(): Promise<boolean> {
+		let sourcefilled = (this.sourceIsDacpac && await this.existsDacpac(this.sourceTextBox.value))
+			|| (this.sourceIsProject && this.existsProjectFile(this.sourceTextBox.value))
+			|| (this.sourceIsDatabase && !isNullOrUndefined(this.sourceDatabaseDropdown.value) && this.sourceDatabaseDropdown.values.findIndex(x => this.matchesValue(x, this.sourceDbEditable)) !== -1);
+		let targetfilled = (this.targetIsDacpac && await this.existsDacpac(this.targetTextBox.value))
+			|| (this.targetIsProject && this.existsProjectFile(this.targetTextBox.value))
+			|| (this.targetIsDatabase && !isNullOrUndefined(this.targetDatabaseDropdown.value) && this.targetDatabaseDropdown.values.findIndex(x => this.matchesValue(x, this.targetDbEditable)) !== -1);
+
+		return sourcefilled && targetfilled;
+	}
+
+	public async handleOkButtonClick(): Promise<void> {
+		await this.execute();
+		this.dispose();
+	}
+
+	protected showErrorMessage(message: string): void {
+		this.dialog.message = {
+			text: message,
+			level: getAzdataApi()!.window.MessageLevel.Error
+		};
+	}
+
+	async validate(): Promise<boolean> {
+		try {
+
+			if ((this.sourceIsProject || this.targetIsProject) && !vscode.extensions.getExtension(loc.sqlDatabaseProjectExtensionId)) {
+				this.showErrorMessage(loc.noProjectExtension);
+				return false;
+			}
+
+			if (this.sourceIsProject && this.targetIsProject) {
+				try {
+					await this.getDsp(true);
+				} catch (eSource) {
+					try {
+						await this.getDsp(false);
+					} catch (eTarget) {
+						this.showErrorMessage(loc.dspErrorSourceAndTarget);
+						return false;
+					}
+
+					this.showErrorMessage(loc.dspErrorSource);
+					return false;
+				}
+			}
+
+			if (this.sourceIsProject) {
+				try {
+					await this.getDsp(true);
+				} catch (eSource) {
+					this.showErrorMessage(loc.dspErrorSource);
+					return false;
+				}
+			}
+
+			if (this.targetIsProject) {
+				try {
+					await this.getDsp(false);
+				} catch (eSource) {
+					this.showErrorMessage(loc.dspErrorTarget);
+					return false;
+				}
+			}
+
+			return true;
+		} catch (e) {
+			this.showErrorMessage(e?.message ? e.message : e);
+			return false;
+		}
+	}
+
+	private dispose(): void {
+		this.toDispose.forEach(disposable => disposable.dispose());
+	}
+
+	protected async cancel(): Promise<void> {
+	}
 }
 
 export interface ConnectionDropdownValue extends azdata.CategoryValue {
@@ -754,4 +1055,3 @@ export interface ConnectionDropdownValue extends azdata.CategoryValue {
 function isNullOrUndefined(val: any): boolean {
 	return val === null || val === undefined;
 }
-

--- a/extensions/schema-compare/src/extension.ts
+++ b/extensions/schema-compare/src/extension.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { SchemaCompareMainWindow } from './schemaCompareMainWindow';
 
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
-	vscode.commands.registerCommand('schemaCompare.start', async (context: any) => { await new SchemaCompareMainWindow(undefined, extensionContext, undefined).start(context); });
+	vscode.commands.registerCommand('schemaCompare.start', async (sourceContext: any, targetContext: any = undefined, comparisonResult: any = undefined) => { await new SchemaCompareMainWindow(undefined, extensionContext, undefined).start(sourceContext, targetContext, comparisonResult); });
 }
 
 export function deactivate(): void {

--- a/extensions/schema-compare/src/localizedConstants.ts
+++ b/extensions/schema-compare/src/localizedConstants.ts
@@ -15,9 +15,11 @@ export const FileTextBoxLabel: string = localize('schemaCompareDialog.fileTextBo
 export const DacpacRadioButtonLabel: string = localize('schemaCompare.dacpacRadioButtonLabel', "Data-tier Application File (.dacpac)");
 export const DatabaseRadioButtonLabel: string = localize('schemaCompare.databaseButtonLabel', "Database");
 export const RadioButtonsLabel: string = localize('schemaCompare.radioButtonsLabel', "Type");
+export const ProjectRadioButtonLabel: string = localize('schemaCompare.projectButtonLabel', "Database Project");
 export const ServerDropdownLabel: string = localize('schemaCompareDialog.serverDropdownTitle', "Server");
 export const DatabaseDropdownLabel: string = localize('schemaCompareDialog.databaseDropdownTitle', "Database");
 export const SchemaCompareLabel: string = localize('schemaCompare.dialogTitle', "Schema Compare");
+export const StructureDropdownLabel: string = localize('schemaCompareDialog.structureDropdownLabel', "Folder Structure");
 export const differentSourceMessage: string = localize('schemaCompareDialog.differentSourceMessage', "A different source schema has been selected. Compare to see the comparison?");
 export const differentTargetMessage: string = localize('schemaCompareDialog.differentTargetMessage', "A different target schema has been selected. Compare to see the comparison?");
 export const differentSourceTargetMessage: string = localize('schemaCompareDialog.differentSourceTargetMessage', "Different source and target schemas have been selected. Compare to see the comparison?");
@@ -30,6 +32,12 @@ export const targetDatabase: string = localize('schemaCompareDialog.targetDataba
 export const sourceServer: string = localize('schemaCompareDialog.sourceServerDropdown', "Source Server");
 export const targetServer: string = localize('schemaCompareDialog.targetServerDropdown', "Target Server");
 export const defaultText: string = localize('schemaCompareDialog.defaultUser', "default");
+export const targetStructure = localize('targetStructure', "Target Folder Structure");
+export const file = localize('file', "File");
+export const flat = localize('flat', "Flat");
+export const objectType = localize('objectType', "Object Type");
+export const schema = localize('schema', "Schema");
+export const schemaObjectType = localize('schemaObjectType', "Schema/Object Type");
 export const open: string = localize('schemaCompare.openFile', "Open");
 export const selectSourceFile: string = localize('schemaCompare.selectSourceFile', "Select source file");
 export const selectTargetFile: string = localize('schemaCompare.selectTargetFile', "Select target file");
@@ -61,7 +69,7 @@ export const include: string = localize('schemaCompare.includeColumnName', "Incl
 export const action: string = localize('schemaCompare.actionColumn', "Action");
 export const targetName: string = localize('schemaCompare.targetNameColumn', "Target Name");
 export const generateScriptDisabled: string = localize('schemaCompare.generateScriptButtonDisabledTitle', "Generate script is enabled when the target is a database");
-export const applyDisabled: string = localize('schemaCompare.applyButtonDisabledTitle', "Apply is enabled when the target is a database");
+export const applyDisabled: string = localize('schemaCompare.applyButtonDisabledTitle', "Apply is enabled when the target is a database or database project");
 export function cannotExcludeMessageDependent(diffEntryName: string, firstDependentName: string): string { return localize('schemaCompare.cannotExcludeMessageWithDependent', "Cannot exclude {0}. Included dependents exist, such as {1}", diffEntryName, firstDependentName); }
 export function cannotIncludeMessageDependent(diffEntryName: string, firstDependentName: string): string { return localize('schemaCompare.cannotIncludeMessageWithDependent', "Cannot include {0}. Excluded dependents exist, such as {1}", diffEntryName, firstDependentName); }
 export function cannotExcludeMessage(diffEntryName: string): string { return localize('schemaCompare.cannotExcludeMessage', "Cannot exclude {0}. Included dependents exist", diffEntryName); }
@@ -318,3 +326,21 @@ export function cancelErrorMessage(errorMessage: string): string { return locali
 export function generateScriptErrorMessage(errorMessage: string): string { return localize('schemaCompare.generateScriptErrorMessage', "Generate script failed: '{0}'", (errorMessage) ? errorMessage : 'Unknown'); }
 export function applyErrorMessage(errorMessage: string): string { return localize('schemaCompare.updateErrorMessage', "Schema Compare Apply failed '{0}'", errorMessage ? errorMessage : 'Unknown'); }
 export function openScmpErrorMessage(errorMessage: string): string { return localize('schemaCompare.openScmpErrorMessage', "Open scmp failed: '{0}'", (errorMessage) ? errorMessage : 'Unknown'); }
+export const applyError: string = localize('schemaCompare.applyError', "There was an error updating the project");
+export const dspErrorSource: string = localize('schemaCompareDialog.dspErrorSource', "The source .sqlproj file does not specify a database schema component");
+export const dspErrorTarget: string = localize('schemaCompareDialog.dspErrorTarget', "The target .sqlproj file does not specify a database schema component");
+export const dspErrorSourceAndTarget: string = localize('schemaCompareDialog.dspErrorSourceAndTarget', "The .sqlproj files do not specify a database schema component");
+export const noProjectExtension: string = localize('schemaCompareDialog.noProjectExtension', "The sql-database-projects extension is required to perform schema comparison with database projects");
+export const noProjectExtensionApply: string = localize('schemaCompareDialog.noProjectExtensionApply', "The sql-database-projects extension is required to apply changes to a project");
+
+// Information messages
+export const applySuccess: string = localize('schemaCompare.applySuccess', "Project was successfully updated");
+
+// Extensions
+export const sqlDatabaseProjectExtensionId: string = localize('schemaCompare.sqlDatabaseProjectExtensionId', "microsoft.sql-database-projects");
+
+// Commands
+export const sqlDatabaseProjectsGetTargetScripts: string = localize('schemaCompare.sqlDatabaseProjectsGetTargetScripts', "sqlDatabaseProjects.schemaCompareGetTargetScripts");
+export const sqlDatabaseProjectsGetDsp: string = localize('schemaCompare.sqlDatabaseProjectsGetDsp', "sqlDatabaseProjects.schemaCompareGetDsp");
+export const sqlDatabaseProjectsPublishChanges: string = localize('schemaCompare.sqlDatabaseProjectsPublishChanges', "sqlDatabaseProjects.schemaComparePublishProjectChanges");
+export const sqlDatabaseProjectsShowProjectsView: string = localize('schemaCompare.sqlDatabaseProjectsShowProjectsView', "sqlDatabaseProjects.schemaCompareShowProjectsView");

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -81,14 +81,33 @@ export class SchemaCompareMainWindow {
 		this.editor = azdata.workspace.createModelViewEditor(loc.SchemaCompareLabel, { retainContextWhenHidden: true, supportsSave: true, resourceName: schemaCompareResourceName }, 'SchemaCompareEditor');
 	}
 
-	// schema compare can get started with three contexts for the source:
+	// schema compare can get started with four contexts for the source:
 	// 1. undefined
 	// 2. connection profile
 	// 3. dacpac
-	public async start(context: any): Promise<void> {
-		// if schema compare was launched from a db, set that as the source
-		let profile = context ? <azdata.IConnectionProfile>context.connectionProfile : undefined;
-		let sourceDacpac = context as string;
+	// 4. project
+	public async start(sourceContext: any, targetContext: mssql.SchemaCompareEndpointInfo = undefined, comparisonResult: mssql.SchemaCompareResult = undefined): Promise<void> {
+		const targetIsSetAsProject: boolean = targetContext && targetContext.endpointType === mssql.SchemaCompareEndpointType.Project;
+
+		// if schema compare was launched from a db or a connection profile, set that as the source
+		let profile: azdata.IConnectionProfile;
+
+		if (targetIsSetAsProject) {
+			profile = sourceContext;
+			this.targetEndpointInfo = targetContext;
+		} else {
+			profile = sourceContext ? <azdata.IConnectionProfile>sourceContext.connectionProfile : undefined;
+		}
+
+		let sourceDacpac = undefined;
+		let sourceProject = undefined;
+
+		if (!profile && sourceContext as string && (sourceContext as string).endsWith('.dacpac')) {
+			sourceDacpac = sourceContext as string;
+		} else if (!profile) {
+			sourceProject = sourceContext as string;
+		}
+
 		if (profile) {
 			let ownerUri = await azdata.connection.getUriForConnection((profile.id));
 			let usr = profile.userName;
@@ -104,7 +123,11 @@ export class SchemaCompareMainWindow {
 				ownerUri: ownerUri,
 				packageFilePath: '',
 				connectionDetails: undefined,
-				connectionName: profile.connectionName
+				connectionName: profile.connectionName,
+				projectFilePath: '',
+				targetScripts: [],
+				dsp: '',
+				folderStructure: ''
 			};
 		} else if (sourceDacpac) {
 			this.sourceEndpointInfo = {
@@ -114,7 +137,25 @@ export class SchemaCompareMainWindow {
 				databaseName: '',
 				ownerUri: '',
 				packageFilePath: sourceDacpac,
-				connectionDetails: undefined
+				connectionDetails: undefined,
+				projectFilePath: '',
+				targetScripts: [],
+				dsp: '',
+				folderStructure: ''
+			};
+		} else if (sourceProject) {
+			this.sourceEndpointInfo = {
+				endpointType: mssql.SchemaCompareEndpointType.Project,
+				packageFilePath: '',
+				serverDisplayName: '',
+				serverName: '',
+				databaseName: '',
+				ownerUri: '',
+				connectionDetails: undefined,
+				projectFilePath: sourceProject,
+				targetScripts: [],
+				dsp: undefined,
+				folderStructure: ''
 			};
 		}
 
@@ -123,6 +164,10 @@ export class SchemaCompareMainWindow {
 			this.registerContent(),
 			this.editor.openEditor()
 		]);
+
+		if (targetIsSetAsProject) {
+			await this.execute(comparisonResult);
+		}
 	}
 
 	private async registerContent(): Promise<void> {
@@ -162,7 +207,8 @@ export class SchemaCompareMainWindow {
 				this.createSourceAndTargetButtons();
 
 				this.sourceName = getEndpointName(this.sourceEndpointInfo);
-				this.targetName = ' ';
+				this.targetName = getEndpointName(this.targetEndpointInfo);
+
 				this.sourceNameComponent = this.view.modelBuilder.inputBox().withProps({
 					value: this.sourceName,
 					title: this.sourceName,
@@ -275,29 +321,37 @@ export class SchemaCompareMainWindow {
 		this.deploymentOptions = deploymentOptions;
 	}
 
-	public async execute() {
-		TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonStarted');
+	public async execute(comparisonResult: mssql.SchemaCompareCompletionResult = undefined) {
 		const service = await this.getService();
 
-		if (!this.operationId) {
-			// create once per page
-			this.operationId = generateGuid();
-		}
+		if (comparisonResult) {
+			this.operationId = comparisonResult.operationId;
+			this.comparisonResult = comparisonResult;
+			this.flexModel.removeItem(this.startText);
+		} else {
+			TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonStarted');
 
-		this.comparisonResult = await service.schemaCompare(this.operationId, this.sourceEndpointInfo, this.targetEndpointInfo, azdata.TaskExecutionMode.execute, this.deploymentOptions);
-		if (!this.comparisonResult || !this.comparisonResult.success) {
-			TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonFailed', undefined, getTelemetryErrorType(this.comparisonResult?.errorMessage))
+			if (!this.operationId) {
+				// create once per page
+				this.operationId = generateGuid();
+			}
+
+			this.comparisonResult = await service.schemaCompare(this.operationId, this.sourceEndpointInfo, this.targetEndpointInfo, azdata.TaskExecutionMode.execute, this.deploymentOptions);
+
+			if (!this.comparisonResult || !this.comparisonResult.success) {
+				TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonFailed', undefined, getTelemetryErrorType(this.comparisonResult?.errorMessage))
+					.withAdditionalProperties({
+						operationId: this.comparisonResult.operationId
+					}).send();
+				vscode.window.showErrorMessage(loc.compareErrorMessage(this.comparisonResult?.errorMessage));
+				return;
+			}
+			TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonFinished')
 				.withAdditionalProperties({
-					operationId: this.comparisonResult.operationId
+					'endTime': Date.now().toString(),
+					'operationId': this.comparisonResult.operationId
 				}).send();
-			vscode.window.showErrorMessage(loc.compareErrorMessage(this.comparisonResult?.errorMessage));
-			return;
 		}
-		TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonFinished')
-			.withAdditionalProperties({
-				'endTime': Date.now().toString(),
-				'operationId': this.comparisonResult.operationId
-			}).send();
 
 		let data = this.getAllDifferences(this.comparisonResult.differences);
 
@@ -359,9 +413,15 @@ export class SchemaCompareMainWindow {
 			// only enable generate script button if the target is a db
 			if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
 				this.generateScriptButton.enabled = true;
-				this.applyButton.enabled = true;
 			} else {
 				this.generateScriptButton.title = loc.generateScriptDisabled;
+			}
+
+			// only enable apply button if the target is a db or a project
+			if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database ||
+				this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+				this.applyButton.enabled = true;
+			} else {
 				this.applyButton.title = loc.applyDisabled;
 			}
 		} else {
@@ -766,7 +826,22 @@ export class SchemaCompareMainWindow {
 				this.setButtonsForRecompare();
 
 				const service = await this.getService();
-				const result = await service.schemaComparePublishChanges(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.execute);
+				let result = undefined;
+
+				if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
+					result = await service.schemaComparePublishDatabaseChanges(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.execute);
+				} else {
+					if (!vscode.extensions.getExtension(loc.sqlDatabaseProjectExtensionId)) {
+						await vscode.window.showErrorMessage(loc.noProjectExtensionApply);
+						return;
+					} else {
+						result = await vscode.commands.executeCommand(loc.sqlDatabaseProjectsPublishChanges, this.comparisonResult.operationId, this.targetEndpointInfo.projectFilePath, this.targetEndpointInfo.folderStructure);
+						if (!result.success) {
+							await vscode.window.showErrorMessage(loc.applyError);
+						}
+					}
+				}
+
 				if (!result || !result.success) {
 					TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareApplyFailed', undefined, getTelemetryErrorType(result.errorMessage))
 						.withAdditionalProperties({
@@ -785,6 +860,11 @@ export class SchemaCompareMainWindow {
 						'endTime': Date.now().toString(),
 						'operationId': this.comparisonResult.operationId
 					}).send();
+
+				if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+					vscode.commands.executeCommand(loc.sqlDatabaseProjectsShowProjectsView);
+					await vscode.window.showInformationMessage(loc.applySuccess);
+				}
 			}
 		});
 	}
@@ -1072,10 +1152,14 @@ export class SchemaCompareMainWindow {
 
 	private setButtonStatesForNoChanges(enableButtons: boolean): void {
 		// generate script and apply can only be enabled if the target is a database
-		if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
+		if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database ||
+			this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
 			this.applyButton.enabled = enableButtons;
-			this.generateScriptButton.enabled = enableButtons;
 			this.applyButton.title = enableButtons ? loc.applyEnabledMessage : loc.applyNoChangesMessage;
+		}
+
+		if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
+			this.generateScriptButton.enabled = enableButtons;
 			this.generateScriptButton.title = enableButtons ? loc.generateScriptEnabledMessage : loc.generateScriptNoChangesMessage;
 		}
 	}

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -126,7 +126,7 @@ export class SchemaCompareMainWindow {
 				connectionName: profile.connectionName,
 				projectFilePath: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				folderStructure: ''
 			};
 		} else if (sourceDacpac) {
@@ -140,7 +140,7 @@ export class SchemaCompareMainWindow {
 				connectionDetails: undefined,
 				projectFilePath: '',
 				targetScripts: [],
-				dsp: '',
+				dataSchemaProvider: '',
 				folderStructure: ''
 			};
 		} else if (sourceProject) {
@@ -154,7 +154,7 @@ export class SchemaCompareMainWindow {
 				connectionDetails: undefined,
 				projectFilePath: sourceProject,
 				targetScripts: [],
-				dsp: undefined,
+				dataSchemaProvider: undefined,
 				folderStructure: ''
 			};
 		}

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -110,8 +110,7 @@ describe('SchemaCompareMainWindow.results @DacFx@', function (): void {
 
 	it('Should show error if publish changes fails', async function (): Promise<void> {
 		let service = createServiceMock();
-		service.setup(x => x.schemaComparePublishChanges(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve({
-			success: false,
+		service.setup(x => x.schemaComparePublishDatabaseChanges(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve({			success: false,
 			errorMessage: 'error1'
 		}));
 
@@ -131,7 +130,7 @@ describe('SchemaCompareMainWindow.results @DacFx@', function (): void {
 
 	it('Should show not error if publish changes succeed', async function (): Promise<void> {
 		let service = createServiceMock();
-		service.setup(x => x.schemaComparePublishChanges(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve({
+		service.setup(x => x.schemaComparePublishDatabaseChanges(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve({
 			success: true,
 			errorMessage: ''
 		}));
@@ -343,7 +342,7 @@ describe('SchemaCompareMainWindow.results @DacFx@', function (): void {
 
 	it('Should not show error if user does not want to publish', async function (): Promise<void> {
 		let service = createServiceMock();
-		service.setup(x => x.schemaComparePublishChanges(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve({
+		service.setup(x => x.schemaComparePublishDatabaseChanges(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve({
 			success: true,
 			errorMessage: ''
 		}));

--- a/extensions/schema-compare/src/test/testSchemaCompareService.ts
+++ b/extensions/schema-compare/src/test/testSchemaCompareService.ts
@@ -5,6 +5,7 @@
 
 import * as azdata from 'azdata';
 import * as mssql from '../../../mssql';
+import { DacExtractTarget } from '../../../mssql/src/contracts';
 
 export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 
@@ -24,7 +25,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetDsp: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
+	schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: DacExtractTarget, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
 		throw new Error('Method not implemented.');
 	}
 

--- a/extensions/schema-compare/src/test/testSchemaCompareService.ts
+++ b/extensions/schema-compare/src/test/testSchemaCompareService.ts
@@ -20,7 +20,11 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		}
 	}
 
-	schemaComparePublishChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+	schemaComparePublishDatabaseChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+		throw new Error('Method not implemented.');
+	}
+
+	schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetDsp: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
 		throw new Error('Method not implemented.');
 	}
 

--- a/extensions/schema-compare/src/test/testUtils.ts
+++ b/extensions/schema-compare/src/test/testUtils.ts
@@ -93,6 +93,10 @@ export const mockDacpacEndpoint: mssql.SchemaCompareEndpointInfo = {
 	serverName: '',
 	databaseName: '',
 	ownerUri: '',
+	projectFilePath: '',
+	folderStructure: '',
+	targetScripts: [],
+	dsp: '',
 	packageFilePath: mockFilePath,
 	connectionDetails: undefined
 };
@@ -103,6 +107,10 @@ export const mockDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = {
 	serverName: '',
 	databaseName: '',
 	ownerUri: '',
+	projectFilePath: '',
+	folderStructure: '',
+	targetScripts: [],
+	dsp: '',
 	packageFilePath: '',
 	connectionDetails: undefined
 };

--- a/extensions/schema-compare/src/test/testUtils.ts
+++ b/extensions/schema-compare/src/test/testUtils.ts
@@ -96,7 +96,7 @@ export const mockDacpacEndpoint: mssql.SchemaCompareEndpointInfo = {
 	projectFilePath: '',
 	folderStructure: '',
 	targetScripts: [],
-	dsp: '',
+	dataSchemaProvider: '',
 	packageFilePath: mockFilePath,
 	connectionDetails: undefined
 };
@@ -110,7 +110,7 @@ export const mockDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = {
 	projectFilePath: '',
 	folderStructure: '',
 	targetScripts: [],
-	dsp: '',
+	dataSchemaProvider: '',
 	packageFilePath: '',
 	connectionDetails: undefined
 };

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
+import type * as azdataType from 'azdata'; // eslint-disable-line no-duplicate-imports
 import * as vscode from 'vscode';
 import * as mssql from '../../mssql';
 import * as os from 'os';
@@ -64,8 +65,11 @@ export function getEndpointName(endpoint: mssql.SchemaCompareEndpointInfo): stri
 			return ' ';
 		}
 
-	} else {
+	} else if (endpoint.endpointType === mssql.SchemaCompareEndpointType.Dacpac) {
 		return endpoint.packageFilePath;
+
+	} else {
+		return endpoint.projectFilePath;
 	}
 }
 
@@ -143,4 +147,25 @@ export async function exists(path: string): Promise<boolean> {
 	} catch (e) {
 		return false;
 	}
+}
+
+// Try to load the azdata API - but gracefully handle the failure in case we're running
+// in a context where the API doesn't exist (such as VS Code)
+let azdataApi: typeof azdataType | undefined = undefined;
+try {
+	azdataApi = require('azdata');
+	if (!azdataApi?.version) {
+		// webpacking makes the require return an empty object instead of throwing an error so make sure we clear the var
+		azdataApi = undefined;
+	}
+} catch {
+	// no-op
+}
+
+/**
+ * Gets the azdata API if it's available in the context this extension is running in.
+ * @returns The azdata API if it's available
+ */
+export function getAzdataApi(): typeof azdataType | undefined {
+	return azdataApi;
 }

--- a/extensions/schema-compare/yarn.lock
+++ b/extensions/schema-compare/yarn.lock
@@ -230,10 +230,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.6.tgz#b8622d50557dd155e9f2f634b7d68fd38de5e94b"
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
-"@types/node@^12.11.7":
-  version "12.12.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.7.tgz#01e4ea724d9e3bd50d90c11fd5980ba317d8fa11"
-  integrity sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==
+"@types/node@^12.20.23":
+  version "12.20.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.23.tgz#d0d5885bb885ee9b1ed114a04ea586540a1b2e2a"
+  integrity sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw==
 
 "@types/sinon@^9.0.4":
   version "9.0.9"

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -16,6 +16,7 @@
     "onCommand:sqlDatabaseProjects.new",
     "onCommand:sqlDatabaseProjects.open",
     "onCommand:sqlDatabaseProjects.createProjectFromDatabase",
+    "onCommand:sqlDatabaseProjects.updateProjectFromDatabase",
     "onCommand:sqlDatabaseProjects.addSqlBinding",
     "workspaceContains:**/*.sqlproj",
     "onView:dataworkspace.views.main"
@@ -136,6 +137,12 @@
         "icon": "images/databaseProjectToolbar.svg"
       },
       {
+        "command": "sqlDatabaseProjects.updateProjectFromDatabase",
+        "title": "%sqlDatabaseProjects.updateProjectFromDatabase%",
+        "category": "%sqlDatabaseProjects.displayName%",
+        "icon": "images/databaseProjectToolbar.svg"
+      },
+      {
         "command": "sqlDatabaseProjects.addDatabaseReference",
         "title": "%sqlDatabaseProjects.addDatabaseReference%",
         "category": "%sqlDatabaseProjects.displayName%"
@@ -170,7 +177,12 @@
         {
           "command": "sqlDatabaseProjects.createProjectFromDatabase",
           "when": "view == dataworkspace.views.main",
-          "group": "1_currentWorkspace"
+          "group": "1_currentWorkspace@1"
+        },
+        {
+          "command": "sqlDatabaseProjects.updateProjectFromDatabase",
+          "when": "view == dataworkspace.views.main",
+          "group": "1_currentWorkspace@2"
         }
       ],
       "commandPalette": [
@@ -238,6 +250,10 @@
           "command": "sqlDatabaseProjects.createProjectFromDatabase"
         },
         {
+          "command": "sqlDatabaseProjects.updateProjectFromDatabase",
+          "when": "false"
+        },
+        {
           "command": "sqlDatabaseProjects.addDatabaseReference",
           "when": "false"
         },
@@ -286,6 +302,11 @@
           "command": "sqlDatabaseProjects.schemaCompare",
           "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.project && azdataAvailable",
           "group": "1_dbProjectsFirst@3"
+        },
+        {
+          "command": "sqlDatabaseProjects.updateProjectFromDatabase",
+          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.project",
+          "group": "1_dbProjectsFirst@4"
         },
         {
           "command": "sqlDatabaseProjects.newItem",
@@ -377,19 +398,33 @@
         {
           "command": "sqlDatabaseProjects.createProjectFromDatabase",
           "when": "nodeType =~ /^(Database|Server)$/ && connectionProvider == MSSQL && mssql:engineedition != 11",
-          "group": "export"
+          "group": "export@1"
+        },
+        {
+          "command": "sqlDatabaseProjects.updateProjectFromDatabase",
+          "when": "nodeType =~ /^(Database|Server)$/ && connectionProvider == MSSQL && mssql:engineedition != 11",
+          "group": "export@2"
         }
       ],
       "dataExplorer/context": [
         {
           "command": "sqlDatabaseProjects.createProjectFromDatabase",
           "when": "nodeType =~ /^(Database|Server)$/ && connectionProvider == MSSQL && mssql:engineedition != 11",
-          "group": "export"
+          "group": "export@1"
+        },
+        {
+          "command": "sqlDatabaseProjects.updateProjectFromDatabase",
+          "when": "nodeType =~ /^(Database|Server)$/ && connectionProvider == MSSQL && mssql:engineedition != 11",
+          "group": "export@2"
         }
       ],
       "dashboard/toolbar": [
         {
           "command": "sqlDatabaseProjects.createProjectFromDatabase",
+          "when": "connectionProvider == 'MSSQL' && mssql:engineedition != 11"
+        },
+        {
+          "command": "sqlDatabaseProjects.updateProjectFromDatabase",
           "when": "connectionProvider == 'MSSQL' && mssql:engineedition != 11"
         }
       ]

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -10,6 +10,7 @@
 	"sqlDatabaseProjects.publish": "Publish",
 	"sqlDatabaseProjects.deployLocal": "Deploy",
 	"sqlDatabaseProjects.createProjectFromDatabase": "Create Project From Database",
+	"sqlDatabaseProjects.updateProjectFromDatabase": "Update Project From Database",
 	"sqlDatabaseProjects.properties": "Properties",
 	"sqlDatabaseProjects.schemaCompare": "Schema Compare",
 	"sqlDatabaseProjects.delete": "Delete",

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -212,6 +212,7 @@ export const targetProject = localize('targetProject', "Target project");
 export const createProjectSettings = localize('createProjectSettings', "Settings");
 export const projectNameLabel = localize('projectNameLabel', "Name");
 export const projectNamePlaceholderText = localize('projectNamePlaceholderText', "Enter project name");
+export const projectLocationLabel = localize('projectLocationLabel', "Location");
 export const projectLocationPlaceholderText = localize('projectLocationPlaceholderText', "Select location to create project");
 export const browseButtonText = localize('browseButtonText', "Browse folder");
 export const selectFolderStructure = localize('selectFolderStructure', "Select folder structure");
@@ -223,9 +224,28 @@ export const selectProjectLocation = localize('selectProjectLocation', "Select p
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
 export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };
 
+// Update Project From Database dialog strings
+
+export const updateProjectFromDatabaseDialogName = localize('updateProjectFromDatabaseDialogName', "Update project from database");
+export const updateProjectDialogOkButtonText = localize('updateProjectDialogOkButtonText', "Update");
+export const noSqlProjFile = localize('noSqlProjFile', "The selected project file does not exist");
+export const noSchemaCompareExtension = localize('noSchemaCompareExtension', "The schema-compare extension needs to be downloaded to a update a project from a database");
+export const projectToUpdatePlaceholderText = localize('projectToUpdatePlaceholderText', "Select project file");
+export const updateAction = localize('updateAction', "Update action");
+export const compareActionRadioButtonLabel = localize('compareActionRadiButtonLabel', "View changes in Schema Compare");
+export const updateActionRadioButtonLabel = localize('updateActionRadiButtonLabel', "Apply all changes");
+export const actionLabel = localize('actionLabel', "Action");
+
+// Update project from database
+
+export const applySuccess = localize('applySuccess', "Project was successfully updated");
+export const equalComparison = localize('equalComparison', "The project is already up to date with the database");
+export const applyError = localize('applyError', "There was an error updating the project");
+export const scmpTempFile = localize('scmpTempFile', ".temp.scmp");
 
 // Error messages
 
+export function compareErrorMessage(errorMessage: string): string { return localize('schemaCompare.compareErrorMessage', "Schema Compare failed: {0}", errorMessage ? errorMessage : 'Unknown'); }
 export const multipleSqlProjFiles = localize('multipleSqlProjFilesSelected', "Multiple .sqlproj files selected; please select only one.");
 export const noSqlProjFiles = localize('noSqlProjFilesSelected', "No .sqlproj file selected; please select one.");
 export const noDataSourcesFile = localize('noDataSourcesFile', "No {0} found", dataSourcesFileName);

--- a/extensions/sql-database-projects/src/common/uiConstants.ts
+++ b/extensions/sql-database-projects/src/common/uiConstants.ts
@@ -20,6 +20,9 @@ export namespace cssStyles {
 	export const createProjectFromDatabaseLabelWidth = '110px';
 	export const createProjectFromDatabaseTextboxWidth = '310px';
 
+	export const updateProjectFromDatabaseLabelWidth = '110px';
+	export const updateProjectFromDatabaseTextboxWidth = '310px';
+
 	// font-styles
 	export namespace fontStyle {
 		export const normal = 'normal';

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -392,6 +392,19 @@ export function timeConversion(duration: number): string {
 	return portions.join(', ');
 }
 
+/**
+ * Map an error message into a short name for the type of error.
+ * @param msg The error message to map
+ */
+export function getTelemetryErrorType(msg: string): string {
+	if (msg && msg.indexOf('Object reference not set to an instance of an object') !== -1) {
+		return 'ObjectReferenceNotSet';
+	}
+	else {
+		return 'Other';
+	}
+}
+
 // Try to load the azdata API - but gracefully handle the failure in case we're running
 // in a context where the API doesn't exist (such as VS Code)
 let azdataApi: typeof azdataType | undefined = undefined;

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as azdataType from 'azdata';
+import * as mssql from '../../../mssql';
 import * as vscode from 'vscode';
-import * as vscodeMssql from 'vscode-mssql';
 import * as templates from '../templates/templates';
 import * as path from 'path';
 
@@ -57,7 +57,12 @@ export default class MainController implements vscode.Disposable {
 		vscode.commands.registerCommand('sqlDatabaseProjects.publish', async (node: WorkspaceTreeItem) => { this.projectsController.publishProject(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.deployLocal', async (node: WorkspaceTreeItem) => { return this.projectsController.deployProject(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.schemaCompare', async (node: WorkspaceTreeItem) => { return this.projectsController.schemaCompare(node); });
-		vscode.commands.registerCommand('sqlDatabaseProjects.createProjectFromDatabase', async (context: azdataType.IConnectionProfile | vscodeMssql.ITreeNodeInfo | undefined) => { return this.projectsController.createProjectFromDatabase(context); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.schemaCompareGetTargetScripts', async (projectFilePath: string): Promise<string[]> => { return await this.projectsController.schemaCompareGetTargetScripts(projectFilePath); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.schemaCompareGetDsp', async (projectFilePath: string): Promise<string> => { return await this.projectsController.schemaCompareGetDsp(projectFilePath); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.schemaComparePublishProjectChanges', async (operationId: string, projectFilePath: string, folderStructure: string): Promise<mssql.SchemaComparePublishProjectResult> => { return await this.projectsController.schemaComparePublishProjectChanges(operationId, projectFilePath, folderStructure); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.schemaCompareShowProjectsView', async () => { await this.projectsController.schemaCompareShowProjectsView(); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.createProjectFromDatabase', async (profile: azdataType.IConnectionProfile) => { await this.projectsController.createProjectFromDatabase(profile); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.updateProjectFromDatabase', async (node: azdataType.IConnectionProfile | WorkspaceTreeItem) => { await this.projectsController.updateProjectFromDatabase(node); });
 
 		vscode.commands.registerCommand('sqlDatabaseProjects.newScript', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.script); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.newPreDeploymentScript', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.preDeployScript); });

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -17,13 +17,14 @@ import type * as mssqlVscode from 'vscode-mssql';
 
 import { promises as fs } from 'fs';
 import { PublishDatabaseDialog } from '../dialogs/publishDatabaseDialog';
-import { Project, reservedProjectFolders, FileProjectEntry, SqlProjectReferenceProjectEntry, IDatabaseReferenceProjectEntry } from '../models/project';
+import { Project, reservedProjectFolders, FileProjectEntry, SqlProjectReferenceProjectEntry, IDatabaseReferenceProjectEntry, EntryType } from '../models/project';
 import { SqlDatabaseProjectTreeViewProvider } from './databaseProjectTreeViewProvider';
 import { FolderNode, FileNode } from '../models/tree/fileFolderTreeItem';
 import { IDeploySettings } from '../models/IDeploySettings';
 import { BaseProjectTreeItem } from '../models/tree/baseTreeItem';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { ImportDataModel } from '../models/api/import';
+import { UpdateDataModel, UpdateAction } from '../models/api/update';
 import { NetCoreTool, DotNetCommandOptions, DotNetError } from '../tools/netcoreTool';
 import { BuildHelper } from '../tools/buildHelper';
 import { readPublishProfile } from '../models/publishProfile/publishProfile';
@@ -31,6 +32,7 @@ import { AddDatabaseReferenceDialog } from '../dialogs/addDatabaseReferenceDialo
 import { ISystemDatabaseReferenceSettings, IDacpacReferenceSettings, IProjectReferenceSettings } from '../models/IDatabaseReferenceSettings';
 import { DatabaseReferenceTreeItem } from '../models/tree/databaseReferencesTreeItem';
 import { CreateProjectFromDatabaseDialog } from '../dialogs/createProjectFromDatabaseDialog';
+import { UpdateProjectFromDatabaseDialog } from '../dialogs/updateProjectFromDatabaseDialog';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
 import { IconPathHelper } from '../common/iconHelper';
 import { DashboardData, PublishData, Status } from '../models/dashboardData/dashboardData';
@@ -418,18 +420,22 @@ export class ProjectsController {
 		return result;
 	}
 
-	public async schemaCompare(treeNode: dataworkspace.WorkspaceTreeItem): Promise<void> {
+	public async schemaCompare(source: dataworkspace.WorkspaceTreeItem | azdataType.IConnectionProfile, targetParam: any = undefined): Promise<void> {
 		try {
 			// check if schema compare extension is installed
 			if (vscode.extensions.getExtension(constants.schemaCompareExtensionId)) {
-				// build project
-				const dacpacPath = await this.buildProject(treeNode);
+				let sourceParam;
 
-				// check that dacpac exists
-				if (await utils.exists(dacpacPath)) {
-					TelemetryReporter.sendActionEvent(TelemetryViews.ProjectController, TelemetryActions.projectSchemaCompareCommandInvoked);
-					await vscode.commands.executeCommand(constants.schemaCompareStartCommand, dacpacPath);
+				if (source as dataworkspace.WorkspaceTreeItem) {
+					sourceParam = this.getProjectFromContext(source as dataworkspace.WorkspaceTreeItem).projectFolderPath;
 				} else {
+					sourceParam = source as azdataType.IConnectionProfile;
+				}
+
+				try {
+					TelemetryReporter.sendActionEvent(TelemetryViews.ProjectController, TelemetryActions.projectSchemaCompareCommandInvoked);
+					await vscode.commands.executeCommand(constants.schemaCompareStartCommand, sourceParam, targetParam, undefined);
+				} catch (e) {
 					throw new Error(constants.buildFailedCannotStartSchemaCompare);
 				}
 			} else {
@@ -447,8 +453,61 @@ export class ProjectsController {
 				.withAdditionalProperties(props)
 				.send();
 
-			void vscode.window.showErrorMessage(utils.getErrorMessage(err));
+			await vscode.window.showErrorMessage(utils.getErrorMessage(err));
 		}
+	}
+
+	public async schemaCompareGetTargetScripts(projectFilePath: string): Promise<string[]> {
+		const project = await Project.openProject(projectFilePath);
+		let files: string[] = [];
+
+		const fileEntries: FileProjectEntry[] = project.files;
+
+		fileEntries.forEach(f => {
+
+			if (f.fsUri.fsPath.endsWith('.sql')) {
+				files.push(f.fsUri.fsPath);
+			}
+		});
+
+		return files;
+	}
+
+	public async schemaCompareGetDsp(projectFilePath: string): Promise<string> {
+		const project = await Project.openProject(projectFilePath);
+		return project.getProjectTargetVersion();
+	}
+
+	public async schemaComparePublishProjectChanges(operationId: string, projectFilePath: string, folderStructure: string): Promise<mssql.SchemaComparePublishProjectResult> {
+		let ext = vscode.extensions.getExtension(mssql.extension.name)!;
+		const service = (await ext.activate() as mssql.IExtension).schemaCompare;
+
+		const projectPath = path.dirname(projectFilePath);
+
+		const result: mssql.SchemaComparePublishProjectResult = await service.schemaComparePublishProjectChanges(operationId, projectPath, folderStructure, utils.getAzdataApi()!.TaskExecutionMode.execute);
+
+		const project = await Project.openProject(projectFilePath);
+
+		let toAdd: vscode.Uri[] = [];
+		result.addedFiles.forEach(f => toAdd.push(vscode.Uri.file(f)));
+		await project.addToProject(toAdd);
+
+		let toRemove: vscode.Uri[] = [];
+		result.deletedFiles.forEach(f => toRemove.push(vscode.Uri.file(f)));
+
+		let toRemoveEntries: FileProjectEntry[] = [];
+		toRemove.forEach(f => toRemoveEntries.push(new FileProjectEntry(f, f.path.replace(projectPath + '\\', ''), EntryType.File)));
+
+		toRemoveEntries.forEach(async f => await project.exclude(f));
+
+		await this.buildProject(project);
+
+		return result;
+	}
+
+	public async schemaCompareShowProjectsView() {
+		const workspaceApi = utils.getDataWorkspaceExtensionApi();
+		workspaceApi.showProjectsView();
 	}
 
 	public async addFolderPrompt(treeNode: dataworkspace.WorkspaceTreeItem): Promise<void> {
@@ -1015,6 +1074,111 @@ export class ProjectsController {
 			await (service as mssqlVscode.IDacFxService).createProjectFromDatabase(model.database, model.filePath, model.projName, model.version, model.connectionUri, model.extractTarget as mssqlVscode.ExtractTarget, TaskExecutionMode.execute as unknown as mssqlVscode.TaskExecutionMode);
 		}
 		// TODO: Check for success; throw error
+	}
+
+	public async updateProjectFromDatabase(context: azdataType.IConnectionProfile | dataworkspace.WorkspaceTreeItem): Promise<UpdateProjectFromDatabaseDialog> {
+		const dialogParam = context.hasOwnProperty('connectionProfile') ? this.getConnectionProfileFromContext(context as azdataType.IConnectionProfile) : this.getProjectFromContext(context as dataworkspace.WorkspaceTreeItem);
+		let updateProjectFromDatabaseDialog = this.getUpdateProjectFromDatabaseDialog(dialogParam as azdataType.IConnectionProfile | Project);
+
+		updateProjectFromDatabaseDialog.updateProjectFromDatabaseCallback = async (model) => await this.updateProjectFromDatabaseCallback(model);
+
+		await updateProjectFromDatabaseDialog.openDialog();
+
+		return updateProjectFromDatabaseDialog;
+	}
+
+	public getUpdateProjectFromDatabaseDialog(dialogParam: azdataType.IConnectionProfile | Project): UpdateProjectFromDatabaseDialog {
+		return new UpdateProjectFromDatabaseDialog(dialogParam);
+	}
+
+	public async updateProjectFromDatabaseCallback(model: UpdateDataModel) {
+		try {
+			await this.updateProjectFromDatabaseApiCall(model);
+		} catch (err) {
+			await vscode.window.showErrorMessage(utils.getErrorMessage(err));
+		}
+	}
+
+	public async updateProjectFromDatabaseApiCall(model: UpdateDataModel): Promise<void> {
+		let ext = vscode.extensions.getExtension(mssql.extension.name)!;
+		const service = (await ext.activate() as mssql.IExtension).schemaCompare;
+		const deploymentOptions = await service.schemaCompareGetDefaultOptions();
+		const operationId = this.generateComparisonGuid();
+
+		model.targetEndpointInfo.targetScripts = await this.schemaCompareGetTargetScripts(model.targetEndpointInfo.projectFilePath);
+		model.targetEndpointInfo.dsp = await this.schemaCompareGetDsp(model.targetEndpointInfo.projectFilePath);
+
+		TelemetryReporter.sendActionEvent(TelemetryViews.ProjectController, 'SchemaComparisonStarted');
+
+		const comparisonResult: mssql.SchemaCompareResult = await service.schemaCompare(
+			operationId, model.sourceEndpointInfo, model.targetEndpointInfo, utils.getAzdataApi()!.TaskExecutionMode.execute, deploymentOptions.defaultDeploymentOptions
+		);
+
+		if (!comparisonResult || !comparisonResult.success) {
+			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, 'SchemaComparisonFailed', undefined, utils.getTelemetryErrorType(comparisonResult?.errorMessage))
+				.withAdditionalProperties({
+					operationId: comparisonResult.operationId
+				}).send();
+			await vscode.window.showErrorMessage(constants.compareErrorMessage(comparisonResult?.errorMessage));
+			return;
+		}
+
+		TelemetryReporter.createActionEvent(TelemetryViews.ProjectController, 'SchemaComparisonFinished')
+			.withAdditionalProperties({
+				'endTime': Date.now().toString(),
+				'operationId': comparisonResult.operationId
+			}).send();
+
+		if (comparisonResult.areEqual) {
+			await vscode.window.showInformationMessage(constants.equalComparison);
+			return;
+		}
+
+		if (model.action === UpdateAction.Update) {
+			const publishResult = await this.schemaComparePublishProjectChanges(
+				operationId, model.targetEndpointInfo.projectFilePath, model.targetEndpointInfo.folderStructure
+			);
+
+			if (publishResult.success) {
+				await vscode.window.showInformationMessage(constants.applySuccess);
+			} else {
+				await vscode.window.showErrorMessage(constants.applyError);
+			}
+
+			await this.schemaCompareShowProjectsView();
+
+		} else if (model.action === UpdateAction.Compare) {
+			await vscode.commands.executeCommand(constants.schemaCompareStartCommand,
+				model.sourceEndpointInfo.connectionDetails,
+				model.targetEndpointInfo,
+				comparisonResult);
+		}
+	}
+
+	private generateComparisonGuid(): string {
+		let hexValues: string[] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
+
+		// c.f. rfc4122 (UUID version 4 = xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+		let oct: string = '';
+		let tmp: number;
+
+		/* tslint:disable:no-bitwise */
+		for (let a: number = 0; a < 4; a++) {
+			tmp = (4294967296 * Math.random()) | 0;
+			oct += hexValues[tmp & 0xF] +
+				hexValues[tmp >> 4 & 0xF] +
+				hexValues[tmp >> 8 & 0xF] +
+				hexValues[tmp >> 12 & 0xF] +
+				hexValues[tmp >> 16 & 0xF] +
+				hexValues[tmp >> 20 & 0xF] +
+				hexValues[tmp >> 24 & 0xF] +
+				hexValues[tmp >> 28 & 0xF];
+		}
+
+		// 'Set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one, respectively'
+		let clockSequenceHi: string = hexValues[8 + (Math.random() * 4) | 0];
+		return oct.substr(0, 8) + '-' + oct.substr(9, 4) + '-4' + oct.substr(13, 3) + '-' + clockSequenceHi + oct.substr(16, 3) + '-' + oct.substr(19, 12);
+		/* tslint:enable:no-bitwise */
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
 import * as vscode from 'vscode';
 import * as mssql from '../../../mssql';
 import * as azdata from 'azdata';
@@ -88,7 +90,7 @@ export class UpdateProjectFromDatabaseDialog {
 	private initializeUpdateProjectFromDatabaseTab(): void {
 		this.updateProjectFromDatabaseTab.registerContent(async view => {
 
-			const connectionRow = await this.createServerRow(view);
+			const connectionRow = this.createServerRow(view);
 			const databaseRow = this.createDatabaseRow(view);
 			const sourceDatabaseFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
 			sourceDatabaseFormSection.addItems([connectionRow, databaseRow]);
@@ -139,13 +141,13 @@ export class UpdateProjectFromDatabaseDialog {
 
 			let formModel = this.formBuilder.component();
 			await view.initializeModel(formModel);
-			await this.connectionButton?.focus();
+			this.connectionButton?.focus();
 			this.initDialogComplete?.resolve();
 		});
 	}
 
-	private async createServerRow(view: azdata.ModelView): Promise<azdata.FlexContainer> {
-		await this.createServerComponent(view);
+	private createServerRow(view: azdata.ModelView): azdata.FlexContainer {
+		this.createServerComponent(view);
 
 		const serverLabel = view.modelBuilder.text().withProps({
 			value: constants.server,
@@ -173,7 +175,7 @@ export class UpdateProjectFromDatabaseDialog {
 		return databaseRow;
 	}
 
-	private async createServerComponent(view: azdata.ModelView) {
+	private createServerComponent(view: azdata.ModelView) {
 		this.serverDropdown = view.modelBuilder.dropDown().withProps({
 			editable: true,
 			fireOnTextChange: true,
@@ -186,7 +188,7 @@ export class UpdateProjectFromDatabaseDialog {
 			this.tryEnableUpdateButton();
 		});
 
-		await this.populateServerDropdown();
+		this.populateServerDropdown();
 	}
 
 	private createDatabaseComponent(view: azdata.ModelView) {
@@ -352,7 +354,7 @@ export class UpdateProjectFromDatabaseDialog {
 		let connection = await azdata.connection.openConnectionDialog();
 		if (connection) {
 			this.connectionId = connection.connectionId;
-			await this.populateServerDropdown();
+			this.populateServerDropdown();
 		}
 	}
 
@@ -368,8 +370,8 @@ export class UpdateProjectFromDatabaseDialog {
 			width: cssStyles.updateProjectFromDatabaseTextboxWidth
 		}).component();
 
-		this.projectFileTextBox.onTextChanged(async () => {
-			await this.projectFileTextBox!.updateProperty('title', this.projectFileTextBox!.value);
+		this.projectFileTextBox.onTextChanged(() => {
+			this.projectFileTextBox!.updateProperty('title', this.projectFileTextBox!.value);
 			this.tryEnableUpdateButton();
 		});
 
@@ -410,7 +412,7 @@ export class UpdateProjectFromDatabaseDialog {
 			}
 
 			this.projectFileTextBox!.value = fileUris[0].fsPath;
-			await this.projectFileTextBox!.updateProperty('title', fileUris[0].fsPath);
+			this.projectFileTextBox!.updateProperty('title', fileUris[0].fsPath);
 		});
 
 		return browseFolderButton;

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -529,7 +529,7 @@ export class UpdateProjectFromDatabaseDialog {
 			projectFilePath: '',
 			folderStructure: '',
 			targetScripts: [],
-			dsp: '',
+			dataSchemaProvider: '',
 			packageFilePath: '',
 			connectionName: serverDropdownValue.connection.options.connectionName
 		};
@@ -539,7 +539,7 @@ export class UpdateProjectFromDatabaseDialog {
 			projectFilePath: this.projectFileTextBox!.value!,
 			folderStructure: this.folderStructureDropDown!.value as string,
 			targetScripts: [],
-			dsp: '',
+			dataSchemaProvider: '',
 			connectionDetails: connectionDetails,
 			databaseName: '',
 			serverDisplayName: '',

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -1,0 +1,603 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as mssql from '../../../mssql';
+import * as azdata from 'azdata';
+import * as constants from '../common/constants';
+import * as newProjectTool from '../tools/newProjectTool';
+import { Deferred } from '../common/promise';
+import { Project } from '../models/project';
+import { cssStyles } from '../common/uiConstants';
+import { IconPathHelper } from '../common/iconHelper';
+import { UpdateDataModel, UpdateAction } from '../models/api/update';
+import { exists, getAzdataApi, getDataWorkspaceExtensionApi } from '../common/utils';
+import path = require('path');
+
+export class UpdateProjectFromDatabaseDialog {
+	public dialog: azdata.window.Dialog;
+	private updateProjectFromDatabaseTab: azdata.window.DialogTab;
+	private serverDropdown: azdata.DropDownComponent | undefined;
+	private connectionButton: azdata.ButtonComponent | undefined;
+	private databaseDropdown: azdata.DropDownComponent | undefined;
+	private projectFileTextBox: azdata.InputBoxComponent | undefined;
+	private folderStructureDropDown: azdata.DropDownComponent | undefined;
+	private compareActionRadioButton: azdata.RadioButtonComponent | undefined;
+	private updateActionRadioButton: azdata.RadioButtonComponent | undefined;
+	private formBuilder: azdata.FormBuilder | undefined;
+	private connectionId: string | undefined;
+	private profile: azdata.IConnectionProfile | undefined;
+	private project: Project | undefined;
+	private action: UpdateAction | undefined;
+	private toDispose: vscode.Disposable[] = [];
+	private initDialogComplete!: Deferred<void>;
+	private initDialogPromise: Promise<void> = new Promise<void>((resolve, reject) => this.initDialogComplete = { resolve, reject });
+
+	public updateProjectFromDatabaseCallback: ((model: UpdateDataModel) => any) | undefined;
+
+	constructor(dialogParam: azdata.IConnectionProfile | Project) {
+		if (dialogParam.hasOwnProperty('connectionName')) {
+			this.profile = dialogParam as azdata.IConnectionProfile;
+			this.project = undefined;
+		} else {
+			this.profile = undefined;
+			this.project = dialogParam as Project;
+		}
+
+		// need to set profile when database is updated as well as here
+		// see what schemaCompare is doing!
+
+		this.dialog = getAzdataApi()!.window.createModelViewDialog(constants.updateProjectFromDatabaseDialogName, 'updateProjectFromDatabaseDialog');
+		this.updateProjectFromDatabaseTab = getAzdataApi()!.window.createTab(constants.updateProjectFromDatabaseDialogName);
+		this.dialog.registerCloseValidator(async () => {
+			return this.validate();
+		});
+	}
+
+	public async openDialog(): Promise<void> {
+		let connection = await azdata.connection.getCurrentConnection();
+		if (connection) {
+			this.connectionId = connection.connectionId;
+		}
+
+		this.initializeDialog();
+
+		this.dialog.okButton.label = constants.updateProjectDialogOkButtonText;
+		this.dialog.okButton.enabled = false;
+		this.toDispose.push(this.dialog.okButton.onClick(async () => await this.handleUpdateButtonClick()));
+
+		this.dialog.cancelButton.label = constants.cancelButtonText;
+
+		getAzdataApi()!.window.openDialog(this.dialog);
+		await this.initDialogPromise;
+
+		this.tryEnableUpdateButton();
+	}
+
+	private dispose(): void {
+		this.toDispose.forEach(disposable => disposable.dispose());
+	}
+
+	private initializeDialog(): void {
+		this.initializeUpdateProjectFromDatabaseTab();
+		this.dialog.content = [this.updateProjectFromDatabaseTab];
+	}
+
+	private initializeUpdateProjectFromDatabaseTab(): void {
+		this.updateProjectFromDatabaseTab.registerContent(async view => {
+
+			const connectionRow = await this.createServerRow(view);
+			const databaseRow = this.createDatabaseRow(view);
+			const sourceDatabaseFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
+			sourceDatabaseFormSection.addItems([connectionRow, databaseRow]);
+
+			const projectLocationRow = this.createProjectLocationRow(view);
+			const folderStructureRow = this.createFolderStructureRow(view);
+			const targetProjectFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
+			targetProjectFormSection.addItems([projectLocationRow, folderStructureRow]);
+
+			const actionRow = this.createActionRow(view);
+			const actionFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
+			actionFormSection.addItems([actionRow]);
+
+			this.formBuilder = <azdata.FormBuilder>view.modelBuilder.formContainer()
+				.withFormItems([
+					{
+						title: constants.sourceDatabase,
+						components: [
+							{
+								component: sourceDatabaseFormSection,
+							}
+						]
+					},
+					{
+						title: constants.targetProject,
+						components: [
+							{
+								component: targetProjectFormSection,
+							}
+						]
+					},
+					{
+						title: constants.updateAction,
+						components: [
+							{
+								component: actionFormSection,
+							}
+						]
+					}
+				], {
+					horizontal: false,
+					titleFontSize: cssStyles.titleFontSize
+				})
+				.withLayout({
+					width: '100%',
+					padding: '10px 10px 0 20px'
+				});
+
+			let formModel = this.formBuilder.component();
+			await view.initializeModel(formModel);
+			await this.connectionButton?.focus();
+			this.initDialogComplete?.resolve();
+		});
+	}
+
+	private async createServerRow(view: azdata.ModelView): Promise<azdata.FlexContainer> {
+		await this.createServerComponent(view);
+
+		const serverLabel = view.modelBuilder.text().withProps({
+			value: constants.server,
+			requiredIndicator: true,
+			width: cssStyles.updateProjectFromDatabaseLabelWidth
+		}).component();
+
+		const connectionRow = view.modelBuilder.flexContainer().withItems([serverLabel, this.serverDropdown!], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-bottom': '-5px', 'margin-top': '-10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
+		connectionRow.addItem(this.connectionButton!, { CSSStyles: { 'margin-right': '0px', 'margin-bottom': '-5px', 'margin-top': '-10px' } });
+
+		return connectionRow;
+	}
+
+	private createDatabaseRow(view: azdata.ModelView): azdata.FlexContainer {
+		this.createDatabaseComponent(view);
+
+		const databaseLabel = view.modelBuilder.text().withProps({
+			value: constants.databaseNameLabel,
+			requiredIndicator: true,
+			width: cssStyles.updateProjectFromDatabaseLabelWidth
+		}).component();
+
+		const databaseRow = view.modelBuilder.flexContainer().withItems([databaseLabel, <azdata.DropDownComponent>this.databaseDropdown!], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-bottom': '-10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
+
+		return databaseRow;
+	}
+
+	private async createServerComponent(view: azdata.ModelView) {
+		this.serverDropdown = view.modelBuilder.dropDown().withProps({
+			editable: true,
+			fireOnTextChange: true,
+			width: cssStyles.updateProjectFromDatabaseTextboxWidth
+		}).component();
+
+		this.createConnectionButton(view);
+
+		this.serverDropdown.onValueChanged(() => {
+			this.tryEnableUpdateButton();
+		});
+
+		await this.populateServerDropdown();
+	}
+
+	private createDatabaseComponent(view: azdata.ModelView) {
+		this.databaseDropdown = view.modelBuilder.dropDown().withProps({
+			editable: true,
+			fireOnTextChange: true,
+			width: cssStyles.updateProjectFromDatabaseTextboxWidth
+		}).component();
+
+		this.databaseDropdown.onValueChanged(() => {
+
+			this.tryEnableUpdateButton();
+		});
+	}
+
+	private async populateServerDropdown() {
+		this.serverDropdown!.loading = true;
+		const values = await this.getServerValues();
+
+		if (values && values.length > 0) {
+			await this.serverDropdown!.updateProperties({
+				values: values,
+				value: values[0]
+			});
+		}
+
+		this.serverDropdown!.loading = false;
+
+		if (this.serverDropdown!.value) {
+			await this.populateDatabaseDropdown();
+		}
+	}
+
+	protected async populateDatabaseDropdown() {
+		const connectionProfile = (this.serverDropdown!.value as ConnectionDropdownValue).connection;
+
+		this.databaseDropdown!.loading = true;
+
+		await this.databaseDropdown!.updateProperties({
+			values: [],
+			value: undefined
+		});
+
+		let values = [];
+		try {
+			values = await this.getDatabaseValues(connectionProfile.connectionId);
+		} catch (e) {
+			// if the user doesn't have access to master, just set the database of the connection profile
+			values = [connectionProfile.databaseName];
+			console.warn(e);
+		}
+
+		if (values && values.length > 0) {
+			await this.databaseDropdown!.updateProperties({
+				values: values,
+				value: values[0],
+			});
+		}
+
+		this.databaseDropdown!.loading = false;
+	}
+
+	private async getServerValues() {
+		let cons = await azdata.connection.getConnections(/* activeConnectionsOnly */ true);
+
+		// This user has no active connections
+		if (!cons || cons.length === 0) {
+			return undefined;
+		}
+
+		// Update connection icon to "connected" state
+		this.connectionButton!.iconPath = IconPathHelper.connect;
+
+		// reverse list so that most recent connections are first
+		cons.reverse();
+
+		let count = -1;
+		let idx = -1;
+		let values = cons.map(c => {
+			count++;
+
+			let usr = c.options.user;
+
+			if (!usr) {
+				usr = constants.defaultUser;
+			}
+
+			let srv = c.options.server;
+
+			let finalName = `${srv} (${usr})`;
+
+			if (c.options.connectionName) {
+				finalName = c.options.connectionName;
+			}
+
+			if (c.connectionId === this.connectionId) {
+				idx = count;
+			}
+
+			return {
+				connection: c,
+				displayName: finalName,
+				name: srv,
+			};
+		});
+
+		// move server of current connection to the top of the list so it is the default
+		if (idx >= 1) {
+			let tmp = values[0];
+			values[0] = values[idx];
+			values[idx] = tmp;
+		}
+
+		values = values.reduce((uniqueValues: { connection: azdata.connection.ConnectionProfile, displayName: string, name: string }[], conn) => {
+			let exists = uniqueValues.find(x => x.displayName === conn.displayName);
+			if (!exists) {
+				uniqueValues.push(conn);
+			}
+			return uniqueValues;
+		}, []);
+
+		return values;
+	}
+
+	protected async getDatabaseValues(connectionId: string) {
+		let idx = -1;
+		let count = -1;
+
+		let values = (await azdata.connection.listDatabases(connectionId)).sort((a, b) => a.localeCompare(b)).map(db => {
+			count++;
+
+			// put currently selected db at the top of the dropdown if there is one
+			if (this.profile && this.profile.databaseName && this.profile.databaseName === db) {
+				idx = count;
+			}
+
+			return db;
+		});
+
+		if (idx >= 0) {
+			let tmp = values[0];
+			values[0] = values[idx];
+			values[idx] = tmp;
+		}
+		return values;
+	}
+
+	private createConnectionButton(view: azdata.ModelView) {
+		this.connectionButton = view.modelBuilder.button().withProps({
+			ariaLabel: constants.selectConnection,
+			iconPath: IconPathHelper.selectConnection,
+			height: '20px',
+			width: '20px'
+		}).component();
+
+		this.connectionButton.onDidClick(async () => {
+			await this.connectionButtonClick();
+			this.connectionButton!.iconPath = IconPathHelper.connect;
+		});
+	}
+
+	private async connectionButtonClick() {
+		let connection = await azdata.connection.openConnectionDialog();
+		if (connection) {
+			this.connectionId = connection.connectionId;
+			await this.populateServerDropdown();
+		}
+	}
+
+	private createProjectLocationRow(view: azdata.ModelView): azdata.FlexContainer {
+		const browseFolderButton: azdata.Component = this.createBrowseFileButton(view);
+
+		const value = this.project ? this.project.projectFilePath : ' ';
+
+		this.projectFileTextBox = view.modelBuilder.inputBox().withProps({
+			value: value,
+			ariaLabel: constants.projectLocationLabel,
+			placeHolder: constants.projectToUpdatePlaceholderText,
+			width: cssStyles.updateProjectFromDatabaseTextboxWidth
+		}).component();
+
+		this.projectFileTextBox.onTextChanged(async () => {
+			await this.projectFileTextBox!.updateProperty('title', this.projectFileTextBox!.value);
+			this.tryEnableUpdateButton();
+		});
+
+		const projectLocationLabel = view.modelBuilder.text().withProps({
+			value: constants.projectLocationLabel,
+			requiredIndicator: true,
+			width: cssStyles.updateProjectFromDatabaseLabelWidth
+		}).component();
+
+		const projectLocationRow = view.modelBuilder.flexContainer().withItems([projectLocationLabel, this.projectFileTextBox], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-bottom': '-5px', 'margin-top': '-10px' } }).component();
+		projectLocationRow.addItem(browseFolderButton, { CSSStyles: { 'margin-right': '0px', 'margin-bottom': '-5px', 'margin-top': '-10px' } });
+
+		return projectLocationRow;
+	}
+
+	private createBrowseFileButton(view: azdata.ModelView): azdata.ButtonComponent {
+		const browseFolderButton = view.modelBuilder.button().withProps({
+			ariaLabel: constants.browseButtonText,
+			iconPath: IconPathHelper.folder_blue,
+			height: '18px',
+			width: '18px'
+		}).component();
+
+		browseFolderButton.onDidClick(async () => {
+			let fileUris = await vscode.window.showOpenDialog({
+				canSelectFiles: true,
+				canSelectFolders: false,
+				canSelectMany: false,
+				openLabel: constants.selectString,
+				defaultUri: newProjectTool.defaultProjectSaveLocation(),
+				filters: {
+					'Files': ['sqlproj']
+				}
+			});
+
+			if (!fileUris || fileUris.length === 0) {
+				return;
+			}
+
+			this.projectFileTextBox!.value = fileUris[0].fsPath;
+			await this.projectFileTextBox!.updateProperty('title', fileUris[0].fsPath);
+		});
+
+		return browseFolderButton;
+	}
+
+	private createFolderStructureRow(view: azdata.ModelView): azdata.FlexContainer {
+		this.folderStructureDropDown = view.modelBuilder.dropDown().withProps({
+			values: [constants.file, constants.flat, constants.objectType, constants.schema, constants.schemaObjectType],
+			value: constants.schemaObjectType,
+			ariaLabel: constants.folderStructureLabel,
+			required: true,
+			width: cssStyles.updateProjectFromDatabaseTextboxWidth
+		}).component();
+
+		this.folderStructureDropDown.onValueChanged(() => {
+			this.tryEnableUpdateButton();
+		});
+
+		const folderStructureLabel = view.modelBuilder.text().withProps({
+			value: constants.folderStructureLabel,
+			requiredIndicator: true,
+			width: cssStyles.createProjectFromDatabaseLabelWidth
+		}).component();
+
+		const folderStructureRow = view.modelBuilder.flexContainer().withItems([folderStructureLabel, <azdata.DropDownComponent>this.folderStructureDropDown], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-bottom': '-10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
+
+		return folderStructureRow;
+	}
+
+	private createActionRow(view: azdata.ModelView): azdata.FlexContainer {
+		this.compareActionRadioButton = view.modelBuilder.radioButton().withProps({
+			name: 'action',
+			label: constants.compareActionRadioButtonLabel
+		}).component();
+
+		this.updateActionRadioButton = view.modelBuilder.radioButton().withProps({
+			name: 'action',
+			label: constants.updateActionRadioButtonLabel
+		}).component();
+
+		this.compareActionRadioButton.onDidClick(async () => {
+			this.action = UpdateAction.Compare;
+			this.tryEnableUpdateButton();
+		});
+
+		this.updateActionRadioButton.onDidClick(async () => {
+			this.action = UpdateAction.Update;
+			this.tryEnableUpdateButton();
+		});
+
+		let radioButtons = view.modelBuilder.flexContainer()
+			.withLayout({ flexFlow: 'column' })
+			.withItems([this.compareActionRadioButton, this.updateActionRadioButton])
+			.withProps({ ariaRole: 'radiogroup' })
+			.component();
+
+		const actionLabel = view.modelBuilder.text().withProps({
+			value: constants.actionLabel,
+			requiredIndicator: true,
+			width: cssStyles.updateProjectFromDatabaseLabelWidth
+		}).component();
+
+		const actionRow = view.modelBuilder.flexContainer().withItems([actionLabel, <azdata.FlexContainer>radioButtons], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-bottom': '-10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
+
+		return actionRow;
+	}
+
+	// only enable Update button if all fields are filled
+	public tryEnableUpdateButton(): void {
+		if (this.serverDropdown!.value && this.databaseDropdown!.value &&
+			this.projectFileTextBox!.value && this.folderStructureDropDown!.value &&
+			this.action !== undefined) {
+			this.dialog.okButton.enabled = true;
+		} else {
+			this.dialog.okButton.enabled = false;
+		}
+	}
+
+	public async handleUpdateButtonClick(): Promise<void> {
+		const serverDropdownValue = this.serverDropdown!.value! as azdata.CategoryValue as ConnectionDropdownValue;
+		const ownerUri = await azdata.connection.getUriForConnection(serverDropdownValue.connection.connectionId);
+
+		let connection = (await azdata.connection.getConnections(true)).filter(con => con.connectionId === serverDropdownValue.connection.connectionId)[0];
+		connection.databaseName = this.databaseDropdown!.value! as string;
+
+		const credentials = await azdata.connection.getCredentials(connection.connectionId);
+		if (credentials.hasOwnProperty('password')) {
+			connection.password = connection.options.password = credentials.password;
+		}
+
+		const connectionDetails: azdata.IConnectionProfile = {
+			id: connection.connectionId,
+			userName: connection.userName,
+			password: connection.password,
+			serverName: connection.serverName,
+			databaseName: connection.databaseName,
+			connectionName: connection.connectionName,
+			providerName: connection.providerId,
+			groupId: connection.groupId,
+			groupFullName: connection.groupFullName,
+			authenticationType: connection.authenticationType,
+			savePassword: connection.savePassword,
+			saveProfile: connection.saveProfile,
+			options: connection.options,
+		};
+
+		const sourceEndpointInfo: mssql.SchemaCompareEndpointInfo = {
+			endpointType: mssql.SchemaCompareEndpointType.Database,
+			databaseName: this.databaseDropdown!.value! as string,
+			serverDisplayName: serverDropdownValue.displayName,
+			serverName: serverDropdownValue.name!,
+			connectionDetails: connectionDetails,
+			ownerUri: ownerUri,
+			projectFilePath: '',
+			folderStructure: '',
+			targetScripts: [],
+			dsp: '',
+			packageFilePath: '',
+			connectionName: serverDropdownValue.connection.options.connectionName
+		};
+
+		const targetEndpointInfo: mssql.SchemaCompareEndpointInfo = {
+			endpointType: mssql.SchemaCompareEndpointType.Project,
+			projectFilePath: this.projectFileTextBox!.value!,
+			folderStructure: this.folderStructureDropDown!.value as string,
+			targetScripts: [],
+			dsp: '',
+			connectionDetails: connectionDetails,
+			databaseName: '',
+			serverDisplayName: '',
+			serverName: '',
+			ownerUri: '',
+			packageFilePath: '',
+		};
+
+		const model: UpdateDataModel = {
+			sourceEndpointInfo: sourceEndpointInfo,
+			targetEndpointInfo: targetEndpointInfo,
+			action: this.action!
+		};
+
+		getAzdataApi()!.window.closeDialog(this.dialog);
+		await this.updateProjectFromDatabaseCallback!(model);
+
+		this.dispose();
+	}
+
+	async validate(): Promise<boolean> {
+		try {
+			if (await getDataWorkspaceExtensionApi().validateWorkspace() === false) {
+				return false;
+			}
+			// the selected location should be an existing directory
+			const parentDirectoryExists = await exists(path.dirname(this.projectFileTextBox!.value!));
+			if (!parentDirectoryExists) {
+				this.showErrorMessage(constants.ProjectParentDirectoryNotExistError(this.projectFileTextBox!.value!));
+				return false;
+			}
+
+			// the selected location must contain a .sqlproj file
+			const fileExists = await exists(this.projectFileTextBox!.value!);
+			if (!fileExists) {
+				this.showErrorMessage(constants.noSqlProjFile);
+				return false;
+			}
+
+			// schema compare extension must be downloaded
+			if (!vscode.extensions.getExtension(constants.schemaCompareExtensionId)) {
+				this.showErrorMessage(constants.noSchemaCompareExtension);
+				return false;
+			}
+
+			return true;
+		} catch (err) {
+			this.showErrorMessage(err?.message ? err.message : err);
+			return false;
+		}
+	}
+
+	protected showErrorMessage(message: string): void {
+		this.dialog.message = {
+			text: message,
+			level: getAzdataApi()!.window.MessageLevel.Error
+		};
+	}
+}
+
+export interface ConnectionDropdownValue extends azdata.CategoryValue {
+	connection: azdata.connection.ConnectionProfile;
+}

--- a/extensions/sql-database-projects/src/models/api/update.ts
+++ b/extensions/sql-database-projects/src/models/api/update.ts
@@ -1,0 +1,12 @@
+import * as mssql from '../../../../mssql';
+
+export interface UpdateDataModel {
+	sourceEndpointInfo: mssql.SchemaCompareEndpointInfo;
+	targetEndpointInfo: mssql.SchemaCompareEndpointInfo;
+	action: UpdateAction;
+}
+
+export const enum UpdateAction {
+	Compare = 0,
+	Update = 1
+}


### PR DESCRIPTION
This PR fixes #13308

This PR is kept as a draft for now as integration and unit tests still need to be added.

This PR adds a SQL database project endpoint to schema compare, so project comparison can occur without having to rely on dacpac files. It also adds the functionality to apply schema differences to a project from schema compare, as shown below:

![Compare](https://user-images.githubusercontent.com/32072322/131766295-2f9e62c0-0260-4d9a-8364-6ea2628f2468.png)

Applying changes to a project can also be done from the new "Update Project From Database" dialog, which offers the functionality to update all changes directly or to open the comparison results in schema compare. The new dialog looks like this:

![Update](https://user-images.githubusercontent.com/32072322/131766299-14c72296-56eb-4f5b-88f5-5472def1eafa.png)

More information on how to test will be added to this comment once tests are written.