### PR TITLE
Add additional tests for handling relative links in notebooks.

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
@@ -61,6 +61,9 @@ suite('Noteboook Link Handler', function (): void {
 
 		result = new NotebookLinkHandler(notebookUri, Object.assign(document.createElement('a'), { href: '/tmp/inner/stuff.png' }), configurationService);
 		assert.strictEqual(result.getLinkUrl(), `.${path.sep}inner${path.sep}stuff.png`, 'Basic link test below folder failed');
+
+		result = new NotebookLinkHandler(notebookUri, Object.assign(document.createElement('a'), { href: '/other/stuff.png' }), configurationService);
+		assert.strictEqual(result.getLinkUrl(), `..${path.sep}other${path.sep}stuff.png`, 'Basic link test in different above folder failed');
 	});
 
 	test('Should return anchor links', () => {

--- a/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
@@ -124,9 +124,31 @@ suite('Link Callout Dialog', function (): void {
 		assert.strictEqual(unquoteText(undefined), undefined);
 	});
 
-	test('Should return file link properly', async function (): Promise<void> {
+	test('Should return absolute file link properly', async function (): Promise<void> {
 		const defaultLabel = 'defaultLabel';
 		const sampleUrl = 'C:/Test/Test.ipynb';
+		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, defaultLabel, sampleUrl,
+			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
+		linkCalloutDialog.render();
+
+		let deferred = new Deferred<ILinkCalloutDialogOptions>();
+		// When I first open the callout dialog
+		linkCalloutDialog.open().then(value => {
+			deferred.resolve(value);
+		});
+		linkCalloutDialog.url = sampleUrl;
+
+		// And insert the dialog
+		linkCalloutDialog.insert();
+		let result = await deferred.promise;
+		assert.strictEqual(result.insertUnescapedLinkLabel, defaultLabel, 'Label not returned correctly');
+		assert.strictEqual(result.insertUnescapedLinkUrl, sampleUrl, 'URL not returned correctly');
+		assert.strictEqual(result.insertEscapedMarkdown, `[${defaultLabel}](${sampleUrl})`, 'Markdown not returned correctly');
+	});
+
+	test('Should return relative file link properly', async function (): Promise<void> {
+		const defaultLabel = 'defaultLabel';
+		const sampleUrl = '../../Test.ipynb';
 		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, defaultLabel, sampleUrl,
 			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
 		linkCalloutDialog.render();


### PR DESCRIPTION
Added some relative links cases to the Link Dialog and Link Handler tests to better capture the manual steps in our test plan.