### PR TITLE
Add guids to RunAll and RunCell events

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -376,11 +376,12 @@ export class RunAllCellsAction extends Action {
 	public override async run(context: URI): Promise<void> {
 		try {
 			const editor = this._notebookService.findNotebookEditor(context);
+			await editor.runAllCells();
+
 			const azdata_notebook_guid: string = editor.model.getMetaValue('azdata_notebook_guid');
 			this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.RunAll)
 				.withAdditionalProperties({ azdata_notebook_guid })
 				.send();
-			await editor.runAllCells();
 		} catch (e) {
 			this.notificationService.error(getErrorMessage(e));
 		}

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -376,12 +376,13 @@ export class RunAllCellsAction extends Action {
 	public override async run(context: URI): Promise<void> {
 		try {
 			const editor = this._notebookService.findNotebookEditor(context);
-			await editor.runAllCells();
 
 			const azdata_notebook_guid: string = editor.model.getMetaValue('azdata_notebook_guid');
 			this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.RunAll)
 				.withAdditionalProperties({ azdata_notebook_guid })
 				.send();
+
+			await editor.runAllCells();
 		} catch (e) {
 			this.notificationService.error(getErrorMessage(e));
 		}

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -375,8 +375,11 @@ export class RunAllCellsAction extends Action {
 	}
 	public override async run(context: URI): Promise<void> {
 		try {
-			this._telemetryService.sendActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.RunAll);
 			const editor = this._notebookService.findNotebookEditor(context);
+			const azdata_notebook_guid: string = editor.model.getMetaValue('azdata_notebook_guid');
+			this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.RunAll)
+				.withAdditionalProperties({ azdata_notebook_guid })
+				.send();
 			await editor.runAllCells();
 		} catch (e) {
 			this.notificationService.error(getErrorMessage(e));

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookActions.test.ts
@@ -189,6 +189,10 @@ suite('Notebook Actions', function (): void {
 	});
 
 	test('Run All Cells Action', async function (): Promise<void> {
+		const testNotebookModel = TypeMoq.Mock.ofType<INotebookModel>(NotebookModelStub);
+		testNotebookModel.setup(x => x.getMetaValue(TypeMoq.It.isAny())).returns(() => undefined);
+		mockNotebookEditor.setup(x => x.model).returns(() => testNotebookModel.object);
+
 		let mockNotification = TypeMoq.Mock.ofType<INotificationService>(TestNotificationService);
 		mockNotification.setup(n => n.notify(TypeMoq.It.isAny()));
 

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -561,8 +561,9 @@ export class CellModel extends Disposable implements ICellModel {
 			this._outputCounter = 0;
 			// Hide IntelliSense suggestions list when running cell to match SSMS behavior
 			this._commandService.executeCommand('hideSuggestWidget');
+			const azdata_notebook_guid: string = this.notebookModel.getMetaValue('azdata_notebook_guid');
 			this._telemetryService?.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.RunCell)
-				.withAdditionalProperties({ cell_language: kernel.name })
+				.withAdditionalProperties({ cell_language: kernel.name, azdata_cell_guid: this._cellGuid, azdata_notebook_guid })
 				.send();
 			// If cell is currently running and user clicks the stop/cancel button, call kernel.interrupt()
 			// This matches the same behavior as JupyterLab


### PR DESCRIPTION
This PR adds

- the azdata_notebook_guid as an additional property to the RunAll notebook 
- add the azdata_notebook_guid and azdata_cell_guid as properties to the RunCell event 

This will help identify which notebooks and cells are being ran in our telemetry pipeline.