### PR TITLE
fix sorting bug

### DIFF
--- a/src/sql/base/browser/ui/table/tableDataView.ts
+++ b/src/sql/base/browser/ui/table/tableDataView.ts
@@ -33,15 +33,15 @@ export function defaultSort<T extends Slick.SlickData>(args: Slick.OnSortEventAr
 	const comparer: (a: T, b: T) => number = (a: T, b: T) => {
 		const value1 = cellValueGetter(a[field]);
 		const value2 = cellValueGetter(b[field]);
-		const isValue1Number = !isNaN(Number(value1));
-		const isValue2Number = !isNaN(Number(value2));
+		const num1 = Number(value1);
+		const num2 = Number(value2);
+		const isValue1Number = !isNaN(num1);
+		const isValue2Number = !isNaN(num2);
 		// Order: undefined -> number -> string
 		if (value1 === undefined || value2 === undefined) {
 			return value1 === value2 ? 0 : (value1 === undefined ? -1 : 1);
 		} else if (isValue1Number || isValue2Number) {
 			if (isValue1Number && isValue2Number) {
-				const num1 = Number(value1);
-				const num2 = Number(value2);
 				return num1 === num2 ? 0 : num1 > num2 ? 1 : -1;
 			} else {
 				return isValue1Number ? -1 : 1;

--- a/src/sql/base/browser/ui/table/tableDataView.ts
+++ b/src/sql/base/browser/ui/table/tableDataView.ts
@@ -24,26 +24,33 @@ function defaultCellValueGetter(data: any): any {
 	return data;
 }
 
-function defaultSort<T extends Slick.SlickData>(args: Slick.OnSortEventArgs<T>, data: Array<T>, cellValueGetter: CellValueGetter = defaultCellValueGetter): Array<T> {
+export function defaultSort<T extends Slick.SlickData>(args: Slick.OnSortEventArgs<T>, data: Array<T>, cellValueGetter: CellValueGetter = defaultCellValueGetter): Array<T> {
 	if (!args.sortCol || !args.sortCol.field || data.length === 0) {
 		return data;
 	}
 	const field = args.sortCol.field;
 	const sign = args.sortAsc ? 1 : -1;
-	let sampleData = data[0][field];
-	sampleData = types.isObject(sampleData) ? cellValueGetter(sampleData) : sampleData;
-	let comparer: (a: T, b: T) => number;
-	if (!isNaN(Number(sampleData))) {
-		comparer = (a: T, b: T) => {
-			let anum = Number(cellValueGetter(a[field]));
-			let bnum = Number(cellValueGetter(b[field]));
-			return anum === bnum ? 0 : anum > bnum ? 1 : -1;
-		};
-	} else {
-		comparer = (a: T, b: T) => {
-			return stringCompare(cellValueGetter(a[field]), cellValueGetter(b[field]));
-		};
-	}
+	const comparer: (a: T, b: T) => number = (a: T, b: T) => {
+		const value1 = cellValueGetter(a[field]);
+		const value2 = cellValueGetter(b[field]);
+		const isValue1Number = !isNaN(Number(value1));
+		const isValue2Number = !isNaN(Number(value2));
+		// Order: undefined -> number -> string
+		if (value1 === undefined || value2 === undefined) {
+			return value1 === value2 ? 0 : (value1 === undefined ? -1 : 1);
+		} else if (isValue1Number || isValue2Number) {
+			if (isValue1Number && isValue2Number) {
+				const num1 = Number(value1);
+				const num2 = Number(value2);
+				return num1 === num2 ? 0 : num1 > num2 ? 1 : -1;
+			} else {
+				return isValue1Number ? -1 : 1;
+			}
+		} else {
+			return stringCompare(value1, value2);
+		}
+	};
+
 	return data.sort((a, b) => comparer(a, b) * sign);
 }
 

--- a/src/sql/base/test/browser/ui/table/tableDataView.test.ts
+++ b/src/sql/base/test/browser/ui/table/tableDataView.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { TableDataView } from 'sql/base/browser/ui/table/tableDataView';
+import { defaultSort, TableDataView } from 'sql/base/browser/ui/table/tableDataView';
 
 suite('TableDataView', () => {
 	test('Data can be filtered and filter can be cleared', () => {
@@ -172,6 +172,55 @@ suite('TableDataView', () => {
 		// find will loop around once it reaches the end
 		findValue = await dataView.findNext();
 		assert.deepStrictEqual(findValue, { row: 2, col: 0 });
+	});
+
+	test('Default Sorter test', async () => {
+		const originalData: Slick.SlickData[] = [
+			{ fieldName: '10b' },
+			{ fieldName: undefined },
+			{ fieldName: '100.01' },
+			{ fieldName: undefined },
+			{ fieldName: '10.1' },
+			{ fieldName: 'abc' }
+		];
+
+		const sortAscArg: Slick.OnSortEventArgs<Slick.SlickData> = {
+			sortAsc: true,
+			sortCol: {
+				field: 'fieldName'
+			},
+			multiColumnSort: false,
+			grid: undefined
+		};
+
+		const sortDescArg: Slick.OnSortEventArgs<Slick.SlickData> = {
+			sortAsc: false,
+			sortCol: {
+				field: 'fieldName'
+			},
+			multiColumnSort: false,
+			grid: undefined
+		};
+		const expectedAsc: Slick.SlickData[] = [
+			{ fieldName: undefined },
+			{ fieldName: undefined },
+			{ fieldName: '10.1' },
+			{ fieldName: '100.01' },
+			{ fieldName: '10b' },
+			{ fieldName: 'abc' }
+		];
+		const sortedAsc = defaultSort(sortAscArg, originalData);
+		assert.deepStrictEqual(sortedAsc, expectedAsc, 'ascending sorting is not working as expected');
+		const expectedDesc: Slick.SlickData[] = [
+			{ fieldName: 'abc' },
+			{ fieldName: '10b' },
+			{ fieldName: '100.01' },
+			{ fieldName: '10.1' },
+			{ fieldName: undefined },
+			{ fieldName: undefined },
+		];
+		const sortedDesc = defaultSort(sortDescArg, originalData);
+		assert.deepStrictEqual(sortedDesc, expectedDesc, 'descending sorting is not working as expected');
 	});
 });
 

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -491,7 +491,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 			(offset, count) => { return this.loadData(offset, count); },
 			undefined,
 			undefined,
-			(data: ICellValue) => { return data?.displayValue; },
+			(data: ICellValue) => { return data.isNull ? undefined : data?.displayValue; },
 			{
 				inMemoryDataProcessing: this.options.inMemoryDataProcessing,
 				inMemoryDataCountThreshold: this.options.inMemoryDataCountThreshold


### PR DESCRIPTION
This PR fixes #17633

root cause
1. the current implementation relies on the sample data (the first row in the data set) to determine the  column type, it works well for certain scenarios, but for scenarios described in issue above, it will produce inconsistent results.
2. we are treating Null as a string (using its display value) when sorting, when sorting with strings the results will be wrong.

fix:
1. use the order: undefined -> number -> string to sort the values which will produce consistent results.
2. treat null as a special value

new results using the example provided in the issue:
![image](https://user-images.githubusercontent.com/13777222/144110666-9611548f-985e-4047-aefe-4ed30755226d.png)

![image](https://user-images.githubusercontent.com/13777222/144110613-5308da30-188e-47c0-951b-f319c17cb8d7.png)

results with mixed values: null, empty string, string, number

![image](https://user-images.githubusercontent.com/13777222/144110829-0adb6253-86b3-41c9-b307-6d9b4b247499.png)

![image](https://user-images.githubusercontent.com/13777222/144110854-fae13edd-1f56-46d6-9d6d-e20f03213076.png)
