### PR TITLE
Revert change to unit test runner grep option

### DIFF
--- a/scripts/test-unstable.bat
+++ b/scripts/test-unstable.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-set "ADS_TEST_GREP=(@UNSTABLE@|Unexpected Errors & Loader Errors)"
+set "ADS_TEST_GREP=/(@UNSTABLE@|Unexpected Errors & Loader Errors)/"
 set ADS_TEST_INVERT_GREP=
 
 echo Running UNSTABLE ADS Core Tests

--- a/scripts/test-unstable.sh
+++ b/scripts/test-unstable.sh
@@ -12,7 +12,7 @@ fi
 
 cd $ROOT
 
-export ADS_TEST_GREP=@UNSTABLE@
+export ADS_TEST_GREP=/(@UNSTABLE@|Unexpected Errors & Loader Errors)/
 export ADS_TEST_INVERT_GREP=
 
 echo Running UNSTABLE ADS Core Tests

--- a/test/unit/electron/renderer.js
+++ b/test/unit/electron/renderer.js
@@ -296,10 +296,9 @@ function runTests(opts) {
 	}
 
 	return loadTests(opts).then(() => {
-
 		if (opts.grep) {
-			// {{SQL CARBON EDIT}}
-			mocha.grep(new RegExp(opts.grep));
+			mocha.grep(opts.grep);
+			// {{SQL CARBON EDIT}} Add invert option
 			if (opts.invert) {
 				mocha.invert();
 			}


### PR DESCRIPTION
This was done in https://github.com/microsoft/azuredatastudio/commit/effa50a9bd107e1ce3c9a397f776dedce33244d9 - but instead we can just surround the text in /'s to have mocha parse it as a regex properly. 

This is being done so that we can use the https://github.com/microsoft/vscode-selfhost-test-provider for our tests since that passes in the regex strings which were then being parsed incorrectly by the regex constructor. 