### PR TITLE
update dashboard taskbar separator

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
@@ -39,11 +39,6 @@ dashboard-page .carbon-taskbar .monaco-action-bar .actions-container .action-ite
 	background-position: left;
 }
 
-dashboard-page .actions-container .taskbarSeparator {
-	height: 14px;
-	margin-right: 16px;
-}
-
 dashboard-page .editor-toolbar {
 	flex: 0 0 auto;
 	flex-flow: row;


### PR DESCRIPTION
This PR fixes #17408 
the style of the separator is now defined in the taskbar component, the only actual customation is the height which is causing problem. so removing it altogether.

before
![image](https://user-images.githubusercontent.com/13777222/144302863-fed8519e-525f-4d26-868e-8647f8156d73.png)

after
![image](https://user-images.githubusercontent.com/13777222/144302843-ef85be8b-5b75-4843-ab5b-b2abf034945d.png)

style defined in the taskbar component:
![image](https://user-images.githubusercontent.com/13777222/144302919-d44e8ecc-d67e-4570-9730-a2f6cb76de67.png)
