### PR TITLE
fix test-extension-unit.js on mac

### DIFF
--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -76,6 +76,7 @@ for (const ext of argv.extensions) {
 	console.log(`Command used: ${command}`);
 
 	if (os.platform() === 'darwin') {
+		// passing in env on mac causes the executing the command to fail, so only pass in env for windows and linux
 		console.log(execSync(command, { stdio: 'inherit'}));
 	} else {
 		const env = {

--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -74,12 +74,17 @@ for (const ext of argv.extensions) {
 
 	const command = `${process.env.INTEGRATION_TEST_ELECTRON_PATH} ${LINUX_EXTRA_ARGS} --extensionDevelopmentPath=${path.join(__dirname, '..', 'extensions', ext)} --extensionTestsPath=${path.join(__dirname, '..', 'extensions', ext, 'out', 'test')} --user-data-dir=${VSCODEUSERDATADIR} --extensions-dir=${VSCODEEXTENSIONSDIR} --remote-debugging-port=9222 --disable-telemetry --disable-crash-reporter --disable-updates --no-cached-data --disable-keytar`;
 	console.log(`Command used: ${command}`);
-	const env = {
-		VSCODE_CLI: 1,
-		ELECTRON_ENABLE_STACK_DUMPING: 1,
-		ELECTRON_ENABLE_LOGGING: 1
-	};
-	console.log(execSync(command, { stdio: 'inherit', env: env}));
+
+	if (os.platform() === 'darwin') {
+		console.log(execSync(command, { stdio: 'inherit'}));
+	} else {
+		const env = {
+			VSCODE_CLI: 1,
+			ELECTRON_ENABLE_STACK_DUMPING: 1,
+			ELECTRON_ENABLE_LOGGING: 1
+		};
+		console.log(execSync(command, { stdio: 'inherit', env: env}));
+	}
 
 	// clean up
 	if (!process.env.NO_CLEANUP) {


### PR DESCRIPTION
Running test-extensions-unit.js(ex: `node test-extensions-unit.js sql-database-projects`) started not working on mac after this commit https://github.com/microsoft/azuredatastudio/commit/867a96388230066d7ed7cdb88cd90e54f0a15670 added the env stuff when executing the command. 

Error: 
![image](https://user-images.githubusercontent.com/31145923/140587572-4222b22c-fb86-44af-8ed6-4d9a41637c43.png)

The tests were still running on windows, so this only updates the script to not pass in the env info for mac. The env stuff wasn't there before and I think this script is only used for local testing, so it should be ok to not have for mac.