### PR TITLE
use placeholder for table name in add sql bindings quickpick

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -80,6 +80,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 	const objectName = await vscode.window.showInputBox({
 		prompt: selectedBinding.type === BindingType.input ? constants.sqlTableOrViewToQuery : constants.sqlTableToUpsert,
 		placeHolder: constants.placeHolderObject,
+		validateInput: input => input ? undefined : constants.nameMustNotBeEmpty,
 		ignoreFocusOut: true
 	});
 

--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -79,7 +79,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 	// 3. ask for object name for the binding
 	const objectName = await vscode.window.showInputBox({
 		prompt: selectedBinding.type === BindingType.input ? constants.sqlTableOrViewToQuery : constants.sqlTableToUpsert,
-		value: constants.placeHolderObject,
+		placeHolder: constants.placeHolderObject,
 		ignoreFocusOut: true
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17248. This is how it looks now with a placeholder:

![image](https://user-images.githubusercontent.com/31145923/135936921-2cf3f7aa-e518-4a0f-b34f-a7abf45c47b7.png)

