### PR TITLE
Fix split cell icon disabled after converting from text to code

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
@@ -82,6 +82,9 @@ export class SplitCellAction extends CellActionBase {
 		this._register(context.cell.onCurrentEditModeChanged(currentMode => {
 			this.enabled = currentMode === CellEditModes.WYSIWYG ? false : true;
 		}));
+		this._register(context.cell.notebookModel.onCellTypeChanged(_ => {
+			this.enabled = context.cell.currentMode === CellEditModes.WYSIWYG ? false : true;
+		}));
 	}
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/microsoft/azuredatastudio/issues/17405

https://user-images.githubusercontent.com/23462877/138150915-75efd94a-f6eb-4c09-9d35-36c2732f4ca3.mov



