### PR TITLE
undo adding space in net core sdk location setting

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -43,7 +43,7 @@
       {
         "title": "%sqlDatabaseProjects.Settings%",
         "properties": {
-          "sqlDatabaseProjects.netCoreSDK Location": {
+          "sqlDatabaseProjects.netCoreSDKLocation": {
             "type": "string",
             "description": "%sqlDatabaseProjects.netCoreInstallLocation%"
           },

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -17,7 +17,7 @@ import { ShellCommandOptions, ShellExecutionHelper } from './shellExecutionHelpe
 const localize = nls.loadMessageBundle();
 
 export const DBProjectConfigurationKey: string = 'sqlDatabaseProjects';
-export const NetCoreInstallLocationKey: string = 'netCoreSDK Location';
+export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
 export const NetCoreDoNotAskAgainKey: string = 'netCoreDoNotAsk';
 export const NetCoreDowngradeDoNotShowAgainKey: string = 'netCoreDowngradeDoNotShow';
 export const NetCoreNonWindowsDefaultPath = '/usr/local/share';


### PR DESCRIPTION
Undo adding the space in the config so customers don't lose this setting if they had it configured. We'll need to update this again later to remove the core from the name since it isn't just .net core anymore.
