### PR TITLE
Revert "Bump tools service (#17607)"

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.146",
+	"version": "3.0.0-release.143",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",


### PR DESCRIPTION
This version of Tools Service splits an API in two, so Schema Compare is broken until the new ADS logic is in place.  Because that'll take a few days for code to be reviewed and out, I'm reverting Tools Service and will do a multi-step swapover.