### PR TITLE
Check if file is dirty before adding sql binding

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -484,7 +484,7 @@ export const createNewLocalAppSettingWithIcon = `$(add) ${createNewLocalAppSetti
 export const valueMustNotBeEmpty = localize('valueMustNotBeEmpty', "Value must not be empty");
 export const enterConnectionStringSettingName = localize('enterConnectionStringSettingName', "Enter connection string setting name");
 export const enterConnectionString = localize('enterConnectionString', "Enter connection string");
-export const saveChangesInFile = localize('saveChangesInFile', "There are unsaved changes in the current file. Save before continuing?");
+export const saveChangesInFile = localize('saveChangesInFile', "There are unsaved changes in the current file. Save now?");
 export const save = localize('save', "Save");
 export function settingAlreadyExists(settingName: string) { return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName); }
 export function failedToParse(errorMessage: string) { return localize('failedToParse', 'Failed to parse "{0}": {1}.', azureFunctionLocalSettingsFileName, errorMessage); }

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -484,6 +484,8 @@ export const createNewLocalAppSettingWithIcon = `$(add) ${createNewLocalAppSetti
 export const valueMustNotBeEmpty = localize('valueMustNotBeEmpty', "Value must not be empty");
 export const enterConnectionStringSettingName = localize('enterConnectionStringSettingName', "Enter connection string setting name");
 export const enterConnectionString = localize('enterConnectionString', "Enter connection string");
+export const saveChangesInFile = localize('saveChangesInFile', "There are unsaved changes in the current file. Save before continuing?");
+export const save = localize('save', "Save");
 export function settingAlreadyExists(settingName: string) { return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName); }
 export function failedToParse(errorMessage: string) { return localize('failedToParse', 'Failed to parse "{0}": {1}.', azureFunctionLocalSettingsFileName, errorMessage); }
 export function jsonParseError(error: string, line: number, column: number) { return localize('jsonParseError', '{0} near line "{1}", column "{2}"', error, line, column); }

--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -22,7 +22,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 				return;
 			}
 
-			await vscode.window.activeTextEditor?.document.save();
+			await vscode.window.activeTextEditor!.document.save();
 		}
 	}
 

--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -14,6 +14,16 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 		// this command only shows in the command palette when the active editor is a .cs file, so we can safely assume that's the scenario
 		// when this is called without a uri
 		uri = vscode.window.activeTextEditor!.document.uri;
+
+		if (vscode.window.activeTextEditor!.document.isDirty) {
+			const result = await vscode.window.showWarningMessage(constants.saveChangesInFile, { modal: true }, constants.save);
+
+			if (result !== constants.save) {
+				return;
+			}
+
+			await vscode.window.activeTextEditor?.document.save();
+		}
 	}
 
 	// get all the Azure functions in the file


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17156. This adds a check for if the file is dirty before starting the add sql bindings quickpick flow.

If cancelled, the add sql binding quickpick doesn't start:
![dontSave](https://user-images.githubusercontent.com/31145923/134989121-d4bfb5ad-527a-49a9-adb1-2244706cfe90.gif)

If save is selected, the file is saved before the quickpick starts:
![save](https://user-images.githubusercontent.com/31145923/134989136-11bd401e-74b0-4048-97ea-9ca3723f9b3a.gif)


*gifs aren't updated, but the warning string is updated now to `There are unsaved changes in the current file. Save now?`