### PR TITLE
Kusto and AzureMonitor version bump

### DIFF
--- a/extensions/azuremonitor/config.json
+++ b/extensions/azuremonitor/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.131",
+	"version": "3.0.0-release.133",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",

--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuremonitor",
   "description": "%azuremonitor.description%",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "publisher": "Microsoft",
   "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "activationEvents": [

--- a/extensions/kusto/config.json
+++ b/extensions/kusto/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.125",
+	"version": "3.0.0-release.133",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",

--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kusto",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "publisher": "Microsoft",
   "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "activationEvents": [


### PR DESCRIPTION
Bumped AzureMonitor and Kusto to use SqlToolsService 133. Bumped extension version for Kusto to 0.5.7 and AzureMonitor to 0.1.8

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
