### PR TITLE
Add additional properties to wizard page navigation events

### DIFF
--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -227,7 +227,10 @@ export class WizardModal extends Modal {
 				.withAdditionalProperties({
 					wizardName: this._wizard.name,
 					pageNavigationFrom: this._wizard.pages[prevPageIndex].pageName ?? prevPageIndex,
-					pageNavigationTo: this._wizard.pages[index].pageName ?? index
+					pageNavigationTo: this._wizard.pages[index].pageName ?? index,
+					pageNavigationFromIndex: prevPageIndex,
+					pageNavigationToIndex: index,
+					direction: index > prevPageIndex ? 'forward' : 'backward'
 				}).send();
 		}
 	}


### PR DESCRIPTION
Direction is a little redundant since it can be calculated from the index, but figured it's easier to save the backend a little extra processing and just do it here. 