### PR TITLE
update .net sdk location strings now that .net 6 is supported

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -43,9 +43,9 @@
       {
         "title": "%sqlDatabaseProjects.Settings%",
         "properties": {
-          "sqlDatabaseProjects.netCoreSDKLocation": {
+          "sqlDatabaseProjects.dotnetSDK Location": {
             "type": "string",
-            "description": "%sqlDatabaseProjects.netCoreInstallLocation%"
+            "description": "%sqlDatabaseProjects.dotnetInstallLocation%"
           },
           "sqlDatabaseProjects.netCoreDoNotAsk": {
             "type": "boolean",

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -33,7 +33,7 @@
 	"sqlDatabaseProjects.generateProjectFromOpenApiSpec": "Generate SQL Project from OpenAPI/Swagger spec",
 
 	"sqlDatabaseProjects.Settings": "Database Projects",
-	"sqlDatabaseProjects.netCoreInstallLocation": "Full path to .NET Core SDK on the machine.",
+	"sqlDatabaseProjects.dotnetInstallLocation": "Full path to .NET SDK on the machine.",
 	"sqlDatabaseProjects.netCoreDoNotAsk": "Whether to prompt the user to install .NET Core when not detected.",
 	"sqlDatabaseProjects.nodejsDoNotAsk": "Whether to prompt the user to install Node.js when not detected.",
 	"sqlDatabaseProjects.autorestSqlVersion": "Which version of Autorest.Sql to use from NPM.  Latest will be used if not set.",

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -330,8 +330,8 @@ export const postDeployScriptFriendlyName = localize('postDeployScriptFriendlyNa
 
 // Build
 
-export const DotnetInstallationConfirmation: string = localize('sqlDatabaseProjects.DotnetInstallationConfirmation', "The .NET SDK cannot be located. Project build will not work. Please install .NET Core SDK version 3.1 or update the .NET SDK location in settings if already installed.");
-export function NetCoreSupportedVersionInstallationConfirmation(installedVersion: string) { return localize('sqlDatabaseProjects.NetCoreSupportedVersionInstallationConfirmation', "Currently installed .NET Core SDK version is {0}, which is not supported. Project build will not work. Please install .NET Core SDK version 3.1 or update the .NET SDK supported version location in settings if already installed.", installedVersion); }
+export const DotnetInstallationConfirmation: string = localize('sqlDatabaseProjects.DotnetInstallationConfirmation', "The .NET SDK cannot be located. Project build will not work. Please install .NET Core SDK version 3.1 or higher or update the .NET SDK location in settings if already installed.");
+export function NetCoreSupportedVersionInstallationConfirmation(installedVersion: string) { return localize('sqlDatabaseProjects.NetCoreSupportedVersionInstallationConfirmation', "Currently installed .NET Core SDK version is {0}, which is not supported. Project build will not work. Please install .NET Core SDK version 3.1 or higher or update the .NET SDK supported version location in settings if already installed.", installedVersion); }
 export const UpdateDotnetLocation: string = localize('sqlDatabaseProjects.UpdateDotnetLocation', "Update Location");
 export const projectsOutputChannel = localize('sqlDatabaseProjects.outputChannel', "Database Projects");
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -319,9 +319,9 @@ export const postDeployScriptFriendlyName = localize('postDeployScriptFriendlyNa
 
 // Build
 
-export const NetCoreInstallationConfirmation: string = localize('sqlDatabaseProjects.NetCoreInstallationConfirmation', "The .NET Core SDK cannot be located. Project build will not work. Please install .NET Core SDK version 3.1 or update the .NET Core SDK location in settings if already installed.");
-export function NetCoreSupportedVersionInstallationConfirmation(installedVersion: string) { return localize('sqlDatabaseProjects.NetCoreSupportedVersionInstallationConfirmation', "Currently installed .NET Core SDK version is {0}, which is not supported. Project build will not work. Please install .NET Core SDK version 3.1 or update the .NET Core SDK supported version location in settings if already installed.", installedVersion); }
-export const UpdateNetCoreLocation: string = localize('sqlDatabaseProjects.UpdateNetCoreLocation', "Update Location");
+export const DotnetInstallationConfirmation: string = localize('sqlDatabaseProjects.DotnetInstallationConfirmation', "The .NET SDK cannot be located. Project build will not work. Please install .NET Core SDK version 3.1 or update the .NET SDK location in settings if already installed.");
+export function NetCoreSupportedVersionInstallationConfirmation(installedVersion: string) { return localize('sqlDatabaseProjects.NetCoreSupportedVersionInstallationConfirmation', "Currently installed .NET Core SDK version is {0}, which is not supported. Project build will not work. Please install .NET Core SDK version 3.1 or update the .NET SDK supported version location in settings if already installed.", installedVersion); }
+export const UpdateDotnetLocation: string = localize('sqlDatabaseProjects.UpdateDotnetLocation', "Update Location");
 export const projectsOutputChannel = localize('sqlDatabaseProjects.outputChannel', "Database Projects");
 
 // Prompt buttons

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -10,7 +10,7 @@ import * as templates from '../templates/templates';
 import * as path from 'path';
 
 import { ProjectsController } from './projectController';
-import { NetCoreTool } from '../tools/netcoreTool';
+import { DBProjectConfigurationKey, DotnetInstallLocationKey, NetCoreInstallLocationKey, NetCoreTool } from '../tools/netcoreTool';
 import { IconPathHelper } from '../common/iconHelper';
 import { WorkspaceTreeItem } from 'dataworkspace';
 import * as constants from '../common/constants';
@@ -45,6 +45,13 @@ export default class MainController implements vscode.Disposable {
 	}
 
 	public async activate(): Promise<SqlDatabaseProjectProvider> {
+		// upgrade path from former netCoreSDKLocation setting to dotnetSDK Location setting
+		// copy old setting's value to new setting
+		const oldNetCoreInstallSetting = vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreInstallLocationKey];
+		if (oldNetCoreInstallSetting && !vscode.workspace.getConfiguration(DBProjectConfigurationKey)[DotnetInstallLocationKey]) {
+			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(DotnetInstallLocationKey, oldNetCoreInstallSetting, true);
+		}
+
 		await this.initializeDatabaseProjects();
 		return new SqlDatabaseProjectProvider(this.projectsController);
 	}

--- a/extensions/sql-database-projects/src/test/netCoreTool.test.ts
+++ b/extensions/sql-database-projects/src/test/netCoreTool.test.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import { NetCoreTool, DBProjectConfigurationKey, NetCoreInstallLocationKey, NetCoreNonWindowsDefaultPath } from '../tools/netcoreTool';
+import { NetCoreTool, DBProjectConfigurationKey, DotnetInstallLocationKey, NetCoreNonWindowsDefaultPath } from '../tools/netcoreTool';
 import { getQuotedPath } from '../common/utils';
 import { isNullOrUndefined } from 'util';
 import { generateTestFolderPath } from './testUtils';
@@ -29,7 +29,7 @@ describe('NetCoreTool: Net core tests', function (): void {
 	it('Should override dotnet default value with settings', async function (): Promise<void> {
 		try {
 			// update settings and validate
-			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(NetCoreInstallLocationKey, 'test value path', true);
+			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(DotnetInstallLocationKey, 'test value path', true);
 			const netcoreTool = new NetCoreTool(testContext.outputChannel);
 			sinon.stub(netcoreTool, 'showInstallDialog').returns(Promise.resolve());
 			should(netcoreTool.netcoreInstallLocation).equal('test value path'); // the path in settings should be taken
@@ -37,7 +37,7 @@ describe('NetCoreTool: Net core tests', function (): void {
 		}
 		finally {
 			// clean again
-			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(NetCoreInstallLocationKey, '', true);
+			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(DotnetInstallLocationKey, '', true);
 		}
 	});
 

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -11,13 +11,13 @@ import * as semver from 'semver';
 import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { DoNotAskAgain, Install, NetCoreInstallationConfirmation, NetCoreSupportedVersionInstallationConfirmation, UpdateNetCoreLocation } from '../common/constants';
+import { DoNotAskAgain, Install, DotnetInstallationConfirmation, NetCoreSupportedVersionInstallationConfirmation, UpdateDotnetLocation } from '../common/constants';
 import * as utils from '../common/utils';
 import { ShellCommandOptions, ShellExecutionHelper } from './shellExecutionHelper';
 const localize = nls.loadMessageBundle();
 
 export const DBProjectConfigurationKey: string = 'sqlDatabaseProjects';
-export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
+export const DotnetInstallLocationKey: string = 'dotnetSDK Location';
 export const NetCoreDoNotAskAgainKey: string = 'netCoreDoNotAsk';
 export const NetCoreNonWindowsDefaultPath = '/usr/local/share';
 export const winPlatform: string = 'win32';
@@ -66,12 +66,12 @@ export class NetCoreTool extends ShellExecutionHelper {
 	public async showInstallDialog(): Promise<void> {
 		let result;
 		if (this.netCoreInstallState === netCoreInstallState.netCoreNotPresent) {
-			result = await vscode.window.showErrorMessage(NetCoreInstallationConfirmation, UpdateNetCoreLocation, Install, DoNotAskAgain);
+			result = await vscode.window.showErrorMessage(DotnetInstallationConfirmation, UpdateDotnetLocation, Install, DoNotAskAgain);
 		} else {
-			result = await vscode.window.showErrorMessage(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!), UpdateNetCoreLocation, Install, DoNotAskAgain);
+			result = await vscode.window.showErrorMessage(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!), UpdateDotnetLocation, Install, DoNotAskAgain);
 		}
 
-		if (result === UpdateNetCoreLocation) {
+		if (result === UpdateDotnetLocation) {
 			//open settings
 			await vscode.commands.executeCommand('workbench.action.openGlobalSettings');
 		} else if (result === Install) {
@@ -93,7 +93,7 @@ export class NetCoreTool extends ShellExecutionHelper {
 	}
 
 	public get netcoreInstallLocation(): string {
-		return vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreInstallLocationKey] ||
+		return vscode.workspace.getConfiguration(DBProjectConfigurationKey)[DotnetInstallLocationKey] ||
 			this.defaultLocalInstallLocationByDistribution;
 	}
 
@@ -194,7 +194,7 @@ export class NetCoreTool extends ShellExecutionHelper {
 
 		if (!(await this.findOrInstallNetCore(skipVersionSupportedCheck))) {
 			if (this.netCoreInstallState === netCoreInstallState.netCoreNotPresent) {
-				throw new DotNetError(NetCoreInstallationConfirmation);
+				throw new DotNetError(DotnetInstallationConfirmation);
 			} else {
 				throw new DotNetError(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!));
 			}

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -17,6 +17,7 @@ import { ShellCommandOptions, ShellExecutionHelper } from './shellExecutionHelpe
 const localize = nls.loadMessageBundle();
 
 export const DBProjectConfigurationKey: string = 'sqlDatabaseProjects';
+export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
 export const DotnetInstallLocationKey: string = 'dotnetSDK Location';
 export const NetCoreDoNotAskAgainKey: string = 'netCoreDoNotAsk';
 export const NetCoreNonWindowsDefaultPath = '/usr/local/share';

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -24,7 +24,7 @@ export const NetCoreNonWindowsDefaultPath = '/usr/local/share';
 export const winPlatform: string = 'win32';
 export const macPlatform: string = 'darwin';
 export const linuxPlatform: string = 'linux';
-export const minSupportedNetCoreVersionForBuild: string = '3.1.0';
+export const minSupportedNetCoreVersionForBuild: string = '3.1.0'; // TODO: watch out for EOL support in Dec 2022
 
 export const enum netCoreInstallState {
 	netCoreNotPresent,

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -24,7 +24,7 @@ export const NetCoreNonWindowsDefaultPath = '/usr/local/share';
 export const winPlatform: string = 'win32';
 export const macPlatform: string = 'darwin';
 export const linuxPlatform: string = 'linux';
-export const minSupportedNetCoreVersionForBuild: string = '3.1.0'; // TODO: watch out for EOL support in Dec 2022
+export const minSupportedNetCoreVersionForBuild: string = '3.1.0'; // TODO: watch out for EOL support in Dec 2022 https://github.com/microsoft/azuredatastudio/issues/17800
 
 export const enum netCoreInstallState {
 	netCoreNotPresent,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17685. This updates a couple user facing strings and the related variables to remove "Core" since .net 5 and 6 are also supported, not just .net core anymore.
![image](https://user-images.githubusercontent.com/31145923/143935491-ab3635e3-149b-4636-b85b-314c6e5e8711.png)

