### PR TITLE
Adding a couple telemetry points for sql bindings quickpick

### DIFF
--- a/extensions/sql-database-projects/src/common/telemetry.ts
+++ b/extensions/sql-database-projects/src/common/telemetry.ts
@@ -34,6 +34,6 @@ export enum TelemetryActions {
 	updateProjectForRoundtrip = 'updateProjectForRoundtrip',
 	changePlatformType = 'changePlatformType',
 	updateSystemDatabaseReferencesInProjFile = 'updateSystemDatabaseReferencesInProjFile',
-	sqlBindingsQuickPickStart = 'sqlBindingsQuickPickStart',
-	addSqlBinding = 'addSqlBinding'
+	startAddSqlBinding = 'startAddSqlBinding',
+	finishAddSqlBinding = 'finishAddSqlBinding'
 }

--- a/extensions/sql-database-projects/src/common/telemetry.ts
+++ b/extensions/sql-database-projects/src/common/telemetry.ts
@@ -15,7 +15,8 @@ export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, pack
 export enum TelemetryViews {
 	ProjectController = 'ProjectController',
 	SqlProjectPublishDialog = 'SqlProjectPublishDialog',
-	ProjectTree = 'ProjectTree'
+	ProjectTree = 'ProjectTree',
+	SqlBindingsQuickPick = 'SqlBindingsQuickPick'
 }
 
 export enum TelemetryActions {
@@ -32,5 +33,7 @@ export enum TelemetryActions {
 	build = 'build',
 	updateProjectForRoundtrip = 'updateProjectForRoundtrip',
 	changePlatformType = 'changePlatformType',
-	updateSystemDatabaseReferencesInProjFile = 'updateSystemDatabaseReferencesInProjFile'
+	updateSystemDatabaseReferencesInProjFile = 'updateSystemDatabaseReferencesInProjFile',
+	sqlBindingsQuickPickStart = 'sqlBindingsQuickPickStart',
+	addSqlBinding = 'addSqlBinding'
 }

--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -6,7 +6,7 @@ import { PackageHelper } from '../tools/packageHelper';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
 
 export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, packageHelper: PackageHelper): Promise<void> {
-	TelemetryReporter.sendActionEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.sqlBindingsQuickPickStart);
+	TelemetryReporter.sendActionEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.startAddSqlBinding);
 
 	if (!uri) {
 		// this command only shows in the command palette when the active editor is a .cs file, so we can safely assume that's the scenario
@@ -91,17 +91,18 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 	try {
 		const result = await azureFunctionsService.addSqlBinding(selectedBinding.type, uri.fsPath, azureFunctionName, objectName, connectionStringSetting);
 
-		TelemetryReporter.createActionEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.addSqlBinding)
-			.withAdditionalProperties({ bindingType: selectedBinding.label })
-			.send();
-
 		if (!result.success) {
 			void vscode.window.showErrorMessage(result.errorMessage);
+			TelemetryReporter.sendErrorEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding);
 			return;
 		}
+
+		TelemetryReporter.createActionEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding)
+			.withAdditionalProperties({ bindingType: selectedBinding.label })
+			.send();
 	} catch (e) {
 		void vscode.window.showErrorMessage(e);
-		TelemetryReporter.sendErrorEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.addSqlBinding);
+		TelemetryReporter.sendErrorEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding);
 		return;
 	}
 


### PR DESCRIPTION
Adding a couple telemetry points to measure how many times the sql bindings quick pick is opened and how many times a sql binding actually gets added.