### PR TITLE
add category for Add Sql Binding command

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -171,7 +171,8 @@
       },
       {
         "command": "sqlDatabaseProjects.addSqlBinding",
-        "title": "%sqlDatabaseProjects.addSqlBinding%"
+        "title": "%sqlDatabaseProjects.addSqlBinding%",
+        "category": "MS SQL"
       }
     ],
     "menus": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #https://github.com/microsoft/azuredatastudio/issues/17255. I added the "MS SQL" category to the "Add SQL Binding" command so it's like the commands contributed by the MSSQL extension, but we can change it to something else if another category makes more sense. This command only shows in the command palette when the current file is a C# file.

![image](https://user-images.githubusercontent.com/31145923/135939894-7376b575-fe83-42ed-81af-894fca8a1568.png)

