### PR TITLE
Refactoring readProjFile()

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -162,8 +162,8 @@ export class Project implements ISqlProject {
 	 * @returns Set of files included in project as specified by the sqlproj
 	 */
 	async loadFilesInProject(): Promise<void> {
-		let filesSet: Set<string> = new Set();
-		let entriesWithType: { relativePath: string, typeAttribute: string }[] = [];
+		const filesSet: Set<string> = new Set();
+		const entriesWithType: { relativePath: string, typeAttribute: string }[] = [];
 
 		// default glob include pattern for msbuild sdk style projects
 		if (this._isMsbuildSdkStyleProject) {

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -159,7 +159,6 @@ export class Project implements ISqlProject {
 	/**
 	 * Gets all the files specified by <Build Inlude="..."> and removes all the files specified by <Build Remove="...">
 	 * and all files included by the default glob of the folder of the sqlproj if it's an msbuild sdk style project
-	 * @returns Set of files included in project as specified by the sqlproj
 	 */
 	async loadFilesInProject(): Promise<void> {
 		const filesSet: Set<string> = new Set();


### PR DESCRIPTION
- Moved the bigger chunks of logic in `readProjFile()` to their own helper functions (files, folders, pre/post deploy scripts, and database references) so `readProjFile()` is easier to read.
- Use a set instead of checking if a files already there before adding it to avoid duplicates when loading the files included in the project.
