### PR TITLE
Change few default settings for adsweb

### DIFF
--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -81,6 +81,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 	if (!storagePath) {
 		return undefined;
 	}
+
+	const config = vscode.workspace.getConfiguration('accounts.azure.auth');
+	if (vscode.env.uiKind === vscode.UIKind.Web) {
+		await config.update('deviceCode', true, vscode.ConfigurationTarget.Global);
+	}
+
 	updatePiiLoggingLevel();
 
 	// Create the provider service and activate

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -82,6 +82,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 		return undefined;
 	}
 
+	// TODO: Since Code Grant auth doesnt work in web mode, enabling Device code auth by default for web mode. We can remove this once we have that working in web mode.
 	const config = vscode.workspace.getConfiguration('accounts.azure.auth');
 	if (vscode.env.uiKind === vscode.UIKind.Web) {
 		await config.update('deviceCode', true, vscode.ConfigurationTarget.Global);

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -30,6 +30,11 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	IconPathHelper.setExtensionContext(extensionContext);
 
 	const appContext = new AppContext(extensionContext);
+
+	const config = vscode.workspace.getConfiguration('notebook');
+	if (vscode.env.uiKind === vscode.UIKind.Web) {
+		await config.update('allowRoot', true, vscode.ConfigurationTarget.Global);
+	}
 	/**
 	 *  									***** IMPORTANT *****
 	 * If changes are made to bookTreeView.openBook, please ensure backwards compatibility with its current state.

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -31,6 +31,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 
 	const appContext = new AppContext(extensionContext);
 
+	// TODO: Notebook doesn't work without root setting enabled in web mode. Once we start using non-root containers, we can remove this code.
 	const config = vscode.workspace.getConfiguration('notebook');
 	if (vscode.env.uiKind === vscode.UIKind.Web) {
 		await config.update('allowRoot', true, vscode.ConfigurationTarget.Global);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Setting different default value for few settings like devicecode auth and notebook allowRoot for ADS web mode
