### PR TITLE
Add Out of Scope label comment

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -34,6 +34,3 @@ medium-term roadmap.  The issue is being closed to reduce active issues to focus
 enhancements that are being considered for an upcoming release.  We will review closed issues
 with the 'Out of Scope' label when doing long-term planning."
   close: true
-
--Out of Scope:
-  reopen: true

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,3 +1,4 @@
+# actions for Needs Logs label
 Needs Logs:
   comment: "We need more info to debug your particular issue. If you could attach your logs to the issue (ensure no private data is in them), it would help us fix the issue much faster.
 
@@ -26,9 +27,13 @@ There are two types of logs to collect:
 
 - This will open the log folder locally. Please zip up this folder and attach it to the issue."
 
-
+# actions for Out of Scope label
 Out of Scope:
   comment: "Thank you for opening this suggestion!  This enhancement is not planned in our
 medium-term roadmap.  The issue is being closed to reduce active issues to focus on
 enhancements that are being considered for an upcoming release.  We will review closed issues
 with the 'Out of Scope' label when doing long-term planning."
+  close: true
+
+-Out of Scope:
+  reopen: true

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -25,3 +25,10 @@ There are two types of logs to collect:
 - Run the command: **`Developer: Open Logs Folder`**
 
 - This will open the log folder locally. Please zip up this folder and attach it to the issue."
+
+
+Out of Scope:
+  comment: "Thank you for opening this suggestion!  This enhancement is not planned in our
+medium-term roadmap.  The issue is being closed to reduce active issues to focus on
+enhancements that are being considered for an upcoming release.  We will review closed issues
+with the 'Out of Scope' label when doing long-term planning."


### PR DESCRIPTION
I'm planning to triage through older enhancements and plan to use labels for auto-comments/closing issues.  Please read the comment and let me know if there are suggestions.
