### PR TITLE
Add AAD token expiration handling for query runner

### DIFF
--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -233,7 +233,6 @@ export class RunQueryAction extends QueryTaskbarAction {
 			editor = this.editor;
 		}
 
-		await this.connectionManagementService.refreshAzureAccountTokenIfNecessary(this.editor.input.uri);
 		if (this.isConnected(editor)) {
 			// Hide IntelliSense suggestions list when running query to match SSMS behavior
 			this.commandService?.executeCommand('hideSuggestWidget');
@@ -306,7 +305,6 @@ export class EstimatedQueryPlanAction extends QueryTaskbarAction {
 
 	public override async run(): Promise<void> {
 		if (!this.editor.isSelectionEmpty()) {
-			await this.connectionManagementService.refreshAzureAccountTokenIfNecessary(this.editor.input.uri);
 			if (this.isConnected(this.editor)) {
 				// If we are already connected, run the query
 				this.runQuery(this.editor);
@@ -346,7 +344,6 @@ export class ActualQueryPlanAction extends QueryTaskbarAction {
 
 	public override async run(): Promise<void> {
 		if (!this.editor.isSelectionEmpty()) {
-			await this.connectionManagementService.refreshAzureAccountTokenIfNecessary(this.editor.input.uri);
 			if (this.isConnected(this.editor)) {
 				// If we are already connected, run the query
 				this.runQuery(this.editor);

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -327,7 +327,9 @@ class SqlKernel extends Disposable implements nb.IKernel {
 				// TODO when we can just show error as an output, should show an "execution canceled" error in output
 				this._future.handleDone().catch(err => onUnexpectedError(err));
 			}
-			this._queryRunner.runQuery(code).catch(err => onUnexpectedError(err));
+			this._connectionManagementService.refreshAzureAccountTokenIfNecessary(this._connectionPath).then(() => {
+				this._queryRunner.runQuery(code).catch(err => onUnexpectedError(err));
+			}).catch(err => onUnexpectedError(err));
 		} else if (this._currentConnection && this._currentConnectionProfile) {
 			this._queryRunner = this._instantiationService.createInstance(QueryRunner, this._connectionPath);
 			this.addQueryEventListeners(this._queryRunner);

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -327,9 +327,7 @@ class SqlKernel extends Disposable implements nb.IKernel {
 				// TODO when we can just show error as an output, should show an "execution canceled" error in output
 				this._future.handleDone().catch(err => onUnexpectedError(err));
 			}
-			this._connectionManagementService.refreshAzureAccountTokenIfNecessary(this._connectionPath).then(() => {
-				this._queryRunner.runQuery(code).catch(err => onUnexpectedError(err));
-			}).catch(err => onUnexpectedError(err));
+			this._queryRunner.runQuery(code).catch(err => onUnexpectedError(err));
 		} else if (this._currentConnection && this._currentConnectionProfile) {
 			this._queryRunner = this._instantiationService.createInstance(QueryRunner, this._connectionPath);
 			this.addQueryEventListeners(this._queryRunner);

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -212,7 +212,9 @@ export class QueryManagementService implements IQueryManagementService {
 		}
 		let handler = this._requestHandlers.get(providerId);
 		if (handler) {
-			return action(handler);
+			return this._connectionService.refreshAzureAccountTokenIfNecessary(uri).then(() => {
+				return action(handler);
+			});
 		} else {
 			return Promise.reject(new Error('No Handler Registered'));
 		}


### PR DESCRIPTION
This PR fixes #17104 by adding a refresh AAD token call before calling query request handler. This allows all components that run query to take advantage of the token refresh call so we don't need to do it multiple times.

The refresh mechanism was initially added with this PR #16936 

I captured the images with following steps:
1. Create a notebook from a server connection with AAD-MFA auth.
2. Wait for 1 hour so AAD token gets expired then run a sql query that requires connection.

Before:
![image](https://user-images.githubusercontent.com/21186993/134094977-893e1459-9c5e-4b8f-90ba-befe890665a7.png)
After:
![image](https://user-images.githubusercontent.com/21186993/134095039-5ae14515-99bf-455b-b389-82fb37f2261c.png)

