### PR TITLE
add unsupported version warning

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -976,4 +976,12 @@ declare module 'azdata' {
 			expiresOn?: number
 		}
 	}
+
+	export interface ConnectionInfoSummary {
+		/**
+		 * Indicates whether the server version is supported. The default value is true. If the value is false, ADS will show a warning message.
+		 * Users can still connect to the servers with unsupported versions(e.g. SQL Server 2005) but some features might not work.
+		 */
+		isSupportedVersion?: boolean;
+	}
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -979,9 +979,13 @@ declare module 'azdata' {
 
 	export interface ConnectionInfoSummary {
 		/**
-		 * Indicates whether the server version is supported. The default value is true. If the value is false, ADS will show a warning message.
-		 * Users can still connect to the servers with unsupported versions(e.g. SQL Server 2005) but some features might not work.
+		 * Indicates whether the server version is supported by ADS. The default value is true. If the value is false, ADS will show a warning message.
 		 */
 		isSupportedVersion?: boolean;
+
+		/**
+		 * The messages that will be appended to the Azure Data Studio's warning message about unsupported versions.
+		 */
+		unsupportedVersionMessage?: string;
 	}
 }

--- a/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
@@ -197,6 +197,11 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'default': true,
 			'description': localize('connection.parseClipboardForConnectionStringDescription', "Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.")
+		},
+		'connection.showUnsupportedServerVersionWarning': {
+			'type': 'boolean',
+			'default': true,
+			'description': localize('connection.showUnsupportedServerVersionWarning', "Whether to show the warning message when user connects to a server version that is not supported by Azure Data Studio.")
 		}
 	}
 });

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1045,6 +1045,9 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			if (this._connectionStatusManager.isDefaultTypeUri(info.ownerUri)) {
 				this._connectionGlobalStatus.setStatusToConnected(info.connectionSummary);
 			}
+			if (info.isSupportedVersion === false) {
+				this._notificationService.warn(nls.localize('connection.unsupportedServerVersionWarning', "The server version is no longer supported. You may still connect to it but some features in Azure Data Studio might not work as expected."));
+			}
 		} else {
 			connection.connectHandler(false, info.errorMessage, info.errorNumber, info.messages);
 			this._telemetryService.createErrorEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.TelemetryError.DatabaseConnectionError, info.errorNumber.toString())

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -42,7 +42,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import * as interfaces from 'sql/platform/connection/common/interfaces';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { Memento, MementoObject } from 'vs/workbench/common/memento';
-import { INotificationService } from 'vs/platform/notification/common/notification';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { entries } from 'sql/base/common/collections';
 import { values } from 'vs/base/common/collections';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
@@ -72,6 +72,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	private _mementoObj: MementoObject;
 	private _connectionStore: ConnectionStore;
 	private _connectionStatusManager: ConnectionStatusManager;
+	private _connectionsGotUnsupportedVersionWarning: string[] = [];
 
 	private static readonly CONNECTION_MEMENTO = 'ConnectionManagement';
 	private static readonly _azureResources: AzureResource[] =
@@ -1045,8 +1046,22 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			if (this._connectionStatusManager.isDefaultTypeUri(info.ownerUri)) {
 				this._connectionGlobalStatus.setStatusToConnected(info.connectionSummary);
 			}
-			if (info.isSupportedVersion === false) {
-				this._notificationService.warn(nls.localize('connection.unsupportedServerVersionWarning', "The server version is no longer supported. You may still connect to it but some features in Azure Data Studio might not work as expected."));
+
+			const connectionUniqueId = connection.connectionProfile.getConnectionInfoId();
+			if (info.isSupportedVersion === false
+				&& this._connectionsGotUnsupportedVersionWarning.indexOf(connectionUniqueId) === -1
+				&& this._configurationService.getValue<boolean>('connection.showUnsupportedServerVersionWarning')) {
+				const warningMessage = nls.localize('connection.unsupportedServerVersionWarning', "The server version is not supported by Azure Data Studio, you may still connect to it but some features in Azure Data Studio might not work as expected.");
+				this._connectionsGotUnsupportedVersionWarning.push(connectionUniqueId);
+				this._notificationService.prompt(Severity.Warning,
+					`${warningMessage} ${info.unsupportedVersionMessage ?? ''}`, [
+					{
+						label: nls.localize('connection.neverShowUnsupportedVersionWarning', "Don't show again"),
+						run: () => {
+							this._configurationService.updateValue('connection.showUnsupportedServerVersionWarning', false).catch(e => errors.onUnexpectedError(e));
+						}
+					}
+				]);
 			}
 		} else {
 			connection.connectHandler(false, info.errorMessage, info.errorNumber, info.messages);


### PR DESCRIPTION
This PR fixes #16856

the interface that I am modifying is for the object passed back to ADS core by the connection provider, adding a flag so that the connection can tell us whether the target server is unsupported.

the logic of determining whether a SQL Server is supported needs to be added in STS, I will have a separate PR.