### PR TITLE
Fix assessment results dialog telemetry

### DIFF
--- a/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
@@ -66,7 +66,7 @@ export class AssessmentResultsDialog {
 	public async openDialog(dialogName?: string) {
 		if (!this._isOpen) {
 			this._isOpen = true;
-			this.dialog = azdata.window.createModelViewDialog(this.title, this.title, 'wide');
+			this.dialog = azdata.window.createModelViewDialog(this.title, 'AssessmentResults', 'wide');
 
 			this.dialog.okButton.label = AssessmentResultsDialog.SelectButtonText;
 			this._disposables.push(this.dialog.okButton.onClick(async () => await this.execute()));


### PR DESCRIPTION
The second parameter is the name to be used for telemetry purposes and should: 

1. Never be localized text
2. Never be the title in general (especially for a dialog that changes its title - in this case for the server it ran the assessment against for example)