### PR TITLE
Remove list filter logic to allow all available DMS regions to be used

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -44,30 +44,7 @@ export async function getLocations(account: azdata.Account, subscription: Subscr
 		return sqlMigrationResourceLocations.includes(loc.displayName);
 	});
 
-	// Only including the regions that have migration service deployed for public preview.
-	const publicPreviewLocations = [
-		'eastus',
-		'canadaeast',
-		'canadacentral',
-		'centralus',
-		'westus2',
-		'westus',
-		'southcentralus',
-		'westeurope',
-		'uksouth',
-		'australiaeast',
-		'southeastasia',
-		'japaneast',
-		'centralindia',
-		'eastus2',
-		'eastus2euap',
-		'francecentral',
-		'southindia',
-		'australiasoutheast',
-		'northcentralus'
-	];
-
-	return filteredLocations.filter(v => publicPreviewLocations.includes(v.name));
+	return filteredLocations;
 }
 
 export type AzureProduct = azureResource.AzureGraphResource;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes: 

The ADS UI queries all the regions DMS V2 is available and limits the discovered regions to a smaller fixed list. 

- remove list filter logic to allow all available DMS regions to be used.

**Locations results before ->**
![image](https://user-images.githubusercontent.com/87131830/135497021-556817f3-00bf-4b2d-8182-e17e0dd11841.png)

**Locations result after ->**
![Screenshot (98)](https://user-images.githubusercontent.com/87131830/135495387-f78d16bf-700a-41a4-8a7d-35533a7ecb1b.png)
