### PR TITLE
Hide add sql binding quickpick

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -17,7 +17,6 @@
     "onCommand:sqlDatabaseProjects.open",
     "onCommand:sqlDatabaseProjects.createProjectFromDatabase",
     "onCommand:sqlDatabaseProjects.generateProjectFromOpenApiSpec",
-    "onCommand:sqlDatabaseProjects.addSqlBinding",
     "workspaceContains:**/*.sqlproj",
     "onView:dataworkspace.views.main"
   ],
@@ -168,11 +167,6 @@
         "command": "sqlDatabaseProjects.generateProjectFromOpenApiSpec",
         "title": "%sqlDatabaseProjects.generateProjectFromOpenApiSpec%",
         "category": "%sqlDatabaseProjects.displayName%"
-      },
-      {
-        "command": "sqlDatabaseProjects.addSqlBinding",
-        "title": "%sqlDatabaseProjects.addSqlBinding%",
-        "category": "MS SQL"
       }
     ],
     "menus": {
@@ -271,10 +265,6 @@
         {
           "command": "sqlDatabaseProjects.changeTargetPlatform",
           "when": "false"
-        },
-        {
-          "command": "sqlDatabaseProjects.addSqlBinding",
-          "when": "editorLangId == csharp && !azdataAvailable"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
Hiding the add sql bindings quickpick until sql bindings is public preview and on nuget.