### PR TITLE
Move project entry classes to separate file

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -17,7 +17,7 @@ import type * as mssqlVscode from 'vscode-mssql';
 
 import { promises as fs } from 'fs';
 import { PublishDatabaseDialog } from '../dialogs/publishDatabaseDialog';
-import { Project, reservedProjectFolders, FileProjectEntry, SqlProjectReferenceProjectEntry, IDatabaseReferenceProjectEntry } from '../models/project';
+import { Project, reservedProjectFolders } from '../models/project';
 import { SqlDatabaseProjectTreeViewProvider } from './databaseProjectTreeViewProvider';
 import { FolderNode, FileNode } from '../models/tree/fileFolderTreeItem';
 import { IDeploySettings } from '../models/IDeploySettings';
@@ -42,6 +42,7 @@ import { SqlTargetPlatform } from 'sqldbproj';
 import { AutorestHelper } from '../tools/autorestHelper';
 import { createNewProjectFromDatabaseWithQuickpick } from '../dialogs/createProjectFromDatabaseQuickpick';
 import { addDatabaseReferenceQuickpick } from '../dialogs/addDatabaseReferenceQuickpick';
+import { FileProjectEntry, IDatabaseReferenceProjectEntry, SqlProjectReferenceProjectEntry } from '../models/projectEntry';
 
 const maxTableLength = 10;
 

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -9,12 +9,13 @@ import * as path from 'path';
 import * as constants from '../common/constants';
 import * as utils from '../common/utils';
 
-import { Project, SystemDatabase } from '../models/project';
+import { Project } from '../models/project';
 import { cssStyles } from '../common/uiConstants';
 import { IconPathHelper } from '../common/iconHelper';
 import { ISystemDatabaseReferenceSettings, IDacpacReferenceSettings, IProjectReferenceSettings } from '../models/IDatabaseReferenceSettings';
 import { Deferred } from '../common/promise';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
+import { SystemDatabase } from '../models/projectEntry';
 
 export enum ReferenceType {
 	project,

--- a/extensions/sql-database-projects/src/models/IDatabaseReferenceSettings.ts
+++ b/extensions/sql-database-projects/src/models/IDatabaseReferenceSettings.ts
@@ -3,8 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SystemDatabase } from './project';
 import { Uri } from 'vscode';
