### PR TITLE
fix sql bindings error message not showing

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -32,7 +32,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 	try {
 		getAzureFunctionsResult = await azureFunctionsService.getAzureFunctions(uri.fsPath);
 	} catch (e) {
-		void vscode.window.showErrorMessage(e);
+		void vscode.window.showErrorMessage(e.message);
 		return;
 	}
 
@@ -104,7 +104,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 		try {
 			settings = await azureFunctionsUtils.getLocalSettingsJson(path.join(path.dirname(projectUri.fsPath!), constants.azureFunctionLocalSettingsFileName));
 		} catch (e) {
-			void vscode.window.showErrorMessage(e);
+			void vscode.window.showErrorMessage(e.message);
 			return;
 		}
 
@@ -164,7 +164,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 					}
 				} catch (e) {
 					// display error message and show select setting quickpick again
-					void vscode.window.showErrorMessage(e);
+					void vscode.window.showErrorMessage(e.message);
 				}
 				// If user cancels out of this or doesn't want to overwrite an existing setting
 				// just return them to the select setting quickpick in case they changed their mind
@@ -201,7 +201,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 			.withAdditionalProperties({ bindingType: selectedBinding.label })
 			.send();
 	} catch (e) {
-		void vscode.window.showErrorMessage(e);
+		void vscode.window.showErrorMessage(e.message);
 		TelemetryReporter.sendErrorEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding);
 		return;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The error message wasn't showing when I was trying to add an error for https://github.com/microsoft/sqltoolsservice/pull/1259 and it was because `e.message` needs to be passed to `showErrorMessage()`, not `e`.

![image](https://user-images.githubusercontent.com/31145923/136117788-d62517ce-527a-4fc2-9dba-c69d9a05cf8c.png)
