### PR TITLE
[Port] Fix URL protocol for non-insiders builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.33.0",
-  "distro": "01b299c0f340f6cf9dc10290b3aadea449c7940f",
+  "distro": "e39d1a2d41862fb0f5b4e8fc0886680e32ea5e27",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Port of https://github.com/microsoft/azuredatastudio/pull/17442

Fixes https://github.com/microsoft/azuredatastudio/issues/17439

Note that I couldn't use the same distro hash since there had been other changes made for main that aren't in the 1.33 branch. 