### PR TITLE
AzureMonitor kernel name change

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -73,8 +73,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 			this.resources = this.resources.concat(this.metadata.settings.azureDevOpsResource);
 		}
 
-		if (this.metadata.settings.azureLogAnalyticsResource) {
-			this.resources = this.resources.concat(this.metadata.settings.azureLogAnalyticsResource);
+		if (this.metadata.settings.azureMonitorLogsResource) {
+			this.resources = this.resources.concat(this.metadata.settings.azureMonitorLogsResource);
 		}
 
 		if (this.metadata.settings.azureKustoResource) {

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -71,10 +71,10 @@ const publicAzureSettings: ProviderSettings = {
 				endpoint: '499b84ac-1321-427f-aa17-267ca6975798',
 				azureResourceId: AzureResource.AzureDevOps,
 			},
-			azureLogAnalyticsResource: {
+			azureMonitorLogsResource: {
 				id: SettingIds.ala,
 				endpoint: 'https://api.loganalytics.io',
-				azureResourceId: AzureResource.AzureLogAnalytics,
+				azureResourceId: AzureResource.AzureMonitorLogs,
 			},
 			azureStorageResource: {
 				id: SettingIds.storage,
@@ -136,10 +136,10 @@ const usGovAzureSettings: ProviderSettings = {
 				endpoint: 'https://vault.usgovcloudapi.net',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
-			azureLogAnalyticsResource: {
+			azureMonitorLogsResource: {
 				id: SettingIds.ala,
 				endpoint: 'https://api.loganalytics.us',
-				azureResourceId: AzureResource.AzureLogAnalytics,
+				azureResourceId: AzureResource.AzureMonitorLogs,
 			},
 			azureStorageResource: {
 				id: SettingIds.storage,
@@ -195,10 +195,10 @@ const usNatAzureSettings: ProviderSettings = {
 				endpoint: 'https://vault.cloudapi.eaglex.ic.gov',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
-			azureLogAnalyticsResource: {
+			azureMonitorLogsResource: {
 				id: SettingIds.ala,
 				endpoint: 'https://api.loganalytics.azure.eaglex.ic.gov',
-				azureResourceId: AzureResource.AzureLogAnalytics,
+				azureResourceId: AzureResource.AzureMonitorLogs,
 			},
 			azureStorageResource: {
 				id: SettingIds.storage,
@@ -299,10 +299,10 @@ const chinaAzureSettings: ProviderSettings = {
 				endpoint: 'https://vault.azure.cn',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
-			azureLogAnalyticsResource: {
+			azureMonitorLogsResource: {
 				id: SettingIds.ala,
 				endpoint: 'https://api.loganalytics.azure.cn',
-				azureResourceId: AzureResource.AzureLogAnalytics,
+				azureResourceId: AzureResource.AzureMonitorLogs,
 			},
 			azureStorageResource: {
 				id: SettingIds.storage,

--- a/extensions/azurecore/src/azureResource/azure-resource.d.ts
+++ b/extensions/azurecore/src/azureResource/azure-resource.d.ts
@@ -27,7 +27,7 @@ declare module 'azureResource' {
 			postgresServer = 'microsoft.dbforpostgresql/servers',
 			azureArcService = 'microsoft.azuredata/datacontrollers',
 			storageAccount = 'microsoft.storage/storageaccounts',
-			logAnalytics = 'microsoft.operationalinsights/workspaces'
+			azureMonitorLogs = 'microsoft.operationalinsights/workspaces'
 		}
 
 		export interface IAzureResourceProvider extends DataProvider {

--- a/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorService.ts
+++ b/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorService.ts
@@ -15,7 +15,7 @@ export interface AzureMonitorGraphData extends GraphData {
 	};
 }
 
-const instanceQuery = `where type == "${azureResource.AzureResourceType.logAnalytics}"`;
+const instanceQuery = `where type == "${azureResource.AzureResourceType.azureMonitorLogs}"`;
 
 export class AzureMonitorResourceService extends ResourceServiceBase<AzureMonitorGraphData, azureResource.AzureResourceDatabaseServer> {
 

--- a/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider.ts
@@ -29,7 +29,7 @@ export class AzureMonitorTreeDataProvider extends ResourceTreeDataProviderBase<a
 
 	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: AzureAccount): TreeItem {
 		return {
-			id: `LogAnalytics_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
+			id: `AzureMonitorLogs_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: this.browseConnectionMode ? `${databaseServer.name} (${AzureMonitorTreeDataProvider.containerLabel}, ${databaseServer.subscription.name})` : databaseServer.name,
 			iconPath: {
 				dark: this._extensionContext.asAbsolutePath('resources/dark/azure_monitor_dark.svg'),
@@ -48,7 +48,7 @@ export class AzureMonitorTreeDataProvider extends ResourceTreeDataProviderBase<a
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',
-				providerName: 'LOGANALYTICS',
+				providerName: 'AZUREMONITORLOGS',
 				saveProfile: false,
 				options: {},
 				azureAccount: account.key.accountId,
@@ -56,7 +56,7 @@ export class AzureMonitorTreeDataProvider extends ResourceTreeDataProviderBase<a
 				azureResourceId: databaseServer.id,
 				azurePortalEndpoint: account.properties.providerSettings.settings.portalEndpoint
 			},
-			childProvider: 'LOGANALYTICS',
+			childProvider: 'AZUREMONITORLOGS',
 			type: ExtensionNodeType.Server
 		};
 	}

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -121,12 +121,12 @@ declare module 'azurecore' {
 		/**
 		 * Information that describes the Azure Kusto resource
 		 */
-		 azureKustoResource?: Resource;
+		azureKustoResource?: Resource;
 
 		/**
 		 * Information that describes the Azure Log Analytics resource
 		 */
-		azureLogAnalyticsResource?: Resource;
+		azureMonitorLogsResource?: Resource;
 
 		/**
 		 * Information that describes the Azure Storage resourceI

--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuremonitor",
   "description": "%azuremonitor.description%",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "Microsoft",
   "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "activationEvents": [
@@ -9,7 +9,7 @@
   ],
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.31.0"
+    "azdata": ">=1.33.0"
   },
   "main": "./out/main",
   "repository": {
@@ -19,11 +19,11 @@
   "typings": "./src/azuremonitor",
   "contributes": {
     "connectionProvider": {
-      "providerId": "LOGANALYTICS",
-      "languageMode": "loganalytics",
+      "providerId": "AZUREMONITORLOGS",
+      "languageMode": "azuremonitorlogs",
       "displayName": "%azuremonitor.displayName%",
-      "notebookKernelAlias": "LogAnalytics",
-      "azureResource": "AzureLogAnalytics",
+      "notebookKernelAlias": "AzureMonitorLogs",
+      "azureResource": "AzureMonitorLogs",
       "iconPath": [
         {
           "id": "azuremonitor:cloud",
@@ -127,7 +127,7 @@
       ]
     },
     "dashboard": {
-      "provider": "LOGANALYTICS",
+      "provider": "AZUREMONITORLOGS",
       "flavors": [
         {
           "flavor": "cloud",
@@ -178,20 +178,20 @@
     },
     "languages": [
       {
-        "id": "loganalytics",
+        "id": "azuremonitorlogs",
         "aliases": [
-          "LogAnalytics",
-          "loganalytics"
+          "AzureMonitorLogs",
+          "azuremonitorlogs"
         ],
         "extensions": [
-          ".loganalytics"
+          ".azuremonitorlogs"
         ],
         "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
       {
-        "language": "loganalytics",
+        "language": "azuremonitorlogs",
         "scopeName": "source.azuremonitor",
         "path": "./syntaxes/azuremonitor.tmLanguage"
       }

--- a/extensions/azuremonitor/src/azuremonitorServer.ts
+++ b/extensions/azuremonitor/src/azuremonitorServer.ts
@@ -129,7 +129,7 @@ function generateHandleServerProviderEvent() {
 
 function getClientOptions(_context: AppContext): ClientOptions {
 	return {
-		documentSelector: ['loganalytics'],
+		documentSelector: [Constants.providerId.toLowerCase()],
 		synchronize: {
 			configurationSection: Constants.extensionConfigSectionName
 		},

--- a/extensions/azuremonitor/src/constants.ts
+++ b/extensions/azuremonitor/src/constants.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 export const serviceName = 'AzureMonitor Tools Service';
-export const providerId = 'LOGANALYTICS';
+export const providerId = 'AZUREMONITORLOGS';
 export const serviceCrashLink = 'https://github.com/Microsoft/azuredatastudio/issues';
 export const extensionConfigSectionName = 'azuremonitor';
 
@@ -14,7 +14,7 @@ export const integratedAuth = 'integrated';
 export const serverPropName = 'server';
 export const userPropName = 'user';
 export const passwordPropName = 'password';
-export const azuremonitorProviderName = 'LOGANALYTICS';
+export const azuremonitorProviderName = 'AZUREMONITORLOGS';
 
 // SERVICE NAMES //////////////////////////////////////////////////////////
 export const ObjectExplorerService = 'objectexplorer';

--- a/extensions/azuremonitor/src/contextProvider.ts
+++ b/extensions/azuremonitor/src/contextProvider.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 
 import * as types from './types';
+import { providerId } from './constants';
 
 export enum BuiltInCommands {
 	SetContext = 'setContext',
@@ -41,7 +42,7 @@ export default class ContextProvider {
 		let edition: number | undefined;
 		let isCluster: boolean = false;
 		let serverMajorVersion: number | undefined;
-		if (e.profile.providerName.toLowerCase() === 'loganalytics' && !types.isUndefinedOrNull(e.serverInfo) && !types.isUndefinedOrNull(e.serverInfo.engineEditionId)) {
+		if (e.profile.providerName.toLowerCase() === providerId.toLowerCase() && !types.isUndefinedOrNull(e.serverInfo) && !types.isUndefinedOrNull(e.serverInfo.engineEditionId)) {
 			if (isCloudEditions.some(i => i === e.serverInfo.engineEditionId)) {
 				iscloud = true;
 			} else {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2310,7 +2310,7 @@ declare module 'azdata' {
 		/**
 		 * Azure Log Analytics
 		 */
-		AzureLogAnalytics = 8,
+		AzureMonitorLogs = 8,
 		/**
 		 * Azure Storage
 		 */

--- a/src/sql/platform/accounts/common/interfaces.ts
+++ b/src/sql/platform/accounts/common/interfaces.ts
@@ -58,7 +58,7 @@ export enum AzureResource {
 	MicrosoftResourceManagement = 5,
 	AzureDevOps = 6,
 	MsGraph = 7,
-	AzureLogAnalytics = 8,
+	AzureMonitorLogs = 8,
 	AzureStorage = 9,
 	AzureKusto = 10
 }

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -439,7 +439,7 @@ export enum AzureResource {
 	MicrosoftResourceManagement = 5,
 	AzureDevOps = 6,
 	MsGraph = 7,
-	AzureLogAnalytics = 8,
+	AzureMonitorLogs = 8,
 	AzureStorage = 9,
 	AzureKusto = 10
 }

--- a/src/sql/workbench/common/constants.ts
+++ b/src/sql/workbench/common/constants.ts
@@ -71,3 +71,8 @@ export const RESULTS_GRID_DEFAULTS = {
 	cellPadding: [5, 8, 4],
 	rowHeight: 24
 };
+
+export const azuremonitorLogsProviderName = 'AZUREMONITORLOGS';
+export const azureMonitorLogsLanguageMode = 'AzureMonitorLogs';
+export const kustoLanguageMode = 'Kusto';
+export const sqlLanguageMode = 'Sql';

--- a/src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service.ts
@@ -12,6 +12,7 @@ import { MenuItem, IBreadcrumbService } from 'sql/base/browser/ui/breadcrumb/int
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 
 import * as nls from 'vs/nls';
+import { azuremonitorLogsProviderName } from 'sql/workbench/common/constants';
 
 export enum BreadcrumbClass {
 	DatabasePage,
@@ -61,7 +62,7 @@ export class BreadcrumbService implements IBreadcrumbService {
 	}
 
 	private getDbBreadcrumb(profile: ConnectionProfile): MenuItem {
-		let defaultDatabaseName = profile.providerName === 'LOGANALYTICS' ? 'workspace-name' : 'database-name';
+		let defaultDatabaseName = profile.providerName === azuremonitorLogsProviderName ? 'workspace-name' : 'database-name';
 
 		return {
 			label: profile.databaseName ? profile.databaseName : defaultDatabaseName,

--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -42,6 +42,7 @@ import { IRange } from 'vs/editor/common/core/range';
 import { UntitledQueryEditorInput } from 'sql/base/query/browser/untitledQueryEditorInput';
 import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
+import { azureMonitorLogsLanguageMode, azuremonitorLogsProviderName } from 'sql/workbench/common/constants';
 
 const QUERY_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'queryEditorViewState';
 
@@ -290,9 +291,9 @@ export class QueryEditor extends EditorPane {
 				{ action: this._listDatabasesAction }
 			];
 		}
-		else if (providerId === 'LOGANALYTICS' || this.modeService.getExtensions('LogAnalytics').indexOf(fileExtension) > -1) {
+		else if (providerId === azuremonitorLogsProviderName || this.modeService.getExtensions(azureMonitorLogsLanguageMode).indexOf(fileExtension) > -1) {
 			if (this.input instanceof UntitledQueryEditorInput) {
-				this.input.setMode('loganalytics');
+				this.input.setMode(azuremonitorLogsProviderName.toLowerCase());
 			}
 
 			content = [

--- a/src/sql/workbench/contrib/query/browser/queryInputFactory.ts
+++ b/src/sql/workbench/contrib/query/browser/queryInputFactory.ts
@@ -23,6 +23,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IQueryEditorService } from 'sql/workbench/services/queryEditor/common/queryEditorService';
 import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
+import { azureMonitorLogsLanguageMode, kustoLanguageMode, sqlLanguageMode } from 'sql/workbench/common/constants';
 
 const editorInputFactoryRegistry = Registry.as<IEditorInputFactoryRegistry>(EditorExtensions.EditorInputFactories);
 
@@ -32,7 +33,7 @@ export class QueryEditorLanguageAssociation implements ILanguageAssociation {
 	 * The language IDs that are associated with the query editor. These are case sensitive for comparing with what's
 	 * registered in the ModeService registry.
 	 */
-	static readonly languages = ['Kusto', 'LogAnalytics', 'SQL'];	//TODO Add language id here for new languages supported in query editor. Make it easier to contribute new extension's languageID
+	static readonly languages = [kustoLanguageMode, azureMonitorLogsLanguageMode, sqlLanguageMode];	//TODO Add language id here for new languages supported in query editor. Make it easier to contribute new extension's languageID
 
 
 	constructor(@IInstantiationService private readonly instantiationService: IInstantiationService,

--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -16,6 +16,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ItemContextKey } from 'sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerContext';
 import { EditDataAction } from 'sql/workbench/browser/scriptingActions';
 import { DatabaseEngineEdition } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { azuremonitorLogsProviderName } from 'sql/workbench/common/constants';
 
 //#region -- Data Explorer
 // Script as Create
@@ -101,7 +102,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	},
 	when: ContextKeyExpr.and(
 		ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
-		ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
+		ConnectionContextKey.Provider.notEqualsTo(azuremonitorLogsProviderName),
 		ContextKeyExpr.or(
 			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
 			TreeNodeContextKey.NodeType.isEqualTo(NodeType.View)
@@ -118,7 +119,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	},
 	when: ContextKeyExpr.or(
 		ContextKeyExpr.and(ConnectionContextKey.Provider.isEqualTo('KUSTO'), TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table)),
-		ContextKeyExpr.and(ConnectionContextKey.Provider.isEqualTo('LOGANALYTICS'), TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table)))
+		ContextKeyExpr.and(ConnectionContextKey.Provider.isEqualTo(azuremonitorLogsProviderName), TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table)))
 });
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
@@ -132,7 +133,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		ContextKeyExpr.and(
 			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
-			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
+			ConnectionContextKey.Provider.notEqualsTo(azuremonitorLogsProviderName),
 			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
 			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlDataWarehouse.toString())
 		)
@@ -148,7 +149,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	when:
 		ContextKeyExpr.and(
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
-			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
+			ConnectionContextKey.Provider.notEqualsTo(azuremonitorLogsProviderName),
 			ContextKeyExpr.or(
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
@@ -228,7 +229,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	when:
 		ContextKeyExpr.and(
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
-			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
+			ConnectionContextKey.Provider.notEqualsTo(azuremonitorLogsProviderName),
 			ContextKeyExpr.or(
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
@@ -288,7 +289,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerWidgetContext, {
 	when:
 		ContextKeyExpr.and(
 			ItemContextKey.ConnectionProvider.notEqualsTo('kusto'),
-			ItemContextKey.ConnectionProvider.notEqualsTo('loganalytics'),
+			ItemContextKey.ConnectionProvider.notEqualsTo(azuremonitorLogsProviderName.toLowerCase()),
 			ContextKeyExpr.or(
 				ItemContextKey.ItemType.isEqualTo('view'),
 				ItemContextKey.ItemType.isEqualTo('table')
@@ -306,7 +307,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerWidgetContext, {
 		ContextKeyExpr.and(
 			ContextKeyExpr.or(
 				ItemContextKey.ConnectionProvider.isEqualTo('kusto'),
-				ItemContextKey.ConnectionProvider.isEqualTo('loganalytics')
+				ItemContextKey.ConnectionProvider.isEqualTo(azuremonitorLogsProviderName.toLowerCase())
 			),
 			ItemContextKey.ItemType.isEqualTo('table')
 		),
@@ -329,7 +330,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerWidgetContext, {
 			ItemContextKey.ItemType.isEqualTo('table'),
 			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
 			ItemContextKey.ConnectionProvider.notEqualsTo('kusto'),
-			ItemContextKey.ConnectionProvider.notEqualsTo('loganalytics'),
+			ItemContextKey.ConnectionProvider.notEqualsTo(azuremonitorLogsProviderName.toLowerCase()),
 			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlDataWarehouse.toString())
 		),
 	order: 2
@@ -394,7 +395,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerWidgetContext, {
 	when: ContextKeyExpr.and(
 		ItemContextKey.ItemType.notEqualsTo('database'),
 		ItemContextKey.ConnectionProvider.notEqualsTo('kusto'),
-		ItemContextKey.ConnectionProvider.notEqualsTo('loganalytics')),
+		ItemContextKey.ConnectionProvider.notEqualsTo(azuremonitorLogsProviderName.toLowerCase())),
 	order: 2
 });
 //#endregion

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -75,7 +75,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 	private static readonly CONNECTION_MEMENTO = 'ConnectionManagement';
 	private static readonly _azureResources: AzureResource[] =
-		[AzureResource.ResourceManagement, AzureResource.Sql, AzureResource.OssRdbms, AzureResource.AzureLogAnalytics, AzureResource.AzureKusto];
+		[AzureResource.ResourceManagement, AzureResource.Sql, AzureResource.OssRdbms, AzureResource.AzureMonitorLogs, AzureResource.AzureKusto];
 
 	constructor(
 		@IConnectionDialogService private _connectionDialogService: IConnectionDialogService,

--- a/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
@@ -24,6 +24,7 @@ import { getCurrentGlobalConnection } from 'sql/workbench/browser/taskUtilities'
 import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
+import { azuremonitorLogsProviderName } from 'sql/workbench/common/constants';
 
 const defaults: INewSqlEditorOptions = {
 	open: true
@@ -121,7 +122,7 @@ export class QueryEditorService implements IQueryEditorService {
 
 	////// Private functions
 	private createUntitledSqlFilePath(providerName?: string): Promise<string> {
-		if (providerName === 'LOGANALYTICS' || providerName === 'KUSTO') {
+		if (providerName === azuremonitorLogsProviderName || providerName === 'KUSTO') {
 			return this.createPrefixedSqlFilePath('KQLQuery');
 		}
 

--- a/src/vs/workbench/contrib/tags/electron-sandbox/workspaceTagsService.ts
+++ b/src/vs/workbench/contrib/tags/electron-sandbox/workspaceTagsService.ts
@@ -158,7 +158,7 @@ const PyMetaModulesToLookFor = [
 const PyModulesToLookFor = [
 	'azure',
 	'azure-appconfiguration',
-	'azure-loganalytics',
+	'azure-azuremonitorlogs',
 	'azure-synapse-nspkg',
 	'azure-synapse-spark',
 	'azure-synapse-artifacts',
@@ -466,7 +466,7 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			"workspace.py.azure-identity" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-iothub-device-client" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-keyvault" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-loganalytics" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-azuremonitorlogs" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-mgmt" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-ml" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-monitor" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },


### PR DESCRIPTION
Changed LogAnalytics providerId and Kernel name to AzureMonitorLogs. Created constant to simplify references.

PR Open for ToolsService change:
https://github.com/microsoft/sqltoolsservice/pull/1247

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
