### PR TITLE
Add launch target for sample-resource-deployment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -269,6 +269,31 @@
 			"presentation": {
 				"group": "4_web"
 			}
+		},
+		{
+			"name": "Run Sample Resource Deployment Extension",
+			"type": "sqlopsExtensionHost",
+			"request": "launch",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql.bat"
+			},
+			"osx": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh"
+			},
+			"linux": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh"
+			},
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/samples/sample-resource-deployment"
+			],
+			"outFiles": [
+				"${workspaceRoot}/samples/sample-resource-deployment/out/**/*.js"
+			],
+			"preLaunchTask": "Watch sample-resource-deployment",
+			"presentation": {
+				"group": "5_samples"
+			},
+			"timeout": 30000
 		}
 	],
 	"compounds": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -231,6 +231,18 @@
 			"group": "build",
 			"label": "npm: tsec-compile-check",
 			"detail": "node_modules/tsec/bin/tsec -p src/tsconfig.json --noEmit"
+		},
+		{
+			"type": "npm",
+			"script": "watch",
+			"label": "Watch sample-resource-deployment",
+			"path": "./samples/sample-resource-deployment/package.json",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": "build"
 		}
 	]
 }


### PR DESCRIPTION
This way people can directly launch the sample extension and debug into it to see how it works themselves. (as well as starting a watch task in the background)