### PR TITLE
Add BDC spark connection logging

### DIFF
--- a/extensions/notebook/src/common/logger.ts
+++ b/extensions/notebook/src/common/logger.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 
 class LoggerImpl {
-	private _output: vscode.OutputChannel;
+	private _output: vscode.OutputChannel | undefined;
 
 	constructor() {
 	}
@@ -16,11 +16,11 @@ class LoggerImpl {
 	}
 
 	log(msg: string): void {
-		this._output.appendLine(`[${new Date().toISOString()}] ${msg}`);
+		this._output?.appendLine(`[${new Date().toISOString()}] ${msg}`);
 	}
 
 	show(): void {
-		this._output.show(true);
+		this._output?.show(true);
 	}
 }
 

--- a/extensions/notebook/src/common/logger.ts
+++ b/extensions/notebook/src/common/logger.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+class LoggerImpl {
+	private _output: vscode.OutputChannel;
+
+	constructor() {
+	}
+
+	initialize(channel: vscode.OutputChannel) {
+		this._output = channel;
+	}
+
+	log(msg: string): void {
+		this._output.appendLine(`[${new Date().toISOString()}] ${msg}`);
+	}
+
+	show(): void {
+		this._output.show(true);
+	}
+}
+
+const Logger = new LoggerImpl();
+export default Logger;

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -19,6 +19,7 @@ import { RemoteBookDialogModel } from './dialog/remoteBookDialogModel';
 import { IconPathHelper } from './common/iconHelper';
 import { ExtensionContextHelper } from './common/extensionContextHelper';
 import { BookTreeItem } from './book/bookTreeItem';
+import Logger from './common/logger';
 
 const localize = nls.loadMessageBundle();
 
@@ -30,7 +31,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	IconPathHelper.setExtensionContext(extensionContext);
 
 	const appContext = new AppContext(extensionContext);
-
+	Logger.initialize(appContext.outputChannel);
 	// TODO: Notebook doesn't work without root setting enabled in web mode. Once we start using non-root containers, we can remove this code.
 	const config = vscode.workspace.getConfiguration('notebook');
 	if (vscode.env.uiKind === vscode.UIKind.Web) {


### PR DESCRIPTION
Add some basic logging to help debug issue with spark BDC connections a customer is having.

I added the logger instead of passing in the appcontext because I think that's a much better pattern to use overall, easier to access and will let us add stuff like outputting to different sources, logging levels, etc. later on. 

I plan to come back and add logging level awareness so we don't log everything to the output channel all the time. This first PR is just to get the logging out there to help debug the issue ASAP

example output 

![image](https://user-images.githubusercontent.com/28519865/136124487-72b4ba0c-dd3e-44af-bf7d-6964f744dc62.png)


