### PR TITLE
Present autorest generation errors to user upon failure

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -425,7 +425,7 @@ export const autorestPostDeploymentScriptName = 'PostDeploymentScript.sql';
 export const nodeButNotAutorestFound = localize('nodeButNotAutorestFound', "Autorest tool not found in system path, but found Node.js.  Running via npx.  Please execute 'npm install autorest -g' to install permanently.");
 export const nodeNotFound = localize('nodeNotFound', "Neither autorest nor Node.js (npx) found in system path.  Please install Node.js for autorest generation to work.");
 export const selectSpecFile = localize('selectSpecFile', "Select OpenAPI/Swagger spec file");
-export function generatingProjectFailed(errorMessage: string) { return localize('generatingProjectFailed', "Generating project via AutoRest failed: {0}", errorMessage); }
+export function generatingProjectFailed(errorMessage: string) { return localize('generatingProjectFailed', "Generating project via AutoRest failed.  Check output pane for more details. Error: {0}", errorMessage); }
 export function multipleMostDeploymentScripts(count: number) { return localize('multipleMostDeploymentScripts', "Unexpected number of {0} files: {1}", autorestPostDeploymentScriptName, count); }
 export const specSelectionText = localize('specSelectionText', "OpenAPI/Swagger spec");
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -966,6 +966,7 @@ export class ProjectsController {
 			return project;
 		} catch (err) {
 			void vscode.window.showErrorMessage(constants.generatingProjectFailed(utils.getErrorMessage(err)));
+			this._outputChannel.show();
 			return;
 		}
 	}

--- a/extensions/sql-database-projects/src/test/autorestHelper.test.ts
+++ b/extensions/sql-database-projects/src/test/autorestHelper.test.ts
@@ -47,7 +47,7 @@ describe('Autorest tests', function (): void {
 	});
 
 	it('Should construct a correct autorest command for project generation', async function (): Promise<void> {
-		const expectedOutput = 'autorest --use:autorest-sql-testing@latest --input-file="/some/path/test.yaml" --output-folder="/some/output/path" --clear-output-folder';
+		const expectedOutput = 'autorest --use:autorest-sql-testing@latest --input-file="/some/path/test.yaml" --output-folder="/some/output/path" --clear-output-folder --verbose';
 
 		const autorestHelper = new AutorestHelper(testContext.outputChannel);
 		const constructedCommand = autorestHelper.constructAutorestCommand((await autorestHelper.detectInstallation())!, '/some/path/test.yaml', '/some/output/path');

--- a/extensions/sql-database-projects/src/tools/autorestHelper.ts
+++ b/extensions/sql-database-projects/src/tools/autorestHelper.ts
@@ -101,6 +101,6 @@ export class AutorestHelper extends ShellExecutionHelper {
 	 */
 	public constructAutorestCommand(executable: string, specPath: string, outputFolder: string): string {
 		// TODO: should --clear-output-folder be included? We should always be writing to a folder created just for this, but potentially risky
-		return `${executable} --use:${autorestPackageName}@${this.autorestSqlPackageVersion} --input-file="${specPath}" --output-folder="${outputFolder}" --clear-output-folder`;
+		return `${executable} --use:${autorestPackageName}@${this.autorestSqlPackageVersion} --input-file="${specPath}" --output-folder="${outputFolder}" --clear-output-folder --verbose`;
 	}
 }


### PR DESCRIPTION
Fixes #17245

Autorest is now run with `--verbose` option, and it will open the output pane (where the error output should be) upon failure