### PR TITLE
use the actual unique id to compare connection

### DIFF
--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -82,7 +82,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		this.options['databaseDisplayName'] = this.databaseName;
 	}
 
-	public static matchesProfile(a: interfaces.IConnectionProfile, b: interfaces.IConnectionProfile): boolean {
+	public static matchesProfile(a: interfaces.IConnectionProfile | undefined, b: interfaces.IConnectionProfile | undefined): boolean {
 		return a && b && a.getOptionsKey() === b.getOptionsKey();
 	}
 

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -7,7 +7,6 @@ import { ConnectionProfileGroup } from 'sql/platform/connection/common/connectio
 import * as azdata from 'azdata';
 import { ProviderConnectionInfo } from 'sql/platform/connection/common/providerConnectionInfo';
 import * as interfaces from 'sql/platform/connection/common/interfaces';
-import { equalsIgnoreCase } from 'vs/base/common/strings';
 import { generateUuid } from 'vs/base/common/uuid';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { isString } from 'vs/base/common/types';
@@ -84,28 +83,12 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 	}
 
 	public static matchesProfile(a: interfaces.IConnectionProfile, b: interfaces.IConnectionProfile): boolean {
-		return a && b
-			&& a.providerName === b.providerName
-			&& ConnectionProfile.nullCheckEqualsIgnoreCase(a.serverName, b.serverName)
-			&& ConnectionProfile.nullCheckEqualsIgnoreCase(a.databaseName, b.databaseName)
-			&& ConnectionProfile.nullCheckEqualsIgnoreCase(a.userName, b.userName)
-			&& ConnectionProfile.nullCheckEqualsIgnoreCase(a.options['databaseDisplayName'], b.options['databaseDisplayName'])
-			&& a.authenticationType === b.authenticationType
-			&& a.groupId === b.groupId;
+		return a && b && a.getOptionsKey() === b.getOptionsKey();
 	}
 
 	public matches(other: interfaces.IConnectionProfile): boolean {
 		return ConnectionProfile.matchesProfile(this, other);
 
-	}
-
-	private static nullCheckEqualsIgnoreCase(a?: string, b?: string) {
-		if (a && !b || b && !a) {
-			return false;
-		} else {
-			let bothNull: boolean = !a && !b;
-			return bothNull ? bothNull : equalsIgnoreCase(a!, b!);
-		}
 	}
 
 	public generateNewId() {

--- a/src/sql/platform/connection/test/node/connectionStatusManager.test.ts
+++ b/src/sql/platform/connection/test/node/connectionStatusManager.test.ts
@@ -251,6 +251,7 @@ suite('SQL ConnectionStatusManager tests', () => {
 		newConnection.options['databaseDisplayName'] = newConnection.databaseName;
 		connections.addConnection(newConnection, 'test_uri_1');
 		connections.addConnection(newConnection, 'test_uri_2');
+		newConnection = new ConnectionProfile(capabilitiesService, newConnection);
 
 		// Get the connections and verify that the duplicate is only returned once
 		let activeConnections = connections.getActiveConnectionProfiles();


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio-postgresql/issues/113

there are 2 bugs behind this issue:
1. one needs to be made in PG extension, @nasc17 as we chatted offline, please add 'isIdentity= true' to the port option in your package.json, this will make ADS be able to treat them as different connections.
2. Object explorer is not using the actual unique string of connections to compare instead it is using the hardcoded options when looking for existing profiles, I am fixing this problem with this PR.

btw, MSSQL do not have the same issue because we are hardcoding it in ADS core to append the port number after the server name.