### PR TITLE
Fix notebook toolbar icons not rendering

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -476,21 +476,28 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 				viewsDropdownMenuActionViewItem.setActionContext(this._notebookParams.notebookUri);
 			}
 
-			this._actionBar.setContent([
-				{ element: buttonDropdownContainer },
-				{ action: this._runAllCellsAction },
-				{ element: Taskbar.createTaskbarSeparator() },
-				{ element: kernelContainer },
-				{ element: attachToContainer },
-				{ element: spacerElement },
-			]);
-
 			if (this._showToolbarActions) {
-				this._actionBar.addElement(viewsDropdownContainer);
-				this._actionBar.addAction(collapseCellsAction);
-				this._actionBar.addAction(clearResultsButton);
-				this._actionBar.addAction(this._trustedAction);
-				this._actionBar.addAction(runParametersAction);
+				this._actionBar.setContent([
+					{ element: buttonDropdownContainer },
+					{ action: this._runAllCellsAction },
+					{ element: Taskbar.createTaskbarSeparator() },
+					{ element: kernelContainer },
+					{ element: attachToContainer },
+					{ element: spacerElement },
+					{ element: viewsDropdownContainer },
+					{ action: collapseCellsAction },
+					{ action: clearResultsButton },
+					{ action: this._trustedAction },
+					{ action: runParametersAction },
+				]);
+			} else {
+				this._actionBar.setContent([
+					{ element: buttonDropdownContainer },
+					{ action: this._runAllCellsAction },
+					{ element: Taskbar.createTaskbarSeparator() },
+					{ element: kernelContainer },
+					{ element: attachToContainer },
+				]);
 			}
 		} else {
 			let kernelContainer = document.createElement('div');
@@ -523,18 +530,25 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			this._actionBar = new Taskbar(taskbar, { actionViewItemProvider: action => this.actionItemProvider(action as Action) });
 			this._actionBar.context = this._notebookParams.notebookUri;
 
-			this._actionBar.setContent([
-				{ action: addCodeCellButton },
-				{ action: addTextCellButton },
-				{ element: kernelContainer },
-				{ element: attachToContainer },
-				{ action: this._runAllCellsAction },
-			]);
-
 			if (this._showToolbarActions) {
-				this._actionBar.addAction(this._trustedAction);
-				this._actionBar.addAction(clearResultsButton);
-				this._actionBar.addAction(collapseCellsAction);
+				this._actionBar.setContent([
+					{ action: addCodeCellButton },
+					{ action: addTextCellButton },
+					{ element: kernelContainer },
+					{ element: attachToContainer },
+					{ action: this._trustedAction },
+					{ action: this._runAllCellsAction },
+					{ action: clearResultsButton },
+					{ action: collapseCellsAction },
+				]);
+			} else {
+				this._actionBar.setContent([
+					{ action: addCodeCellButton },
+					{ action: addTextCellButton },
+					{ element: kernelContainer },
+					{ element: attachToContainer },
+					{ action: this._runAllCellsAction },
+				]);
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/17382

The icons were failing to render at this line:
https://github.com/microsoft/azuredatastudio/blob/dacfddc523ddcd254b606ed683c238c92e88b720/src/sql/workbench/contrib/notebook/browser/notebook.component.ts#L489
because the viewsDropdownContainer is null when the notebook views feature is off. 

I changed it back to use setContent (which allows nulls) for now. I can come back to clean up the code here a bit but I figured since it's ask mode, I'll make as few line changes as possible.
