### PR TITLE
Change recompare message after changing options to modal

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -66,9 +66,19 @@ export class SchemaCompareOptionsDialog {
 		this.optionsModel.setObjectTypeOptions();
 		this.schemaComparison.setDeploymentOptions(this.optionsModel.deploymentOptions);
 
+		const yesItem: vscode.MessageItem = {
+			title: loc.YesButtonText,
+			isCloseAffordance: true
+		};
+
+		const noItem: vscode.MessageItem = {
+			title: loc.NoButtonText,
+			isCloseAffordance: true
+		};
+
 		if (this.optionsChanged) {
-			vscode.window.showWarningMessage(loc.OptionsChangedMessage, { modal: true }, loc.YesButtonText).then((result) => {
-				if (result === loc.YesButtonText) {
+			vscode.window.showInformationMessage(loc.OptionsChangedMessage, { modal: true }, yesItem, noItem).then((result) => {
+				if (result.title === loc.YesButtonText) {
 					this.schemaComparison.startCompare();
 				}
 			});

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -67,7 +67,7 @@ export class SchemaCompareOptionsDialog {
 		this.schemaComparison.setDeploymentOptions(this.optionsModel.deploymentOptions);
 
 		if (this.optionsChanged) {
-			vscode.window.showWarningMessage(loc.OptionsChangedMessage, loc.YesButtonText, loc.NoButtonText).then((result) => {
+			vscode.window.showWarningMessage(loc.OptionsChangedMessage, { modal: true }, loc.YesButtonText).then((result) => {
 				if (result === loc.YesButtonText) {
 					this.schemaComparison.startCompare();
 				}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #16981. We got some feedback that it wasn't obvious that the schema compare results aren't updated when options are changed, so this change makes it a blocking notification so the user needs to acknowledge that they need to recompare to see the options applied.

old:
![image](https://user-images.githubusercontent.com/31145923/131925231-f7bc8137-0c57-4f8e-9fd2-71d404a29bab.png)

new:
![image](https://user-images.githubusercontent.com/31145923/134072390-a241ab1e-f71f-4cd3-9ca3-dfffe8a03621.png)

