### PR TITLE
check if url is already encoded before encoding

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/common/utils.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/common/utils.ts
@@ -26,15 +26,7 @@ export function escapeLabel(unescapedLabel: string): string {
  */
 export function escapeUrl(unescapedUrl: string): string {
 	let firstEscape = strings.escape(unescapedUrl);
-	return firstEscape.replace(/%20/g, '%2520')
-		.replace(/\s/g, '%20')
-		.replace(/[()]/g, function (match) {
-			switch (match) {
-				case '(': return '%28';
-				case ')': return '%29';
-				default: return match;
-			}
-		});
+	return firstEscape.replace(/\s/g, '%20');
 }
 
 /**

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/common/utils.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/common/utils.ts
@@ -26,7 +26,15 @@ export function escapeLabel(unescapedLabel: string): string {
  */
 export function escapeUrl(unescapedUrl: string): string {
 	let firstEscape = strings.escape(unescapedUrl);
-	return firstEscape.replace(/\s/g, '%20');
+	return firstEscape.replace(/%20/g, '%2520')
+		.replace(/\s/g, '%20')
+		.replace(/[()]/g, function (match) {
+			switch (match) {
+				case '(': return '%28';
+				case ')': return '%29';
+				default: return match;
+			}
+		});
 }
 
 /**

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -274,13 +274,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				let linkUrl = notebookLink.getLinkUrl();
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
-				// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-				// skip encoding it if it's already encoded
-				let encodedLinkURL = escapeUrl(linkUrl);
-				if (encodedLinkURL !== decodeURI(encodedLinkURL)) {
-					encodedLinkURL = encodeURI(linkUrl);
-				}
-				document.execCommand('insertHTML', false, `<a href="${encodedLinkURL}" title="${encodedLinkURL}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
+				document.execCommand('insertHTML', false, `<a href="${linkUrl}" title="${linkUrl}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}
 		} else if (type === MarkdownButtonType.IMAGE_PREVIEW) {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -25,7 +25,6 @@ import { escape } from 'vs/base/common/strings';
 import { IImageCalloutDialogOptions, ImageCalloutDialog } from 'sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog';
 import { TextCellEditModes } from 'sql/workbench/services/notebook/common/contracts';
 import { NotebookLinkHandler } from 'sql/workbench/contrib/notebook/browser/notebookLinkHandler';
-import { escapeUrl } from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/utils';
 
 export const MARKDOWN_TOOLBAR_SELECTOR: string = 'markdown-toolbar-component';
 const linksRegex = /\[(?<text>.+)\]\((?<url>[^ ]+)(?: "(?<title>.+)")?\)/;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -270,7 +270,6 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				needsTransform = false;
 			} else {
 				let notebookLink = new NotebookLinkHandler(this.cellModel?.notebookModel?.notebookUri, linkCalloutResult.insertUnescapedLinkUrl, this._configurationService);
-				let linkUrl = notebookLink.getLinkUrl();
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
 				let encodedLinkUrl = notebookLink.getEncodedLinkUrl();

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -273,7 +273,8 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				let linkUrl = notebookLink.getLinkUrl();
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
-				document.execCommand('insertHTML', false, `<a href="${linkUrl}" title="${linkUrl}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
+				let encodedLinkUrl = notebookLink.getEncodedLinkUrl();
+				document.execCommand('insertHTML', false, `<a href="${encodedLinkUrl}" title="${encodedLinkUrl}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}
 		} else if (type === MarkdownButtonType.IMAGE_PREVIEW) {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -25,6 +25,7 @@ import { escape } from 'vs/base/common/strings';
 import { IImageCalloutDialogOptions, ImageCalloutDialog } from 'sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog';
 import { TextCellEditModes } from 'sql/workbench/services/notebook/common/contracts';
 import { NotebookLinkHandler } from 'sql/workbench/contrib/notebook/browser/notebookLinkHandler';
+import { escapeUrl } from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/utils';
 
 export const MARKDOWN_TOOLBAR_SELECTOR: string = 'markdown-toolbar-component';
 const linksRegex = /\[(?<text>.+)\]\((?<url>[^ ]+)(?: "(?<title>.+)")?\)/;
@@ -274,7 +275,11 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
 				// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-				let encodedLinkURL = encodeURI(linkUrl);
+				// skip encoding it if it's already encoded
+				let encodedLinkURL = escapeUrl(linkUrl);
+				if (encodedLinkURL !== decodeURI(encodedLinkURL)) {
+					encodedLinkURL = encodeURI(linkUrl);
+				}
 				document.execCommand('insertHTML', false, `<a href="${encodedLinkURL}" title="${encodedLinkURL}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -88,13 +88,6 @@ export class NotebookLinkHandler {
 			 * We return the absolute path for the link so that it will get used in the as the href for the anchor HTML element
 			 * (in linkCalloutDialog document.execCommand('insertHTML') and therefore will call getLinkURL() with HTMLAnchorElement to then get the relative path
 			*/
-			// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-			// skip encoding it if it's already encoded
-			let encodedLinkURL = this._link;
-			if (this._isFile || encodedLinkURL === unescape(encodedLinkURL)) {
-				encodedLinkURL = encodeURI(this._link);
-				return encodedLinkURL;
-			}
 			return this._link;
 		} else {
 			// cases where we pass the HTMLAnchorElement
@@ -123,6 +116,15 @@ export class NotebookLinkHandler {
 			// Web links
 			return this._href || '';
 		}
+	}
+
+	public getEncodedLinkUrl(): string {
+		// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
+		// skip encoding it if it's already encoded
+		if (this._link === unescape(this._link.toString())) {
+			return encodeURI(this._link);
+		}
+		return this._link.toString();
 	}
 
 	/**

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -91,8 +91,8 @@ export class NotebookLinkHandler {
 			*/
 			// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
 			// skip encoding it if it's already encoded
