### PR TITLE
Fix "unsupported version" error when adding sql binding package

### DIFF
--- a/extensions/sql-database-projects/src/tools/packageHelper.ts
+++ b/extensions/sql-database-projects/src/tools/packageHelper.ts
@@ -47,8 +47,8 @@ export class PackageHelper {
 			commandTitle: constants.addPackage,
 			argument: this.constructAddPackageArguments(projectUri, packageName, packageVersion)
 		};
-
-		await this.netCoreTool.runDotnetCommand(addOptions);
+		// Add package can be done with any version of .NET so skip the supported version check
+		await this.netCoreTool.runDotnetCommand(addOptions, true);
 	}
 
 	/**


### PR DESCRIPTION
Currently we're throwing an error when adding the SQL binding package reference if the user has .NET 6 installed on their machine. But the version check is supposed to only be for building a sql proj - adding a package reference with .NET 6 is fine.

Fixing this to allow callers to say they don't care about the version of .NET as long as it's installed