### PR TITLE
sql-database-projects dialog completion cleanup

### DIFF
--- a/extensions/sql-database-projects/src/common/promise.ts
+++ b/extensions/sql-database-projects/src/common/promise.ts
@@ -6,7 +6,20 @@
 /**
  * Deferred promise
  */
-export interface Deferred<T> {
-	resolve: (result: T | Promise<T>) => void;
-	reject: (reason: any) => void;
+export class Deferred<T = void> {
+	promise: Promise<T>;
+	resolve!: (value: T | PromiseLike<T>) => void;
+	reject!: (reason?: any) => void;
+	constructor() {
+		this.promise = new Promise<T>((resolve, reject) => {
+			this.resolve = resolve;
+			this.reject = reject;
+		});
+	}
+
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult>;
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => void): Thenable<TResult>;
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult> {
+		return this.promise.then(onfulfilled, onrejected);
+	}
 }

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -54,7 +54,7 @@ export default class MainController implements vscode.Disposable {
 		vscode.commands.registerCommand('sqlDatabaseProjects.properties', async (node: WorkspaceTreeItem) => { return vscode.window.showErrorMessage(`Properties not yet implemented: ${node.element.uri.path}`); }); // TODO
 
 		vscode.commands.registerCommand('sqlDatabaseProjects.build', async (node: WorkspaceTreeItem) => { return this.projectsController.buildProject(node); });
-		vscode.commands.registerCommand('sqlDatabaseProjects.publish', async (node: WorkspaceTreeItem) => { this.projectsController.publishProject(node); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.publish', async (node: WorkspaceTreeItem) => { return this.projectsController.publishProject(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.schemaCompare', async (node: WorkspaceTreeItem) => { return this.projectsController.schemaCompare(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.createProjectFromDatabase', async (context: azdataType.IConnectionProfile | vscodeMssql.ITreeNodeInfo | undefined) => { return this.projectsController.createProjectFromDatabase(context); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.generateProjectFromOpenApiSpec', async () => { return this.projectsController.generateProjectFromOpenApiSpec(); });

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -300,13 +300,13 @@ export class ProjectsController {
 	 * Builds and publishes a project
 	 * @param treeNode a treeItem in a project's hierarchy, to be used to obtain a Project
 	 */
-	public publishProject(treeNode: dataworkspace.WorkspaceTreeItem): PublishDatabaseDialog;
+	public async publishProject(treeNode: dataworkspace.WorkspaceTreeItem): Promise<void>;
 	/**
 	 * Builds and publishes a project
 	 * @param project Project to be built and published
 	 */
-	public publishProject(project: Project): PublishDatabaseDialog;
-	public publishProject(context: Project | dataworkspace.WorkspaceTreeItem): PublishDatabaseDialog | undefined {
+	public async publishProject(project: Project): Promise<void>;
+	public async publishProject(context: Project | dataworkspace.WorkspaceTreeItem): Promise<void> {
 		const project: Project = this.getProjectFromContext(context);
 		if (utils.getAzdataApi()) {
 			let publishDatabaseDialog = this.getPublishDialog(project);
@@ -317,10 +317,9 @@ export class ProjectsController {
 
 			publishDatabaseDialog.openDialog();
 
-			return publishDatabaseDialog;
+			return publishDatabaseDialog.waitForClose();
 		} else {
-			void launchPublishDatabaseQuickpick(project, this);
-			return undefined;
+			return launchPublishDatabaseQuickpick(project, this);
 		}
 	}
 

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -46,8 +46,7 @@ export class AddDatabaseReferenceDialog {
 	public currentReferenceType: ReferenceType | undefined;
 
 	private toDispose: vscode.Disposable[] = [];
-	private initDialogComplete: Deferred<void> | undefined;
-	private initDialogPromise: Promise<void> = new Promise<void>((resolve, reject) => this.initDialogComplete = { resolve, reject });
+	private initDialogComplete: Deferred = new Deferred();
 
 	public addReference: ((proj: Project, settings: ISystemDatabaseReferenceSettings | IDacpacReferenceSettings | IProjectReferenceSettings) => any) | undefined;
 
@@ -86,7 +85,7 @@ export class AddDatabaseReferenceDialog {
 		this.dialog.cancelButton.label = constants.cancelButtonText;
 
 		utils.getAzdataApi()!.window.openDialog(this.dialog);
-		await this.initDialogPromise;
+		await this.initDialogComplete.promise;
 	}
 
 	private dispose(): void {
@@ -144,7 +143,7 @@ export class AddDatabaseReferenceDialog {
 				await this.systemDatabaseRadioButton?.focus();
 			}
 
-			this.initDialogComplete?.resolve();
+			this.initDialogComplete.resolve();
 		});
 	}
 

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -29,8 +29,7 @@ export class CreateProjectFromDatabaseDialog {
 	private formBuilder: azdataType.FormBuilder | undefined;
 	private connectionId: string | undefined;
 	private toDispose: vscode.Disposable[] = [];
-	private initDialogComplete!: Deferred<void>;
-	private initDialogPromise: Promise<void> = new Promise<void>((resolve, reject) => this.initDialogComplete = { resolve, reject });
+	private initDialogComplete: Deferred = new Deferred();
 
 	public createProjectFromDatabaseCallback: ((model: ImportDataModel) => any) | undefined;
 
@@ -51,7 +50,7 @@ export class CreateProjectFromDatabaseDialog {
 		this.dialog.cancelButton.label = constants.cancelButtonText;
 
 		getAzdataApi()!.window.openDialog(this.dialog);
-		await this.initDialogPromise;
+		await this.initDialogComplete.promise;
 
 		if (this.profile) {
 			await this.updateConnectionComponents(getConnectionName(this.profile), this.profile.id, this.profile.databaseName!);

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -364,7 +364,7 @@ describe('ProjectsController', function (): void {
 				projController.callBase = true;
 				projController.setup(x => x.getPublishDialog(TypeMoq.It.isAny())).returns(() => publishDialog.object);
 
-				projController.object.publishProject(new Project('FakePath'));
+				void projController.object.publishProject(new Project('FakePath'));
 				should(opened).equal(true);
 			});
 
@@ -395,13 +395,15 @@ describe('ProjectsController', function (): void {
 					return Promise.resolve(undefined);
 				});
 
-				let dialog = projController.object.publishProject(proj);
-				await dialog.publishClick();
+				let dialogPromise = projController.object.publishProject(proj);
+				await publishDialog.object.publishClick();
+				await dialogPromise;
 
 				should(holler).equal(publishHoller, 'executionCallback() is supposed to have been setup and called for Publish scenario');
 
-				dialog = projController.object.publishProject(proj);
-				await dialog.generateScriptClick();
+				dialogPromise = projController.object.publishProject(proj);
+				await publishDialog.object.generateScriptClick();
+				await dialogPromise;
 
 				should(holler).equal(generateHoller, 'executionCallback() is supposed to have been setup and called for GenerateScript scenario');
 			});


### PR DESCRIPTION
Needed to make some changes for some work I'm doing to have the publish command be await-able and decided to do some cleanup while I was here.

- Put implementation of deferred stuff in a class so we don't have to keep redefining it
- Have publishProject return a promise indicating completion instead of the dialog itself. That only seemed to be necessary for tests and that's easy enough to fix.

Note that currently this does NOT handle the case where the user cancels out of the dialog. I want to come back and fix that by adding a waitForClose() function on the dialog itself that the core API code handles correctly so I'm just leaving this as it is for now since it isn't going to break anything (we only use it for tests currently)