### PR TITLE
Fix query editors restoring as plain text

### DIFF
--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -206,6 +206,11 @@ export class QueryEditor extends EditorPane {
 		this._register(this.connectionManagementService.onLanguageFlavorChanged(() => {
 			this.setTaskbarContent();
 		}));
+		this._register(this.capabilitiesService.onCapabilitiesRegistered(c => {
+			if (c.id === this.currentProvider) {
+				this.setTaskbarContent();
+			}
+		}));
 	}
 
 	/**
@@ -268,13 +273,17 @@ export class QueryEditor extends EditorPane {
 		return this._listDatabasesActionItem;
 	}
 
-	private setTaskbarContent(): void {
-		const previewFeaturesEnabled = this.configurationService.getValue('workbench')['enablePreviewFeatures'];
+	private get currentProvider(): string | undefined {
 		const connectionProfile = this.connectionManagementService.getConnectionProfile(this.input?.uri);
-		const fileExtension = path.extname(this.input?.uri || '');
-		const providerId = connectionProfile?.providerName ||
+		return connectionProfile?.providerName ||
 			this.connectionManagementService.getProviderIdFromUri(this.input?.uri) ||
 			this.connectionManagementService.getDefaultProviderId();
+	}
+
+	private setTaskbarContent(): void {
+		const previewFeaturesEnabled = this.configurationService.getValue('workbench')['enablePreviewFeatures'];
+		const fileExtension = path.extname(this.input?.uri || '');
+		const providerId = this.currentProvider;
 		const content: ITaskbarContent[] = [
 			{ action: this._runQueryAction },
 			{ action: this._cancelQueryAction },
@@ -294,7 +303,8 @@ export class QueryEditor extends EditorPane {
 		}
 
 		// Only show the databases dropdown if the connection provider supports it.
-		if (this.capabilitiesService.getCapabilities(providerId).connection?.connectionOptions?.find(option => option.specialValueType === ConnectionOptionSpecialType.databaseName)) {
+		// If the provider we're using isn't registered yet then default to not showing it - we'll update once the provider is registered
+		if (this.capabilitiesService.getCapabilities(providerId)?.connection?.connectionOptions?.find(option => option.specialValueType === ConnectionOptionSpecialType.databaseName)) {
 			content.push({ action: this._listDatabasesAction });
 		}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/17642

This was broken in  https://github.com/microsoft/azuredatastudio/pull/17538

When restoring the editors we don't have providers registered yet and so providerId was undefined which meant it was throwing an exception on line 297 (attempting to get connection of undefined).

Fixing this by defaulting to not showing the dropdown and then hooking up to the capabilities service to listen for when our provider is registered and updating the taskbar again then. 