### PR TITLE
Markdown Horizontal Scrollbar Fix

### DIFF
--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -37,6 +37,7 @@ export class QueryTextEditor extends BaseTextEditor {
 	private _hideLineNumbers: boolean;
 	private _scrollbarHeight: number;
 	private _lineHeight: number;
+	private _shouldAddHorizontalScrollbarHeight: boolean = false;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -123,6 +124,10 @@ export class QueryTextEditor extends BaseTextEditor {
 		return editorWidget.getScrollHeight();
 	}
 
+	public get shouldAddHorizontalScrollbar(): boolean {
+		return this._shouldAddHorizontalScrollbarHeight;
+	}
+
 	public setHeightToScrollHeight(configChanged?: boolean, isEditorCollapsed?: boolean,) {
 		let editorWidget = this.getControl() as ICodeEditor;
 		let layoutInfo = editorWidget.getLayoutInfo();
@@ -146,7 +151,6 @@ export class QueryTextEditor extends BaseTextEditor {
 		// number of lines that wrap). Finally, viewportColumn is calculated on editor resizing automatically; we can use it to ensure
 		// that the viewportColumn will always be greater than any character's column in an editor.
 		let numberWrappedLines = 0;
-		let shouldAddHorizontalScrollbarHeight = false;
 		if (!this._lineHeight || configChanged) {
 			this._lineHeight = editorWidget.getOption(EditorOption.lineHeight) || 18;
 		}
@@ -162,14 +166,14 @@ export class QueryTextEditor extends BaseTextEditor {
 			for (let line = 1; line <= lineCount; line++) {
 				// The horizontal scrollbar always appears 1 column past the viewport column when word wrap is disabled
 				if (editorWidgetModel.getLineMaxColumn(line) >= layoutInfo.viewportColumn + 1) {
-					shouldAddHorizontalScrollbarHeight = true;
+					this._shouldAddHorizontalScrollbarHeight = true;
 					break;
 				}
 			}
 		}
 		let editorHeightUsingLines = this._lineHeight * (lineCount + numberWrappedLines);
 		let editorHeightUsingMinHeight = Math.max(Math.min(editorHeightUsingLines, this._maxHeight), this._minHeight);
-		editorHeightUsingMinHeight = shouldAddHorizontalScrollbarHeight ? editorHeightUsingMinHeight + this._scrollbarHeight : editorHeightUsingMinHeight;
+		editorHeightUsingMinHeight = this._shouldAddHorizontalScrollbarHeight ? editorHeightUsingMinHeight + this._scrollbarHeight : editorHeightUsingMinHeight;
 		this.setHeight(editorHeightUsingMinHeight);
 	}
 

--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -151,6 +151,7 @@ export class QueryTextEditor extends BaseTextEditor {
 		// number of lines that wrap). Finally, viewportColumn is calculated on editor resizing automatically; we can use it to ensure
 		// that the viewportColumn will always be greater than any character's column in an editor.
 		let numberWrappedLines = 0;
+		this._shouldAddHorizontalScrollbarHeight = false;
 		if (!this._lineHeight || configChanged) {
 			this._lineHeight = editorWidget.getOption(EditorOption.lineHeight) || 18;
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -280,28 +280,33 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 	}
 
 	public horizontalScrollbar(): void {
-		if (this._configurationService.getValue('editor.wordWrap') && this.cellModel.cellType !== CellTypes.Code) {
-			// Get Markdown View Horizontal Scrollbar
+		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code) {
+			// Get Markdown Split View Horizontal Scrollbar
 			let horizontalScrollbar = this.codeElement.nativeElement.querySelector('div.invisible.scrollbar.horizontal');
 
-			let editorBottomPos = Math.floor(this.codeElement.nativeElement.closest('.show-markdown .editor').getBoundingClientRect().bottom) - Math.floor(this.codeElement.nativeElement.closest('.show-markdown .editor').getBoundingClientRect().top);
+			let editorBottomPos = this.codeElement.nativeElement.closest('.show-markdown .editor').getBoundingClientRect().bottom - this.codeElement.nativeElement.closest('.show-markdown .editor').getBoundingClientRect().top;
 			let viewportHeight = DOM.getTotalHeight(document.querySelector('.scrollable'));
-			let viewportTop = Math.floor(document.querySelector('.scrollable').getBoundingClientRect().top);
-			let viewportLeft = Math.floor(document.querySelector('.scrollable').getBoundingClientRect().left);
-			let marginLeft = DOM.getContentWidth(document.querySelector('div.margin'));
+			let viewportTop = document.querySelector('.scrollable').getBoundingClientRect().top;
 
-			let toolbarOffsetHeight = DOM.getContentHeight(document.querySelector('markdown-toolbar-component')) + DOM.getContentHeight(document.querySelector('cell-toolbar-component'));
 			// Horizontal Scrollbar Values when fixed
+			let toolbarOffsetHeight = DOM.getContentHeight(document.querySelector('markdown-toolbar-component')) + DOM.getContentHeight(document.querySelector('cell-toolbar-component'));
 			let horizontalTop = viewportTop + viewportHeight - horizontalScrollbar.scrollHeight - 10;
-			let horizontalScrollbarLeft = viewportLeft + marginLeft;
 
 			// Set the bottom to recognize when the bottom of the active cell is larger than the visible area (viewport)
 			editorBottomPos = editorBottomPos + toolbarOffsetHeight + horizontalScrollbar.scrollHeight;
 
+			// If the Editor of the cell is past the scrollable area we will change the scrollbar to be fixed to the bottom of the visible area (viewport)
 			if (editorBottomPos >= viewportHeight) {
-				horizontalScrollbar.setAttribute('style', `opacity: 1; position: fixed; left: ${horizontalScrollbarLeft}px; top: ${horizontalTop}px`);
+				horizontalScrollbar.style.opacity = 1;
+				horizontalScrollbar.style.position = 'fixed';
+				horizontalScrollbar.style.left = '';
+				horizontalScrollbar.style.top = horizontalTop + 'px';
 			} else {
-				horizontalScrollbar.setAttribute('style', `opacity: 1; position: absolute; left: 0; bottom: ${horizontalScrollbar.scrollHeight}px`);
+				horizontalScrollbar.style.opacity = 1;
+				horizontalScrollbar.style.position = 'absolute';
+				horizontalScrollbar.style.left = 0 + 'px';
+				horizontalScrollbar.style.top = '';
+				horizontalScrollbar.style.bottom = horizontalScrollbar.scrollHeight + 'px';
 			}
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -243,9 +243,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			this.onContentChanged.emit();
 			this.checkForLanguageMagics();
 			// When content is updated we have to also update the horizontal scrollbar
-			if (this._editor.shouldAddHorizontalScrollbar) {
-				this.horizontalScrollbar();
-			}
+			this.horizontalScrollbar();
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('editor.wordWrap') || e.affectsConfiguration('editor.fontSize')) {
@@ -293,9 +291,9 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 	 */
 	public horizontalScrollbar(): void {
 		let showScrollbar: boolean = this._editor.shouldAddHorizontalScrollbar;
+		let horizontalScrollbar: HTMLElement = this.codeElement.nativeElement.querySelector('div.scrollbar.horizontal');
 		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code && this.cellModel.source.length > 0 && showScrollbar) {
 			// Get markdown split view horizontal scrollbar
-			let horizontalScrollbar: HTMLElement = this.codeElement.nativeElement.querySelector('div.scrollbar.horizontal');
 			let viewport: HTMLElement = document.querySelector('.scrollable');
 			let markdownEditor: HTMLElement = this.codeElement.nativeElement.closest('.show-markdown .editor');
 
@@ -326,6 +324,8 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 				horizontalScrollbar.style.top = horizontalTop + 'px';
 				horizontalScrollbar.style.bottom = '';
 			}
+		} else {
+			horizontalScrollbar.style.opacity = '0';
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -288,45 +288,37 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 	 * or it will set it to the bottom of the markdown editor if it is in the viewport (visible area)
 	 */
 	public horizontalScrollbar(): void {
-		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code && this.cellModel.source[0] !== '') {
+		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code && this.cellModel.source.length > 0) {
 			// Get markdown split view horizontal scrollbar
-			let horizontalScrollbar = this.codeElement.nativeElement.querySelector('div.invisible.scrollbar.horizontal');
-			let markdownEditor: HTMLElement = this.codeElement.nativeElement.closest('.show-markdown .editor');
-			let markdownEditorBottom = Math.floor(markdownEditor.getBoundingClientRect().bottom);
-			let markdownEditorTop = Math.floor(markdownEditor.getBoundingClientRect().top);
+			let horizontalScrollbar: HTMLElement = this.codeElement.nativeElement.querySelector('div.scrollbar.horizontal');
 			let viewport: HTMLElement = document.querySelector('.scrollable');
+			let markdownEditor: HTMLElement = this.codeElement.nativeElement.closest('.show-markdown .editor');
+
+			//Get values based on current context of the editor and ADS window
+			let markdownEditorBottom = Math.floor(markdownEditor.getBoundingClientRect().bottom);
 			let viewportBottom = Math.floor(viewport.getBoundingClientRect().bottom);
-
-			// Compare the editor bottom position to the scrollable area in
-			// order to decide whether to make the horizontal scrollbar fixed or absolute
-			let editorArea = markdownEditorBottom - markdownEditorTop;
 			let viewportHeight = DOM.getTotalHeight(viewport);
+			let viewportTop = Math.floor(document.querySelector('.scrollable').getBoundingClientRect().top);
 
-			// Horizontal scrollbar values used when fixed
-			let viewportTop = document.querySelector('.scrollable').getBoundingClientRect().top;
 			// Have to offset the height based on the contents the multiple horizontal scrollbars that are present in markdown editor and notebook
-			let horizontalTop = viewportTop + viewportHeight - horizontalScrollbar.scrollHeight - horizontalScrollbar.scrollHeight;
+			let horizontalTop = Math.floor(Math.abs(viewportTop + viewportHeight) - Math.abs(2 * horizontalScrollbar.scrollHeight));
 
-			// Set the bottom position of the markdown editor area of the active cell
-			let toolbarOffsetHeight = DOM.getContentHeight(document.querySelector('markdown-toolbar-component')) + DOM.getContentHeight(document.querySelector('cell-toolbar-component'));
-			editorArea = editorArea + toolbarOffsetHeight + horizontalScrollbar.scrollHeight;
-
-			// This condition will check to see if the bottom of the editor is in the viewable area (which can change on scrolling)
+			// This condition will check to see if the bottom of the editor is in the scrollable area (viewport)
 			// if it is then we will set the horizontal scrollbar to the bottom of the editor space
-			if (markdownEditorBottom <= viewportBottom) {
-				// When scrollbar is not fixed and cell is still in visible area
-				horizontalScrollbar.style.opacity = 1;
+			if (markdownEditorBottom < viewportBottom) {
+				horizontalScrollbar.style.opacity = '1';
 				horizontalScrollbar.style.position = 'absolute';
-				horizontalScrollbar.style.left = 0 + 'px';
+				horizontalScrollbar.style.left = '0px';
 				horizontalScrollbar.style.top = '';
-				horizontalScrollbar.style.bottom = horizontalScrollbar.scrollHeight + 'px';
-				// This condition checks if bottom of the editor is past the scrollable area (viewport)
+				horizontalScrollbar.style.bottom = horizontalScrollbar.clientHeight + 'px';
+				// This condition checks if bottom of the editor is not within the scrollable area (viewport)
 				// we will change the horizontal scrollbar to be fixed to the bottom of the scrollable area (viewport)
-			} else if (editorArea >= viewportHeight) {
-				horizontalScrollbar.style.opacity = 1;
+			} else {
+				horizontalScrollbar.style.opacity = '1';
 				horizontalScrollbar.style.position = 'fixed';
 				horizontalScrollbar.style.left = '';
 				horizontalScrollbar.style.top = horizontalTop + 'px';
+				horizontalScrollbar.style.bottom = '';
 			}
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -300,7 +300,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			let viewportHeight = DOM.getTotalHeight(viewport);
 			let viewportTop = Math.floor(document.querySelector('.scrollable').getBoundingClientRect().top);
 
-			// Have to offset the height based on the contents the multiple horizontal scrollbars that are present in markdown editor and notebook
+			// Have to offset the height based on the contents viewport and the additional scrollbars that are present in markdown editor and notebook
 			let horizontalTop = Math.floor(Math.abs(viewportTop + viewportHeight) - Math.abs(2 * horizontalScrollbar.scrollHeight));
 
 			// This condition will check to see if the bottom of the editor is in the scrollable area (viewport)

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -242,6 +242,10 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 
 			this.onContentChanged.emit();
 			this.checkForLanguageMagics();
+			// When content is updated we have to also update the horizontal scrollbar
+			if (this._editor.shouldAddHorizontalScrollbar) {
+				this.horizontalScrollbar();
+			}
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('editor.wordWrap') || e.affectsConfiguration('editor.fontSize')) {
@@ -288,7 +292,8 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 	 * or it will set it to the bottom of the markdown editor if it is in the viewport (visible area)
 	 */
 	public horizontalScrollbar(): void {
-		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code && this.cellModel.source.length > 0) {
+		let showScrollbar: boolean = this._editor.shouldAddHorizontalScrollbar;
+		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code && this.cellModel.source.length > 0 && showScrollbar) {
 			// Get markdown split view horizontal scrollbar
 			let horizontalScrollbar: HTMLElement = this.codeElement.nativeElement.querySelector('div.scrollbar.horizontal');
 			let viewport: HTMLElement = document.querySelector('.scrollable');

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -280,17 +280,30 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 	}
 
 	public horizontalScrollbar(): void {
-		// Get Markdown View Horizontal Scrollbar
-		let horizontalScrollbar: Element = this.codeElement.nativeElement.querySelector('div.invisible.scrollbar.horizontal');
-		horizontalScrollbar.classList.add('markdownScrollbar');
+		if (this._configurationService.getValue('editor.wordWrap') && this.cellModel.cellType !== CellTypes.Code) {
+			// Get Markdown View Horizontal Scrollbar
+			let horizontalScrollbar = this.codeElement.nativeElement.querySelector('div.invisible.scrollbar.horizontal');
 
-		// code-component - scrollable = size of the terminal window
-		let codeComponentHeight = this._editor.scrollHeight;
-		let scrollableHeight = document.getElementsByClassName('scrollable')[0].clientHeight;
-		let scrollbarHeight = codeComponentHeight - scrollableHeight;
-		//let leftStyle = this.codeElement.nativeElement.querySelector('div.margin').offsetWidth;
+			let editorBottomPos = Math.floor(this.codeElement.nativeElement.closest('.show-markdown .editor').getBoundingClientRect().bottom) - Math.floor(this.codeElement.nativeElement.closest('.show-markdown .editor').getBoundingClientRect().top);
+			let viewportHeight = DOM.getTotalHeight(document.querySelector('.scrollable'));
+			let viewportTop = Math.floor(document.querySelector('.scrollable').getBoundingClientRect().top);
+			let viewportLeft = Math.floor(document.querySelector('.scrollable').getBoundingClientRect().left);
+			let marginLeft = DOM.getContentWidth(document.querySelector('div.margin'));
 
-		horizontalScrollbar.setAttribute('style', `bottom: ${scrollbarHeight}px; left: 60px; opacity: 1; position: fixed`);
+			let toolbarOffsetHeight = DOM.getContentHeight(document.querySelector('markdown-toolbar-component')) + DOM.getContentHeight(document.querySelector('cell-toolbar-component'));
+			// Horizontal Scrollbar Values when fixed
+			let horizontalTop = viewportTop + viewportHeight - horizontalScrollbar.scrollHeight - 10;
+			let horizontalScrollbarLeft = viewportLeft + marginLeft;
+
+			// Set the bottom to recognize when the bottom of the active cell is larger than the visible area (viewport)
+			editorBottomPos = editorBottomPos + toolbarOffsetHeight + horizontalScrollbar.scrollHeight;
+
+			if (editorBottomPos >= viewportHeight) {
+				horizontalScrollbar.setAttribute('style', `opacity: 1; position: fixed; left: ${horizontalScrollbarLeft}px; top: ${horizontalTop}px`);
+			} else {
+				horizontalScrollbar.setAttribute('style', `opacity: 1; position: absolute; left: 0; bottom: ${horizontalScrollbar.scrollHeight}px`);
+			}
+		}
 	}
 
 	protected initActionBar() {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -309,15 +309,13 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			// Set opacity for both fixed and absolute
 			horizontalScrollbar.style.opacity = '1';
 
-			// This condition will check to see if the bottom of the editor is in the scrollable area (viewport)
-			// if it is then we will set the horizontal scrollbar to the bottom of the editor space
+			// If the bottom of the editor is in the viewport, then set the horizontal scrollbar to the bottom of the editor space
 			if (markdownEditorBottom < viewportBottom) {
 				horizontalScrollbar.style.position = 'absolute';
 				horizontalScrollbar.style.left = '0px';
 				horizontalScrollbar.style.top = '';
 				horizontalScrollbar.style.bottom = '0px';
-				// This condition checks if bottom of the editor is not within the scrollable area (viewport)
-				// we will change the horizontal scrollbar to be fixed to the bottom of the scrollable area (viewport)
+				// If the bottom of the editor is not in the viewport, then set the horizontal scrollbar to the bottom of the viewport
 			} else {
 				horizontalScrollbar.style.position = 'fixed';
 				horizontalScrollbar.style.left = '';
@@ -325,6 +323,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 				horizontalScrollbar.style.bottom = '';
 			}
 		} else {
+			// If horizontal scrollbar is not needed then set do not show it
 			horizontalScrollbar.style.opacity = '0';
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -281,14 +281,15 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 
 	public horizontalScrollbar(): void {
 		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code) {
-			// Get Markdown Split View Horizontal Scrollbar
+			// Get markdown split view horizontal scrollbar
 			let horizontalScrollbar = this.codeElement.nativeElement.querySelector('div.invisible.scrollbar.horizontal');
 
+			// Compare the editor bottom position to the scrollable area in order to decide whether to make the horizontal scrollbar fixed or absolute
 			let editorBottomPos = this.codeElement.nativeElement.closest('.show-markdown .editor').getBoundingClientRect().bottom - this.codeElement.nativeElement.closest('.show-markdown .editor').getBoundingClientRect().top;
 			let viewportHeight = DOM.getTotalHeight(document.querySelector('.scrollable'));
-			let viewportTop = document.querySelector('.scrollable').getBoundingClientRect().top;
 
-			// Horizontal Scrollbar Values used when fixed
+			// Horizontal scrollbar values used when fixed
+			let viewportTop = document.querySelector('.scrollable').getBoundingClientRect().top;
 			let horizontalTop = viewportTop + viewportHeight - horizontalScrollbar.scrollHeight - 10;
 
 			// Set the bottom position of the markdown editor area of the active cell

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -303,18 +303,19 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			// Have to offset the height based on the contents viewport and the additional scrollbars that are present in markdown editor and notebook
 			let horizontalTop = Math.floor(Math.abs(viewportTop + viewportHeight) - Math.abs(2 * horizontalScrollbar.scrollHeight));
 
+			// Set opacity for both fixed and absolute
+			horizontalScrollbar.style.opacity = '1';
+
 			// This condition will check to see if the bottom of the editor is in the scrollable area (viewport)
 			// if it is then we will set the horizontal scrollbar to the bottom of the editor space
 			if (markdownEditorBottom < viewportBottom) {
-				horizontalScrollbar.style.opacity = '1';
 				horizontalScrollbar.style.position = 'absolute';
 				horizontalScrollbar.style.left = '0px';
 				horizontalScrollbar.style.top = '';
-				horizontalScrollbar.style.bottom = horizontalScrollbar.clientHeight + 'px';
+				horizontalScrollbar.style.bottom = '0px';
 				// This condition checks if bottom of the editor is not within the scrollable area (viewport)
 				// we will change the horizontal scrollbar to be fixed to the bottom of the scrollable area (viewport)
 			} else {
-				horizontalScrollbar.style.opacity = '1';
 				horizontalScrollbar.style.position = 'fixed';
 				horizontalScrollbar.style.left = '';
 				horizontalScrollbar.style.top = horizontalTop + 'px';

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import 'vs/css!./code';
 
-import { OnInit, Component, Input, Inject, ElementRef, ViewChild, Output, EventEmitter, OnChanges, SimpleChange, forwardRef, ChangeDetectorRef, HostListener } from '@angular/core';
+import { OnInit, Component, Input, Inject, ElementRef, ViewChild, Output, EventEmitter, OnChanges, SimpleChange, forwardRef, ChangeDetectorRef } from '@angular/core';
 
 import { QueryTextEditor } from 'sql/workbench/browser/modelComponents/queryTextEditor';
 import { ICellModel, CellExecutionState } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -111,19 +111,6 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		this._register({ dispose: () => this.updateConnectionState(false) });
 	}
 
-	// On scroll wheel we will have to adjust the horizontal scrollbar
-	@HostListener('document:mousewheel', ['$event'])
-	onDocumentMousewheelEvent(event) {
-		this.horizontalScrollbar();
-	}
-
-	@HostListener('window:scroll', [])
-	onScroll(): void {
-		this.horizontalScrollbar();
-		// eslint-disable-next-line no-console
-		console.log('SCROLL BAR');
-	}
-
 	ngOnInit() {
 		this._register(this.themeService.onDidColorThemeChange(this.updateTheme, this));
 		this.updateTheme(this.themeService.getColorTheme());
@@ -262,6 +249,9 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			}
 		}));
 		this._register(this.model.layoutChanged(() => this._layoutEmitter.fire(), this));
+		// Handles mouse wheel and scrollbar events
+		this._register(Event.debounce(this.model.onScroll.event, (l, e) => e, 250, /*leading=*/false)
+			(() => this.horizontalScrollbar()));
 		this._register(this.cellModel.onExecutionStateChange(event => {
 			if (event === CellExecutionState.Running && !this.cellModel.stdInVisible) {
 				this.setFocusAndScroll();

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -288,20 +288,21 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			let viewportHeight = DOM.getTotalHeight(document.querySelector('.scrollable'));
 			let viewportTop = document.querySelector('.scrollable').getBoundingClientRect().top;
 
-			// Horizontal Scrollbar Values when fixed
-			let toolbarOffsetHeight = DOM.getContentHeight(document.querySelector('markdown-toolbar-component')) + DOM.getContentHeight(document.querySelector('cell-toolbar-component'));
+			// Horizontal Scrollbar Values used when fixed
 			let horizontalTop = viewportTop + viewportHeight - horizontalScrollbar.scrollHeight - 10;
 
-			// Set the bottom to recognize when the bottom of the active cell is larger than the visible area (viewport)
+			// Set the bottom position of the markdown editor area of the active cell
+			let toolbarOffsetHeight = DOM.getContentHeight(document.querySelector('markdown-toolbar-component')) + DOM.getContentHeight(document.querySelector('cell-toolbar-component'));
 			editorBottomPos = editorBottomPos + toolbarOffsetHeight + horizontalScrollbar.scrollHeight;
 
-			// If the Editor of the cell is past the scrollable area we will change the scrollbar to be fixed to the bottom of the visible area (viewport)
+			// When the editor of the cell is past the scrollable area we will change the horizontal scrollbar to be fixed to the bottom of the visible area (viewport)
 			if (editorBottomPos >= viewportHeight) {
 				horizontalScrollbar.style.opacity = 1;
 				horizontalScrollbar.style.position = 'fixed';
 				horizontalScrollbar.style.left = '';
 				horizontalScrollbar.style.top = horizontalTop + 'px';
 			} else {
+				// When scrollbar is not fixed and cell is still in visible area
 				horizontalScrollbar.style.opacity = 1;
 				horizontalScrollbar.style.position = 'absolute';
 				horizontalScrollbar.style.left = 0 + 'px';

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -264,7 +264,6 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			}
 			this._layoutEmitter.fire();
 		}));
-
 		this.layout();
 
 		if (this._cellModel.isCollapsed) {
@@ -277,6 +276,21 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			DOM.getContentWidth(this.codeElement.nativeElement),
 			DOM.getContentHeight(this.codeElement.nativeElement)));
 		this._editor.setHeightToScrollHeight(false, this._cellModel.isCollapsed);
+		this.horizontalScrollbar();
+	}
+
+	public horizontalScrollbar(): void {
+		// Get Markdown View Horizontal Scrollbar
+		let horizontalScrollbar: Element = this.codeElement.nativeElement.querySelector('div.invisible.scrollbar.horizontal');
+		horizontalScrollbar.classList.add('markdownScrollbar');
+
+		// code-component - scrollable = size of the terminal window
+		let codeComponentHeight = this._editor.scrollHeight;
+		let scrollableHeight = document.getElementsByClassName('scrollable')[0].clientHeight;
+		let scrollbarHeight = codeComponentHeight - scrollableHeight;
+		//let leftStyle = this.codeElement.nativeElement.querySelector('div.margin').offsetWidth;
+
+		horizontalScrollbar.setAttribute('style', `bottom: ${scrollbarHeight}px; left: 60px; opacity: 1; position: fixed`);
 	}
 
 	protected initActionBar() {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -117,6 +117,13 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		this.horizontalScrollbar();
 	}
 
+	@HostListener('window:scroll', [])
+	onScroll(): void {
+		this.horizontalScrollbar();
+		// eslint-disable-next-line no-console
+		console.log('SCROLL BAR');
+	}
+
 	ngOnInit() {
 		this._register(this.themeService.onDidColorThemeChange(this.updateTheme, this));
 		this.updateTheme(this.themeService.getColorTheme());
@@ -291,14 +298,14 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 	 * or it will set it to the bottom of the markdown editor if it is in the viewport (visible area)
 	 */
 	public horizontalScrollbar(): void {
-		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code) {
+		if (this._configurationService.getValue('editor.wordWrap') === 'off' && this.cellModel.cellType !== CellTypes.Code && this.cellModel.source[0] !== '') {
 			// Get markdown split view horizontal scrollbar
 			let horizontalScrollbar = this.codeElement.nativeElement.querySelector('div.invisible.scrollbar.horizontal');
 			let markdownEditor: HTMLElement = this.codeElement.nativeElement.closest('.show-markdown .editor');
-			let markdownEditorBottom = markdownEditor.getBoundingClientRect().bottom;
-			let markdownEditorTop = markdownEditor.getBoundingClientRect().top;
+			let markdownEditorBottom = Math.floor(markdownEditor.getBoundingClientRect().bottom);
+			let markdownEditorTop = Math.floor(markdownEditor.getBoundingClientRect().top);
 			let viewport: HTMLElement = document.querySelector('.scrollable');
-			let viewportBottom = viewport.getBoundingClientRect().bottom;
+			let viewportBottom = Math.floor(viewport.getBoundingClientRect().bottom);
 
 			// Compare the editor bottom position to the scrollable area in
 			// order to decide whether to make the horizontal scrollbar fixed or absolute
@@ -307,6 +314,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 
 			// Horizontal scrollbar values used when fixed
 			let viewportTop = document.querySelector('.scrollable').getBoundingClientRect().top;
+			// Have to offset the height based on the contents the multiple horizontal scrollbars that are present in markdown editor and notebook
 			let horizontalTop = viewportTop + viewportHeight - horizontalScrollbar.scrollHeight - horizontalScrollbar.scrollHeight;
 
 			// Set the bottom position of the markdown editor area of the active cell

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -120,8 +120,3 @@ code-component .parameter span {
 	padding: 3px 7px;
 	text-align: center;
 }
-
-code-component .invisible.scrollbar.horizontal.fade {
-	position: fixed !important;
-	opacity: 1 !important;
-}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -120,3 +120,8 @@ code-component .parameter span {
 	padding: 3px 7px;
 	text-align: center;
 }
+
+code-component .invisible.scrollbar.horizontal.fade {
+	position: fixed !important;
+	opacity: 1 !important;
+}

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -54,6 +54,7 @@ import { CellToolbarComponent } from 'sql/workbench/contrib/notebook/browser/cel
 import { NotebookViewsExtension } from 'sql/workbench/services/notebook/browser/notebookViews/notebookViewsExtension';
 import { MaskedLabeledMenuItemActionItem } from 'sql/platform/actions/browser/menuEntryActionViewItem';
 import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
+import { Emitter } from 'vs/base/common/event';
 
 export const NOTEBOOK_SELECTOR: string = 'notebook-component';
 
@@ -84,6 +85,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	private navigationResult: nb.NavigationResult;
 	public previewFeaturesEnabled: boolean = false;
 	public doubleClickEditEnabled: boolean;
+	private _onScroll = new Emitter<void>();
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
@@ -223,6 +225,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	//Saves scrollTop value on scroll change
 	public scrollHandler(event: Event) {
 		this._scrollTop = (<HTMLElement>event.srcElement).scrollTop;
+		this.model.onScroll.fire();
 	}
 
 	public unselectActiveCell() {
@@ -339,6 +342,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this._register(this._model.kernelChanged((kernelArgs) => this.handleKernelChanged(kernelArgs)));
 		this._register(this._model.onCellTypeChanged(() => this.detectChanges()));
 		this._register(this._model.layoutChanged(() => this.detectChanges()));
+		this._register(this.model.onScroll.event(() => this._onScroll.fire()));
 
 		this.setLoading(false);
 		// Check if URI fragment is present; if it is, navigate to section by default

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -80,6 +80,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _trustedMode: boolean;
 	private _onActiveCellChanged = new Emitter<ICellModel | undefined>();
 	private _onCellTypeChanged = new Emitter<ICellModel>();
+	private _onScrollEmitter = new Emitter<void>();
 
 	private _cells: ICellModel[] | undefined;
 	private _defaultLanguageInfo: nb.ILanguageInfo | undefined;
@@ -211,6 +212,10 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	public get contextsChanged(): Event<void> {
 		return this._contextsChangedEmitter.event;
+	}
+
+	public get onScroll(): Emitter<void> {
+		return this._onScrollEmitter;
 	}
 
 	public get contextsLoading(): Event<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #14483 & fixes #15943.

This PR addresses the horizontal scrollbar issues users see when they have word wrap off in the split view for markdown cells. Every time the user updates the layout (either from editing the cell, scrolling the terminal window over the cell, or making the ADS smaller in resolution) we have to set the horizontal scrollbar accordingly. The way we can identify whether to set the horizontal to a fixed position is only by comparing the markdown editor space to that of the scrollable space. This required additional offset values as well in order to get a precise comparison. 

https://user-images.githubusercontent.com/23587151/133418762-dfaa6eed-4beb-432a-8a3e-03955f27e06f.mp4


