### PR TITLE
Check if database is specified in connection dialog 

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -297,6 +297,11 @@ declare module 'azdata' {
 		azureAccount?: string;
 		azureResourceId?: string;
 		azurePortalEndpoint?: string;
+
+		/**
+		 * Gets a boolean value of if the user specified a database to connect to
+		 */
+		connectToDatabase?: boolean;
 	}
 
 	/*

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -71,6 +71,9 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 					this.options.expiresOn = model.options.expiresOn;
 				}
 			}
+			if (model.connectToDatabase) {
+				this.connectToDatabase = true;
+			}
 		} else {
 			//Default for a new connection
 			this.savePassword = false;
@@ -157,6 +160,14 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 
 	public set azureResourceId(value: string | undefined) {
 		this.options['azureResourceId'] = value;
+	}
+
+	public get connectToDatabase() {
+		return this.options['connectToDatabase'];
+	}
+
+	public set connectToDatabase(value: boolean | undefined) {
+		this.options['connectToDatabase'] = value;
 	}
 
 	public get registeredServerDescription(): string {

--- a/src/sql/platform/connection/common/utils.ts
+++ b/src/sql/platform/connection/common/utils.ts
@@ -135,8 +135,5 @@ export function findProfileInGroup(og: IConnectionProfile, groups: ConnectionPro
 }
 
 export function isMaster(profile: IConnectionProfile): boolean {
-	// TODO: the connection profile should have a property to indicate whether the connection is a server connection or database connection
-	// created issue to track the problem: https://github.com/Microsoft/azuredatastudio/issues/5193.
-	return (profile.providerName === mssqlProviderName && profile.databaseName?.toLowerCase() === 'master')
-		|| (profile.providerName.toLowerCase() === 'pgsql' && profile.databaseName?.toLowerCase() === 'postgres');
+	return (!profile.connectToDatabase);
 }

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -196,6 +196,11 @@ export class ConnectionDialogService implements IConnectionDialogService {
 					profile.providerName = Constants.mssqlProviderName;
 				}
 
+				// Determine if database has been specified to connect to
+				if (profile.databaseName && !(profile.databaseName === `''`)) {
+					profile.connectToDatabase = true;
+				}
+
 				// Disable password prompt during reconnect if connected with an empty password
 				if (profile.password === '' && profile.savePassword === false) {
 					profile.savePassword = true;

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -643,8 +643,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 							} else {
 								this._angularEventing.sendAngularEvent(editor.uri, AngularEventType.NAV_DATABASE);
 							}
-							found = true;
 						}, errors.onUnexpectedError);
+					found = true;
 				}
 			}
 		});


### PR DESCRIPTION
Add property to the connection profile to indicate whether the connection is a server connection or database connection. 

![opentodatabase](https://user-images.githubusercontent.com/69922333/136061938-99d11427-8c2a-4b55-9a38-c400e5c8b56d.gif)

This PR fixes https://github.com/microsoft/azuredatastudio-postgresql/issues/46 
This PR fixes https://github.com/Microsoft/azuredatastudio/issues/5193
