### PR TITLE
Updating pipeline linux agent image to Ubuntu 18.04

### DIFF
--- a/build/azure-pipelines/linux/Dockerfile
+++ b/build/azure-pipelines/linux/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 \
 	libkrb5-dev git apt-transport-https ca-certificates curl gnupg-agent software-properties-common \
-	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++-4.9
+	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++-4.9 python-dev
 
 RUN rm /usr/bin/gcc
 RUN rm /usr/bin/g++

--- a/build/azure-pipelines/linux/Dockerfile
+++ b/build/azure-pipelines/linux/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 \
 	libkrb5-dev git apt-transport-https ca-certificates curl gnupg-agent software-properties-common \
-	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++-4.9 python-dev
+	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++-4.9 python-dev \
+	libgbm-dev
 
 RUN rm /usr/bin/gcc
 RUN rm /usr/bin/g++

--- a/build/azure-pipelines/linux/Dockerfile
+++ b/build/azure-pipelines/linux/Dockerfile
@@ -1,6 +1,10 @@
 #Download base image ubuntu 18.04
 FROM ubuntu:18.04
 
+#Adding apt repos for g++-4.9
+RUN echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+RUN echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+
 # Update Software repository
 RUN apt-get update && apt-get upgrade -y
 

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: linux-x64
-    image: sqltoolscontainers.azurecr.io/linux-build-agent:3
+    image: sqltoolscontainers.azurecr.io/linux-build-agent:6
     endpoint: SqlToolsContainers
 
 jobs:


### PR DESCRIPTION






Doing this update since Ubuntu 16.04 used in the current linux builds has passed EOL 


This PR fixes #17773

Link to the adhoc build: 
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=131021&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=34fc863e-00ed-50b5-30ee-f50930ed6e81

