### PR TITLE
Update license path to refer to raw text file

### DIFF
--- a/product.json
+++ b/product.json
@@ -5,7 +5,7 @@
 	"dataFolderName": ".azuredatastudio",
 	"win32MutexName": "azuredatastudio",
 	"licenseName": "Microsoft EULA",
-	"licenseUrl": "https://github.com/Microsoft/azuredatastudio/blob/main/LICENSE.txt",
+	"licenseUrl": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/LICENSE.txt",
 	"win32DirName": "Azure Data Studio",
 	"win32NameVersion": "Azure Data Studio",
 	"win32RegValueName": "azuredatastudio",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #9163.  So the license link in the product opens the raw license text file rather than Github page with repo header, etc.

![image](https://user-images.githubusercontent.com/599935/135684761-8ada393e-1150-4722-952a-6a0a56f45faa.png)

