### PR TITLE
Fix split cell icon disabled after converting from text to code

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
@@ -82,6 +82,9 @@ export class SplitCellAction extends CellActionBase {
 		this._register(context.cell.onCurrentEditModeChanged(currentMode => {
 			this.enabled = currentMode === CellEditModes.WYSIWYG ? false : true;
 		}));
+		this._register(context.cell.notebookModel.onCellTypeChanged(_ => {
+			this.enabled = context.cell.currentMode === CellEditModes.WYSIWYG ? false : true;
+		}));
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/17405
