### PR TITLE
update the vmImage for build jobs

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -53,7 +53,7 @@ jobs:
 - job: Windows
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_WIN32'], 'true'))
   pool:
-    vmImage: VS2017-Win2016
+    vmImage: 'windows-2019'
   dependsOn:
   - Compile
   steps:

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -20,7 +20,7 @@ jobs:
 - job: macOS
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_MACOS'], 'true'), ne(variables['VSCODE_QUALITY'], 'saw'))
   pool:
-    vmImage: macOS-latest
+    vmImage: 'macOS-10.15'
   dependsOn:
   - Compile
   steps:
@@ -30,7 +30,7 @@ jobs:
 - job: macOS_Signing
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_MACOS'], 'true'), eq(variables['signed'], true), ne(variables['VSCODE_QUALITY'], 'saw'))
   pool:
-    vmImage: macOS-latest
+    vmImage: 'macOS-10.15'
   dependsOn:
   - macOS
   steps:

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -27,7 +27,7 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { tar --force-local -xzf $(Pipeline.Workspace)/compilation.tar.gz }
+      exec { tar -xf $(Pipeline.Workspace)/compilation.tar.gz }
     displayName: Extract compilation output
 
   - powershell: |


### PR DESCRIPTION
update the vmImage for jobs to upgrade to newer windows version
![image](https://user-images.githubusercontent.com/13777222/142126124-f3911659-27ba-48b1-a792-6aa83710f4e8.png)

for macos I am updating it to use more specific version (the current value of  macos-latest) to avoid unexpected failures just in case.

tested the changes with the Ad Hoc product build pipeline.