### PR TITLE
Remove .net 6 version cutoff for building sql projects

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -51,10 +51,6 @@
             "type": "boolean",
             "description": "%sqlDatabaseProjects.netCoreDoNotAsk%"
           },
-          "sqlDatabaseProjects.netCoreDowngradeDoNotShow": {
-            "type": "boolean",
-            "description": "%sqlDatabaseProjects.netCoreDowngradeDoNotShow%"
-          },
           "sqlDatabaseProjects.nodejsDoNotAsk": {
             "type": "boolean",
             "description": "%sqlDatabaseProjects.nodejsDoNotAsk%"

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -35,7 +35,6 @@
 	"sqlDatabaseProjects.Settings": "Database Projects",
 	"sqlDatabaseProjects.netCoreInstallLocation": "Full path to .NET Core SDK on the machine.",
 	"sqlDatabaseProjects.netCoreDoNotAsk": "Whether to prompt the user to install .NET Core when not detected.",
-	"sqlDatabaseProjects.netCoreDowngradeDoNotShow": "Whether to prompt the user to install .NET SDK version and add global.json to project when a newer unsupported version is detected.",
 	"sqlDatabaseProjects.nodejsDoNotAsk": "Whether to prompt the user to install Node.js when not detected.",
 	"sqlDatabaseProjects.autorestSqlVersion": "Which version of Autorest.Sql to use from NPM.  Latest will be used if not set.",
 	"sqlDatabaseProjects.welcome": "No database projects currently open.\n[New Project](command:sqlDatabaseProjects.new)\n[Open Project](command:sqlDatabaseProjects.open)\n[Create Project From Database](command:sqlDatabaseProjects.importDatabase)",

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -321,14 +321,12 @@ export const postDeployScriptFriendlyName = localize('postDeployScriptFriendlyNa
 
 export const NetCoreInstallationConfirmation: string = localize('sqlDatabaseProjects.NetCoreInstallationConfirmation', "The .NET Core SDK cannot be located. Project build will not work. Please install .NET Core SDK version 3.1 or update the .NET Core SDK location in settings if already installed.");
 export function NetCoreSupportedVersionInstallationConfirmation(installedVersion: string) { return localize('sqlDatabaseProjects.NetCoreSupportedVersionInstallationConfirmation', "Currently installed .NET Core SDK version is {0}, which is not supported. Project build will not work. Please install .NET Core SDK version 3.1 or update the .NET Core SDK supported version location in settings if already installed.", installedVersion); }
-export function NetCoreVersionDowngradeConfirmation(installedVersion: string) { return localize('sqlDatabaseProjects.NetCoreVersionDowngradeConfirmation', "Installed .NET SDK version {0} is newer than the currently supported versions. Project build will not work. Please install .NET Core SDK version 3.1 and include a global.json in the project folder specifying the SDK version to use. [More Information](https://docs.microsoft.com/dotnet/core/versions/selection)", installedVersion); }
 export const UpdateNetCoreLocation: string = localize('sqlDatabaseProjects.UpdateNetCoreLocation', "Update Location");
 export const projectsOutputChannel = localize('sqlDatabaseProjects.outputChannel', "Database Projects");
 
 // Prompt buttons
 export const Install: string = localize('sqlDatabaseProjects.Install', "Install");
 export const DoNotAskAgain: string = localize('sqlDatabaseProjects.doNotAskAgain', "Don't Ask Again");
-export const DoNotShowAgain: string = localize('sqlDatabaseProjects.doNotShowAgain', "Don't Show Again");
 
 // SqlProj file XML names
 export const ItemGroup = 'ItemGroup';

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -23,7 +23,7 @@ export const NetCoreNonWindowsDefaultPath = '/usr/local/share';
 export const winPlatform: string = 'win32';
 export const macPlatform: string = 'darwin';
 export const linuxPlatform: string = 'linux';
-export const minSupportedNetCoreVersion: string = '3.1.0';
+export const minSupportedNetCoreVersionForBuild: string = '3.1.0';
 
 export const enum netCoreInstallState {
 	netCoreNotPresent,
@@ -47,7 +47,7 @@ export class NetCoreTool extends ShellExecutionHelper {
 	 */
 	public async findOrInstallNetCore(skipVersionSupportedCheck = false): Promise<boolean> {
 		if (!this.isNetCoreInstallationPresent || (this.isNetCoreInstallationPresent && !skipVersionSupportedCheck)) {
-			if ((!this.isNetCoreInstallationPresent || !await this.isNetCoreVersionSupported())) {
+			if ((!this.isNetCoreInstallationPresent || !await this.isNetCoreVersionSupportedForBuild())) {
 				if (vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDoNotAskAgainKey] !== true) {
 					void this.showInstallDialog();		// Removing await so that Build and extension load process doesn't wait on user input
 				}
@@ -126,16 +126,16 @@ export class NetCoreTool extends ShellExecutionHelper {
 	}
 
 	/**
-	 * This function checks if the installed dotnet version is atleast minSupportedNetCoreVersion.
-	 * Versions lower than minSupportedNetCoreVersion aren't supported for building projects.
+	 * This function checks if the installed dotnet version is at least minSupportedNetCoreVersionForBuild.
+	 * Versions lower than minSupportedNetCoreVersionForBuild aren't supported for building projects.
 	 * Returns: True if installed dotnet version is supported, false otherwise.
 	 * 			Undefined if dotnet isn't installed.
 	 */
-	private async isNetCoreVersionSupported(): Promise<boolean | undefined> {
+	private async isNetCoreVersionSupportedForBuild(): Promise<boolean | undefined> {
 		try {
 			const spawn = child_process.spawn;
 			let child: child_process.ChildProcessWithoutNullStreams;
-			let isSupported: boolean | undefined = undefined;
+			let isSupported: boolean = false;
 			const stdoutBuffers: Buffer[] = [];
 
 			child = spawn('dotnet --version', [], {
@@ -149,7 +149,7 @@ export class NetCoreTool extends ShellExecutionHelper {
 					this.netCoreSdkInstalledVersion = Buffer.concat(stdoutBuffers).toString('utf8').trim();
 
 					try {
-						if (semver.gte(this.netCoreSdkInstalledVersion, minSupportedNetCoreVersion)) {		// Net core version greater than or equal to minSupportedNetCoreVersion are supported for Build
+						if (semver.gte(this.netCoreSdkInstalledVersion, minSupportedNetCoreVersionForBuild)) {		// Net core version greater than or equal to minSupportedNetCoreVersion are supported for Build
 							isSupported = true;
 						} else {
 							isSupported = false;

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -51,6 +51,7 @@ export class NetCoreTool extends ShellExecutionHelper {
 				if (vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDoNotAskAgainKey] !== true) {
 					void this.showInstallDialog();		// Removing await so that Build and extension load process doesn't wait on user input
 				}
+				return false;
 			}
 		}
 

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -45,10 +45,12 @@ export class NetCoreTool extends ShellExecutionHelper {
 	 * @returns True if .NET version was found and is supported
 	 * 			False if .NET version isn't present or present but not supported
 	 */
-	public async findOrInstallNetCore(): Promise<boolean> {
-		if ((!this.isNetCoreInstallationPresent || !await this.isNetCoreVersionSupported())) {
-			if (vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDoNotAskAgainKey] !== true) {
-				void this.showInstallDialog();		// Removing await so that Build and extension load process doesn't wait on user input
+	public async findOrInstallNetCore(skipVersionSupportedCheck = false): Promise<boolean> {
+		if (!this.isNetCoreInstallationPresent || (this.isNetCoreInstallationPresent && !skipVersionSupportedCheck)) {
+			if ((!this.isNetCoreInstallationPresent || !await this.isNetCoreVersionSupported())) {
+				if (vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDoNotAskAgainKey] !== true) {
+					void this.showInstallDialog();		// Removing await so that Build and extension load process doesn't wait on user input
+				}
 			}
 		}
 

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -11,7 +11,7 @@ import * as semver from 'semver';
 import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { DoNotAskAgain, DoNotShowAgain, Install, NetCoreInstallationConfirmation, NetCoreSupportedVersionInstallationConfirmation, NetCoreVersionDowngradeConfirmation, UpdateNetCoreLocation } from '../common/constants';
+import { DoNotAskAgain, Install, NetCoreInstallationConfirmation, NetCoreSupportedVersionInstallationConfirmation, UpdateNetCoreLocation } from '../common/constants';
 import * as utils from '../common/utils';
 import { ShellCommandOptions, ShellExecutionHelper } from './shellExecutionHelper';
 const localize = nls.loadMessageBundle();
@@ -19,19 +19,16 @@ const localize = nls.loadMessageBundle();
 export const DBProjectConfigurationKey: string = 'sqlDatabaseProjects';
 export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
 export const NetCoreDoNotAskAgainKey: string = 'netCoreDoNotAsk';
-export const NetCoreDowngradeDoNotShowAgainKey: string = 'netCoreDowngradeDoNotShow';
 export const NetCoreNonWindowsDefaultPath = '/usr/local/share';
 export const winPlatform: string = 'win32';
 export const macPlatform: string = 'darwin';
 export const linuxPlatform: string = 'linux';
 export const minSupportedNetCoreVersion: string = '3.1.0';
-export const maxSupportedNetCoreVersionCutoff: string = '';	// un-set this to allow latest
 
 export const enum netCoreInstallState {
 	netCoreNotPresent,
 	netCoreVersionNotSupported,
-	netCoreVersionSupported,
-	netCoreVersionTooHigh
+	netCoreVersionSupported
 }
 
 const dotnet = os.platform() === 'win32' ? 'dotnet.exe' : 'dotnet';
@@ -48,15 +45,10 @@ export class NetCoreTool extends ShellExecutionHelper {
 	 * @returns True if .NET version was found and is supported
 	 * 			False if .NET version isn't present or present but not supported
 	 */
-	public async findOrInstallNetCore(skipVersionSupportedCheck = false): Promise<boolean> {
-		if (!this.isNetCoreInstallationPresent || (this.isNetCoreInstallationPresent && !skipVersionSupportedCheck)) {
-			if (!this.isNetCoreInstallationPresent || !await this.isNetCoreVersionSupported()) {
-				if (this.netCoreInstallState === netCoreInstallState.netCoreVersionSupported && vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDoNotAskAgainKey] !== true) {
-					void this.showInstallDialog();		// Removing await so that Build and extension load process doesn't wait on user input
-				} else if (this.netCoreInstallState === netCoreInstallState.netCoreVersionTooHigh && vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDowngradeDoNotShowAgainKey] !== true) {
-					void this.showDowngradeDialog();
-				}
-				return false;
+	public async findOrInstallNetCore(): Promise<boolean> {
+		if ((!this.isNetCoreInstallationPresent || !await this.isNetCoreVersionSupported())) {
+			if (vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDoNotAskAgainKey] !== true) {
+				void this.showInstallDialog();		// Removing await so that Build and extension load process doesn't wait on user input
 			}
 		}
 
@@ -86,15 +78,6 @@ export class NetCoreTool extends ShellExecutionHelper {
 		} else if (result === DoNotAskAgain) {
 			const config = vscode.workspace.getConfiguration(DBProjectConfigurationKey);
 			await config.update(NetCoreDoNotAskAgainKey, true, vscode.ConfigurationTarget.Global);
-		}
-	}
-
-	public async showDowngradeDialog(): Promise<void> {
-		const result = await vscode.window.showErrorMessage(NetCoreVersionDowngradeConfirmation(this.netCoreSdkInstalledVersion!), DoNotShowAgain);
-
-		if (result === DoNotShowAgain) {
-			const config = vscode.workspace.getConfiguration(DBProjectConfigurationKey);
-			await config.update(NetCoreDowngradeDoNotShowAgainKey, true, vscode.ConfigurationTarget.Global);
 		}
 	}
 
@@ -140,8 +123,8 @@ export class NetCoreTool extends ShellExecutionHelper {
 	}
 
 	/**
-	 * This function checks if the installed dotnet version is between minSupportedNetCoreVersion (inclusive) and maxSupportedNetCoreVersionCutoff (exclusive).
-	 * When maxSupportedNetCoreVersionCutoff is not set, the latest dotnet version is assumed to be supported and only the min version is checked.
+	 * This function checks if the installed dotnet version is atleast minSupportedNetCoreVersion.
+	 * Versions lower than minSupportedNetCoreVersion aren't supported for building projects.
 	 * Returns: True if installed dotnet version is supported, false otherwise.
 	 * 			Undefined if dotnet isn't installed.
 	 */
@@ -149,7 +132,7 @@ export class NetCoreTool extends ShellExecutionHelper {
 		try {
 			const spawn = child_process.spawn;
 			let child: child_process.ChildProcessWithoutNullStreams;
-			let installState: netCoreInstallState = netCoreInstallState.netCoreVersionSupported;
+			let isSupported: boolean | undefined = undefined;
 			const stdoutBuffers: Buffer[] = [];
 
 			child = spawn('dotnet --version', [], {
@@ -163,21 +146,10 @@ export class NetCoreTool extends ShellExecutionHelper {
 					this.netCoreSdkInstalledVersion = Buffer.concat(stdoutBuffers).toString('utf8').trim();
 
 					try {
-						// minSupportedDotnetVersion <= supported version < maxSupportedDotnetVersion
-						if (semver.gte(this.netCoreSdkInstalledVersion, minSupportedNetCoreVersion)) {
-							// If maxSupportedNetCoreVersionCutoff is not set, the latest .NET version is allowed
-							if (maxSupportedNetCoreVersionCutoff) {
-								if (semver.lt(this.netCoreSdkInstalledVersion, maxSupportedNetCoreVersionCutoff)) {
-									installState = netCoreInstallState.netCoreVersionSupported;
-								} else {
-									installState = netCoreInstallState.netCoreVersionTooHigh;
-								}
-							} else {
-								installState = netCoreInstallState.netCoreVersionSupported;
-							}
+						if (semver.gte(this.netCoreSdkInstalledVersion, minSupportedNetCoreVersion)) {		// Net core version greater than or equal to minSupportedNetCoreVersion are supported for Build
+							isSupported = true;
 						} else {
-							// .NET version is too low
-							installState = netCoreInstallState.netCoreVersionNotSupported;
+							isSupported = false;
 						}
 						resolve({ stdout: this.netCoreSdkInstalledVersion });
 					} catch (err) {
@@ -192,8 +164,13 @@ export class NetCoreTool extends ShellExecutionHelper {
 				});
 			});
 
-			this.netCoreInstallState = installState;
-			return installState === netCoreInstallState.netCoreVersionSupported;
+			if (isSupported) {
+				this.netCoreInstallState = netCoreInstallState.netCoreVersionSupported;
+			} else {
+				this.netCoreInstallState = netCoreInstallState.netCoreVersionNotSupported;
+			}
+
+			return isSupported;
 		} catch (err) {
 			console.log(err);
 			this.netCoreInstallState = netCoreInstallState.netCoreNotPresent;
@@ -215,8 +192,6 @@ export class NetCoreTool extends ShellExecutionHelper {
 		if (!(await this.findOrInstallNetCore(skipVersionSupportedCheck))) {
 			if (this.netCoreInstallState === netCoreInstallState.netCoreNotPresent) {
 				throw new DotNetError(NetCoreInstallationConfirmation);
-			} else if (this.netCoreInstallState === netCoreInstallState.netCoreVersionTooHigh && vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDowngradeDoNotShowAgainKey] === true) {
-				// Assume user has used global.json to override SDK version and proceed with build as is
 			} else {
 				throw new DotNetError(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!));
 			}

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -25,7 +25,7 @@ export const winPlatform: string = 'win32';
 export const macPlatform: string = 'darwin';
 export const linuxPlatform: string = 'linux';
 export const minSupportedNetCoreVersion: string = '3.1.0';
-export const maxSupportedNetCoreVersionCutoff: string = '6.0.0';	// un-set this to allow latest
+export const maxSupportedNetCoreVersionCutoff: string = '';	// un-set this to allow latest
 
 export const enum netCoreInstallState {
 	netCoreNotPresent,


### PR DESCRIPTION
ADS has been updated to use DacFx 160, which supports building sql project with .net 6, so we can remove this version cutoff. I verified that after this cutoff version is unset, projects are successfully building when .net 6 is installed.
