### PR TITLE
Notebook Views initialization fix

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.component.ts
@@ -45,7 +45,7 @@ export class NotebookEditorComponent extends AngularDisposable {
 	public views: NotebookViewsExtension;
 	public activeView: INotebookView;
 	public viewMode: ViewMode;
-	public ViewMode = ViewMode;
+	public ViewMode = ViewMode; //For use of the enum in the template
 
 	constructor(
 		@Inject(ILogService) private readonly logService: ILogService,

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookViewsExtension.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookViewsExtension.test.ts
@@ -75,6 +75,19 @@ suite('NotebookViews', function (): void {
 		notebookViews = await initializeExtension();
 	});
 
+	test('should not modify the notebook document until a view is created', async () => {
+		//Create some content
+		notebookViews.notebook.addCell(CellTypes.Code, 0);
+		const cell = notebookViews.notebook.cells[0];
+
+		assert.strictEqual(notebookViews.getNotebookMetadata(), undefined);
+		assert.strictEqual(notebookViews.getCellMetadata(cell), undefined);
+
+		//Check that the view is created
+		notebookViews.createNewView(defaultViewName);
+		assert.notStrictEqual(notebookViews.getNotebookMetadata(), undefined);
+	});
+
 	test('create new view', async function (): Promise<void> {
 		assert.strictEqual(notebookViews.getViews().length, 0, 'notebook should not initially generate any views');
 


### PR DESCRIPTION
This PR fixes #17061

Separate the Views load from the initialization. This way we can load previously created views, and only add the new views data to the document when needed. For now, this happens only when a view is created.
