### PR TITLE
update add file/folder for msbuild sdk style projects

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -1359,7 +1359,7 @@ export class Project implements ISqlProject {
 		// If folder doesn't exist, create it
 		await fs.mkdir(absoluteFolderPath, { recursive: true });
 
-		// don't need to add the folder to the sqlproj if this is an msbuild sdk style project because globbing will get all the folder
+		// don't need to add the folder to the sqlproj if this is an msbuild sdk style project because globbing will get the folders
 		if (this.isMsbuildSdkStyleProject) {
 			return this.createFileProjectEntry(relativeFolderPath, EntryType.Folder);
 		}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -593,10 +593,7 @@ export class Project implements ISqlProject {
 		}
 
 		// Ensure that parent folder item exist in the project for the corresponding file path
-		// msbuild sdk projects use globbing to get the folders, so we don't need to do this
-		if (!this.isMsbuildSdkStyleProject) {
-			await this.ensureFolderItems(path.relative(this.projectFolderPath, path.dirname(absoluteFilePath)));
-		}
+		await this.ensureFolderItems(path.relative(this.projectFolderPath, path.dirname(absoluteFilePath)));
 
 		// Check if file already has been added to sqlproj
 		const normalizedRelativeFilePath = utils.convertSlashesForSqlProj(relativeFilePath);
@@ -1361,6 +1358,11 @@ export class Project implements ISqlProject {
 
 		// If folder doesn't exist, create it
 		await fs.mkdir(absoluteFolderPath, { recursive: true });
+
+		// don't need to add the folder to the sqlproj if this is an msbuild sdk style project because globbing will get all the folder
+		if (this.isMsbuildSdkStyleProject) {
+			return this.createFileProjectEntry(relativeFolderPath, EntryType.Folder);
+		}
 
 		// Add project file entries for all folders in the path.
 		// SSDT expects all folders to be explicitly listed in the project file, so we construct

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -593,7 +593,10 @@ export class Project implements ISqlProject {
 		}
 
 		// Ensure that parent folder item exist in the project for the corresponding file path
-		await this.ensureFolderItems(path.relative(this.projectFolderPath, path.dirname(absoluteFilePath)));
+		// msbuild sdk projects use globbing to get the folders, so we don't need to do this
+		if (!this.isMsbuildSdkStyleProject) {
+			await this.ensureFolderItems(path.relative(this.projectFolderPath, path.dirname(absoluteFilePath)));
+		}
 
 		// Check if file already has been added to sqlproj
 		const normalizedRelativeFilePath = utils.convertSlashesForSqlProj(relativeFilePath);
@@ -863,7 +866,7 @@ export class Project implements ISqlProject {
 		return outputItemGroup;
 	}
 
-	private addFileToProjFile(path: string, xmlTag: string, attributes?: Map<string, string>): void {
+	private async addFileToProjFile(path: string, xmlTag: string, attributes?: Map<string, string>): Promise<void> {
 		let itemGroup;
 
 		if (xmlTag === constants.PreDeploy || xmlTag === constants.PostDeploy) {
@@ -876,6 +879,14 @@ export class Project implements ISqlProject {
 			}
 		}
 		else {
+			const currentFiles = await this.readFilesInProject();
+
+			// don't need to add an entry if it's already included by a glob pattern
+			// unless it has an attribute that needs to be added, like external streaming job which needs it so it can be determined if validation can run on it
+			if (attributes?.size === 0 && currentFiles.find(f => f.relativePath === utils.convertSlashesForSqlProj(path))) {
+				return;
+			}
+
 			itemGroup = this.findOrCreateItemGroup(xmlTag);
 		}
 
@@ -1202,7 +1213,7 @@ export class Project implements ISqlProject {
 	private async addToProjFile(entry: ProjectEntry, xmlTag?: string, attributes?: Map<string, string>): Promise<void> {
 		switch (entry.type) {
 			case EntryType.File:
-				this.addFileToProjFile((<FileProjectEntry>entry).relativePath, xmlTag ? xmlTag : constants.Build, attributes);
+				await this.addFileToProjFile((<FileProjectEntry>entry).relativePath, xmlTag ? xmlTag : constants.Build, attributes);
 				break;
 			case EntryType.Folder:
 				this.addFolderToProjFile((<FileProjectEntry>entry).relativePath);

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -947,6 +947,40 @@ describe('Project: Msbuild sdk style project content operations', function (): v
 		// <Build Remove="file1.sql" />
 		should(project.files.filter(f => f.relativePath === 'file1.sql').length).equal(0);
 	});
+
+	it('Should only add Build entries to sqlproj for files not included by project folder glob and external streaming jobs', async function (): Promise<void> {
+		projFilePath = await testUtils.createTestSqlProjFile(baselines.openNewStyleSqlProjectBaseline);
+		const project = await Project.openProject(projFilePath);
+
+		const folderPath = 'Stored Procedures';
+		const scriptPath = path.join(folderPath, 'Fake Stored Proc.sql');
+		const scriptContents = 'SELECT \'This is not actually a stored procedure.\'';
+
+		const scriptPathTagged = 'Fake External Streaming Job.sql';
+		const scriptContentsTagged = 'EXEC sys.sp_create_streaming_job \'job\', \'SELECT 7\'';
+
+		const outsideFolderScriptPath = path.join('..', 'Other Fake Stored Proc.sql');
+		const outsideFolderScriptContents = 'SELECT \'This is also not actually a stored procedure.\'';
+
+		await project.addScriptItem(scriptPath, scriptContents);
+		await project.addScriptItem(scriptPathTagged, scriptContentsTagged, templates.externalStreamingJob);
+		await project.addScriptItem(outsideFolderScriptPath, outsideFolderScriptContents);
+
+		const newProject = await Project.openProject(projFilePath);
+
+		should(newProject.files.find(f => f.type === EntryType.Folder && f.relativePath === convertSlashesForSqlProj(folderPath))).not.equal(undefined);
+		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(scriptPath))).not.equal(undefined);
+		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(scriptPathTagged))).not.equal(undefined);
+		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(scriptPathTagged))?.sqlObjectType).equal(constants.ExternalStreamingJob);
+		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(outsideFolderScriptPath))).not.equal(undefined);
+
+		// only the external streaming job and file outside of the project folder should have been added to the sqlproj
+		const projFileText = (await fs.readFile(projFilePath)).toString();
+		should(projFileText.includes('<Build Include="Stored Procedures\\Fake Stored Proc.sql" />')).equal(false, projFileText);
+		should(projFileText.includes('<Build Include="Fake External Streaming Job.sql" Type="ExternalStreamingJob" />')).equal(true, projFileText);
+		should(projFileText.includes('<Build Include="..\\Other Fake Stored Proc.sql" />')).equal(true, projFileText);
+	});
+
 });
 
 describe('Project: add SQLCMD Variables', function (): void {

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -962,9 +962,12 @@ describe('Project: Msbuild sdk style project content operations', function (): v
 		const outsideFolderScriptPath = path.join('..', 'Other Fake Stored Proc.sql');
 		const outsideFolderScriptContents = 'SELECT \'This is also not actually a stored procedure.\'';
 
+		const otherFolderPath = 'OtherFolder';
+
 		await project.addScriptItem(scriptPath, scriptContents);
 		await project.addScriptItem(scriptPathTagged, scriptContentsTagged, templates.externalStreamingJob);
 		await project.addScriptItem(outsideFolderScriptPath, outsideFolderScriptContents);
+		await project.addFolderItem(otherFolderPath);
 
 		const newProject = await Project.openProject(projFilePath);
 
@@ -973,12 +976,15 @@ describe('Project: Msbuild sdk style project content operations', function (): v
 		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(scriptPathTagged))).not.equal(undefined);
 		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(scriptPathTagged))?.sqlObjectType).equal(constants.ExternalStreamingJob);
 		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(outsideFolderScriptPath))).not.equal(undefined);
