### PR TITLE
Corrects Web Build Pipeline ENOENT Error

### DIFF
--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -37,18 +37,7 @@ import { setup as setupLaunchTests } from './areas/workbench/launch.test';*/
 
 const tmpDir = tmp.dirSync({ prefix: 't' }) as { name: string; removeCallback: Function; };
 const testDataPath = tmpDir.name;
-if (fs.existsSync(tmpDir.name)) {
-	console.log(`Directory: ${tmpDir.name} exists.`);
-} else {
-	console.log(`Directory: ${tmpDir.name} does not exist.`);
-}
-const testLogPath = tmpDir.name + '/d/logs';
-if (fs.existsSync(testLogPath)) {
-	console.log(`Log directory ${testLogPath} exists.`);
-} else {
-	console.log(`Log directory ${testLogPath} does not exist.`);
-}
-
+process.once('exit', () => rimraf.sync(testDataPath));
 
 const [, , ...args] = process.argv;
 const opts = minimist(args, {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -279,6 +279,7 @@ after(async function () {
 	if (opts.log) {
 		const logsDir = path.join(userDataDir, 'logs');
 		const destLogsDir = path.join(path.dirname(opts.log), 'logs');
+		// {{ SQL CARBON EDIT }} Checks for the existence of the logs directory before accessing.
 		if (fs.existsSync(logsDir)) {
 			await new Promise((c, e) => ncp(logsDir, destLogsDir, err => err ? e(err) : c(undefined)));
 		}

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -279,13 +279,16 @@ after(async function () {
 	if (opts.log) {
 		const logsDir = path.join(userDataDir, 'logs');
 		const destLogsDir = path.join(path.dirname(opts.log), 'logs');
-		if (fs.existsSync(logsDir)) {
-			console.log(`Path to log dir: ${logsDir} available for copying.`);
-		} else {
-			console.log(`Path to log dir: ${logsDir} not available for copying.`);
-		}
 
-		await new Promise((c, e) => ncp(logsDir, destLogsDir, err => err ? e(err) : c(undefined)));
+		// {{ SQL CARBON EDIT }}
+		/**
+		 * The logs directory is not present during the ADS web build, but is during the Darwin build.
+		 * In situations where the directory is missing and a copy attempt is made, bash exits with code 255 and raises an error
+		 * explaining that there's no such file or directory. This check prevents that error from occurring.
+		 */
+		if (fs.existsSync(logsDir)) {
+			await new Promise((c, e) => ncp(logsDir, destLogsDir, err => err ? e(err) : c(undefined)));
+		}
 	}
 
 	await new Promise((c, e) => rimraf(testDataPath, { maxBusyTries: 10 }, err => err ? e(err) : c(undefined)));

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -275,16 +275,6 @@ before(async function () {
 
 after(async function () {
 	await new Promise(c => setTimeout(c, 500)); // wait for shutdown
-
-	if (opts.log) {
-		const logsDir = path.join(userDataDir, 'logs');
-		const destLogsDir = path.join(path.dirname(opts.log), 'logs');
-		// {{ SQL CARBON EDIT }} Checks for the existence of the logs directory before accessing.
-		if (fs.existsSync(logsDir)) {
-			await new Promise((c, e) => ncp(logsDir, destLogsDir, err => err ? e(err) : c(undefined)));
-		}
-	}
-
 	await new Promise((c, e) => rimraf(testDataPath, { maxBusyTries: 10 }, err => err ? e(err) : c(undefined)));
 });
 

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -284,10 +284,13 @@ after(async function () {
 		/**
 		 * The logs directory is not present during the ADS web build, but is during the Darwin build.
 		 * In situations where the directory is missing and a copy attempt is made, bash exits with code 255 and raises an error
-		 * explaining that there's no such file or directory. This check prevents that error from occurring.
+		 * explaining that there's no such file or directory. This prevents that error from occurring.
 		 */
-		if (fs.existsSync(logsDir)) {
+		try {
 			await new Promise((c, e) => ncp(logsDir, destLogsDir, err => err ? e(err) : c(undefined)));
+		}
+		catch (ex) {
+			console.warn(`Caught exception from ncp: ${ex}`);
 		}
 	}
 

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -279,7 +279,9 @@ after(async function () {
 	if (opts.log) {
 		const logsDir = path.join(userDataDir, 'logs');
 		const destLogsDir = path.join(path.dirname(opts.log), 'logs');
-		await new Promise((c, e) => ncp(logsDir, destLogsDir, err => err ? e(err) : c(undefined)));
+		if (fs.existsSync(logsDir)) {
+			await new Promise((c, e) => ncp(logsDir, destLogsDir, err => err ? e(err) : c(undefined)));
+		}
 	}
 
 	await new Promise((c, e) => rimraf(testDataPath, { maxBusyTries: 10 }, err => err ? e(err) : c(undefined)));

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -37,7 +37,18 @@ import { setup as setupLaunchTests } from './areas/workbench/launch.test';*/
 
 const tmpDir = tmp.dirSync({ prefix: 't' }) as { name: string; removeCallback: Function; };
 const testDataPath = tmpDir.name;
-process.once('exit', () => rimraf.sync(testDataPath));
+if (fs.existsSync(tmpDir.name)) {
+	console.log(`Directory: ${tmpDir.name} exists.`);
+} else {
+	console.log(`Directory: ${tmpDir.name} does not exist.`);
+}
+const testLogPath = tmpDir.name + '/d/logs';
+if (fs.existsSync(testLogPath)) {
+	console.log(`Log directory ${testLogPath} exists.`);
+} else {
+	console.log(`Log directory ${testLogPath} does not exist.`);
+}
+
 
 const [, , ...args] = process.argv;
 const opts = minimist(args, {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -10,7 +10,6 @@ import * as minimist from 'minimist';
 import * as tmp from 'tmp';
 import * as rimraf from 'rimraf';
 import * as mkdirp from 'mkdirp';
-import { ncp } from 'ncp';
 import {
 	Application,
 	Quality,

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -10,6 +10,7 @@ import * as minimist from 'minimist';
 import * as tmp from 'tmp';
 import * as rimraf from 'rimraf';
 import * as mkdirp from 'mkdirp';
+import { ncp } from 'ncp';
 import {
 	Application,
 	Quality,
@@ -274,6 +275,19 @@ before(async function () {
 
 after(async function () {
 	await new Promise(c => setTimeout(c, 500)); // wait for shutdown
+
+	if (opts.log) {
+		const logsDir = path.join(userDataDir, 'logs');
+		const destLogsDir = path.join(path.dirname(opts.log), 'logs');
+		if (fs.existsSync(logsDir)) {
+			console.log(`Path to log dir: ${logsDir} available for copying.`);
+		} else {
+			console.log(`Path to log dir: ${logsDir} not available for copying.`);
+		}
+
+		await new Promise((c, e) => ncp(logsDir, destLogsDir, err => err ? e(err) : c(undefined)));
+	}
+
 	await new Promise((c, e) => rimraf(testDataPath, { maxBusyTries: 10 }, err => err ? e(err) : c(undefined)));
 });
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17632 

This PR resolves an ENOENT (Error no Entry) error affecting smoke tests in the web build pipeline. The ENOENT error was occurring because an attempt to copy from a path that didn't exist was being made.

In regard to the missing screenshots, the YAML file is already configured to capture screenshots when a test fails, but doesn't capture any for passing tests. In this case, tests weren't failing, so there weren't any screenshots.

