### PR TITLE
Add excludeFlags to extenson marketplace query

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -675,7 +675,6 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		if (extensionPolicy === ExtensionsPolicy.allowMicrosoft) {
 			filteredExtensions = filteredExtensions.filter(ext => ext.publisher && ext.publisher.displayName === 'Microsoft');
 		}
-
 		return { galleryExtensions: filteredExtensions, total: actualTotal };
 	}
 

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -542,6 +542,10 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 			.withPage(1, pageSize)
 			.withFilter(FilterType.Target, 'Microsoft.VisualStudio.Code');
 
+		if (options.excludeFlags) {
+			query = query.withFilter(FilterType.ExcludeWithFlags, options.excludeFlags); // {{SQL CARBON EDIT}} exclude extensions matching excludeFlags options
+		}
+
 		if (text) {
 			// Use category filter instead of "category:themes"
 			text = text.replace(/\bcategory:("([^"]*)"|([^"]\S*))(\s+|\b|$)/g, (_, quotedCategory, category) => {
@@ -645,6 +649,12 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 					}
 				});
 			}
+
+			// {{SQL CARBON EDIT}} - filter out extensions that match the excludeFlags options
+			const flags = query.criteria.filter(x => x.filterType === FilterType.ExcludeWithFlags).map(v => v.value ? v.value.toLocaleLowerCase() : undefined);
+			if (flags && flags.length > 0) {
+				filteredExtensions = filteredExtensions.filter(e => !e.flags || flags.find(x => x === e.flags) === undefined);
+			}
 		}
 
 		// Sorting
@@ -665,6 +675,10 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		if (extensionPolicy === ExtensionsPolicy.allowMicrosoft) {
 			filteredExtensions = filteredExtensions.filter(ext => ext.publisher && ext.publisher.displayName === 'Microsoft');
 		}
+
+		// filter out preview
+		// filteredExtensions = filteredExtensions.filter(ext => !ext.flags || ext.flags.indexOf('hidden') < 0);
+
 		return { galleryExtensions: filteredExtensions, total: actualTotal };
 	}
 
@@ -811,7 +825,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		*/
 		const log = (duration: number) => this.telemetryService.publicLog('galleryService:downloadVSIX', { ...data, duration });
 
-		// {{SQL Carbon Edit}} - Don't append install or update on to the URL
+		// {{SQL CARBON EDIT}} - Don't append install or update on to the URL
 		// const operationParam = operation === InstallOperation.Install ? 'install' : operation === InstallOperation.Update ? 'update' : '';
 		const operationParam = undefined;
 		const downloadAsset = operationParam ? {

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -653,7 +653,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 			// {{SQL CARBON EDIT}} - filter out extensions that match the excludeFlags options
 			const flags = query.criteria.filter(x => x.filterType === FilterType.ExcludeWithFlags).map(v => v.value ? v.value.toLocaleLowerCase() : undefined);
 			if (flags && flags.length > 0) {
-				filteredExtensions = filteredExtensions.filter(e => !e.flags || flags.find(x => x === e.flags) === undefined);
+				filteredExtensions = filteredExtensions.filter(e => !e.flags || flags.find(x => x === e.flags.toLocaleLowerCase()) === undefined);
 			}
 		}
 

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -676,9 +676,6 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 			filteredExtensions = filteredExtensions.filter(ext => ext.publisher && ext.publisher.displayName === 'Microsoft');
 		}
 
-		// filter out preview
-		// filteredExtensions = filteredExtensions.filter(ext => !ext.flags || ext.flags.indexOf('hidden') < 0);
-
 		return { galleryExtensions: filteredExtensions, total: actualTotal };
 	}
 

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -136,7 +136,11 @@ export interface IQueryOptions {
 	sortBy?: SortBy;
 	sortOrder?: SortOrder;
 	source?: string;
-	excludeFlags?: string; // {{SQL CARBON EDIT}} do not show extensions matching excludeFlags in the marketplace
+	// {{SQL CARBON EDIT}} do not show extensions matching excludeFlags in the marketplace
+	// This field only supports an exact match of a single flag.  It doesn't currently
+	// support setting multiple flags such as "hidden,preview" since this functionality isn't
+	// required by current usage scenarios.
+	excludeFlags?: string;
 }
 
 export const enum StatisticType {

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -136,6 +136,7 @@ export interface IQueryOptions {
 	sortBy?: SortBy;
 	sortOrder?: SortOrder;
 	source?: string;
+	excludeFlags?: string; // {{SQL CARBON EDIT}} do not show extensions matching excludeFlags in the marketplace
 }
 
 export const enum StatisticType {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -751,6 +751,7 @@ export class ExtensionsListView extends ViewPane {
 	// {{SQL CARBON EDIT}}
 	private getAllMarketplaceModel(query: Query, options: IQueryOptions, token: CancellationToken): Promise<IPagedModel<IExtension>> {
 		const value = query.value.trim().toLowerCase();
+		options.excludeFlags = 'hidden'; // {{SQL CARBON EDIT}} exclude extensions with 'hidden' flag from marketplace query
 		return this.extensionsWorkbenchService.queryLocal()
 			.then(result => result.filter(e => e.type === ExtensionType.User))
 			.then(local => {


### PR DESCRIPTION
This PR adds the ability to hide gallery extensions from the Extension Manager Marketplace UI if the extension has the `'hidden'` flag set.  The extension will still show up in the extension dependencies view and the Installed extensions UIs if applicable.  The use-case is to support extensions taking dependencies on "implementation detail"-type extensions that are needed at runtime but don't make sense to surface to users.