+		should(newProject.files.find(f => f.type === EntryType.Folder && f.relativePath === convertSlashesForSqlProj(otherFolderPath))).not.equal(undefined);
 
 		// only the external streaming job and file outside of the project folder should have been added to the sqlproj
 		const projFileText = (await fs.readFile(projFilePath)).toString();
+		should(projFileText.includes('<Folder Include="Stored Procedures" />')).equal(false, projFileText);
 		should(projFileText.includes('<Build Include="Stored Procedures\\Fake Stored Proc.sql" />')).equal(false, projFileText);
 		should(projFileText.includes('<Build Include="Fake External Streaming Job.sql" Type="ExternalStreamingJob" />')).equal(true, projFileText);
 		should(projFileText.includes('<Build Include="..\\Other Fake Stored Proc.sql" />')).equal(true, projFileText);
+		should(projFileText.includes('<Folder Include="OtherFolder" />')).equal(false, projFileText);
 	});
 
 });


### PR DESCRIPTION
For msbuild sdk style projects, the folders and most of the files can be found by the project folder globbing, so a build entry only needs to be added to the sqlproj in a couple cases:
- file is outside the project's folder
- external streaming job because it needs the Type attribute (`<Build Include="ExternalStreamingJob2.sql" Type="ExternalStreamingJob" />`) to identify it as an external streaming job so the extension knows that streaming job validation can run on it.
