### PR TITLE
Add AAD token refresh to object explorer

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -769,7 +769,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		return treeNode;
 	}
 
-	public getSessionConnectionProfile(sessionId: string): IConnectionProfile {
+	public getSessionConnectionProfile(sessionId: string): azdata.IConnectionProfile {
 		return this._sessions[sessionId].connection.toIConnectionProfile();
 	}
 

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -373,6 +373,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 	}
 
 	private async callExpandOrRefreshFromProvider(provider: azdata.ObjectExplorerProviderBase, nodeInfo: azdata.ExpandNodeInfo, refresh: boolean = false): Promise<boolean> {
+		await this._connectionManagementService.refreshAzureAccountTokenIfNecessary(Utils.generateUri(this._sessions[nodeInfo.sessionId].connection));
 		if (refresh) {
 			return provider.refreshNode(nodeInfo);
 		} else {
@@ -728,7 +729,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		return treeNode;
 	}
 
-	public getSessionConnectionProfile(sessionId: string): azdata.IConnectionProfile {
+	public getSessionConnectionProfile(sessionId: string): IConnectionProfile {
 		return this._sessions[sessionId].connection.toIConnectionProfile();
 	}
 

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -401,19 +401,9 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 		let conn = this._sessions[sessionId].connection;
 		try {
-			// const rootNode = this._activeObjectExplorerNodes[conn.id];
 			await this._connectionManagementService.addSavedPassword(conn);
 			await this.closeSession(providerId, this.getSession(sessionId));
 			await this.createNewSession(providerId, conn);
-			// TODO reconstruct tree
-			// this._activeObjectExplorerNodes[conn.id] = rootNode;
-			// let queue: TreeNode [] = [];
-			// queue.push(rootNode);
-			// while (queue.length > 0) {
-			// 	let curr = queue.shift();
-			// 	curr = await this.refreshNodeInView(conn.id, curr.nodePath);
-			// 	curr?.children?.forEach(node => queue.push(node));
-			// }
 		} catch (err) {
 			this.sendUpdateNodeEvent(conn, err);
 			throw err;


### PR DESCRIPTION
This PR fixes #17087 by adding a `refreshSessionIfNecessary` call before provider expand/refresh node.

Note that OE doesn't create server connection via connection management service so in ADS we don't have the uri to connection mapping stored. This makes it difficult to reuse the `refreshAzureAccountTokenIfNecessary` from CMS. There are multiple gaps to fill on both ADS and STS side if we take this approach.

I chose to check the connection expiry info stored in session status. Once a token is expired, OE will just close the previous session and create a new session using a refreshed token. This way we can avoid updating session map and blinding context in STS.

This change does NOT re-construct the previously expanded nodes if a refresh happens, so users will only see nodes like `Databases` and `Security` not their children.

Screenshots of expanding/refreshing a node in an expired OE session:

Before
#TODO

After:
![Screen Shot 2021-09-24 at 15 15 07](https://user-images.githubusercontent.com/21186993/134745075-15bb5322-b734-4d23-ba11-dcfa3e7e615c.png)

