### PR TITLE
Don't log internal command executions from ext host

### DIFF
--- a/src/sql/workbench/contrib/telemetry/common/telemetry.contribution.ts
+++ b/src/sql/workbench/contrib/telemetry/common/telemetry.contribution.ts
@@ -34,7 +34,7 @@ export class SqlTelemetryContribution extends Disposable implements IWorkbenchCo
 						'selectNextSuggestion'].some(id => id === e.commandId) &&
 						// Events from src\vs\editor\contrib\wordOperations\wordOperations.ts
 						!e.commandId.startsWith('cursor') &&
-						!e.commandId.startsWith('_vscode_delegate')) {
+						!e.commandId.startsWith('_')) { // Commands starting with _ are internal commands which generally aren't useful to us currently
 						// Note - this event is duplicated in extHostCommands to also ensure logging of all commands contributed by extensions
 						telemetryService.sendActionEvent(TelemetryView.Shell, TelemetryAction.adsCommandExecuted, e.commandId);
 					}

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -160,7 +160,12 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 	private async _doExecuteCommand<T>(id: string, args: any[], retry: boolean): Promise<T> {
 
 		if (this._commands.has(id)) {
-			this._mainThreadTelemetryProxy.$publicLog(TelemetryKeys.EventName.Action, { properties: { action: TelemetryKeys.TelemetryAction.adsCommandExecuted, view: TelemetryKeys.TelemetryView.ExtensionHost, target: id } }); // {{SQL CARBON EDIT}} Log ext-contributed commands. Only logging here to avoid double-logging for command executions coming from core (which are already logged)
+			// {{SQL CARBON EDIT}} Log ext-contributed commands (which never get send to the main thread if called from the ext host).
+			// Only logging here to avoid double-logging for command executions coming from core (which are already logged)
+			if (!id.startsWith('_')) { // Commands starting with _ are internal commands which generally aren't useful to us currently
+				this._mainThreadTelemetryProxy.$publicLog(TelemetryKeys.EventName.Action, { properties: { action: TelemetryKeys.TelemetryAction.adsCommandExecuted, view: TelemetryKeys.TelemetryView.ExtensionHost, target: id } });
+			}
+
 			// we stay inside the extension host and support
 			// to pass any kind of parameters around
 			return this._executeContributedCommand<T>(id, args);


### PR DESCRIPTION
Filtering out all internal commands (start with _) to reduce number of events being sent for stuff we don't use. 