### PR TITLE
Fix publisher for VS Code extensions

### DIFF
--- a/extensions/data-workspace/package.vscode.json
+++ b/extensions/data-workspace/package.vscode.json
@@ -1,5 +1,6 @@
 {
 	"name": "data-workspace-vscode",
+	"publisher": "ms-mssql",
 	"extensionDependencies": [
 		"ms-mssql.mssql"
 	]

--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -8,7 +8,7 @@ declare module 'dataworkspace' {
 	import * as vscode from 'vscode';
 	export const enum extension {
 		name = 'Microsoft.data-workspace',
-		vscodeName = 'Microsoft.data-workspace-vscode'
+		vscodeName = 'ms-mssql.data-workspace-vscode'
 	}
 
 	/**

--- a/extensions/sql-database-projects/package.vscode.json
+++ b/extensions/sql-database-projects/package.vscode.json
@@ -1,7 +1,8 @@
 {
 	"name": "sql-database-projects-vscode",
+	"publisher": "ms-mssql",
 	"extensionDependencies": [
 		"ms-mssql.mssql",
-		"Microsoft.data-workspace-vscode"
+		"ms-mssql.data-workspace-vscode"
 	]
 }

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -7,7 +7,7 @@ declare module 'sqldbproj' {
 	import * as vscode from 'vscode';
 	export const enum extension {
 		name = 'Microsoft.sql-database-projects',
-		vsCodeName = 'Microsoft.sql-database-projects-vscode'
+		vsCodeName = 'ms-mssql.sql-database-projects-vscode'
 	}
 
 	/**


### PR DESCRIPTION
Publisher for VS Code extensions needs to match ID of the publisher on the VS Code marketplace (ms-mssql, not Microsoft)