### PR TITLE
Add back "Remove Project"

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -29,7 +29,7 @@
           "dataworkspace.excludedProjects": {
             "type": "array",
             "default": [],
-            "description": ""
+            "description": "%projects.excludedProjectsDescription%"
           },
           "projects.defaultProjectSaveLocation": {
             "type": "string",

--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -26,7 +26,7 @@
       {
         "title": "Projects",
         "properties": {
-          "dataworkspace.projects": {
+          "dataworkspace.excludedProjects": {
             "type": "array",
             "default": [],
             "description": ""
@@ -69,6 +69,10 @@
         "icon": "$(close)"
       },
       {
+        "command": "projects.removeProject",
+        "title": "%remove-project-command%"
+      },
+      {
         "command": "projects.manageProject",
         "title": "%manage-project-command%"
       }
@@ -109,6 +113,10 @@
           "when": "false"
         },
         {
+          "command": "projects.removeProject",
+          "when": "false"
+        },
+        {
           "command": "projects.openExisting"
         },
         {
@@ -121,6 +129,11 @@
           "command": "projects.manageProject",
           "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.project && azdataAvailable",
           "group": "0_projectsFirst@1"
+        },
+        {
+          "command": "projects.removeProject",
+          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.project",
+          "group": "9_dbProjectsLast@9"
         }
       ]
     },

--- a/extensions/data-workspace/package.nls.json
+++ b/extensions/data-workspace/package.nls.json
@@ -12,5 +12,6 @@
 	"open-existing-command": "Open existing",
 	"projects.defaultProjectSaveLocation": "Full path to folder where new projects are saved by default.",
 	"projects.showNotAddedProjectsInWorkspacePrompt": "Always show information message when the current workspace folders contain projects that have not been added to the workspace's projects.",
-	"manage-project-command": "Manage"
+	"manage-project-command": "Manage",
+	"projects.excludedProjectsDescription": "List of projects in the workspace to exclude from the projects viewlet"
 }

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -62,6 +62,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		return vscode.commands.executeCommand('workbench.action.closeFolder');
 	}));
 
