### PR TITLE
Resolves same-origin-policy violation when ADS web is running in a container

### DIFF
--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -94,6 +94,8 @@ export namespace Schemas {
 }
 
 class RemoteAuthoritiesImpl {
+	private readonly _defaultWebPort = 80;
+
 	private readonly _hosts: { [authority: string]: string | undefined; } = Object.create(null);
 	private readonly _ports: { [authority: string]: number | undefined; } = Object.create(null);
 	private readonly _connectionTokens: { [authority: string]: string | undefined; } = Object.create(null);
@@ -134,7 +136,7 @@ class RemoteAuthoritiesImpl {
 		}
 		return URI.from({
 			scheme: platform.isWeb ? this._preferredWebSchema : Schemas.vscodeRemoteResource,
-			authority: `${host}:${port}`,
+			authority: platform.isWeb && port === this._defaultWebPort ? `${host}` : `${host}:${port}`, // {{SQL CARBON EDIT}} appending port to authority causes same-origin-policy violation in web mode.
 			path: `/vscode-remote-resource`,
 			query
 		});

--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -136,7 +136,7 @@ class RemoteAuthoritiesImpl {
 		}
 		return URI.from({
 			scheme: platform.isWeb ? this._preferredWebSchema : Schemas.vscodeRemoteResource,
-			authority: platform.isWeb && port === this._defaultWebPort ? `${host}` : `${host}:${port}`, // {{SQL CARBON EDIT}} appending port to authority causes same-origin-policy violation in web mode.
+			authority: platform.isWeb && port === this._defaultWebPort ? `${host}` : `${host}:${port}`, // {{SQL CARBON EDIT}} addresses same-origin-policy violation in web mode when port number is in authority, but not in URI.
 			path: `/vscode-remote-resource`,
 			query
 		});

--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -94,7 +94,7 @@ export namespace Schemas {
 }
 
 class RemoteAuthoritiesImpl {
-	private readonly _defaultWebPort = 80;
+	private readonly _defaultWebPort = 80; // {{SQL CARBON EDIT}}
 
 	private readonly _hosts: { [authority: string]: string | undefined; } = Object.create(null);
 	private readonly _ports: { [authority: string]: number | undefined; } = Object.create(null);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17172

The change is to resolve the same-origin policy violation that only occurs when ADS web is running in a container and the themes or language syntax settings are changed.