### PR TITLE
vbump sqltools service

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.139",
+	"version": "3.0.0-release.142",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",


### PR DESCRIPTION
the changes are:
1. table designer changes
2. reduced packages to fix the out of disk space error.

![image](https://user-images.githubusercontent.com/13777222/138741141-755ffb6a-a7cc-4ac4-87c4-52a11c8992a9.png)