+	context.subscriptions.push(vscode.commands.registerCommand('projects.removeProject', async (treeItem: WorkspaceTreeItem) => {
+		await workspaceService.removeProject(vscode.Uri.file(treeItem.element.project.projectFilePath));
+	}));
+
 	context.subscriptions.push(vscode.commands.registerCommand('projects.manageProject', async (treeItem: WorkspaceTreeItem) => {
 		const dashboard = new ProjectDashboard(workspaceService, treeItem);
 		await dashboard.showDashboard();

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -16,6 +16,9 @@ import { TelemetryReporter, TelemetryViews, TelemetryActions } from '../common/t
 import { Deferred } from '../common/promise';
 import { getAzdataApi } from '../common/utils';
 
+const WorkspaceConfigurationName = 'dataworkspace';
+const ExcludedProjectsConfigurationName = 'excludedProjects';
+
 export class WorkspaceService implements IWorkspaceService {
 	private _onDidWorkspaceProjectsChange: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
 	readonly onDidWorkspaceProjectsChange: vscode.Event<void> = this._onDidWorkspaceProjectsChange?.event;
@@ -93,8 +96,14 @@ export class WorkspaceService implements IWorkspaceService {
 			}
 		}
 
-		// 3. If any new projects are detected, fire event to refresh projects tree
+		// 3. Check if the project was previously excluded and remove it from the list of excluded projects if it was
+		const excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
+		const updatedExcludedProjects = excludedProjects.filter(excludedProj => !projectFiles.find(newProj => newProj.fsPath === excludedProj));
+		if (excludedProjects.length !== updatedExcludedProjects.length) {
+			await this.setWorkspaceConfigurationValue(ExcludedProjectsConfigurationName, excludedProjects);
+		}
 
+		// 4. If any new projects are detected, fire event to refresh projects tree
 		if (newProjectAdded) {
 			this._onDidWorkspaceProjectsChange.fire();
 		}
@@ -126,6 +135,10 @@ export class WorkspaceService implements IWorkspaceService {
 		if (this.openedProjects === undefined) {
 			throw new Error(constants.openedProjectsUndefinedAfterRefresh);
 		}
+
+		// remove excluded projects specified in workspace file
+		const excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
+		this.openedProjects = this.openedProjects.filter(project => !excludedProjects.find(excludedProject => excludedProject === project.fsPath));
 
 		// filter by specified extension
 		if (ext) {
@@ -256,5 +269,31 @@ export class WorkspaceService implements IWorkspaceService {
 		if (extension.isActive && extension.exports && !ProjectProviderRegistry.providers.includes(extension.exports)) {
 			ProjectProviderRegistry.registerProvider(extension.exports, extension.id);
 		}
+	}
+
+	/**
+	 * Adds the specified project to list of projects to hide in projects viewlet. This list is kept track of in the workspace file
+	 * @param projectFile uri of project to remove from projects viewlet
+	 */
+	async removeProject(projectFile: vscode.Uri): Promise<void> {
+		if (vscode.workspace.workspaceFile) {
+			TelemetryReporter.createActionEvent(TelemetryViews.WorkspaceTreePane, TelemetryActions.ProjectRemovedFromWorkspace)
+				.withAdditionalProperties({
+					projectType: path.extname(projectFile.fsPath)
+				}).send();
+
+			let excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
+			excludedProjects.push(projectFile.fsPath);
+			await this.setWorkspaceConfigurationValue(ExcludedProjectsConfigurationName, [...new Set(excludedProjects)]);
+			this._onDidWorkspaceProjectsChange.fire();
+		}
+	}
+
+	getWorkspaceConfigurationValue<T>(configurationName: string): T {
+		return vscode.workspace.getConfiguration(WorkspaceConfigurationName).get(configurationName) as T;
+	}
+
+	async setWorkspaceConfigurationValue(configurationName: string, value: any): Promise<void> {
+		await vscode.workspace.getConfiguration(WorkspaceConfigurationName).update(configurationName, value, vscode.ConfigurationTarget.Workspace);
 	}
 }

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -282,7 +282,7 @@ export class WorkspaceService implements IWorkspaceService {
 					projectType: path.extname(projectFile.fsPath)
 				}).send();
 
-			let excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
+			const excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
 			excludedProjects.push(vscode.workspace.asRelativePath(projectFile.fsPath));
 			await this.setWorkspaceConfigurationValue(ExcludedProjectsConfigurationName, [...new Set(excludedProjects)]);
 			this._onDidWorkspaceProjectsChange.fire();

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -276,17 +276,15 @@ export class WorkspaceService implements IWorkspaceService {
 	 * @param projectFile uri of project to remove from projects viewlet
 	 */
 	async removeProject(projectFile: vscode.Uri): Promise<void> {
-		if (vscode.workspace.workspaceFile) {
-			TelemetryReporter.createActionEvent(TelemetryViews.WorkspaceTreePane, TelemetryActions.ProjectRemovedFromWorkspace)
-				.withAdditionalProperties({
-					projectType: path.extname(projectFile.fsPath)
-				}).send();
+		TelemetryReporter.createActionEvent(TelemetryViews.WorkspaceTreePane, TelemetryActions.ProjectRemovedFromWorkspace)
+			.withAdditionalProperties({
+				projectType: path.extname(projectFile.fsPath)
+			}).send();
 
-			const excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
-			excludedProjects.push(vscode.workspace.asRelativePath(projectFile.fsPath));
-			await this.setWorkspaceConfigurationValue(ExcludedProjectsConfigurationName, [...new Set(excludedProjects)]);
-			this._onDidWorkspaceProjectsChange.fire();
-		}
+		const excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
+		excludedProjects.push(vscode.workspace.asRelativePath(projectFile.fsPath));
+		await this.setWorkspaceConfigurationValue(ExcludedProjectsConfigurationName, [...new Set(excludedProjects)]);
+		this._onDidWorkspaceProjectsChange.fire();
 	}
 
 	getWorkspaceConfigurationValue<T>(configurationName: string): T {

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -98,9 +98,9 @@ export class WorkspaceService implements IWorkspaceService {
 
 		// 3. Check if the project was previously excluded and remove it from the list of excluded projects if it was
 		const excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
-		const updatedExcludedProjects = excludedProjects.filter(excludedProj => !projectFiles.find(newProj => newProj.fsPath === excludedProj));
+		const updatedExcludedProjects = excludedProjects.filter(excludedProj => !projectFiles.find(newProj => vscode.workspace.asRelativePath(newProj) === excludedProj));
 		if (excludedProjects.length !== updatedExcludedProjects.length) {
-			await this.setWorkspaceConfigurationValue(ExcludedProjectsConfigurationName, excludedProjects);
+			await this.setWorkspaceConfigurationValue(ExcludedProjectsConfigurationName, updatedExcludedProjects);
 		}
 
 		// 4. If any new projects are detected, fire event to refresh projects tree
@@ -138,7 +138,7 @@ export class WorkspaceService implements IWorkspaceService {
 
 		// remove excluded projects specified in workspace file
 		const excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
-		this.openedProjects = this.openedProjects.filter(project => !excludedProjects.find(excludedProject => excludedProject === project.fsPath));
+		this.openedProjects = this.openedProjects.filter(project => !excludedProjects.find(excludedProject => excludedProject === vscode.workspace.asRelativePath(project)));
 
 		// filter by specified extension
 		if (ext) {
@@ -283,7 +283,7 @@ export class WorkspaceService implements IWorkspaceService {
 				}).send();
 
 			let excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
-			excludedProjects.push(projectFile.fsPath);
+			excludedProjects.push(vscode.workspace.asRelativePath(projectFile.fsPath));
 			await this.setWorkspaceConfigurationValue(ExcludedProjectsConfigurationName, [...new Set(excludedProjects)]);
 			this._onDidWorkspaceProjectsChange.fire();
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #16986. This adds back remove project which was removed in #15921, but this time the projects excluded from the projects viewlet are specified in the workspace file. When a project is added back using the "Open existing project" dialog, it gets removed from the exclude list.

I also tested this with an untitled workspace and verified that remove project works and also still works after saving the workspace file.

example of removing and adding back a project:
![removeProject](https://user-images.githubusercontent.com/31145923/134998515-79f99f17-4aa8-4adc-a23c-f364020c46a1.gif)

