### PR TITLE
allow extension to control whether add/remove rows should be enabled

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1123,6 +1123,14 @@ declare module 'azdata' {
 			 * The properties to be displayed in the columns table. Default values are: Name, Type, Length, Precision, Scale, IsPrimaryKey, AllowNulls, DefaultValue.
 			 */
 			columnsTableProperties?: string[];
+			/**
+			 * Whether user can add columns. The default value is true.
+			 */
+			canAddColumns?: boolean;
+			/**
+			 * Whether user can remove columns. The default value is true.
+			 */
+			canRemoveColumns?: boolean;
 		}
 
 		/**
@@ -1201,6 +1209,16 @@ declare module 'azdata' {
 			 * The data to be displayed.
 			 */
 			data?: DesignerTableComponentDataItem[];
+
+			/**
+			 * Whether user can add new rows to the table. The default value is true.
+			 */
+			canAddRows?: boolean;
+
+			/**
+			 * Whether user can remove rows from the table. The default value is true.
+			 */
+			canRemoveRows?: boolean;
 		}
 
 		/**

--- a/src/sql/base/browser/ui/designer/interfaces.ts
+++ b/src/sql/base/browser/ui/designer/interfaces.ts
@@ -154,16 +154,29 @@ export interface DesignerTableProperties extends ComponentProperties {
 	columns?: string[];
 
 	/**
-	 * The display name of the object type
+	 * The display name of the object type.
 	 */
 	objectTypeDisplayName: string;
 
 	/**
-	 * the properties of the table data item
+	 * The properties of the table data item.
 	 */
 	itemProperties?: DesignerDataPropertyInfo[];
 
+	/**
+	 * The data to be displayed.
+	 */
 	data?: DesignerTableComponentRowData[];
+
+	/**
+	 * Whether user can add new rows to the table. The default value is true.
+	 */
+	canAddRows?: boolean;
+
+	/**
+	 * Whether user can remove rows from the table. The default value is true.
+	 */
+	canRemoveRows?: boolean;
 }
 
 export interface DesignerTableComponentRowData {

--- a/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
+++ b/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
@@ -232,7 +232,7 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 			columnProperties.push(...designerInfo.view.additionalTableColumnProperties);
 		}
 
-		const columnsTableProperties = designerInfo.view.columnsTableProperties || [
+		const columnsTableProperties = designerInfo.view.columnsTableProperties?.length > 0 ? designerInfo.view.columnsTableProperties : [
 			designers.TableColumnProperty.Name,
 			designers.TableColumnProperty.Type,
 			designers.TableColumnProperty.Length,
@@ -253,7 +253,9 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 						ariaLabel: localize('tableDesigner.columnsTabTitle', "Columns"),
 						columns: columnsTableProperties,
 						itemProperties: columnProperties,
-						objectTypeDisplayName: localize('tableDesigner.columnTypeName', "Column")
+						objectTypeDisplayName: localize('tableDesigner.columnTypeName', "Column"),
+						canAddRows: designerInfo.view.canAddColumns,
+						canRemoveRows: designerInfo.view.canRemoveColumns
 					}
 				}
 			]


### PR DESCRIPTION
1. add options to allow extension to control whether add/remove rows should be enabled
2. if multiple groups are detected, add a default 'General' group for the properties that do not have a group specified.
3. adjust the min size for content pane.

![image](https://user-images.githubusercontent.com/13777222/140233151-04900115-c88c-4ddd-83d9-cefa02bfe409.png)


code reviewers:
for this PR, I wrapped 2 blocks of existing code into if statements and changed the indention, it would be much easier to review the changes if you ignore the whitespaces
![image](https://user-images.githubusercontent.com/13777222/140233367-f545767b-e5e0-406c-aac5-eff4b821418c.png)
