### PR TITLE
Update reference to html-query-plan to use npm.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -751,7 +751,7 @@
 					"chart.js",
 					"plotly.js",
 					"angular2-grid",
-					"html-query-plan",
+					"kburtram-query-plan",
 					"html-to-image",
 					"turndown",
 					"gridstack",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "chokidar": "3.5.2",
     "graceful-fs": "4.2.6",
     "gridstack": "^3.1.3",
-    "html-query-plan": "git://github.com/kburtram/html-query-plan.git#2.6",
+    "kburtram-query-plan": "2.6.1",
     "html-to-image": "^1.6.2",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.3",

--- a/remote/package.json
+++ b/remote/package.json
@@ -19,7 +19,7 @@
     "cookie": "^0.4.0",
     "graceful-fs": "4.2.6",
     "gridstack": "^3.1.3",
-    "html-query-plan": "git://github.com/kburtram/html-query-plan.git#2.6",
+    "kburtram-query-plan": "2.6.1",
     "html-to-image": "^1.6.2",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.3",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -15,7 +15,7 @@
 		"ansi_up": "^3.0.0",
 		"chart.js": "^2.9.4",
 		"gridstack": "^3.1.3",
-		"html-query-plan": "git://github.com/kburtram/html-query-plan.git#2.6",
+		"kburtram-query-plan": "2.6.1",
 		"html-to-image": "^1.6.2",
 		"iconv-lite-umd": "0.6.8",
 		"jquery": "3.5.0",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -176,10 +176,6 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-"html-query-plan@git://github.com/kburtram/html-query-plan.git#2.6":
-  version "2.5.0"
-  resolved "git://github.com/kburtram/html-query-plan.git#c524feb824e4960897ad875a37af068376a2b4a3"
-
 html-to-image@^1.6.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.7.0.tgz#4ca93bb90c0b9392edaafbfd5d94e8f0d666e18b"
@@ -216,6 +212,11 @@ jschardet@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-3.0.0.tgz#898d2332e45ebabbdb6bf2feece9feea9a99e882"
   integrity sha512-lJH6tJ77V8Nzd5QWRkFYCLc13a3vADkh3r/Fi8HupZGWk2OVVDfnZP8V/VgQgZ+lzW0kG2UGb5hFgt3V3ndotQ==
+
+kburtram-query-plan@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/kburtram-query-plan/-/kburtram-query-plan-2.6.1.tgz#6b86128ec30c53694b53c4ee0e32d64350eb0c2c"
+  integrity sha512-7Brjwp0YOCGug1cmfvcG8s1kN4MOwiLgOmKWS0+QSq5qCH9Bcv78vKAI7Pq1Ro6rTbpiTIRITsFKYrF4XTVlQw==
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -393,10 +393,6 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-"html-query-plan@git://github.com/kburtram/html-query-plan.git#2.6":
-  version "2.5.0"
-  resolved "git://github.com/kburtram/html-query-plan.git#c524feb824e4960897ad875a37af068376a2b4a3"
-
 html-to-image@^1.6.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.7.0.tgz#4ca93bb90c0b9392edaafbfd5d94e8f0d666e18b"
@@ -515,6 +511,11 @@ jsonfile@^4.0.0:
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+kburtram-query-plan@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/kburtram-query-plan/-/kburtram-query-plan-2.6.1.tgz#6b86128ec30c53694b53c4ee0e32d64350eb0c2c"
+  integrity sha512-7Brjwp0YOCGug1cmfvcG8s1kN4MOwiLgOmKWS0+QSq5qCH9Bcv78vKAI7Pq1Ro6rTbpiTIRITsFKYrF4XTVlQw==
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"

--- a/src/sql/workbench/contrib/queryPlan/browser/queryPlan.ts
+++ b/src/sql/workbench/contrib/queryPlan/browser/queryPlan.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/qp';
-import * as QP from 'html-query-plan';
+import * as QP from 'kburtram-query-plan';
 
 import { IPanelView, IPanelTab } from 'sql/base/browser/ui/panel/panel';
 

