### PR TITLE
SQL Proj - Added an option to deploy to docker to select the base image

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -135,12 +135,13 @@ export const enterPortNumber = localize('enterPortNumber', "Enter port number or
 export const enterConnectionStringEnvName = localize('enterConnectionStringEnvName', "Enter connection string environment variable name");
 export const enterConnectionStringTemplate = localize('enterConnectionStringTemplate', "Enter connection string template");
 export const enterPassword = localize('enterPassword', "Enter password");
+export const enterBaseImage = localize('enterBaseImage', "Enter the base SQL Server docker image or press enter to use the default value");
 export const portMustBeNumber = localize('portMustNotBeNumber', "Port must a be number");
 export const valueCannotBeEmpty = localize('valueCannotBeEmpty', "Value cannot be empty");
 export const dockerImageLabelPrefix = 'source=sqldbproject';
 export const dockerImageNamePrefix = 'sqldbproject';
 export const connectionNamePrefix = 'SQLDbProject';
-export const dockerBaseImage = 'mcr.microsoft.com/azure-sql-edge:latest';
+export const defaultDockerBaseImage = 'mcr.microsoft.com/mssql/server:2019-latest';
 export const commandsFolderName = 'commands';
 export const mssqlFolderName = '.mssql';
 export const dockerFileName = 'Dockerfile';

--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
@@ -104,12 +104,27 @@ export async function launchPublishToDockerContainerQuickpick(project: Project):
 		return undefined;
 	}
 
+	let baseImage: string | undefined = '';
+	baseImage = await vscode.window.showInputBox({
+		title: constants.enterBaseImage,
+		ignoreFocusOut: true,
+		value: constants.defaultDockerBaseImage,
+		validateInput: input => utils.isEmptyString(input) ? constants.valueCannotBeEmpty : undefined
+	}
+	);
+
+	// Return when user hits escape
+	if (!baseImage) {
+		return undefined;
+	}
+
 	localDbSetting = {
 		serverName: 'localhost',
 		userName: 'sa',
 		dbName: project.projectFileName,
 		password: password,
 		port: +portNumber,
+		dockerBaseImage: baseImage
 	};
 
 	let deploySettings = await getPublishDatabaseSettings(project, false);

--- a/extensions/sql-database-projects/src/models/deploy/deployProfile.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployProfile.ts
@@ -21,4 +21,5 @@ export interface ILocalDbSetting {
 	userName: string,
 	password: string,
 	dbName: string,
+	dockerBaseImage: string
 }

--- a/extensions/sql-database-projects/src/models/deploy/deployProfile.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployProfile.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import { IDeploySettings } from '../IDeploySettings';
 
 export enum AppSettingType {
@@ -21,5 +26,6 @@ export interface ILocalDbSetting {
 	userName: string,
 	password: string,
 	dbName: string,
-	dockerBaseImage: string
+	dockerBaseImage: string,
+	connectionRetryTimeout?: number
 }

--- a/extensions/sql-database-projects/src/models/deploy/deployService.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployService.ts
@@ -20,6 +20,9 @@ export class DeployService {
 	constructor(private _outputChannel: vscode.OutputChannel) {
 	}
 
+	private DefaultSqlRetryTimeoutInSec: number = 10;
+	private DefaultSqlNumberOfRetries: number = 10;
+
 	private createConnectionStringTemplate(runtime: string | undefined): string {
 		switch (runtime?.toLocaleLowerCase()) {
 			case 'dotnet':
@@ -254,7 +257,7 @@ export class DeployService {
 		return connectionResult ? connectionResult.connectionId : <string>connection;
 	}
 
-	public async getConnection(profile: ILocalDbSetting, savePassword: boolean, database: string, timeoutInSeconds: number = 10): Promise<string | undefined> {
+	public async getConnection(profile: ILocalDbSetting, savePassword: boolean, database: string): Promise<string | undefined> {
 		const getAzdataApi = await utils.getAzdataApi();
 		let connection = await utils.retry(
 			constants.connectingToSqlServerOnDockerMessage,
@@ -264,7 +267,7 @@ export class DeployService {
 			this.validateConnection,
 			this.formatConnectionResult,
 			this._outputChannel,
-			10, timeoutInSeconds);
+			this.DefaultSqlNumberOfRetries, profile.connectionRetryTimeout || this.DefaultSqlRetryTimeoutInSec);
 
 		if (connection) {
 			const connectionResult = <ConnectionResult>connection;

--- a/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
+++ b/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
@@ -71,7 +71,8 @@ describe('deploy service', function (): void {
 				password: 'PLACEHOLDER',
 				port: 1433,
 				serverName: 'localhost',
-				userName: 'sa'
+				userName: 'sa',
+				dockerBaseImage: 'image'
 			}
 		};
 		const projFilePath = await testUtils.createTestSqlProjFile(baselines.newProjectFileBaseline);
@@ -93,7 +94,8 @@ describe('deploy service', function (): void {
 			password: 'PLACEHOLDER',
 			port: 1433,
 			serverName: 'localhost',
-			userName: 'sa'
+			userName: 'sa',
+			dockerBaseImage: 'image'
 		};
 
 		const deployService = new DeployService(testContext.outputChannel);
@@ -138,7 +140,8 @@ describe('deploy service', function (): void {
 				password: 'PLACEHOLDER',
 				port: 1433,
 				serverName: 'localhost',
-				userName: 'sa'
+				userName: 'sa',
+				dockerBaseImage: 'image'
 			}
 		};
 

--- a/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
+++ b/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
@@ -72,7 +72,8 @@ describe('deploy service', function (): void {
 				port: 1433,
 				serverName: 'localhost',
 				userName: 'sa',
-				dockerBaseImage: 'image'
+				dockerBaseImage: 'image',
+				connectionRetryTimeout: 1
 			}
 		};
 		const projFilePath = await testUtils.createTestSqlProjFile(baselines.newProjectFileBaseline);
@@ -95,7 +96,8 @@ describe('deploy service', function (): void {
 			port: 1433,
 			serverName: 'localhost',
 			userName: 'sa',
-			dockerBaseImage: 'image'
+			dockerBaseImage: 'image',
+			connectionRetryTimeout: 1
 		};
 
 		const deployService = new DeployService(testContext.outputChannel);
@@ -105,7 +107,7 @@ describe('deploy service', function (): void {
 		sandbox.stub(azdata.connection, 'getUriForConnection').returns(Promise.resolve('connection'));
 		sandbox.stub(azdata.tasks, 'startBackgroundOperation').callThrough();
 		sandbox.stub(childProcess, 'exec').yields(undefined, 'id');
-		let connection = await deployService.getConnection(localDbSettings, false, 'master', 2);
+		let connection = await deployService.getConnection(localDbSettings, false, 'master');
 		should(connection).equals('connection');
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Adding an option when publishing to docker container to enter the base image. Changed the default base image to SQL server 2019
<img width="750" alt="Screen Shot 2021-09-13 at 3 52 00 PM" src="https://user-images.githubusercontent.com/17187348/133167477-cc203780-f85d-4e0c-825b-28031a9df913.png">

