### PR TITLE
Fix extensions-lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "core-ci": "node --max_old_space_size=4095 ./node_modules/gulp/bin/gulp.js core-ci",
     "extensions-ci": "node --max_old_space_size=4095 ./node_modules/gulp/bin/gulp.js extensions-ci",
     "sqllint": "eslint --no-eslintrc -c .eslintrc.sql.ts.json --rulesdir ./build/lib/eslint --ext .ts ./src/sql",
-    "extensions-lint": "eslint --rulesdir ./build/lib/eslint --ext .ts ./extensions/azurecore"
+    "extensions-lint": "eslint --rulesdir ./build/lib/eslint --ext .ts ./extensions"
   },
   "dependencies": {
     "@angular/animations": "~4.1.3",


### PR DESCRIPTION
This was accidently scoped down in an earlier PR, reverting back to checking entire extensions directory