--- a/src/vs/code/browser/workbench/workbench-dev.html
+++ b/src/vs/code/browser/workbench/workbench-dev.html
@@ -59,7 +59,7 @@
 				'angular2-grid': `${window.location.origin}/static/remote/web/node_modules/angular2-grid/bundles/NgGrid.umd.js`,
 				'angular2-slickgrid': `${window.location.origin}/static/remote/web/node_modules/angular2-slickgrid/out/bundles/angular2-slickgrid.umd.js`,
 				'chart.js':  `${window.location.origin}/static/remote/web/node_modules/chart.js/dist/Chart.bundle.min.js`,
-				'html-query-plan': `${window.location.origin}/static/remote/web/node_modules/html-query-plan/dist/index.min.js`,
+				'kburtram-query-plan': `${window.location.origin}/static/remote/web/node_modules/kburtram-query-plan/dist/index.min.js`,
 				'html-to-image': `${window.location.origin}/static/remote/web/node_modules/html-to-image/dist/html-to-image.js`,
 				'ng2-charts': `${window.location.origin}/static/remote/web/node_modules/ng2-charts/bundles/ng2-charts.umd.js`,
 				'rxjs/Observable': `${window.location.origin}/static/remote/web/node_modules/rxjs/bundles/Rx.min.js?0`,

--- a/src/vs/code/browser/workbench/workbench.html
+++ b/src/vs/code/browser/workbench/workbench.html
@@ -59,7 +59,7 @@
 				'angular2-grid': `${window.location.origin}/static/node_modules/angular2-grid/bundles/NgGrid.umd.js`,
 				'angular2-slickgrid': `${window.location.origin}/static/node_modules/angular2-slickgrid/out/bundles/angular2-slickgrid.umd.js`,
 				'chart.js':  `${window.location.origin}/static/node_modules/chart.js/dist/Chart.bundle.min.js`,
-				'html-query-plan': `${window.location.origin}/static/node_modules/html-query-plan/dist/index.min.js`,
+				'kburtram-query-plan': `${window.location.origin}/static/node_modules/kburtram-query-plan/dist/index.min.js`,
 				'html-to-image': `${window.location.origin}/static/node_modules/html-to-image/dist/html-to-image.js`,
 				'ng2-charts': `${window.location.origin}/static/node_modules/ng2-charts/bundles/ng2-charts.umd.js`,
 				'rxjs/Observable': `${window.location.origin}/static/node_modules/rxjs/bundles/Rx.min.js?0`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5321,10 +5321,6 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
   integrity sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==
 
-"html-query-plan@git://github.com/kburtram/html-query-plan.git#2.6":
-  version "2.5.0"
-  resolved "git://github.com/kburtram/html-query-plan.git#c524feb824e4960897ad875a37af068376a2b4a3"
-
 html-to-image@^1.6.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.7.0.tgz#4ca93bb90c0b9392edaafbfd5d94e8f0d666e18b"
@@ -6358,6 +6354,11 @@ just-extend@^4.0.2:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
+kburtram-query-plan@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/kburtram-query-plan/-/kburtram-query-plan-2.6.1.tgz#6b86128ec30c53694b53c4ee0e32d64350eb0c2c"
+  integrity sha512-7Brjwp0YOCGug1cmfvcG8s1kN4MOwiLgOmKWS0+QSq5qCH9Bcv78vKAI7Pq1Ro6rTbpiTIRITsFKYrF4XTVlQw==
 
 keytar@7.2.0:
   version "7.2.0"


### PR DESCRIPTION
Change the reference to html-query-plan to use npm.js.  I've changed the name of the package to an obviously temporary name so that it won't be confused with the official package.  This package is planned to be replaced in Dec once we have an the internal execution plan control available.
