### PR TITLE
Fix backups not restoring in correct editor

### DIFF
--- a/src/sql/workbench/common/constants.ts
+++ b/src/sql/workbench/common/constants.ts
@@ -29,10 +29,11 @@ export const SearchViewFocusedKey = new RawContextKey<boolean>('notebookSearchVi
 export const InputBoxFocusedKey = new RawContextKey<boolean>('inputBoxFocus', false);
 export const SearchInputBoxFocusedKey = new RawContextKey<boolean>('searchInputBoxFocus', false);
 
+// !! Do not change these or updates won't be able to deserialize editors correctly !!
 export const UNTITLED_NOTEBOOK_TYPEID = 'workbench.editorinputs.untitledNotebookInput';
-export const UNTITLED_QUERY_EDITOR_TYPEID = 'workbench.editorinputs.untitledQueryInput';
-export const FILE_QUERY_EDITOR_TYPEID = 'workbench.editorinputs.fileQueryInput';
-export const RESOURCE_VIEWER_TYPEID = 'workbench.editorinputs.resourceViewerInput';
+export const UNTITLED_QUERY_EDITOR_TYPEID = 'workbench.editorInput.untitledQueryInput';
+export const FILE_QUERY_EDITOR_TYPEID = 'workbench.editorInput.fileQueryInput';
+export const RESOURCE_VIEWER_TYPEID = 'workbench.editorInput.resourceViewerInput';
 
 export const JUPYTER_PROVIDER_ID = 'jupyter';
 


### PR DESCRIPTION
Addresses https://github.com/microsoft/azuredatastudio/issues/17450

This was broken by https://github.com/microsoft/azuredatastudio/pull/16914/files - where along with moving stuff around the input IDs were changed. This means that when going from an older version of ADS with the original IDs to the newer one ADS couldn't find the correct factory to deserialize the input so falls back to plain text.