### PR TITLE
Use updated markdown renderer from vscode

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -341,7 +341,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[useNewMarkdownRendererKey]: {
 			'type': 'boolean',
-			default: false,
+			default: true,
 			'description': localize('notebook.useNewMarkdownRenderer', "Whether to use the newer version of the markdown renderer for Notebooks. This may result in markdown being rendered differently than previous versions.")
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -10,7 +10,7 @@ import { URI } from 'vs/base/common/uri';
 import { TestConfigurationService } from 'sql/platform/connection/test/common/testConfigurationService';
 
 suite('NotebookMarkdownRenderer', () => {
-	let notebookMarkdownRenderer = new NotebookMarkdownRenderer(new TestConfigurationService({ user: { 'notebook': { 'useNewMarkdownRenderer': false } } }));
+	let notebookMarkdownRenderer = new NotebookMarkdownRenderer(new TestConfigurationService({ user: { 'notebook': { 'useNewMarkdownRenderer': true } } }));
 	test('image rendering conforms to default', () => {
 		const markdown = { value: `![image](someimageurl 'caption')` };
 		const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown(markdown);
@@ -107,7 +107,7 @@ suite('NotebookMarkdownRenderer', () => {
 
 	test('table followed by blank line with space and then header renders correctly (#16245)', function (): void {
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: '<table></table>\n \n### Hello', isTrusted: true });
-		assert.strictEqual(result.innerHTML, '<table></table>\n\n<h3 id="hello">Hello</h3>\n');
+		assert.strictEqual(result.innerHTML, '<table></table>\n \n<h3 id="hello">Hello</h3>\n');
 	});
 
 	/**
@@ -122,7 +122,7 @@ suite('NotebookMarkdownRenderer', () => {
 		suite('Notebook 91e764e1-95ce-4101-a08b-d1d7888649a4', function (): void {
 			test('Cell 74d8d9db-1b08-4a50-ac2a-e35a16a6af07', function (): void {
 				const markdown = '1) Item 1\n\n2) Item 2\n\n 1) Sub-item 1\n\n 2) Sub-item 2\n\n';
-				const expectedValue = '<ol>\n<li><p>Item 1</p></li>\n<li><p>Item 2</p><ol>\n<li><p>Sub-item 1</p></li>\n<li><p>Sub-item 2</p></li>\n</ol>\n</li>\n</ol>\n';
+				const expectedValue = '<ol>\n<li><p>Item 1</p></li>\n<li><p>Item 2</p></li>\n<li><p>Sub-item 1</p></li>\n<li><p>Sub-item 2</p></li>\n</ol>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
@@ -131,7 +131,7 @@ suite('NotebookMarkdownRenderer', () => {
 		suite('Notebook 15f7b65e-5bcf-43bd-9e75-84c47a0a6e84', function (): void {
 			test('Cell 8b48e63f-abdd-4306-a988-b673d13aab06', function (): void {
 				const markdown = '    ![](attachment:image.png)';
-				const expectedValue = '<pre><code>![](attachment:image.png)</code></pre>\n';
+				const expectedValue = '<pre><code>![](attachment:image.png)\n</code></pre>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
@@ -140,7 +140,7 @@ suite('NotebookMarkdownRenderer', () => {
 		suite('Notebook e054f8e1-f014-4c7c-8a55-65bf13b22bb5', function (): void {
 			test('Cell 0981d264-25f5-489c-901b-74608297f7fc', function (): void {
 				const markdown = 'Some text **%appdata%\\*****Path\\\\To\\\\Folder\\\\<******FileName**>.ext** into **...\\\\Another\\\\****Path\\\\**\n\n';
-				const expectedValue = '<p>Some text <strong>%appdata%***</strong>Path\\To\\Folder\\&lt;******FileName**&gt;.ext** into <strong>...\\Another\\**</strong>Path\\**</p>';
+				const expectedValue = '<p>Some text **%appdata%***<strong>Path\\To\\Folder\\&lt;******FileName**&gt;.ext</strong> into **...\\Another\\***<em>Path\\*</em></p>';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
@@ -149,7 +149,7 @@ suite('NotebookMarkdownRenderer', () => {
 		suite('Notebook ????', function (): void {
 			test('Cell b74f16a2-5b2e-4e58-8c79-9688d6b1f62a', function (): void {
 				const markdown = '# Heading 1\n- Some text\n\n    \n\n- ## Heading 2';
-				const expectedValue = '<h1 id="heading-1">Heading 1</h1>\n<ul>\n<li>Some text</li>\n</ul>\n<ul>\n<li><h2 id="heading-2">Heading 2</h2>\n</li>\n</ul>\n';
+				const expectedValue = '<h1 id="heading-1">Heading 1</h1>\n<ul>\n<li><p>Some text</p></li>\n<li><h2 id="heading-2">Heading 2</h2>\n</li>\n</ul>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
@@ -158,7 +158,7 @@ suite('NotebookMarkdownRenderer', () => {
 		suite('Notebook 56e15822-f884-42ed-944c-789ff8961ba9', function (): void {
 			test('Cell 8b341e16-113f-4ec4-b937-c02884bdb9f3', function (): void {
 				const markdown = 'Some text\n\n      Some more text';
-				const expectedValue = '<p>Some text</p><pre><code>  Some more text</code></pre>\n';
+				const expectedValue = '<p>Some text</p><pre><code>  Some more text\n</code></pre>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
@@ -167,7 +167,7 @@ suite('NotebookMarkdownRenderer', () => {
 		suite('Notebook 03b95d90-a0fc-43c8-b77b-d506f2002904', function (): void {
 			test('Cell e557e19c-8afa-40e4-a61d-ab08443562ee', function (): void {
 				const markdown = '# heading\n##';
-				const expectedValue = '<h1 id="heading">heading</h1>\n<p>##</p>';
+				const expectedValue = '<h1 id="heading">heading</h1>\n<h2 id=""></h2>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
@@ -176,14 +176,14 @@ suite('NotebookMarkdownRenderer', () => {
 		suite('Notebook 8c6d7dc3-4cc9-4b23-93f6-a556a6d5c6f2', function (): void {
 			test('Cell 241d5f74-ba48-4ec4-be0e-02182f20f691', function (): void {
 				const markdown = '1. List item text\n\n \n\n    a. sub-list item';
-				const expectedValue = '<ol>\n<li>List item text</li>\n</ol>\n<pre><code>a. sub-list item</code></pre>\n';
+				const expectedValue = '<ol>\n<li><p>List item text</p><p> a. sub-list item</p></li>\n</ol>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
 
 			test('Cell 8e45da0e-5c24-469e-8ae5-671313bd54a1', function (): void {
 				const markdown = '1.  List Item\n\n    \n\n2.  List Item 2';
-				const expectedValue = '<ol>\n<li> List Item</li>\n</ol>\n<ol start="2">\n<li> List Item 2</li>\n</ol>\n';
+				const expectedValue = '<ol>\n<li><p>List Item</p></li>\n<li><p> List Item 2</p></li>\n</ol>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
@@ -192,14 +192,14 @@ suite('NotebookMarkdownRenderer', () => {
 		suite('Notebook 1a0c01d2-a688-4e51-b39f-04cffb25e7ca', function (): void {
 			test('Cell a2b18efc-bb62-49fa-913d-e953677150ca', function (): void {
 				const markdown = '1. List Item\r\n\nText on new line\r\n\n    a. Sub List Item';
-				const expectedValue = '<ol>\n<li>List Item</li>\n</ol>\n<p>Text on new line</p><pre><code>a. Sub List Item</code></pre>\n';
+				const expectedValue = '<ol>\n<li>List Item</li>\n</ol>\n<p>Text on new line</p><pre><code>a. Sub List Item\n</code></pre>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});
 
 			test('Cell e6ad1eb3-7409-4199-9592-9d13f1e2d8a0', function (): void {
 				const markdown = '1. Text \n\nMore text \n\n    a. Sub-Text';
-				const expectedValue = '<ol>\n<li>Text </li>\n</ol>\n<p>More text </p><pre><code>a. Sub-Text</code></pre>\n';
+				const expectedValue = '<ol>\n<li>Text </li>\n</ol>\n<p>More text </p><pre><code>a. Sub-Text\n</code></pre>\n';
 				const result = notebookMarkdownRenderer.renderMarkdown({ value: markdown, isTrusted: true }).innerHTML;
 				assert.strictEqual(result, expectedValue);
 			});

--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -1160,9 +1160,12 @@
     + '|<\\?[\\s\\S]*?(?:\\?>\\n*|$)' // (3)
     + '|<![A-Z][\\s\\S]*?(?:>\\n*|$)' // (4)
     + '|<!\\[CDATA\\[[\\s\\S]*?(?:\\]\\]>\\n*|$)' // (5)
-    + '|</?(tag)(?: +|\\n|/?>)[\\s\\S]*?(?:\\n{2,}|$)' // (6)
-    + '|<(?!script|pre|style)([a-z][\\w-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:\\n{2,}|$)' // (7) open tag
-    + '|</(?!script|pre|style)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:\\n{2,}|$)' // (7) closing tag
+    // {{SQL CARBON EDIT}} Porting marked.js fix for non-empty lines followed by elements to not render properly
+    // PR where this fix ocurred here: https://github.com/markedjs/marked/pull/2052/files?file-filters%5B%5D=.js, shipped in markedjs 2.0.4
+    + '|</?(tag)(?: +|\\n|/?>)[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (6)
+		+ '|<(?!script|pre|style)([a-z][\\w-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) open tag
+		+ '|</(?!script|pre|style)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) closing tag
+    // {{SQL CARBON EDIT}} end fixes
     + ')',
     def: /^ {0,3}\[(label)\]: *\n? *<?([^\s>]+)>?(?:(?: +\n? *| *\n *)(title))? *(?:\n+|$)/,
     nptable: noopTest$1,


### PR DESCRIPTION
Fixes #16333.

- Ports marked.js fix ([issue](https://github.com/markedjs/marked/issues/2018), [PR](https://github.com/markedjs/marked/pull/2052)). VS Code was [leveraging marked.js 2.0.0](https://github.com/microsoft/vscode/pull/117714), and this was [fixed in 2.0.4](https://github.com/markedjs/marked/releases/tag/v2.0.4).
- Fixes tests that we created during this process
- Leverages new renderer by default (setting can allow customers to go back to old renderer bits in a pinch)