### PR TITLE
Fix sql projects net6 warnings

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -43,7 +43,7 @@
       {
         "title": "%sqlDatabaseProjects.Settings%",
         "properties": {
-          "sqlDatabaseProjects.netCoreSDKLocation": {
+          "sqlDatabaseProjects.netCoreSDK Location": {
             "type": "string",
             "description": "%sqlDatabaseProjects.netCoreInstallLocation%"
           },

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -35,7 +35,7 @@
 	"sqlDatabaseProjects.Settings": "Database Projects",
 	"sqlDatabaseProjects.netCoreInstallLocation": "Full path to .NET Core SDK on the machine.",
 	"sqlDatabaseProjects.netCoreDoNotAsk": "Whether to prompt the user to install .NET Core when not detected.",
-	"sqlDatabaseProjects.netCoreDowngradeDoNotShow": "Whether to prompt the user to set .NET SDK version when a newer unsupported version is detected.",
+	"sqlDatabaseProjects.netCoreDowngradeDoNotShow": "Whether to prompt the user to install .NET SDK version and add global.json to project when a newer unsupported version is detected.",
 	"sqlDatabaseProjects.nodejsDoNotAsk": "Whether to prompt the user to install Node.js when not detected.",
 	"sqlDatabaseProjects.autorestSqlVersion": "Which version of Autorest.Sql to use from NPM.  Latest will be used if not set.",
 	"sqlDatabaseProjects.welcome": "No database projects currently open.\n[New Project](command:sqlDatabaseProjects.new)\n[Open Project](command:sqlDatabaseProjects.open)\n[Create Project From Database](command:sqlDatabaseProjects.importDatabase)",

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -82,9 +82,6 @@ export default class MainController implements vscode.Disposable {
 		IconPathHelper.setExtensionContext(this.extensionContext);
 
 		await templates.loadTemplates(path.join(this.context.extensionPath, 'resources', 'templates'));
-
-		// ensure .net core is installed
-		await this.netcoreTool.findOrInstallNetCore();
 	}
 
 	public dispose(): void {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -252,7 +252,8 @@ export class ProjectsController {
 
 			const message = utils.getErrorMessage(err);
 			if (err instanceof DotNetError) {
-				void vscode.window.showErrorMessage(message);
+				// DotNetErrors already get shown by the netCoreTool so just show this one in the console
+				console.error(message);
 			} else {
 				void vscode.window.showErrorMessage(constants.projBuildFailed(message));
 			}

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -17,7 +17,7 @@ import { ShellCommandOptions, ShellExecutionHelper } from './shellExecutionHelpe
 const localize = nls.loadMessageBundle();
 
 export const DBProjectConfigurationKey: string = 'sqlDatabaseProjects';
-export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
+export const NetCoreInstallLocationKey: string = 'netCoreSDK Location';
 export const NetCoreDoNotAskAgainKey: string = 'netCoreDoNotAsk';
 export const NetCoreDowngradeDoNotShowAgainKey: string = 'netCoreDowngradeDoNotShow';
 export const NetCoreNonWindowsDefaultPath = '/usr/local/share';

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -208,7 +208,8 @@ export class NetCoreTool extends ShellExecutionHelper {
 			} else if (this.netCoreInstallState === netCoreInstallState.netCoreVersionTooHigh && vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDowngradeDoNotShowAgainKey] === true) {
 				// Assume user has used global.json to override SDK version and proceed with build as is
 			} else {
-				throw new DotNetError(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!));
+				// don't continue building if the user hasn't selected the do not show again on the warnings shown from findOrInstallNetCore()
+				return '';
 			}
 		}
 

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -208,8 +208,7 @@ export class NetCoreTool extends ShellExecutionHelper {
 			} else if (this.netCoreInstallState === netCoreInstallState.netCoreVersionTooHigh && vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDowngradeDoNotShowAgainKey] === true) {
 				// Assume user has used global.json to override SDK version and proceed with build as is
 			} else {
-				// don't continue building if the user hasn't selected the do not show again on the warnings shown from findOrInstallNetCore()
-				return '';
+				throw new DotNetError(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!));
 			}
 		}
 


### PR DESCRIPTION
This PR fixes #17667 and the double warning also mentioned in that issue. Now the .net 6 installed warning only shows when trying to build a project and it "Do Not Show Again" hasn't been selected.

before (two warnings):
![image](https://user-images.githubusercontent.com/31145923/141854953-37b13689-1e99-49c5-a62c-87adb27dcf51.png)

now:
![image](https://user-images.githubusercontent.com/31145923/141854738-34e5d78b-02b8-4304-8b06-68e179749f29.png)
