### PR TITLE
Bump non-builtin extensions in release/1.33

### DIFF
--- a/extensions/agent/package.json
+++ b/extensions/agent/package.json
@@ -2,7 +2,7 @@
   "name": "agent",
   "displayName": "SQL Server Agent",
   "description": "Manage and troubleshoot SQL Server Agent jobs",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,7 +2,7 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/asde-deployment/package.json
+++ b/extensions/asde-deployment/package.json
@@ -2,7 +2,7 @@
   "name": "asde-deployment",
   "displayName": "%extension-displayName%",
   "description": "%extension-description%",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -2,7 +2,7 @@
   "name": "azcli",
   "displayName": "%azcli.arc.displayName%",
   "description": "%azcli.arc.description%",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuremonitor",
   "description": "%azuremonitor.description%",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "publisher": "Microsoft",
   "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "activationEvents": [

--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -2,7 +2,7 @@
   "name": "big-data-cluster",
   "displayName": "%text.sqlServerBigDataClusters%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -2,7 +2,7 @@
   "name": "cms",
   "displayName": "%cms.displayName%",
   "description": "%cms.description%",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -2,7 +2,7 @@
   "name": "dacpac",
   "displayName": "SQL Server Dacpac",
   "description": "SQL Server Dacpac for Azure Data Studio.",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "publisher": "Microsoft",
   "preview": false,
   "engines": {

--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -2,7 +2,7 @@
   "name": "data-workspace",
   "displayName": "Data Workspace",
   "description": "Additional common functionality for database projects",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -2,7 +2,7 @@
 	"name": "import",
 	"displayName": "SQL Server Import",
 	"description": "SQL Server Import for Azure Data Studio supports importing CSV or JSON files into SQL Server.",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"publisher": "Microsoft",
 	"preview": true,
 	"engines": {

--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kusto",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "publisher": "Microsoft",
   "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "activationEvents": [

--- a/extensions/machine-learning/package.json
+++ b/extensions/machine-learning/package.json
@@ -2,7 +2,7 @@
   "name": "machine-learning",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {

--- a/extensions/profiler/package.json
+++ b/extensions/profiler/package.json
@@ -2,7 +2,7 @@
 	"name": "profiler",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "0.12.1",
+	"version": "0.12.2",
 	"publisher": "Microsoft",
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -2,7 +2,7 @@
 	"name": "query-history",
 	"displayName": "%queryHistory.displayName%",
 	"description": "%queryHistory.description%",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"publisher": "Microsoft",
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -2,7 +2,7 @@
   "name": "resource-deployment",
   "displayName": "%extension-displayName%",
   "description": "%extension-description%",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -2,7 +2,7 @@
   "name": "schema-compare",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "publisher": "Microsoft",
   "preview": false,
   "engines": {

--- a/extensions/server-report/package.json
+++ b/extensions/server-report/package.json
@@ -2,7 +2,7 @@
 	"name": "server-report",
 	"displayName": "Server Reports",
 	"description": "Server Reports",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"publisher": "Microsoft",
 	"preview": true,
 	"engines": {

--- a/extensions/sql-assessment/package.json
+++ b/extensions/sql-assessment/package.json
@@ -2,7 +2,7 @@
   "name": "sql-assessment",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "Allows users to develop and publish database schemas for MSSQL Databases",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
 	"name": "sql-migration",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"publisher": "Microsoft",
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",


### PR DESCRIPTION
Bump all non-builtin extensions in release/1.33. Some of the extensions won't be released with the hotfix and others are already bumped from what's currently in marketplace. For the first group, we can ignore the vbump. For the second group, we can grab the extension from previous build if that version number is preferred.

Bumping all extensions is quicker than tracking down which will ship at which version in order to get build going sooner. This PR is not intended to be ported back to main.
