### PR TITLE
added localization to general in optionsDialogHelper

### DIFF
--- a/src/sql/workbench/browser/modal/optionsDialogHelper.ts
+++ b/src/sql/workbench/browser/modal/optionsDialogHelper.ts
@@ -167,7 +167,7 @@ export function groupOptionsByCategory(options: azdata.ServiceOption[]): { [cate
 	options.forEach(option => {
 		let groupName = option.groupName;
 		if (groupName === null || groupName === undefined) {
-			groupName = 'General';
+			groupName = localize('optionsDialog.defaultGroupName', 'General');
 		}
 
 		if (!!connectionOptionsMap[groupName]) {


### PR DESCRIPTION
This PR handles the case where if a group name is undefined, it is set to a default value, which is currently unlocalized. This PR adds that in and is required to fully complete https://github.com/microsoft/azuredatastudio/issues/6333