### PR TITLE
Separate ADO jobs for failing canary failures

### DIFF
--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -79,8 +79,13 @@ steps:
 
 - script: |
     set -e
-    yarn npm-run-all -lp core-ci extensions-ci hygiene eslint valid-layers-check sqllint extensions-lint strict-vscode
+    yarn npm-run-all -lp core-ci extensions-ci hygiene eslint valid-layers-check
   displayName: Compile & Hygiene
+
+- script: |
+    set -e
+    yarn npm-run-all -lp sqllint extensions-lint strict-vscode
+  displayName: SQL Hygiene
 
 - script: |
     set -e


### PR DESCRIPTION
Separate new tasks added in sql-product-compile to match product-compile since the product builds don't fail but canary ones do due to OOM errors. (https://github.com/microsoft/azuredatastudio/blob/8806456ca03838af0d8b89e4d5d926fc5aad85aa/build/azure-pipelines/product-compile.yml#L98)

passing build with change - https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=124339&view=logs&j=c7493abb-a1f4-533f-2d24-71780a69f247&t=db214aaa-5757-5bc9-deaf-d5814df213d2