### PR TITLE
Delete azurecore value provider and simplify type

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -322,11 +322,6 @@
         }
       ]
     },
-    "resourceDeploymentValueProviders": [
-      {
-        "id": "subscription-id-to-tenant-id"
-      }
-    ],
     "hasAzureResourceProviders": true
   },
   "dependencies": {

--- a/extensions/azurecore/src/typings/ref.d.ts
+++ b/extensions/azurecore/src/typings/ref.d.ts
@@ -7,5 +7,4 @@
 /// <reference path='../../../../src/vs/vscode.proposed.d.ts'/>
 /// <reference path='../../../../src/sql/azdata.d.ts'/>
 /// <reference path='../../../../src/sql/azdata.proposed.d.ts'/>
-/// <reference path='../../../resource-deployment/src/typings/resource-deployment.d.ts'/>
 /// <reference types='@types/node'/>

--- a/extensions/resource-deployment/src/typings/resource-deployment.d.ts
+++ b/extensions/resource-deployment/src/typings/resource-deployment.d.ts
@@ -27,12 +27,16 @@ declare module 'resource-deployment' {
 	export type InputValueType = string | number | boolean | undefined;
 
 	export interface IValueProvider {
+		/**
+		 * The ID associated with this value provider. Fields use this ID in the package.json to indicate which provider to use to get the value for that field.
+		 * Each ID must be globally unique - an error will be thrown if the same ID is already registered.
+		 */
 		readonly id: string,
 		/**
 		 * Gets a calculated value based on the given input values.
 		 * @param triggerValues A map of the trigger field names and their current values specified in the valueProvider field info
 		*/
-		getValue(triggerValues: string | {[key: string]: InputValueType}): Promise<InputValueType>;
+		getValue(triggerValues: {[key: string]: InputValueType}): Promise<InputValueType>;
 	}
 
 	/**
@@ -44,6 +48,12 @@ declare module 'resource-deployment' {
 
 	export interface IExtension {
 		registerOptionsSourceProvider(provider: IOptionsSourceProvider): vscode.Disposable,
+		/**
+		 * Registers a value provider that resource deployment definitions can use to dynamically fetch the value for specified fields.
+		 * @param provider The provider to register
+		 * @returns A disposable is returned that will unregister the provider when is disposed - this should be used to ensure
+		 * that the provider is unregistered when the extension is uninstalled/deactivated.
+		 */
 		registerValueProvider(provider: IValueProvider): vscode.Disposable
 	}
 }


### PR DESCRIPTION
Some cleanup here - this never ended up being used so getting rid of it and simplifying the type passed to registered value providers so they don't have to check what type is coming in. 

(also adding comments cause comments are good...)