+import { SystemDatabase } from './projectEntry';
 
 export interface IDatabaseReferenceSettings {
 	databaseName?: string;

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -130,9 +130,109 @@ export class Project implements ISqlProject {
 			console.error(utils.getErrorMessage(e));
 		}
 
-		await this.loadAllFilesInProject();
-		await this.loadFolders();
-		this.loadPrePostDeployScripts();
+		// glob style getting files and folders for new msbuild sdk style projects
+		if (this._isMsbuildSdkStyleProject) {
+			const files = await utils.getSqlFilesInFolder(this.projectFolderPath, true);
+			files.forEach(f => {
+				this._files.push(this.createFileProjectEntry(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(f)), EntryType.File));
+			});
+
+			const folders = await utils.getFoldersInFolder(this.projectFolderPath, true);
+			folders.forEach(f => {
+				this._files.push(this.createFileProjectEntry(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(f)), EntryType.Folder));
+			});
+		}
+
+		for (let ig = 0; ig < this.projFileXmlDoc.documentElement.getElementsByTagName(constants.ItemGroup).length; ig++) {
+			const itemGroup = this.projFileXmlDoc.documentElement.getElementsByTagName(constants.ItemGroup)[ig];
+
+			// find all folders and files to include that are specified in the project file
+			try {
+				const buildElements = itemGroup.getElementsByTagName(constants.Build);
+				for (let b = 0; b < buildElements.length; b++) {
+					const relativePath = buildElements[b].getAttribute(constants.Include)!;
+					const fullPath = path.join(utils.getPlatformSafeFileEntryPath(this.projectFolderPath), utils.getPlatformSafeFileEntryPath(relativePath));
+
+					// msbuild sdk style projects can handle other globbing patterns like <Build Include="folder1\*.sql" /> and <Build Include="Production*.sql" />
+					if (this._isMsbuildSdkStyleProject && !(await utils.exists(fullPath))) {
+						// add files from the glob pattern
+						const globFiles = await utils.globWithPattern(fullPath);
+						globFiles.forEach(gf => {
+							const newFileRelativePath = utils.convertSlashesForSqlProj(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(gf)));
+							if (!this._files.find(f => f.relativePath === newFileRelativePath)) {
+								this._files.push(this.createFileProjectEntry(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(gf)), EntryType.File));
+							}
+						});
+
+						// TODO: add support for <Build Remove="file.sql">
+
+					} else {
+						// only add file if it wasn't already added
+						if (!this._files.find(f => f.relativePath === relativePath)) {
+							this._files.push(this.createFileProjectEntry(relativePath, EntryType.File, buildElements[b].getAttribute(constants.Type)!));
+						}
+					}
+				}
+			} catch (e) {
+				void window.showErrorMessage(constants.errorReadingProject(constants.BuildElements, this.projectFilePath));
+				console.error(utils.getErrorMessage(e));
+			}
+
+			try {
+				const folderElements = itemGroup.getElementsByTagName(constants.Folder);
+				for (let f = 0; f < folderElements.length; f++) {
+					const relativePath = folderElements[f].getAttribute(constants.Include)!;
+					// don't add Properties folder since it isn't supported for now and don't add if the folder was already added
+					if (relativePath !== constants.Properties && !this._files.find(f => f.relativePath === utils.trimChars(relativePath, '\\'))) {
+						this._files.push(this.createFileProjectEntry(relativePath, EntryType.Folder));
+					}
+				}
+			} catch (e) {
+				void window.showErrorMessage(constants.errorReadingProject(constants.Folder, this.projectFilePath));
+				console.error(utils.getErrorMessage(e));
+			}
+
+			// find all pre-deployment scripts to include
+			let preDeployScriptCount: number = 0;
+			try {
+				const preDeploy = itemGroup.getElementsByTagName(constants.PreDeploy);
+				for (let pre = 0; pre < preDeploy.length; pre++) {
+					this._preDeployScripts.push(this.createFileProjectEntry(preDeploy[pre].getAttribute(constants.Include)!, EntryType.File));
+					preDeployScriptCount++;
+				}
+			} catch (e) {
+				void window.showErrorMessage(constants.errorReadingProject(constants.PreDeployElements, this.projectFilePath));
+				console.error(utils.getErrorMessage(e));
+			}
+
+			// find all post-deployment scripts to include
+			let postDeployScriptCount: number = 0;
+			try {
+				const postDeploy = itemGroup.getElementsByTagName(constants.PostDeploy);
+				for (let post = 0; post < postDeploy.length; post++) {
+					this._postDeployScripts.push(this.createFileProjectEntry(postDeploy[post].getAttribute(constants.Include)!, EntryType.File));
+					postDeployScriptCount++;
+				}
+			} catch (e) {
+				void window.showErrorMessage(constants.errorReadingProject(constants.PostDeployElements, this.projectFilePath));
+				console.error(utils.getErrorMessage(e));
+			}
+
+			if (preDeployScriptCount > 1 || postDeployScriptCount > 1) {
+				void window.showWarningMessage(constants.prePostDeployCount, constants.okString);
+			}
+
+			// find all none-deployment scripts to include
+			try {
+				const noneItems = itemGroup.getElementsByTagName(constants.None);
+				for (let n = 0; n < noneItems.length; n++) {
+					this._noneDeployScripts.push(this.createFileProjectEntry(noneItems[n].getAttribute(constants.Include)!, EntryType.File));
+				}
+			} catch (e) {
+				void window.showErrorMessage(constants.errorReadingProject(constants.NoneElements, this.projectFilePath));
+				console.error(utils.getErrorMessage(e));
+			}
+		}
 
 		// find all import statements to include
 		try {
@@ -220,158 +320,6 @@ export class Project implements ISqlProject {
 				}));
 			} catch (e) {
 				void window.showErrorMessage(constants.errorReadingProject(constants.ProjectReferenceElement, this.projectFilePath));
-				console.error(utils.getErrorMessage(e));
-			}
-		}
-	}
-
-	async loadAllFilesInProject(): Promise<void> {
-		// first get the files from the default glob pattern
-		const filesSet = await this.tryGetDefaultGlobFiles();
-
-		// add/remove any files listed in the sqlproj
-		// get any special entries with a type attribute
-		let entriesWithType: { relativePath: string, typeAttribute: string }[] = [];
-		await this.getBuildFilesInSqlproj(filesSet, entriesWithType);
-
-		// create a FileProjectEntry for each file
-		filesSet.forEach(f => {
-			const typeEntry = entriesWithType.find(e => e.relativePath === f);
-			this._files.push(this.createFileProjectEntry(f, EntryType.File, typeEntry ? typeEntry.typeAttribute : undefined));
-		});
-	}
-
-	/**
-	 *
-	 * @returns Set of files included by the default glob of the folder of the sqlproj
-	 */
-	async tryGetDefaultGlobFiles(): Promise<Set<string>> {
-		let filesSet: Set<string> = new Set();
-
-		if (this._isMsbuildSdkStyleProject) {
-			try {
-				const globFiles = await utils.getSqlFilesInFolder(this.projectFolderPath, true);
-				globFiles.forEach(f => {
-					filesSet.add(utils.convertSlashesForSqlProj(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(f))));
-				});
-			} catch (e) {
-				console.error(utils.getErrorMessage(e));
-			}
-		}
-
-		return filesSet;
-	}
-
-	/**
-	 * Gets all the files specified by <Build Inlude="..."> and removes all the files specified by <Build Remove="...">
-	 * @returns Set of files included in project as specified by the sqlproj
-	 */
-	async getBuildFilesInSqlproj(filesSet: Set<string>, entriesWithType: { relativePath: string, typeAttribute: string }[]): Promise<void> {
-		for (let ig = 0; ig < this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.ItemGroup).length; ig++) {
-			const itemGroup = this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.ItemGroup)[ig];
-
-			// find all folders and files to include that are specified in the project file
-			try {
-				const buildElements = itemGroup.getElementsByTagName(constants.Build);
-				for (let b = 0; b < buildElements.length; b++) {
-					const relativePath = buildElements[b].getAttribute(constants.Include)!;
-					const fullPath = path.join(utils.getPlatformSafeFileEntryPath(this.projectFolderPath), utils.getPlatformSafeFileEntryPath(relativePath));
-
-					// msbuild sdk style projects can handle other globbing patterns like <Build Include="folder1\*.sql" /> and <Build Include="Production*.sql" />
-					if (this._isMsbuildSdkStyleProject && !(await utils.exists(fullPath))) {
-						// add files from the glob pattern
-						const globFiles = await utils.globWithPattern(fullPath);
-						globFiles.forEach(gf => {
-							const newFileRelativePath = utils.convertSlashesForSqlProj(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(gf)));
-							if (!this._files.find(f => f.relativePath === newFileRelativePath)) {
-								this._files.push(this.createFileProjectEntry(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(gf)), EntryType.File));
-							}
-						});
-
-						// TODO: add support for <Build Remove="file.sql">
-
-					} else {
-						// only add file if it wasn't already added
-						if (!this._files.find(f => f.relativePath === relativePath)) {
-							this._files.push(this.createFileProjectEntry(relativePath, EntryType.File, buildElements[b].getAttribute(constants.Type)!));
-						}
-					}
-				}
-			} catch (e) {
-				void window.showErrorMessage(constants.errorReadingProject(constants.BuildElements, this.projectFilePath));
-				console.error(utils.getErrorMessage(e));
-			}
-		}
-	}
-
-	async loadFolders(): Promise<void> {
-		// glob style getting folders for new msbuild sdk style projects
-		if (this._isMsbuildSdkStyleProject) {
-			const folders = await utils.getFoldersInFolder(this.projectFolderPath, true);
-			folders.forEach(f => {
-				this._files.push(this.createFileProjectEntry(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(f)), EntryType.Folder));
-			});
-		}
-
-		for (let ig = 0; ig < this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.ItemGroup).length; ig++) {
-			const itemGroup = this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.ItemGroup)[ig];
-			try {
-				const folderElements = itemGroup.getElementsByTagName(constants.Folder);
-				for (let f = 0; f < folderElements.length; f++) {
-					const relativePath = folderElements[f].getAttribute(constants.Include)!;
-					// don't add Properties folder since it isn't supported for now and don't add if the folder was already added
-					if (relativePath !== constants.Properties && !this._files.find(f => f.relativePath === utils.trimChars(relativePath, '\\'))) {
-						this._files.push(this.createFileProjectEntry(relativePath, EntryType.Folder));
-					}
-				}
-			} catch (e) {
-				void window.showErrorMessage(constants.errorReadingProject(constants.Folder, this.projectFilePath));
-				console.error(utils.getErrorMessage(e));
-			}
-		}
-	}
-
-	loadPrePostDeployScripts(): void {
-		for (let ig = 0; ig < this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.ItemGroup).length; ig++) {
-			const itemGroup = this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.ItemGroup)[ig];
-			// find all pre-deployment scripts to include
-			let preDeployScriptCount: number = 0;
-			try {
-				const preDeploy = itemGroup.getElementsByTagName(constants.PreDeploy);
-				for (let pre = 0; pre < preDeploy.length; pre++) {
-					this._preDeployScripts.push(this.createFileProjectEntry(preDeploy[pre].getAttribute(constants.Include)!, EntryType.File));
-					preDeployScriptCount++;
-				}
-			} catch (e) {
-				void window.showErrorMessage(constants.errorReadingProject(constants.PreDeployElements, this.projectFilePath));
-				console.error(utils.getErrorMessage(e));
-			}
-
-			// find all post-deployment scripts to include
-			let postDeployScriptCount: number = 0;
-			try {
-				const postDeploy = itemGroup.getElementsByTagName(constants.PostDeploy);
-				for (let post = 0; post < postDeploy.length; post++) {
-					this._postDeployScripts.push(this.createFileProjectEntry(postDeploy[post].getAttribute(constants.Include)!, EntryType.File));
-					postDeployScriptCount++;
-				}
-			} catch (e) {
-				void window.showErrorMessage(constants.errorReadingProject(constants.PostDeployElements, this.projectFilePath));
-				console.error(utils.getErrorMessage(e));
-			}
-
-			if (preDeployScriptCount > 1 || postDeployScriptCount > 1) {
-				void window.showWarningMessage(constants.prePostDeployCount, constants.okString);
-			}
-
-			// find all none-deployment scripts to include
-			try {
-				const noneItems = itemGroup.getElementsByTagName(constants.None);
-				for (let n = 0; n < noneItems.length; n++) {
-					this._noneDeployScripts.push(this.createFileProjectEntry(noneItems[n].getAttribute(constants.Include)!, EntryType.File));
-				}
-			} catch (e) {
-				void window.showErrorMessage(constants.errorReadingProject(constants.NoneElements, this.projectFilePath));
 				console.error(utils.getErrorMessage(e));
 			}
 		}
