### PR TITLE
Enable add sql binding quickpick

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -172,7 +172,8 @@
       {
         "command": "sqlDatabaseProjects.addSqlBinding",
         "title": "%sqlDatabaseProjects.addSqlBinding%",
-        "category": "MS SQL"},
+        "category": "MS SQL"
+      },
       {
         "command": "sqlDatabaseProjects.changeTargetPlatform",
         "title": "%sqlDatabaseProjects.changeTargetPlatform%",
@@ -275,7 +276,7 @@
         },
         {
           "command": "sqlDatabaseProjects.addSqlBinding",
-          "when": "editorLangId == csharp && !azdataAvailable && resourceExtname"
+          "when": "editorLangId == csharp && !azdataAvailable && resourceScheme != untitled"
         },
         {
           "command": "sqlDatabaseProjects.exclude",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -17,6 +17,7 @@
     "onCommand:sqlDatabaseProjects.open",
     "onCommand:sqlDatabaseProjects.createProjectFromDatabase",
     "onCommand:sqlDatabaseProjects.generateProjectFromOpenApiSpec",
+    "onCommand:sqlDatabaseProjects.addSqlBinding",
     "workspaceContains:**/*.sqlproj",
     "onView:dataworkspace.views.main"
   ],
@@ -169,6 +170,10 @@
         "category": "%sqlDatabaseProjects.displayName%"
       },
       {
+        "command": "sqlDatabaseProjects.addSqlBinding",
+        "title": "%sqlDatabaseProjects.addSqlBinding%",
+        "category": "MS SQL"},
+      {
         "command": "sqlDatabaseProjects.changeTargetPlatform",
         "title": "%sqlDatabaseProjects.changeTargetPlatform%",
         "category": "%sqlDatabaseProjects.displayName%"
@@ -267,6 +272,10 @@
         {
           "command": "sqlDatabaseProjects.editProjectFile",
           "when": "false"
+        },
+        {
+          "command": "sqlDatabaseProjects.addSqlBinding",
+          "when": "editorLangId == csharp && !azdataAvailable && resourceExtname"
         },
         {
           "command": "sqlDatabaseProjects.exclude",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "Enables users to develop and publish database schemas for MSSQL Databases",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "Enables users to develop and publish database schemas for MSSQL Databases",
-  "version": "0.15.0",
+  "version": "0.14.0",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -40,5 +40,5 @@
 	"sqlDatabaseProjects.autorestSqlVersion": "Which version of Autorest.Sql to use from NPM.  Latest will be used if not set.",
 	"sqlDatabaseProjects.welcome": "No database projects currently open.\n[New Project](command:sqlDatabaseProjects.new)\n[Open Project](command:sqlDatabaseProjects.open)\n[Create Project From Database](command:sqlDatabaseProjects.importDatabase)",
 
-	"sqlDatabaseProjects.addSqlBinding":"Add SQL Binding"
+	"sqlDatabaseProjects.addSqlBinding":"Add SQL Binding (preview)"
 }


### PR DESCRIPTION
Reverting this PR: https://github.com/microsoft/azuredatastudio/pull/17340 with two new changes:
- added (preview) to command title
- added `resourceExtname` to when clause to hide the command for untitled files and fixes https://github.com/microsoft/azuredatastudio/issues/17571