### PR TITLE
Add link to sql bindings repo

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -466,6 +466,7 @@ export function getTargetPlatformFromVersion(version: string): string {
 export const hostFileName = 'host.json';
 export const sqlExtensionPackageName = 'Microsoft.Azure.WebJobs.Extensions.Sql';
 export const placeHolderObject = '[dbo].[table1]';
+export const sqlBindingsHelpLink = 'https://github.com/Azure/azure-functions-sql-extension/blob/main/README.md';
 
 export const input = localize('input', "Input");
 export const output = localize('output', "Output");

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -489,3 +489,5 @@ export const save = localize('save', "Save");
 export function settingAlreadyExists(settingName: string) { return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName); }
 export function failedToParse(errorMessage: string) { return localize('failedToParse', 'Failed to parse "{0}": {1}.', azureFunctionLocalSettingsFileName, errorMessage); }
 export function jsonParseError(error: string, line: number, column: number) { return localize('jsonParseError', '{0} near line "{1}", column "{2}"', error, line, column); }
+export const moreInformation = localize('moreInformation', "More Information");
+export const addPackageReferenceMessage = localize('addPackageReferenceMessage', 'To use SQL bindings, ensure your Azure Functions project has a reference to {0}', sqlExtensionPackageName);

--- a/extensions/sql-database-projects/src/tools/packageHelper.ts
+++ b/extensions/sql-database-projects/src/tools/packageHelper.ts
@@ -67,7 +67,7 @@ export class PackageHelper {
 			} else {
 				void vscode.window.showInformationMessage(constants.addPackageReferenceMessage, constants.moreInformation).then((result) => {
 					if (result === constants.moreInformation) {
-						void vscode.env.openExternal(vscode.Uri.parse('https://github.com/Azure/azure-functions-sql-extension/blob/main/README.md'));
+						void vscode.env.openExternal(vscode.Uri.parse(constants.sqlBindingsHelpLink));
 					}
 				});
 			}

--- a/extensions/sql-database-projects/src/tools/packageHelper.ts
+++ b/extensions/sql-database-projects/src/tools/packageHelper.ts
@@ -65,11 +65,11 @@ export class PackageHelper {
 			if (project) {
 				await this.addPackage(project, packageName, packageVersion);
 			} else {
-				const result = await vscode.window.showInformationMessage(constants.addPackageReferenceMessage, constants.moreInformation);
-
-				if (result === constants.moreInformation) {
-					void vscode.env.openExternal(vscode.Uri.parse('https://github.com/Azure/azure-functions-sql-extension/blob/main/README.md'));
-				}
+				void vscode.window.showInformationMessage(constants.addPackageReferenceMessage, constants.moreInformation).then((result) => {
+					if (result === constants.moreInformation) {
+						void vscode.env.openExternal(vscode.Uri.parse('https://github.com/Azure/azure-functions-sql-extension/blob/main/README.md'));
+					}
+				});
 			}
 		} catch (e) {
 			void vscode.window.showErrorMessage(e.message);

--- a/extensions/sql-database-projects/src/tools/packageHelper.ts
+++ b/extensions/sql-database-projects/src/tools/packageHelper.ts
@@ -65,7 +65,11 @@ export class PackageHelper {
 			if (project) {
 				await this.addPackage(project, packageName, packageVersion);
 			} else {
-				void vscode.window.showInformationMessage(`To use SQL bindings, ensure your Azure Functions project has a reference to ${constants.sqlExtensionPackageName}`);
+				const result = await vscode.window.showInformationMessage(constants.addPackageReferenceMessage, constants.moreInformation);
+
+				if (result === constants.moreInformation) {
+					void vscode.env.openExternal(vscode.Uri.parse('https://github.com/Azure/azure-functions-sql-extension/blob/main/README.md'));
+				}
 			}
 		} catch (e) {
 			void vscode.window.showErrorMessage(e.message);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #https://github.com/microsoft/azuredatastudio/issues/17253.  If there's only one AF project in the workspace, the package reference gets added automatically, but this warning shows if there are multiple AF projects. This adds a link to the readme of the SQL bindings repo.

![image](https://user-images.githubusercontent.com/31145923/135943263-b40ea72b-a7b4-4cef-96e0-9bb597cd1da9.png)

