### PR TITLE
a couple properties pane UI changes

### DIFF
--- a/src/sql/base/browser/ui/designer/designer.ts
+++ b/src/sql/base/browser/ui/designer/designer.ts
@@ -531,7 +531,7 @@ export class Designer extends Disposable implements IThemable {
 			});
 		} else {
 			groupNames.forEach(group => {
-				const groupHeader = container.appendChild(DOM.$('div.full-row'));
+				const groupHeader = container.appendChild(DOM.$('div.full-row.group-header'));
 				groupHeaders.push(groupHeader);
 				this.styleGroupHeader(groupHeader);
 				groupHeader.innerText = group ?? localize('designer.generalGroupName', "General");

--- a/src/sql/base/browser/ui/designer/designerPropertiesPane.ts
+++ b/src/sql/base/browser/ui/designer/designerPropertiesPane.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CreateComponentsFunc, DesignerUIComponent, SetComponentValueFunc } from 'sql/base/browser/ui/designer/designer';
-import { DesignerViewModel, DesignerDataPropertyInfo, InputBoxProperties, NameProperty } from 'sql/base/browser/ui/designer/interfaces';
+import { DesignerViewModel, DesignerDataPropertyInfo } from 'sql/base/browser/ui/designer/interfaces';
 import * as DOM from 'vs/base/browser/dom';
 import { equals } from 'vs/base/common/objects';
 import { localize } from 'vs/nls';
@@ -69,11 +69,10 @@ export class DesignerPropertiesPane {
 				};
 			});
 		}
-		const name = (<InputBoxProperties>item.viewModel[NameProperty])?.value ?? '';
 		this._titleElement.innerText = localize({
 			key: 'tableDesigner.propertiesPaneTitleWithContext',
-			comment: ['{0} is the place holder for object type', '{1} is the place holder for object name']
-		}, "Properties - {0} {1}", item.type, name);
+			comment: ['{0} is the place holder for object type']
+		}, "{0} Properties", item.type);
 		this._componentMap.forEach((value) => {
 			this._setComponentValue(value.defintion, value.component, item.viewModel);
 		});

--- a/src/sql/base/browser/ui/designer/media/designer.css
+++ b/src/sql/base/browser/ui/designer/media/designer.css
@@ -97,3 +97,8 @@
 .designer-component .content-container .tabbedPanel {
 	border-width: 0px;
 }
+
+.designer-component .components-grid .full-row.group-header {
+	font-weight: bold;
+	line-height: 25px;
+}


### PR DESCRIPTION
1. remove the object name from the properties pane header, it could be long and messy.
2. make the group header more obvious.

before:
![image](https://user-images.githubusercontent.com/13777222/140451642-f60c20f9-e037-4d23-bd6f-fc806238adc8.png)


after:
![image](https://user-images.githubusercontent.com/13777222/140451653-af01e52b-d161-4a05-b7d2-0de57862a48b.png)

