### PR TITLE
Add a button which would allow the user to jump directly to add account dialog from Migration Status Dialog

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -366,7 +366,8 @@ export const FILE_NAME = localize('sql.migration.file.name', "File name");
 export const SIZE_COLUMN_HEADER = localize('sql.migration.size.column.header', "Size");
 export const NO_PENDING_BACKUPS = localize('sql.migration.no.pending.backups', "No pending backups. Click refresh to check current status.");
 //Migration status dialog
-export const ADD_ACCOUNT = localize('sql.migration.status.add.account', "Add your Azure account to view existing migrations and their status.");
+export const ADD_ACCOUNT = localize('sql.migration.status.add.account', "Add account");
+export const ADD_ACCOUNT_MESSAGE = localize('sql.migration.status.add.account.MESSAGE', "Add your Azure account to view existing migrations and their status.");
 export const STATUS_ALL = localize('sql.migration.status.dropdown.all', "Status: All");
 export const STATUS_ONGOING = localize('sql.migration.status.dropdown.ongoing', "Status: Ongoing");
 export const STATUS_COMPLETING = localize('sql.migration.status.dropdown.completing', "Status: Completing");

--- a/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
+++ b/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
@@ -622,7 +622,7 @@ export class DashboardWidget {
 		}).component();
 
 		const addAccountText = view.modelBuilder.text().withProps({
-			value: loc.ADD_ACCOUNT,
+			value: loc.ADD_ACCOUNT_MESSAGE,
 			width: 198,
 			height: 34,
 			CSSStyles: {
@@ -636,16 +636,18 @@ export class DashboardWidget {
 		}).component();
 
 		const addAccountButton = view.modelBuilder.button().withProps({
-			label: 'Add Account',
+			label: loc.ADD_ACCOUNT,
 			width: '100px',
 			enabled: true,
 			CSSStyles: {
-				'margin': 'auto'
+				'margin': '5% 40%',
+				'display': 'none'
 			}
 		}).component();
 
-		this._disposables.push(addAccountButton.onDidClick((e) => {
-			//Fill in here
+		this._disposables.push(addAccountButton.onDidClick(async (e) => {
+			await vscode.commands.executeCommand('workbench.actions.modal.linkedAccount');
+			this.refreshMigrations();
 		}));
 
 		const header = view.modelBuilder.flexContainer().withItems(
@@ -666,6 +668,9 @@ export class DashboardWidget {
 				'display': 'block'
 			});
 			addAccountText.updateCssStyles({
+				'display': 'block'
+			});
+			addAccountButton.updateCssStyles({
 				'display': 'block'
 			});
 			this._migrationStatusCardsContainer.updateCssStyles({

--- a/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
+++ b/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
@@ -615,7 +615,7 @@ export class DashboardWidget {
 			height: 96,
 			CSSStyles: {
 				'opacity': '50%',
-				'margin': '20% auto 10% auto',
+				'margin': '15% auto 10% auto',
 				'filter': 'drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))',
 				'display': 'none'
 			}
@@ -647,7 +647,9 @@ export class DashboardWidget {
 
 		this._disposables.push(addAccountButton.onDidClick(async (e) => {
 			await vscode.commands.executeCommand('workbench.actions.modal.linkedAccount');
-			this.refreshMigrations();
+			addAccountButton.enabled = false;
+			await this.refreshMigrations();
+			addAccountButton.enabled = true;
 		}));
 
 		const header = view.modelBuilder.flexContainer().withItems(

--- a/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
+++ b/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
@@ -635,6 +635,19 @@ export class DashboardWidget {
 			}
 		}).component();
 
+		const addAccountButton = view.modelBuilder.button().withProps({
+			label: 'Add Account',
+			width: '100px',
+			enabled: true,
+			CSSStyles: {
+				'margin': 'auto'
+			}
+		}).component();
+
+		this._disposables.push(addAccountButton.onDidClick((e) => {
+			//Fill in here
+		}));
+
 		const header = view.modelBuilder.flexContainer().withItems(
 			[
 				statusContainerTitle,
@@ -752,6 +765,7 @@ export class DashboardWidget {
 
 		statusContainer.addItem(addAccountImage, {});
 		statusContainer.addItem(addAccountText, {});
+		statusContainer.addItem(addAccountButton, {});
 
 		statusContainer.addItem(this._migrationStatusCardLoadingContainer, {
 			CSSStyles: {

--- a/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
+++ b/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
@@ -648,8 +648,22 @@ export class DashboardWidget {
 		this._disposables.push(addAccountButton.onDidClick(async (e) => {
 			await vscode.commands.executeCommand('workbench.actions.modal.linkedAccount');
 			addAccountButton.enabled = false;
+			let accounts = await azdata.accounts.getAllAccounts();
+
+			if (accounts.length !== 0) {
+				addAccountImage.updateCssStyles({
+					'display': 'none'
+				});
+				addAccountText.updateCssStyles({
+					'display': 'none'
+				});
+				addAccountButton.updateCssStyles({
+					'display': 'none'
+				});
+				this._migrationStatusCardsContainer.updateCssStyles({ 'visibility': 'visible' });
+				this._viewAllMigrationsButton.updateCssStyles({ 'visibility': 'visible' });
+			}
 			await this.refreshMigrations();
-			addAccountButton.enabled = true;
 		}));
 
 		const header = view.modelBuilder.flexContainer().withItems(
@@ -675,13 +689,8 @@ export class DashboardWidget {
 			addAccountButton.updateCssStyles({
 				'display': 'block'
 			});
-			this._migrationStatusCardsContainer.updateCssStyles({
-				'visibility': 'hidden'
-			});
-			buttonContainer.removeItem(this._viewAllMigrationsButton);
-			refreshButton.updateCssStyles({
-				'float': 'right'
-			});
+			this._migrationStatusCardsContainer.updateCssStyles({ 'visibility': 'hidden' });
+			this._viewAllMigrationsButton.updateCssStyles({ 'visibility': 'hidden' });
 		}
 
 		this._inProgressMigrationButton = this.createStatusCard(


### PR DESCRIPTION
This PR 
Adds a button on Migration Status Dialog when the user isnt signed in which would allow the user to jump directly to add Azure account dialog

![Dark](https://user-images.githubusercontent.com/66509246/132174337-e7eaa596-cafb-41ca-b35d-eb269fcb7aa3.PNG)
![Light](https://user-images.githubusercontent.com/66509246/132174362-c3c3de16-8756-4b6d-86f8-081375704cac.PNG)
