### PR TITLE
Fix not being able to type in code cell after switching from text

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -509,6 +509,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			// Move cursor to the richTextCursorPosition
 			// We iterate through the output element childnodes to get to the element of cursor location
 			// If the elements exist, we set the selection, else the cursor defaults to beginning.
+			// Only do this if the cell is active so we don't steal the window selection from another cell
+			// since this function is called whenever any cell in the Notebook changes, not just ourself
 			if (this.isActive() && !this.markdownMode && this.cellModel.richTextCursorPosition) {
 				let selection = window.getSelection();
 				let htmlNodes = this.cellModel.richTextCursorPosition.startElementNodes;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -509,7 +509,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			// Move cursor to the richTextCursorPosition
 			// We iterate through the output element childnodes to get to the element of cursor location
 			// If the elements exist, we set the selection, else the cursor defaults to beginning.
-			if (!this.markdownMode && this.cellModel.richTextCursorPosition) {
+			if (this.isActive() && !this.markdownMode && this.cellModel.richTextCursorPosition) {
 				let selection = window.getSelection();
 				let htmlNodes = this.cellModel.richTextCursorPosition.startElementNodes;
 				let depthToNode = htmlNodes.length;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/17579 (there are some perf issues mentioned there that this doesn't specifically address, we can follow up to see if those are still happening after this fix goes in)

This was introduced by https://github.com/microsoft/azuredatastudio/pull/17180

The problem here is that the `onCellMarkdownModeChanged` and `onCellPreviewModeChanged` callbacks are being called every time we switch cells - even if the text cell in question isn't active. In `focusIfPreviewMode` there was logic added that gets the current window selection and then replaces it with a new selection for the text cell - but this means that if we're moving into a code cell this event is still being fired and thus we're still running the code to get the current selection (which is now on the code cell) and replacing it with the saved element nodes from the text cell (which aren't even valid anymore since we've moved off of edit mode for the text cell)

(this only happens in WYSIWYG mode because of the check on line 512 which only runs this code if there's a saved richTextCursorPosition)

The fix is simple enough...we only want to do this if the current cell is the active one. This seems to fix the issue but we should be looking at all the changes here closely (especially those in the callbacks) and ensuring we aren't going to have any other similar issues. 