### PR TITLE
Fixes ADS Web bug around copying user codes and opening a browser tab when adding an Azure Account.

### DIFF
--- a/src/sql/platform/accounts/common/interfaces.ts
+++ b/src/sql/platform/accounts/common/interfaces.ts
@@ -35,7 +35,7 @@ export interface IAccountManagementService {
 	beginAutoOAuthDeviceCode(providerId: string, title: string, message: string, userCode: string, uri: string): Promise<void>;
 	endAutoOAuthDeviceCode(): void;
 	cancelAutoOAuthDeviceCode(providerId: string): void;
-	copyUserCodeAndOpenBrowser(userCode: string, uri: string): void;
+	copyUserCodeAndOpenBrowser(userCode: string, uri: string): Promise<void>;
 
 	// SERVICE MANAGEMENT METHODS /////////////////////////////////////////
 	registerProvider(providerMetadata: azdata.AccountProviderMetadata, provider: azdata.AccountProvider): void;

--- a/src/sql/platform/accounts/test/common/testAccountManagementService.ts
+++ b/src/sql/platform/accounts/test/common/testAccountManagementService.ts
@@ -35,8 +35,8 @@ export class TestAccountManagementService implements IAccountManagementService {
 		return undefined;
 	}
 
-	copyUserCodeAndOpenBrowser(userCode: string, uri: string): Promise<void> {
-		return undefined;
+	async copyUserCodeAndOpenBrowser(userCode: string, uri: string): Promise<void> {
+		return;
 	}
 
 	getAccountProviderMetadata(): Promise<azdata.AccountProviderMetadata[]> {

--- a/src/sql/platform/accounts/test/common/testAccountManagementService.ts
+++ b/src/sql/platform/accounts/test/common/testAccountManagementService.ts
@@ -35,7 +35,7 @@ export class TestAccountManagementService implements IAccountManagementService {
 		return undefined;
 	}
 
-	copyUserCodeAndOpenBrowser(userCode: string, uri: string): void {
+	copyUserCodeAndOpenBrowser(userCode: string, uri: string): Promise<void> {
 		return undefined;
 	}
 

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -362,12 +362,10 @@ export class AccountManagementService implements IAccountManagementService {
 	/**
 	 * Copy the user code to the clipboard and open a browser to the verification URI
 	 */
-	public copyUserCodeAndOpenBrowser(userCode: string, uri: string): void {
-		this._clipboardService.writeText(userCode).then(() => {
-			this._openerService.open(URI.parse(uri));
-		}).catch(err => {
-			onUnexpectedError(err);
-		});
+	public async copyUserCodeAndOpenBrowser(userCode: string, uri: string): Promise<void> {
+		await this._clipboardService.writeText(userCode).catch(err => onUnexpectedError(err));
+		await this._openerService.open(URI.parse(uri)).catch(err => onUnexpectedError(err));
+
 	}
 
 	private async _registerProvider(providerMetadata: azdata.AccountProviderMetadata, provider: azdata.AccountProvider): Promise<void> {

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -363,8 +363,8 @@ export class AccountManagementService implements IAccountManagementService {
 	 * Copy the user code to the clipboard and open a browser to the verification URI
 	 */
 	public async copyUserCodeAndOpenBrowser(userCode: string, uri: string): Promise<void> {
-		await this._clipboardService.writeText(userCode).catch(err => onUnexpectedError(err));
-		await this._openerService.open(URI.parse(uri)).catch(err => onUnexpectedError(err));
+		await this._clipboardService.writeText(userCode);
+		await this._openerService.open(URI.parse(uri));
 
 	}
 

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -21,7 +21,6 @@ import { localize } from 'vs/nls';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { URI } from 'vs/base/common/uri';
 import { values } from 'vs/base/common/collections';
-import { onUnexpectedError } from 'vs/base/common/errors';
 import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService, Severity, INotification } from 'vs/platform/notification/common/notification';
 import { Action } from 'vs/base/common/actions';

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -363,8 +363,11 @@ export class AccountManagementService implements IAccountManagementService {
 	 * Copy the user code to the clipboard and open a browser to the verification URI
 	 */
 	public copyUserCodeAndOpenBrowser(userCode: string, uri: string): void {
-		this._clipboardService.writeText(userCode).catch(err => onUnexpectedError(err));
-		this._openerService.open(URI.parse(uri)).catch(err => onUnexpectedError(err));
+		this._clipboardService.writeText(userCode).then(() => {
+			this._openerService.open(URI.parse(uri));
+		}).catch(err => {
+			onUnexpectedError(err);
+		});
 	}
 
 	private async _registerProvider(providerMetadata: azdata.AccountProviderMetadata, provider: azdata.AccountProvider): Promise<void> {

--- a/src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController.ts
+++ b/src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController.ts
@@ -72,9 +72,9 @@ export class AutoOAuthDialogController {
 		this._providerId = undefined;
 	}
 
-	private handleOnAddAccount(): void {
+	private async handleOnAddAccount(): Promise<void> {
 		if (this._userCode && this._uri) {
-			this._accountManagementService.copyUserCodeAndOpenBrowser(this._userCode, this._uri);
+			await this._accountManagementService.copyUserCodeAndOpenBrowser(this._userCode, this._uri);
 		} else {
 			throw new Error('Missing user code and uri');
 		}

--- a/src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController.ts
+++ b/src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController.ts
@@ -74,7 +74,7 @@ export class AutoOAuthDialogController {
 
 	private async handleOnAddAccount(): Promise<void> {
 		if (this._userCode && this._uri) {
-			await this._accountManagementService.copyUserCodeAndOpenBrowser(this._userCode, this._uri);
+			return this._accountManagementService.copyUserCodeAndOpenBrowser(this._userCode, this._uri);
 		} else {
 			throw new Error('Missing user code and uri');
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes an issue around copying user codes and opening a new browser window to add an Azure account to ADS.

To test this:
- Launch ADS in web mode.
- Click on "Sign in to Azure"
- Select "Azure Device Code"
- In the "Add Azure Account" blade
- Click on "Copy & Open"
- In the newly opened browser tab
- Paste the code in the login page..

RESULT: The correct user code will be present in the login page.
