### PR TITLE
Reset schema compare window when comparison result is not success

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -291,6 +291,10 @@ export class SchemaCompareMainWindow {
 					operationId: this.comparisonResult.operationId
 				}).send();
 			vscode.window.showErrorMessage(loc.compareErrorMessage(this.comparisonResult?.errorMessage));
+
+			// reset state so a new comparison can be made
+			this.resetWindow();
+
 			return;
 		}
 		TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonFinished')
@@ -647,7 +651,18 @@ export class SchemaCompareMainWindow {
 		});
 	}
 
-	public async cancelCompare() {
+	/**
+	 * Resets state of buttons and text to initial state before a comparison is started/completed
+	 */
+	public resetWindow(): void {
+		// clean the pane
+		this.flexModel.removeItem(this.loader);
+		this.flexModel.removeItem(this.waitText);
+		this.flexModel.addItem(this.startText, { CSSStyles: { 'margin': 'auto' } });
+		this.resetButtons(ResetButtonState.beforeCompareStart);
+	}
+
+	public async cancelCompare(): Promise<void> {
 
 		TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareCancelStarted')
 			.withAdditionalProperties({
@@ -655,11 +670,7 @@ export class SchemaCompareMainWindow {
 				'operationId': this.operationId
 			}).send();
 
-		// clean the pane
-		this.flexModel.removeItem(this.loader);
-		this.flexModel.removeItem(this.waitText);
-		this.flexModel.addItem(this.startText, { CSSStyles: { 'margin': 'auto' } });
-		this.resetButtons(ResetButtonState.beforeCompareStart);
+		this.resetWindow();
 
 		// cancel compare
 		if (this.operationId) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes the error not getting shown as reported in https://github.com/microsoft/azuredatastudio/issues/17077 and https://github.com/microsoft/azuredatastudio/issues/15330. This wasn't a problem before because the schema compare result success was almost never false, even when it should have been if there was an error during the schema compare.

Now that the correct result is getting passed back with the change in https://github.com/microsoft/sqltoolsservice/pull/1250, this exposes this problem that if the schema compare result was not valid, the error message would show, but the loading spinner and wait text wouldn't be removed. Expected behavior is that the schema compare window should get reset so a new comparison can be made.

old:
![oldFailedSchemaCompare](https://user-images.githubusercontent.com/31145923/135136952-3444c1db-f27d-416f-b6e2-0265812983dd.gif)

fixed:
![fixedFailedSchemaCompare](https://user-images.githubusercontent.com/31145923/135136960-2d2fd47c-545a-45ff-8f79-2a5e326fc796.gif)

