### PR TITLE
Fix warning showing twice for create project from db dialog

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -372,9 +372,6 @@ export class CreateProjectFromDatabaseDialog {
 
 	async validate(): Promise<boolean> {
 		try {
-			if (await getDataWorkspaceExtensionApi().validateWorkspace() === false) {
-				return false;
-			}
 			// the selected location should be an existing directory
 			const parentDirectoryExists = await exists(this.projectLocationTextBox!.value!);
 			if (!parentDirectoryExists) {
@@ -388,6 +385,11 @@ export class CreateProjectFromDatabaseDialog {
 				this.showErrorMessage(constants.ProjectDirectoryAlreadyExistError(this.projectNameTextBox!.value!, this.projectLocationTextBox!.value!));
 				return false;
 			}
+
+			if (await getDataWorkspaceExtensionApi().validateWorkspace() === false) {
+				return false;
+			}
+
 			return true;
 		} catch (err) {
 			this.showErrorMessage(err?.message ? err.message : err);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17199. `validateWorkspace()` was getting called twice - once during the dialog validation and then again in the callback. Since the new project and open project dialogs have this validation in the dialog validation, I kept that one and removed the callback one.

Also reordered the validation checks to fix the same problem fixed in #16141 for the new and open project dialogs.
