### PR TITLE
Add .NET Core 3.1 Runtime extension to the marketplace.

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4319,9 +4319,9 @@
 				},
 				{
 					"extensionId": "85",
-					"extensionName": "net-core-3-runtime",
-					"displayName": ".NET Core 3.1 Runtime",
-					"shortDescription": "The .NET Core 3.1 Runtime extension downloads runtime binaries that can be used by other extensions.",
+					"extensionName": "net-6-runtime",
+					"displayName": ".NET 6 Runtime",
+					"shortDescription": "Provides .NET runtime binaries for use by other extensions",
 					"publisher": {
 						"displayName": "Microsoft",
 						"publisherId": "Microsoft",
@@ -4329,30 +4329,34 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.13",
-							"lastUpdated": "9/16/2021",
+							"version": "0.1.0",
+							"lastUpdated": "10/1/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/net-core-3-runtime-1.0.13.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/net-6-runtime-0.1.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4372,7 +4376,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": "hidden"
 				}
 			],
 			"resultMetadata": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4316,6 +4316,59 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+				{
+					"extensionId": "85",
+					"extensionName": "net-core-3-runtime",
+					"displayName": ".NET Core 3.1 Runtime",
+					"shortDescription": "The .NET Core 3.1 Runtime extension downloads runtime binaries that can be used by other extensions.",
+					"publisher": {
+						"displayName": "Microsoft",
+						"publisherId": "Microsoft",
+						"publisherName": "Microsoft"
+					},
+					"versions": [
+						{
+							"version": "1.0.13",
+							"lastUpdated": "9/16/2021",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/net-core-3-runtime-1.0.13.vsix"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/icon.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/LICENSE.rtf"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": ">=1.21.0"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": "preview"
 				}
 			],
 			"resultMetadata": [
@@ -4324,7 +4377,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 71
+							"count": 72
 						}
 					]
 				}

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4363,6 +4363,10 @@
 								{
 									"key": "Microsoft.AzDataEngine",
 									"value": ">=1.21.0"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/Microsoft"
 								}
 							]
 						}

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4308,6 +4308,59 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+				{
+					"extensionId": "85",
+					"extensionName": "net-core-3-runtime",
+					"displayName": ".NET Core 3.1 Runtime",
+					"shortDescription": "The .NET Core 3.1 Runtime extension downloads runtime binaries that can be used by other extensions.",
+					"publisher": {
+						"displayName": "Microsoft",
+						"publisherId": "Microsoft",
+						"publisherName": "Microsoft"
+					},
+					"versions": [
+						{
+							"version": "1.0.13",
+							"lastUpdated": "9/16/2021",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/net-core-3-runtime-1.0.13.vsix"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/icon.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/LICENSE.rtf"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": ">=1.21.0"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": "preview"
 				}
 			],
 			"resultMetadata": [
@@ -4316,7 +4369,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 71
+							"count": 72
 						}
 					]
 				}

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4311,9 +4311,9 @@
 				},
 				{
 					"extensionId": "85",
-					"extensionName": "net-core-3-runtime",
-					"displayName": ".NET Core 3.1 Runtime",
-					"shortDescription": "The .NET Core 3.1 Runtime extension downloads runtime binaries that can be used by other extensions.",
+					"extensionName": "net-6-runtime",
+					"displayName": ".NET 6 Runtime",
+					"shortDescription": "Provides .NET runtime binaries for use by other extensions",
 					"publisher": {
 						"displayName": "Microsoft",
 						"publisherId": "Microsoft",
@@ -4321,30 +4321,34 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.13",
-							"lastUpdated": "9/16/2021",
+							"version": "0.1.0",
+							"lastUpdated": "10/1/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/net-core-3-runtime-1.0.13.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/net-6-runtime-0.1.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-core-3-runtime/21259.2/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4364,7 +4368,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": "hidden"
 				}
 			],
 			"resultMetadata": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4355,6 +4355,10 @@
 								{
 									"key": "Microsoft.AzDataEngine",
 									"value": ">=1.21.0"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/Microsoft"
 								}
 							]
 						}


### PR DESCRIPTION
This is the supporting extension, on which all other extensions that we build will depend. The extension by itself does not add any functionality to ADS and merely allows other extensions to use .NET Core runtime without requiring user to install it manually.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
