### PR TITLE
Replace empty string with space

### DIFF
--- a/src/sql/workbench/services/query/common/gridDataProvider.ts
+++ b/src/sql/workbench/services/query/common/gridDataProvider.ts
@@ -142,6 +142,6 @@ function removeNewLines(inputString: string): string {
 		return 'null';
 	}
 
-	let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, '');
+	let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, ' ');
 	return outputString;
 }


### PR DESCRIPTION
Replaces the empty string with a space when copying a newline character, to follow with other applications

This PR fixes #15220

![Copy screenshot](https://user-images.githubusercontent.com/18018452/135675130-46b80ffc-b0ca-4dfe-b500-96c0653ca01a.png)


