### PR TITLE
save richTextCursorPosition/markdownCursorPosition

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -344,6 +344,10 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		if (this.cellModel.id === this._activeCellId && this._editor.getContainer().offsetParent && ownerDocument && ownerDocument.hasFocus()) {
 			this._editor.focus();
 			this._editor.getContainer().scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+			// Move cursor to the last known location
+			if (this.cellModel.markdownCursorPosition) {
+				this._editor.getControl().setPosition(this.cellModel.markdownCursorPosition);
+			}
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -451,19 +451,21 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			if (this.cellModel.richTextCursorPosition) {
 				let selection = window.getSelection();
 				selection.removeAllRanges();
-				let startContainers = this.cellModel.richTextCursorPosition.startElementNodes; let x = startContainers.length;
-				let outputElement: any = this.output.nativeElement;
-				while (x--) {
-					outputElement = outputElement.childNodes[startContainers[x]];
+				let startContainers = this.cellModel.richTextCursorPosition.startElementNodes;
+				let depthToNode = startContainers.length;
+				let startNodeElement: any = this.output.nativeElement;
+				while (depthToNode--) {
+					startNodeElement = startNodeElement.childNodes[startContainers[depthToNode]];
 				}
-				startContainers = this.cellModel.richTextCursorPosition.endElementNodes; x = startContainers.length;
-				let endContainers: any = this.output.nativeElement;
-				while (x--) {
-					endContainers = endContainers.childNodes[startContainers[x]];
+				startContainers = this.cellModel.richTextCursorPosition.endElementNodes;
+				depthToNode = startContainers.length;
+				let endNodeElement: any = this.output.nativeElement;
+				while (depthToNode--) {
+					endNodeElement = endNodeElement.childNodes[startContainers[depthToNode]];
 				}
 				let range = new Range();
-				range.setStart(outputElement, this.cellModel.richTextCursorPosition.startOffset);
-				range.setEnd(endContainers, this.cellModel.richTextCursorPosition.endOffset);
+				range.setStart(startNodeElement, this.cellModel.richTextCursorPosition.startOffset);
+				range.setEnd(endNodeElement, this.cellModel.richTextCursorPosition.endOffset);
 				selection.addRange(range);
 			}
 		}

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -12,7 +12,7 @@ import { localize } from 'vs/nls';
 import * as notebookUtils from 'sql/workbench/services/notebook/browser/models/notebookUtils';
 import { CellTypes, CellType, NotebookChangeType, TextCellEditModes } from 'sql/workbench/services/notebook/common/contracts';
 import { NotebookModel } from 'sql/workbench/services/notebook/browser/models/notebookModel';
-import { ICellModel, IOutputChangedEvent, CellExecutionState, ICellModelOptions, ITableUpdatedEvent, CellEditModes } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
+import { ICellModel, IOutputChangedEvent, CellExecutionState, ICellModelOptions, ITableUpdatedEvent, CellEditModes, ICaretPosition } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
@@ -31,6 +31,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { IInsightOptions } from 'sql/workbench/common/editor/query/chartState';
+import { IPosition } from 'vs/editor/common/core/position';
 
 let modelId = 0;
 const ads_execute_command = 'ads_execute_command';
@@ -85,6 +86,8 @@ export class CellModel extends Disposable implements ICellModel {
 	private _outputCounter = 0; // When re-executing the same cell, ensure that we apply chart options in the same order
 	private _attachments: nb.ICellAttachments | undefined;
 	private _preventNextChartCache: boolean = false;
+	private _richTextCursorPosition: ICaretPosition;
+	private _markdownCursorPosition: IPosition;
 
 	constructor(cellData: nb.ICellContents,
 		private _options: ICellModelOptions,
@@ -143,6 +146,22 @@ export class CellModel extends Disposable implements ICellModel {
 
 	public get metadata(): any {
 		return this._metadata;
+	}
+
+	public get markdownCursorPosition(): IPosition {
+		return this._markdownCursorPosition;
+	}
+
+	public set markdownCursorPosition(pos: IPosition) {
+		this._markdownCursorPosition = pos;
+	}
+
+	public get richTextCursorPosition(): ICaretPosition {
+		return this._richTextCursorPosition;
+	}
+
+	public set richTextCursorPosition(pos: ICaretPosition) {
+		this._richTextCursorPosition = pos;
 	}
 
 	public get attachments(): nb.ICellAttachments | undefined {

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -23,6 +23,7 @@ import { IModelContentChangedEvent } from 'vs/editor/common/model/textModelEvent
 import type { FutureInternal } from 'sql/workbench/services/notebook/browser/interfaces';
 import { ICellValue, ResultSetSummary } from 'sql/workbench/services/query/common/query';
 import { QueryResultId } from 'sql/workbench/services/notebook/browser/models/cell';
+import { IPosition } from 'vs/editor/common/core/position';
 
 export enum ViewMode {
 	Notebook,
@@ -543,6 +544,15 @@ export interface ICellModel {
 	 * Returns the name of the attachment added to metadata.
 	 */
 	addAttachment(mimeType: string, base64Encoding: string, name: string): string;
+	richTextCursorPosition: ICaretPosition;
+	markdownCursorPosition: IPosition;
+}
+
+export interface ICaretPosition {
+	startElementNodes: any;
+	startOffset: number;
+	endElementNodes: any;
+	endOffset: number;
 }
 
 export interface IModelFactory {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17015 

Added the following two properties to cell model: richTextCursorPosition and markdownCursorPosition
Whenever user shifts between modes, we save the cursor position and use that to restore it back to that position when they switch back.
![restoreCursorOnEdits](https://user-images.githubusercontent.com/12754347/135007162-b89cae6c-f5b0-41cc-b8c7-6db41db4f829.gif)

