### PR TITLE
Remove duplicate pipeline trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,3 @@ jobs:
     vmImage: macOS-latest
   steps:
   - template: build/azure-pipelines/darwin/continuous-build-darwin.yml
-
-trigger:
-  branches:
-    exclude:
-    - electron-11.x.y


### PR DESCRIPTION
Cory noticed this while looking at something else, this was brought in by a VS Code merge a while back. It doesn't really do much since we define our own triggers in ADO anyways (and apparently doesn't cause the parsing to fail) but there's no need for this to be here. 