### PR TITLE
Properly set device code auth type

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureDeviceCode.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureDeviceCode.ts
@@ -51,7 +51,7 @@ export class AzureDeviceCode extends AzureAuth {
 		context: vscode.ExtensionContext,
 		uriEventEmitter: vscode.EventEmitter<vscode.Uri>,
 	) {
-		super(metadata, tokenCache, context, uriEventEmitter, AzureAuthType.AuthCodeGrant, AzureDeviceCode.USER_FRIENDLY_NAME);
+		super(metadata, tokenCache, context, uriEventEmitter, AzureAuthType.DeviceCode, AzureDeviceCode.USER_FRIENDLY_NAME);
 		this.pageTitle = localize('addAccount', "Add {0} account", this.metadata.displayName);
 
 	}

--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -113,7 +113,7 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 
 	private async _getAccountSecurityToken(account: AzureAccount, tenantId: string, resource: azdata.AzureResource): Promise<Token | undefined> {
 		await this.initCompletePromise;
-		const azureAuth = this.getAuthMethod(undefined);
+		const azureAuth = this.getAuthMethod(account);
 		Logger.pii(`Getting account security token for ${JSON.stringify(account.key)} (tenant ${tenantId}). Auth Method = ${azureAuth.userFriendlyName}`, [], []);
 		return azureAuth?.getAccountSecurityToken(account, tenantId, resource);
 	}


### PR DESCRIPTION
This fixes a bug in device code where if the tenant requests a reauthentication during connection, the reauthentication would go back to AuthCodeGrant since the auth type was incorrectly set during the initial account sign-in.

Here is the prompt when the tenant requests a reauthentication.

![image](https://user-images.githubusercontent.com/599935/132597232-b2238a7e-93a0-4ad0-9ed4-b2ec9db6d727.png)

Unfortunately, device code can still fail if tenant has additional devicecode auth policies, such as that the machine is using machine management software, etc.  This is still a problem in webmode where the connecting machine is arbitrary Linux container.

![image](https://user-images.githubusercontent.com/599935/132596867-86940fe3-fbc9-41d2-a64e-f2b7807892bf.png)


