### PR TITLE
Fix localized titles in VS Code marketplace

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-workspace",
-  "displayName": "%extension-displayName%",
-  "description": "%extension-description%",
+  "displayName": "Data Workspace",
+  "description": "Additional common functionality for database projects",
   "version": "0.1.0",
   "publisher": "Microsoft",
   "preview": true,

--- a/extensions/data-workspace/package.nls.json
+++ b/extensions/data-workspace/package.nls.json
@@ -1,6 +1,4 @@
 {
-	"extension-displayName": "Data workspace",
-	"extension-description": "Data workspace",
 	"data-workspace-view-container-name": "Projects",
 	"main-view-name": "Projects",
 	"new-command": "New",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
-  "description": "The SQL Database Projects extension for Azure Data Studio and VS Code allows users to develop and publish database schemas.",
+  "description": "Allows users to develop and publish database schemas for MSSQL Databases",
   "version": "0.14.0",
   "publisher": "Microsoft",
   "preview": true,


### PR DESCRIPTION
VS Code Marketplace doesn't handle localized titles, so just hardcoding to English for now. 