@@ -1322,6 +1270,5 @@ export class Project implements ISqlProject {
 		return folderEntry;
 	}
 }
-
 
 export const reservedProjectFolders = ['Properties', 'Data Sources', 'Database References'];

--- a/extensions/sql-database-projects/src/models/projectEntry.ts
+++ b/extensions/sql-database-projects/src/models/projectEntry.ts
@@ -1,0 +1,161 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as utils from '../common/utils';
+import { IDacpacReferenceSettings, IProjectReferenceSettings } from './IDatabaseReferenceSettings';
+import { IFileProjectEntry } from 'sqldbproj';
+import { Uri } from 'vscode';
+
+/**
+ * Represents an entry in a project file
+ */
+export abstract class ProjectEntry {
+	type: EntryType;
+
+	constructor(type: EntryType) {
+		this.type = type;
+	}
+}
+
+export class FileProjectEntry extends ProjectEntry implements IFileProjectEntry {
+	/**
+	 * Absolute file system URI
+	 */
+	fsUri: Uri;
+	relativePath: string;
+	sqlObjectType: string | undefined;
+
+	constructor(uri: Uri, relativePath: string, entryType: EntryType, sqlObjectType?: string) {
+		super(entryType);
+		this.fsUri = uri;
+		this.relativePath = relativePath;
+		this.sqlObjectType = sqlObjectType;
+	}
+
+	public override toString(): string {
+		return this.fsUri.path;
+	}
+
+	public pathForSqlProj(): string {
+		return utils.convertSlashesForSqlProj(this.fsUri.fsPath);
+	}
+}
+
+/**
+ * Represents a database reference entry in a project file
+ */
+
+export interface IDatabaseReferenceProjectEntry extends FileProjectEntry {
+	databaseName: string;
+	databaseVariableLiteralValue?: string;
+	suppressMissingDependenciesErrors: boolean;
+}
+
+export class DacpacReferenceProjectEntry extends FileProjectEntry implements IDatabaseReferenceProjectEntry {
+	databaseVariableLiteralValue?: string;
+	databaseSqlCmdVariable?: string;
+	serverName?: string;
+	serverSqlCmdVariable?: string;
+	suppressMissingDependenciesErrors: boolean;
+
+	constructor(settings: IDacpacReferenceSettings) {
+		super(settings.dacpacFileLocation, '', EntryType.DatabaseReference);
+		this.databaseSqlCmdVariable = settings.databaseVariable;
+		this.databaseVariableLiteralValue = settings.databaseName;
+		this.serverName = settings.serverName;
+		this.serverSqlCmdVariable = settings.serverVariable;
+		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
+	}
+
+	/**
+	 * File name that gets displayed in the project tree
+	 */
+	public get databaseName(): string {
+		return path.parse(utils.getPlatformSafeFileEntryPath(this.fsUri.fsPath)).name;
+	}
+
+	public override pathForSqlProj(): string {
+		// need to remove the leading slash from path for build to work
+		return utils.convertSlashesForSqlProj(this.fsUri.path.substring(1));
+	}
+}
+
+export class SystemDatabaseReferenceProjectEntry extends FileProjectEntry implements IDatabaseReferenceProjectEntry {
+	constructor(uri: Uri, public ssdtUri: Uri, public databaseVariableLiteralValue: string | undefined, public suppressMissingDependenciesErrors: boolean) {
+		super(uri, '', EntryType.DatabaseReference);
+	}
+
+	/**
+	 * File name that gets displayed in the project tree
+	 */
+	public get databaseName(): string {
+		return path.parse(utils.getPlatformSafeFileEntryPath(this.fsUri.fsPath)).name;
+	}
+
+	public override pathForSqlProj(): string {
+		// need to remove the leading slash for system database path for build to work on Windows
+		return utils.convertSlashesForSqlProj(this.fsUri.path.substring(1));
+	}
+
+	public ssdtPathForSqlProj(): string {
+		// need to remove the leading slash for system database path for build to work on Windows
+		return utils.convertSlashesForSqlProj(this.ssdtUri.path.substring(1));
+	}
+}
+
+export class SqlProjectReferenceProjectEntry extends FileProjectEntry implements IDatabaseReferenceProjectEntry {
+	projectName: string;
+	projectGuid: string;
+	databaseVariableLiteralValue?: string;
+	databaseSqlCmdVariable?: string;
+	serverName?: string;
+	serverSqlCmdVariable?: string;
+	suppressMissingDependenciesErrors: boolean;
+
+	constructor(settings: IProjectReferenceSettings) {
+		super(settings.projectRelativePath!, '', EntryType.DatabaseReference);
+		this.projectName = settings.projectName;
+		this.projectGuid = settings.projectGuid;
+		this.databaseSqlCmdVariable = settings.databaseVariable;
+		this.databaseVariableLiteralValue = settings.databaseName;
+		this.serverName = settings.serverName;
+		this.serverSqlCmdVariable = settings.serverVariable;
+		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
+	}
+
+	public get databaseName(): string {
+		return this.projectName;
+	}
+
+	public override pathForSqlProj(): string {
+		// need to remove the leading slash from path for build to work on Windows
+		return utils.convertSlashesForSqlProj(this.fsUri.path.substring(1));
+	}
+}
+
+export class SqlCmdVariableProjectEntry extends ProjectEntry {
+	constructor(public variableName: string, public defaultValue: string) {
+		super(EntryType.SqlCmdVariable);
+	}
+}
+
+export enum EntryType {
+	File,
+	Folder,
+	DatabaseReference,
+	SqlCmdVariable
+}
+
+export enum DatabaseReferenceLocation {
+	sameDatabase,
+	differentDatabaseSameServer,
+	differentDatabaseDifferentServer
+}
+
+export enum SystemDatabase {
+	master,
+	msdb
+}

