### PR TITLE
Mark schema compare tests as unstable

### DIFF
--- a/extensions/integration-tests/src/test/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/test/schemaCompare.test.ts
@@ -276,7 +276,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 		assertIncludeExcludeResult(excludeResult3, true, 0, 0);
 	});
 
-	test('Schema compare dacpac to database comparison with publishing some changes and then compare again', async function () {
+	test('Schema compare dacpac to database comparison with publishing some changes and then compare again @UNSTABLE@', async function () {
 		this.timeout(testTimeout);
 		const server = await getStandaloneServer();
 		const ownerUri = await getConnectionUri(server);
@@ -351,7 +351,7 @@ suite('Schema compare integration test suite @DacFx@', () => {
 		}
 	});
 
-	test('Schema compare dacpac to database comparison with publishing all changes and then compare again', async function () {
+	test('Schema compare dacpac to database comparison with publishing all changes and then compare again @UNSTABLE@', async function () {
 		this.timeout(testTimeout);
 		const server = await getStandaloneServer();
 		const ownerUri = await getConnectionUri(server);


### PR DESCRIPTION
Marking a couple schema compare integration tests as unstable for now since they've failed a few times in the past month or two.