### PR TITLE
Add Null Shortcut and added NULL text for default NULL value.

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -510,7 +510,7 @@ export class EditDataGridPanel extends GridParentComponent {
 			handled = true;
 		}
 		if (e.ctrlKey && e.keyCode === KeyCode.KEY_0) {
-			this.logService.debug('Command for null insert recognized');
+			//TODO - Need to create an insert null function into cell.
 			handled = true;
 		}
 

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -188,8 +188,12 @@ export class EditDataGridPanel extends GridParentComponent {
 			// render line breaks and strips them, updating the value.
 			/* tslint:disable:no-null-keyword */
 			let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull);
+			let isStringNull = (Services.DBCellValue.isDBCellValue(value) && !value.isNull && value.displayValue === 'NULL');
 			if (valueMissing) {
 				returnVal = 'NULL';
+			}
+			else if (isStringNull) {
+				returnVal = '\'NULL\'';
 			}
 			else if (Services.DBCellValue.isDBCellValue(value)) {
 				returnVal = this.replaceLinebreaks(value.displayValue);
@@ -1091,9 +1095,13 @@ export class EditDataGridPanel extends GridParentComponent {
 		let cellClasses = 'grid-cell-value-container';
 		/* tslint:disable:no-null-keyword */
 		let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull) || value === 'NULL';
+		let isStringNull = (Services.DBCellValue.isDBCellValue(value) && !value.isNull && value.displayValue === 'NULL');
 		if (valueMissing) {
 			valueToDisplay = 'NULL';
 			cellClasses += ' missing-value';
+		}
+		else if (isStringNull) {
+			valueToDisplay = '\'NULL\'';
 		}
 		else if (Services.DBCellValue.isDBCellValue(value)) {
 			valueToDisplay = (value.displayValue + '');

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -189,8 +189,7 @@ export class EditDataGridPanel extends GridParentComponent {
 			/* tslint:disable:no-null-keyword */
 			let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull);
 			if (valueMissing) {
-				/* tslint:disable:no-null-keyword */
-				returnVal = null;
+				returnVal = 'NULL';
 			}
 			else if (Services.DBCellValue.isDBCellValue(value)) {
 				returnVal = this.replaceLinebreaks(value.displayValue);
@@ -1088,7 +1087,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		let valueToDisplay = '';
 		let cellClasses = 'grid-cell-value-container';
 		/* tslint:disable:no-null-keyword */
-		let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull);
+		let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull) || value === 'NULL';
 		if (valueMissing) {
 			valueToDisplay = 'NULL';
 			cellClasses += ' missing-value';

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -509,7 +509,10 @@ export class EditDataGridPanel extends GridParentComponent {
 			handled = true;
 		}
 		if (e.ctrlKey && e.keyCode === KeyCode.KEY_0) {
-			//TODO - Need to create an insert null function into cell.
+			//Replace contents with NULL in cell contents.
+			document.execCommand('selectAll');
+			document.execCommand('delete');
+			document.execCommand('insertText', false, 'NULL');
 			handled = true;
 		}
 

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -509,6 +509,11 @@ export class EditDataGridPanel extends GridParentComponent {
 			this.revertCurrentRow().catch(onUnexpectedError);
 			handled = true;
 		}
+		if (e.ctrlKey && e.keyCode === KeyCode.KEY_0) {
+			this.logService.debug('Command for null insert recognized');
+			handled = true;
+		}
+
 		return handled;
 	}
 


### PR DESCRIPTION
This adds a shortcut tied to the grid panel table that deletes the current content of the cell then replaces it with 'NULL', also added support for 'NULL' as a string to be marked as a missing object (this is required as its the only form of 'NULL' (in text form) that can be parsed into STS currently, and it also changes the default value of a NULL cell to 'NULL' when it is clicked.) These changes help bring it more in line with the current version of SSMS. 

This addresses issue #17023

