### PR TITLE
improvement for the editor crash issue

### DIFF
--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -319,7 +319,7 @@ export class QueryResultsView extends Disposable {
 
 			if (info?.queryRunner?.isDisposed) {
 				this.logService.error(`The query runner for '${input.uri}' has been disposed.`);
-				this.notificationService.error(nls.localize('queryResults.queryEditorCrashError', "We ran into an error and the current query document has stopped working. Please save the document and reopen it."));
+				this.notificationService.error(nls.localize('queryResults.queryEditorCrashError', "The query editor ran into an issue and has stopped working. Please save and reopen it."));
 				return;
 			}
 

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -23,6 +23,8 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { Event } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { attachTabbedPanelStyler } from 'sql/workbench/common/styler';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { ILogService } from 'vs/platform/log/common/log';
 
 class MessagesView extends Disposable implements IPanelView {
 	private messagePanel: MessagePanel;
@@ -170,7 +172,9 @@ export class QueryResultsView extends Disposable {
 		container: HTMLElement,
 		@IThemeService themeService: IThemeService,
 		@IInstantiationService private instantiationService: IInstantiationService,
-		@IQueryModelService private queryModelService: IQueryModelService
+		@IQueryModelService private queryModelService: IQueryModelService,
+		@INotificationService private notificationService: INotificationService,
+		@ILogService private logService: ILogService
 	) {
 		super();
 		this.resultsTab = this._register(new ResultsTab(instantiationService));
@@ -312,6 +316,13 @@ export class QueryResultsView extends Disposable {
 				dynamicTab.captureState(input.state.dynamicModelViewTabsState);
 			});
 			let info = this.queryModelService._getQueryInfo(input.uri) || this.queryModelService._getQueryInfo(URI.parse(input.uri).toString(true));
+
+			if (info?.queryRunner?.isDisposed) {
+				this.logService.error(`The query runner for '${input.uri}' has been disposed.`);
+				this.notificationService.error(nls.localize('queryResults.queryEditorCrashError', "We ran into an error and the current query document has stopped working. Please save the document and reopen it."));
+				return;
+			}
+
 			if (info?.queryRunner) {
 				this.setQueryRunner(info.queryRunner);
 			} else {

--- a/src/sql/workbench/services/query/common/queryRunner.ts
+++ b/src/sql/workbench/services/query/common/queryRunner.ts
@@ -104,6 +104,12 @@ export default class QueryRunner extends Disposable {
 		return this._hasCompleted;
 	}
 
+	private _isDisposed: boolean = false;
+
+	get isDisposed(): boolean {
+		return this._isDisposed;
+	}
+
 	/**
 	 * For public use only, for private use, directly access the member
 	 */
@@ -417,8 +423,10 @@ export default class QueryRunner extends Disposable {
 	}
 
 	public override dispose() {
+		this.logService.info(`Disposing the query runner of: '${this.uri}'', call stack: ${new Error().stack}`);
 		this._batchSets = undefined!;
 		super.dispose();
+		this._isDisposed = true;
 	}
 
 	public changeConnectionUri(oldUri: string, newUri: string): Promise<void> {


### PR DESCRIPTION
This PR fixes #6763

The error message we see is a result of the underlying query running being disposed, we have to be able to reproduce it consistently in order to actually fix the issue. Instead of waiting for the repro steps, I am making the following improvements for both the users and us.
1. when the issue happens, we can stop the editor from crashing so that the users can have a chance to save their queries
2. add  the call stack logging when the query runner is disposed so that when this issue happens we can see what is causing the runner to be disposed, make it easier for us to find the root cause of the issue.  normally the logging will only happen when user close a query window, I think this frequency is acceptable.

this is how it looks when the problem happens
![image](https://user-images.githubusercontent.com/13777222/136127065-317ccec7-4225-4cc9-a62f-32dfe774de57.png)