-			let encodedLinkURL = escapeUrl(this._link);
-			if (encodedLinkURL !== decodeURI(encodedLinkURL)) {
+			let encodedLinkURL = this._link;
+			if (this._isFile || encodedLinkURL === unescape(encodedLinkURL)) {
 				encodedLinkURL = encodeURI(this._link);
 				return encodedLinkURL;
 			}

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -121,8 +121,8 @@ export class NotebookLinkHandler {
 	public getEncodedLinkUrl(): string {
 		// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
 		// skip encoding it if it's already encoded
-		if (this._link === unescape(this._link.toString())) {
-			return encodeURI(this._link);
+		if (this._isFile || this._link === unescape(this._link.toString())) {
+			return encodeURI(this._link.toString());
 		}
 		return this._link.toString();
 	}

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -91,7 +91,7 @@ export class NotebookLinkHandler {
 			*/
 			// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
 			// skip encoding it if it's already encoded
-			let encodedLinkURL = this._isFile ? escapeUrl(this._link) : this._link;
+			let encodedLinkURL = this._isFile ? escapeUrl(this._link) : this._link.replace(/\s/g, '%20'); //replace spaces since we're skipping escape for http links
 			if (encodedLinkURL !== decodeURI(encodedLinkURL)) {
 				encodedLinkURL = encodeURI(this._link);
 				return encodedLinkURL;

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -8,6 +8,7 @@ import * as path from 'vs/base/common/path';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 import { isWindows } from 'vs/base/common/platform';
+import { escapeUrl } from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/utils';
 
 const useAbsolutePathConfigName = 'notebook.useAbsoluteFilePaths';
 
@@ -88,6 +89,13 @@ export class NotebookLinkHandler {
 			 * We return the absolute path for the link so that it will get used in the as the href for the anchor HTML element
 			 * (in linkCalloutDialog document.execCommand('insertHTML') and therefore will call getLinkURL() with HTMLAnchorElement to then get the relative path
 			*/
+			// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
+			// skip encoding it if it's already encoded
+			let encodedLinkURL = this._isFile ? escapeUrl(this._link) : this._link;
+			if (encodedLinkURL !== decodeURI(encodedLinkURL)) {
+				encodedLinkURL = encodeURI(this._link);
+				return encodedLinkURL;
+			}
 			return this._link;
 		} else {
 			// cases where we pass the HTMLAnchorElement

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -8,7 +8,6 @@ import * as path from 'vs/base/common/path';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 import { isWindows } from 'vs/base/common/platform';
-import { escapeUrl } from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/utils';
 
 const useAbsolutePathConfigName = 'notebook.useAbsoluteFilePaths';
 

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -91,7 +91,7 @@ export class NotebookLinkHandler {
 			*/
 			// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
 			// skip encoding it if it's already encoded
-			let encodedLinkURL = this._isFile ? escapeUrl(this._link) : this._link.replace(/\s/g, '%20'); //replace spaces since we're skipping escape for http links
+			let encodedLinkURL = escapeUrl(this._link);
 			if (encodedLinkURL !== decodeURI(encodedLinkURL)) {
 				encodedLinkURL = encodeURI(this._link);
 				return encodedLinkURL;

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
@@ -130,12 +130,12 @@ suite('Noteboook Link Handler', function (): void {
 
 	test('Should return correctly encoded url/filePath', () => {
 		let result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code', configurationService);
-		assert.strictEqual(result.getLinkUrl(), `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
+		assert.strictEqual(result.getEncodedLinkUrl(), `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
 
 		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code', configurationService);
-		assert.strictEqual(result.getLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
+		assert.strictEqual(result.getEncodedLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
 
 		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft/azuredata studio)&type=Code', configurationService);
-		assert.strictEqual(result.getLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
+		assert.strictEqual(result.getEncodedLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
@@ -127,4 +127,15 @@ suite('Noteboook Link Handler', function (): void {
 		result = new NotebookLinkHandler(notebookUri, Object.assign(document.createElement('a'), { href: '/tmp/my%20stuff.png' }), configurationService);
 		assert.strictEqual(result.getLinkUrl(), `.${path.sep}my%2520stuff.png`, 'Basic link test with %20 filename failed');
 	});
+
+	test('Should return correctly encoded url/filePath', () => {
+		let result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code', configurationService);
+		assert.strictEqual(result.getLinkUrl(), `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
+
+		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code', configurationService);
+		assert.strictEqual(result.getLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
+
+		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft/azuredata studio)&type=Code', configurationService);
+		assert.strictEqual(result.getLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
+	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17662 

As the issue states if user enters a encoded url such as https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code we re-encode it and show it as https://github.com/search/advanced?q=test&r=microsoft%252Fazuredatastudio&type=Code. 

In this PR, I've added a check to see if it's already encoded before encoding it.
