### PR TITLE
fix sqlproj encoded @ bug

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -152,7 +152,7 @@ export class Project implements ISqlProject {
 
 				// <Build Include....>
 				for (let b = 0; b < buildElements.length; b++) {
-					const relativePath = buildElements[b].getAttribute(constants.Include)!;
+					let relativePath = buildElements[b].getAttribute(constants.Include)!;
 
 					if (relativePath) {
 						const fullPath = path.join(utils.getPlatformSafeFileEntryPath(this.projectFolderPath), utils.getPlatformSafeFileEntryPath(relativePath));
@@ -170,9 +170,14 @@ export class Project implements ISqlProject {
 						} else {
 							// only add file if it wasn't already added
 							if (!this._files.find(f => f.relativePath === relativePath)) {
-								// SSDT encodes @ to %40, so we need to decode that and any other characters that might have been encoded
-								const decodedRelativePath = decodeURIComponent(relativePath);
-								this._files.push(this.createFileProjectEntry(decodedRelativePath, EntryType.File, buildElements[b].getAttribute(constants.Type)!));
+								// SSDT encodes @ to %40, so we need to decode that so that it shows correctly in the tree
+								// I didn't find any other characters that get encoded, so this check is specifically for %40 to have lower risk of accidentally breaking something
+								// but we can decode all relative paths in the future if we find other characters that get encoded
+								if (relativePath.includes('%40')) {
+									relativePath = decodeURIComponent(relativePath);
+								}
+
+								this._files.push(this.createFileProjectEntry(relativePath, EntryType.File, buildElements[b].getAttribute(constants.Type)!));
 							}
 						}
 					}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -170,7 +170,9 @@ export class Project implements ISqlProject {
 						} else {
 							// only add file if it wasn't already added
 							if (!this._files.find(f => f.relativePath === relativePath)) {
-								this._files.push(this.createFileProjectEntry(relativePath, EntryType.File, buildElements[b].getAttribute(constants.Type)!));
+								// SSDT encodes @ to %40, so we need to decode that and any other characters that might have been encoded
+								const decodedRelativePath = decodeURIComponent(relativePath);
+								this._files.push(this.createFileProjectEntry(decodedRelativePath, EntryType.File, buildElements[b].getAttribute(constants.Type)!));
 							}
 						}
 					}

--- a/extensions/sql-database-projects/src/test/baselines/SSDTProjectAfterUpdateBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/SSDTProjectAfterUpdateBaseline.xml
@@ -63,6 +63,7 @@
   <ItemGroup>
     <Build Include="Tables\Users.sql" />
     <Build Include="Tables\Action History.sql" />
+    <Build Include="Tables\Test%40Info.sql" />
     <Build Include="Views\Maintenance\Database Performance.sql" />
   </ItemGroup>
   <ItemGroup>

--- a/extensions/sql-database-projects/src/test/baselines/SSDTProjectBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/SSDTProjectBaseline.xml
@@ -63,6 +63,7 @@
   <ItemGroup>
     <Build Include="Tables\Users.sql" />
     <Build Include="Tables\Action History.sql" />
+    <Build Include="Tables\Test%40Info.sql" />
     <Build Include="Views\Maintenance\Database Performance.sql" />
   </ItemGroup>
   <ItemGroup>

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -1092,6 +1092,19 @@ describe('Project: round trip updates', function (): void {
 		should(spy.notCalled).be.true();
 		should(project.isMsbuildSdkStyleProject).be.true();
 	}
+
+	it('Should handle SSDT encoded characters in file names in sqlproj', async function (): Promise<void> {
+		sinon.stub(window, 'showWarningMessage').returns(<any>Promise.resolve(constants.yesString));
+
+		projFilePath = await testUtils.createTestSqlProjFile(baselines.SSDTProjectFileBaseline);
+		const project = await Project.openProject(projFilePath); // project gets updated if needed in openProject()
+
+		// verify that test%40info.sql got read as test@info.sql
+		const projFileText = (await fs.readFile(projFilePath)).toString();
+		should(projFileText.includes('Tables\\Test%40Info.sql')).equal(true);
+		should(project.files.filter(f => f.relativePath === 'Tables\\Test@Info.sql').length).equal(1);
+	});
+
 });
 
 async function testUpdateInRoundTrip(fileBeforeupdate: string, fileAfterUpdate: string): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17020. I'm not sure why SSDT encodes @ to %40 for file names in sqlprojs(SSDT doesn't encode spaces in file names in sqlprojs), but this makes it so that they'll get read correctly in ADS.  I didn't find any others that get encoded when I did a little testing in SSDT, but this should also handle it if any other characters that get encoded by SSDT in the sqlproj. 
