### PR TITLE
updated migration cutover page styling

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -325,9 +325,9 @@ export const AZURE_SQL_DATABASE_VIRTUAL_MACHINE = localize('sql.migration.azure.
 export const CANCEL_MIGRATION = localize('sql.migration.cancel.migration', "Cancel migration");
 export function ACTIVE_BACKUP_FILES_ITEMS(fileCount: number) {
 	if (fileCount === 1) {
-		return localize('sql.migration.active.backup.files.items', "Active backup files (1 item)");
+		return localize('sql.migration.active.backup.files.items', "Active backup files (Showing 1-1 of 1 file)");
 	} else {
-		return localize('sql.migration.active.backup.files.multiple.items', "Active backup files ({0} items)", fileCount);
+		return localize('sql.migration.active.backup.files.multiple.items', "Active backup files (Showing 1-{0} of {0} files)", fileCount);
 	}
 }
 export const COPY_MIGRATION_DETAILS = localize('sql.migration.copy.migration.details', "Copy migration details");

--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -200,7 +200,13 @@ export class MigrationCutoverDialog {
 
 				let formItems = [
 					{ component: this.migrationContainerHeader() },
-					{ component: this._view.modelBuilder.separator().withProps({ width: 1000 }).component() },
+					{
+						component: this._view.modelBuilder.separator().withProps({
+							width: 1000, CSSStyles: {
+								'background': '#DDDDDD'
+							}
+						}).component()
+					},
 					{ component: this.migrationInfoGrid() },
 					{ component: this._view.modelBuilder.separator().withProps({ width: 1000 }).component() },
 					{ component: this._fileCount },
@@ -744,7 +750,8 @@ export class MigrationCutoverDialog {
 			CSSStyles: {
 				'font-weight': 'bold',
 				'margin-bottom': '0',
-				'font-size': '12px'
+				'font-size': '12px',
+				'color': '#595959',
 			}
 		}).component();
 		flexContainer.addItem(labelComponent);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Task 1342420: ADS UI - Migration cutover page styling updates
1. Info fields should use a lighter gray : color595959 (see figma)
2. line separator should be a lighter color (see figma)
3. Update the active backup file count text (see figma) 3 items -> "Showing 1-3 of 3 files"

**Before:**
![Screenshot (65)](https://user-images.githubusercontent.com/87131830/133617110-b3bc9b48-4210-4209-99b7-b68f783f6fe0.png)

**After**
![Screenshot (66)](https://user-images.githubusercontent.com/87131830/133617152-6d4c68db-6946-4e42-bc0d-1e38a9c00745.png)

