### PR TITLE
Fix schema compare results showing at bottom after no differences

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -341,19 +341,19 @@ export class SchemaCompareMainWindow {
 			width: '98%'
 		});
 
-		this.splitView.addItem(this.differencesTable);
-		this.splitView.addItem(this.diffEditor);
-		this.splitView.setLayout({
-			orientation: 'vertical',
-			splitViewHeight: 800
-		});
-
 		this.flexModel.removeItem(this.loader);
 		this.flexModel.removeItem(this.waitText);
 		this.resetButtons(ResetButtonState.afterCompareComplete);
 
 		if (this.comparisonResult.differences.length > 0) {
 			this.flexModel.addItem(this.splitView);
+
+			this.splitView.addItem(this.differencesTable);
+			this.splitView.addItem(this.diffEditor);
+			this.splitView.setLayout({
+				orientation: 'vertical',
+				splitViewHeight: 800
+			});
 
 			// create a map of the differences to row numbers
 			for (let i = 0; i < data.length; ++i) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17249. Not sure why this was happening only for the "no differences" state to "differences" state since going from "initial" state to "differences" state is the same thing and doesn't have this problem, but looks like just changing the order of removing and adding the items fixed this.

before:
![beforeSchemaCompare](https://user-images.githubusercontent.com/31145923/136441169-87d1d104-53df-4611-bf9d-ac89978a4333.gif)

fixed:
![fixedSchemaCompare](https://user-images.githubusercontent.com/31145923/136441184-4db5e1a8-8baf-47f5-b0f3-77637ca68699.gif)

