### PR TITLE
properties pane improvements

### DIFF
--- a/src/sql/workbench/browser/designer/designerPropertiesPane.ts
+++ b/src/sql/workbench/browser/designer/designerPropertiesPane.ts
@@ -40,6 +40,10 @@ export class DesignerPropertiesPane {
 		return this._groupHeaders;
 	}
 
+	public get descriptionElement(): HTMLElement {
+		return this._descriptionContainer;
+	}
+
 	public get componentMap(): Map<string, { defintion: DesignerDataPropertyInfo, component: DesignerUIComponent }> {
 		return this._componentMap;
 	}
@@ -50,7 +54,7 @@ export class DesignerPropertiesPane {
 
 	public updateDescription(definition: DesignerDataPropertyInfo) {
 		this._descriptionContainer.style.display = 'block';
-		const title: string = definition.componentProperties.title ?? '';
+		const title: string = definition.componentProperties.title || definition.componentProperties.ariaLabel || '';
 		const description: string = definition.description ?? '';
 		this._descriptionTitleContainer.innerText = title;
 		this._descriptionTextContainer.innerText = description;

--- a/src/sql/workbench/browser/designer/media/designer.css
+++ b/src/sql/workbench/browser/designer/media/designer.css
@@ -103,9 +103,10 @@
 }
 
 .designer-component .description-component {
-	margin: 15px;
-	height: 90px;
-	overflow-y: auto;
+	padding: 10px;
+	flex: 0 0 auto;
+	border-width: 1px 0 0 0;
+	border-style: solid;
 }
 
 .designer-component .description-component-label.codicon.info {
@@ -113,8 +114,7 @@
 	background-position: 2px center;
 	padding-left: 25px;
 	background-size: 16px;
-	font-size: 15px;
-	font-weight: 600;
+	font-weight: bold;
 	margin-block-start: 0px;
 	scroll-margin-block-end: 0px;
 }

--- a/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
+++ b/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
@@ -374,6 +374,7 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 			{
 				componentType: 'table',
 				propertyName: designers.TableForeignKeyProperty.Columns,
+				description: localize('designer.foreignkey.description.columnMapping', "The mapping between foreign key columns and primary key columns."),
 				group: localize('tableDesigner.foreignKeyColumns', "Column Mapping"),
 				componentProperties: <DesignerTableProperties>{
 					ariaLabel: localize('tableDesigner.foreignKeyColumns', "Column Mapping"),


### PR DESCRIPTION
1. previously, once we go into a second level object, it is not possible to show the table object properties, now I am adding logic if the focus goes into a none-table object in the content area, we should the properties of the table.
2. show the description for the tables in the properties pane.
3. adjust the properties pane style

![image](https://user-images.githubusercontent.com/13777222/142355598-4942f044-3ee3-4a37-942a-c29eaf73e1cc.png)

