### PR TITLE
Bump version of sqltoolsservice to fix cancellation not working

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.129",
+	"version": "3.0.0-release.130",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",


### PR DESCRIPTION
This PR addresses: https://github.com/microsoft/azuredatastudio/issues/3231

by bumping the version of SqlToolsService.

Closing the editor while a query is running seems to correctly cancel the current query running on the sql server and allows the user to reconnect back on the connection to try again. (It originally hanged when trying to reconnect to the connection before this change).

This allows cancellation to work in general, especially in the case of infinite loop and very long running queries.