### PR TITLE
Clean up tsconfig.base.json

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -427,7 +427,6 @@
     "sinon": "^9.0.2",
     "tslint": "^5.8.0",
     "typemoq": "^2.1.0",
-    "typescript": "^2.6.1",
     "vscodetestcover": "^1.1.0"
   },
   "__metadata": {

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -10,7 +10,7 @@
 		"strict": true,
 		"strictNullChecks": false,
 		"noImplicitAny": false,
-		"strictOptionalProperties": false,
+		"exactOptionalPropertyTypes": false,
 		"useUnknownInCatchVariables": false,
 		"forceConsistentCasingInFileNames": true,
 		"baseUrl": ".",

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -10,7 +10,7 @@
 		"strict": true,
 		"strictNullChecks": false, // Much of our code isn't strict-null compliant so disable these for now
 		"noImplicitAny": false, // Disable since without strictNullChecks this has lots of errors in both vs and our code
-		"exactOptionalPropertyTypes": false,
+		"strictOptionalProperties": false,
 		"useUnknownInCatchVariables": false,
 		"forceConsistentCasingInFileNames": true,
 		"baseUrl": ".",

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -10,7 +10,7 @@
 		"strict": true,
 		"strictNullChecks": false,
 		"noImplicitAny": false,
-		"exactOptionalPropertyTypes": false,
+		"strictOptionalProperties": false,
 		"useUnknownInCatchVariables": false,
 		"forceConsistentCasingInFileNames": true,
 		"baseUrl": ".",

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -8,7 +8,9 @@
 		"noUnusedLocals": true,
 		"allowUnreachableCode": false,
 		"strict": true,
+		// Much of our code isn't strict-null compliant so disable these for now
 		"strictNullChecks": false,
+		// Disable since without strictNullChecks this has lots of errors in both vs and our code
 		"noImplicitAny": false,
 		"strictOptionalProperties": false,
 		"useUnknownInCatchVariables": false,

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -2,19 +2,15 @@
 	"compilerOptions": {
 		"module": "amd",
 		"moduleResolution": "node",
-		"noImplicitAny": false,
 		"experimentalDecorators": true,
 		"noImplicitReturns": true,
 		"noImplicitOverride": true,
 		"noUnusedLocals": true,
-		"noImplicitThis": true,
-		"alwaysStrict": true,
-		"strictBindCallApply": true,
-		"strictNullChecks": false,
-		"strictPropertyInitialization": false,
 		"allowUnreachableCode": false,
 		"strict": true,
-		"strictOptionalProperties": false,
+		"strictNullChecks": false, // Much of our code isn't strict-null compliant so disable these for now
+		"noImplicitAny": false, // Disable since without strictNullChecks this has lots of errors in both vs and our code
+		"exactOptionalPropertyTypes": false,
 		"useUnknownInCatchVariables": false,
 		"forceConsistentCasingInFileNames": true,
 		"baseUrl": ".",

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -8,8 +8,8 @@
 		"noUnusedLocals": true,
 		"allowUnreachableCode": false,
 		"strict": true,
-		"strictNullChecks": false, // Much of our code isn't strict-null compliant so disable these for now
-		"noImplicitAny": false, // Disable since without strictNullChecks this has lots of errors in both vs and our code
+		"strictNullChecks": false,
+		"noImplicitAny": false,
 		"strictOptionalProperties": false,
 		"useUnknownInCatchVariables": false,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
I finally decided to dig into why we kept needing to do these weird casts in the vs code when merging in their changes. It's because we have `strictNullChecks` set to false - without this the compiler isn't able to do a lot of the type narrowing and other features that it can with that enabled and so it just errors out instead.

Unfortunately enabling that is a large task (as Anthony found out when he tried starting it a while back...) and so I at least decided to document here why we have these values disabled in case other people have the same questions.

During this I did some other cleanup in the tsconfig.base.json : 

`noImplicitThis` `alwaysStrict` `strictBindCallApply` - These are already set to true by `strict` being set to true per https://www.typescriptlang.org/tsconfig#strict so just removing these since they're just redundant

`strictPropertyInitialization` Removing this doesn't seem to cause any compile errors so letting it be set to true by `strict`

Also removed typescript dependency from sql-database-projects - extensions get that from https://github.com/microsoft/azuredatastudio/blob/main/extensions/package.json#L7