--- a/extensions/sql-database-projects/src/models/tree/databaseReferencesTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/databaseReferencesTreeItem.ts
@@ -10,7 +10,7 @@ import * as constants from '../../common/constants';
 import { BaseProjectTreeItem } from './baseTreeItem';
 import { ProjectRootTreeItem } from './projectTreeItem';
 import { IconPathHelper } from '../../common/iconHelper';
-import { IDatabaseReferenceProjectEntry } from '../../models/project';
+import { IDatabaseReferenceProjectEntry } from '../projectEntry';
 
 /**
  * Folder for containing references nodes in the tree

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -8,11 +8,12 @@ import * as path from 'path';
 import { DataSourcesTreeItem } from './dataSourceTreeItem';
 import { BaseProjectTreeItem } from './baseTreeItem';
 import * as fileTree from './fileFolderTreeItem';
-import { Project, EntryType, FileProjectEntry } from '../project';
+import { Project } from '../project';
 import * as utils from '../../common/utils';
 import { DatabaseReferencesTreeItem } from './databaseReferencesTreeItem';
 import { DatabaseProjectItemType, RelativeOuterPath, ExternalStreamingJob, sqlprojExtension } from '../../common/constants';
 import { IconPathHelper } from '../../common/iconHelper';
+import { EntryType, FileProjectEntry } from '../projectEntry';
 
 /**
  * TreeNode root that represents an entire project

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -12,11 +12,12 @@ import * as testUtils from './testUtils';
 import * as constants from '../common/constants';
 
 import { promises as fs } from 'fs';
-import { Project, EntryType, SystemDatabase, SystemDatabaseReferenceProjectEntry, SqlProjectReferenceProjectEntry } from '../models/project';
+import { Project } from '../models/project';
 import { exists, convertSlashesForSqlProj } from '../common/utils';
 import { Uri, window } from 'vscode';
 import { IDacpacReferenceSettings, IProjectReferenceSettings, ISystemDatabaseReferenceSettings } from '../models/IDatabaseReferenceSettings';
 import { SqlTargetPlatform } from 'sqldbproj';
+import { EntryType, SystemDatabaseReferenceProjectEntry, SqlProjectReferenceProjectEntry, SystemDatabase } from '../models/projectEntry';
 
 let projFilePath: string;
 

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -21,7 +21,7 @@ import { SqlDatabaseProjectTreeViewProvider } from '../controllers/databaseProje
 import { ProjectsController } from '../controllers/projectController';
 import { promises as fs } from 'fs';
 import { createContext, TestContext, mockDacFxResult, mockConnectionProfile } from './testContext';
-import { Project, reservedProjectFolders, SystemDatabase, FileProjectEntry, SystemDatabaseReferenceProjectEntry, EntryType } from '../models/project';
+import { Project, reservedProjectFolders } from '../models/project';
 import { PublishDatabaseDialog } from '../dialogs/publishDatabaseDialog';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { FolderNode, FileNode } from '../models/tree/fileFolderTreeItem';
@@ -31,6 +31,7 @@ import { IDacpacReferenceSettings } from '../models/IDatabaseReferenceSettings';
 import { CreateProjectFromDatabaseDialog } from '../dialogs/createProjectFromDatabaseDialog';
 import { ImportDataModel } from '../models/api/import';
 import { SqlTargetPlatform } from 'sqldbproj';
+import { SystemDatabaseReferenceProjectEntry, SystemDatabase, EntryType, FileProjectEntry } from '../models/projectEntry';
 
 let testContext: TestContext;
 

--- a/extensions/sql-database-projects/src/test/projectTree.test.ts
+++ b/extensions/sql-database-projects/src/test/projectTree.test.ts
@@ -8,10 +8,11 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
 
-import { Project, EntryType } from '../models/project';
+import { Project } from '../models/project';
 import { FolderNode, FileNode, sortFileFolderNodes } from '../models/tree/fileFolderTreeItem';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { DatabaseProjectItemType } from '../common/constants';
+import { EntryType } from '../models/projectEntry';
 
 describe('Project Tree tests', function (): void {
 	it('Should correctly order tree nodes by type, then by name', function (): void {


### PR DESCRIPTION
No functionality changes, just moving the project entry classes (file, database references, sqlcmd var) to their own file so they aren't at the bottom of project.ts anymore. 