### PR TITLE
Increase smoke test timeout and python installation timeout

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -51,7 +51,7 @@ export class ConfigurePythonDialog extends Dialog {
 
 	private async _waitForInstallationComplete(): Promise<void> {
 		const installationCompleteNotification = '.notifications-toasts div[aria-label="Notebook dependencies installation is complete, source: Notebook Core Extensions (Extension), notification"]';
-		await this.code.waitForElement(installationCompleteNotification, undefined, 3000); // wait up to 5 minutes for python installation
+		await this.code.waitForElement(installationCompleteNotification, undefined, 6000); // wait up to 5 minutes for python installation
 	}
 
 }

--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -51,7 +51,7 @@ export class ConfigurePythonDialog extends Dialog {
 
 	private async _waitForInstallationComplete(): Promise<void> {
 		const installationCompleteNotification = '.notifications-toasts div[aria-label="Notebook dependencies installation is complete, source: Notebook Core Extensions (Extension), notification"]';
-		await this.code.waitForElement(installationCompleteNotification, undefined, 6000); // wait up to 5 minutes for python installation
+		await this.code.waitForElement(installationCompleteNotification, undefined, 6000); // wait up to 10 minutes for python installation
 	}
 
 }

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -56,6 +56,7 @@ export function setup() {
 		// Python Notebooks
 
 		it('can open new notebook, configure Python, and execute one cell', async function () {
+			this.timeout(600000); // increase the timeout for this test to 10 minutes
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.newUntitledNotebook();
 			await app.workbench.sqlNotebook.addCell('code');

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -56,7 +56,7 @@ export function setup() {
 		// Python Notebooks
 
 		it('can open new notebook, configure Python, and execute one cell', async function () {
-			this.timeout(600000); // increase the timeout for this test to 10 minutes
+			this.timeout(600000); // set timeout to 10 minutes to ensure test does not timeout during python installation
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.newUntitledNotebook();
 			await app.workbench.sqlNotebook.addCell('code');

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -68,7 +68,6 @@ export function setup() {
 			await app.workbench.configurePythonDialog.next();
 			await app.workbench.configurePythonDialog.waitForPageTwoLoaded();
 			await app.workbench.configurePythonDialog.install();
-			await app.captureScreenshot('after installation complete');
 			await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('Python 3');
 
 			await app.workbench.sqlNotebook.runActiveCell();

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -67,7 +67,6 @@ export function setup() {
 			await app.workbench.configurePythonDialog.waitForPageOneLoaded();
 			await app.workbench.configurePythonDialog.next();
 			await app.workbench.configurePythonDialog.waitForPageTwoLoaded();
-			await app.captureScreenshot('before installation complete');
 			await app.workbench.configurePythonDialog.install();
 			await app.captureScreenshot('after installation complete');
 			await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('Python 3');
@@ -143,11 +142,8 @@ export function setup() {
 }
 
 async function openAndRunNotebook(app: Application, filename: string): Promise<void> {
-	await app.captureScreenshot('before python notebook opened');
 	await app.workbench.sqlNotebook.openFile(filename);
-	await app.captureScreenshot('after python notebook opened');
 	await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('Python 3');
-	await app.captureScreenshot('before python kernel loaded');
 
 	await app.workbench.sqlNotebook.notebookToolbar.clearResults();
 	await app.workbench.sqlNotebook.waitForAllResultsGone();

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -67,7 +67,9 @@ export function setup() {
 			await app.workbench.configurePythonDialog.waitForPageOneLoaded();
 			await app.workbench.configurePythonDialog.next();
 			await app.workbench.configurePythonDialog.waitForPageTwoLoaded();
+			await app.captureScreenshot('before installation complete');
 			await app.workbench.configurePythonDialog.install();
+			await app.captureScreenshot('after installation complete');
 			await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('Python 3');
 
 			await app.workbench.sqlNotebook.runActiveCell();
@@ -141,8 +143,11 @@ export function setup() {
 }
 
 async function openAndRunNotebook(app: Application, filename: string): Promise<void> {
+	await app.captureScreenshot('before python notebook opened');
 	await app.workbench.sqlNotebook.openFile(filename);
+	await app.captureScreenshot('after python notebook opened');
 	await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('Python 3');
+	await app.captureScreenshot('before python kernel loaded');
 
 	await app.workbench.sqlNotebook.notebookToolbar.clearResults();
 	await app.workbench.sqlNotebook.waitForAllResultsGone();

--- a/test/smoke/test/index.js
+++ b/test/smoke/test/index.js
@@ -17,7 +17,7 @@ const suite = opts['web'] ? 'Browser Smoke Tests' : 'Smoke Tests';
 
 const options = {
 	color: true,
-	timeout: 300000,
+	timeout: 600000,
 	slow: 30000,
 	grep: opts['f'] || opts['g']
 };

--- a/test/smoke/test/index.js
+++ b/test/smoke/test/index.js
@@ -17,7 +17,7 @@ const suite = opts['web'] ? 'Browser Smoke Tests' : 'Smoke Tests';
 
 const options = {
 	color: true,
-	timeout: 600000,
+	timeout: 300000,
 	slow: 30000,
 	grep: opts['f'] || opts['g']
 };


### PR DESCRIPTION
I ran an ad hoc build with the 10 minute timeout and the python test was able to complete successfully. Based on logs from yesterday's product build, the installation took a little over 5 minutes.