### PR TITLE
add migration state management improvement

### DIFF
--- a/extensions/sql-migration/src/models/migrationLocalStorage.ts
+++ b/extensions/sql-migration/src/models/migrationLocalStorage.ts
@@ -125,8 +125,6 @@ export class MigrationLocalStorage {
 		}
 	}
 
-
-
 	public static async clearMigrations(): Promise<void> {
 		await this.context.globalState.update(this.mementoToken, ([] as MigrationContext[]));
 	}

--- a/extensions/sql-migration/src/models/migrationLocalStorage.ts
+++ b/extensions/sql-migration/src/models/migrationLocalStorage.ts
@@ -20,12 +20,14 @@ export class MigrationLocalStorage {
 		const result: MigrationContext[] = [];
 		const validMigrations: MigrationContext[] = [];
 
+		// fetch saved migrations
 		const migrationMementos: MigrationContext[] = this.context.globalState.get(this.mementoToken) || [];
 		for (let i = 0; i < migrationMementos.length; i++) {
 			const migration = migrationMementos[i];
 			migration.migrationContext = this.removeMigrationSecrets(migration.migrationContext);
 			migration.sessionId = migration.sessionId ?? undefinedSessionId;
 			if (migration.sourceConnectionProfile.serverName === connectionProfile.serverName) {
+				// refresh migration status
 				if (refreshStatus) {
 					try {
 						await this.refreshMigrationAzureAccount(migration);
@@ -59,7 +61,25 @@ export class MigrationLocalStorage {
 			}
 			validMigrations.push(migration);
 		}
-		await this.context.globalState.update(this.mementoToken, validMigrations);
+
+		// only save updated migration context
+		if (refreshStatus) {
+			const migrations: MigrationContext[] = this.context.globalState.get(this.mementoToken) || [];
+			validMigrations.forEach(migration => {
+				const idx = migrations.findIndex(m => m.migrationContext.id === migration.migrationContext.id);
+				if (idx > -1) {
+					migrations[idx] = migration;
+				}
+			});
+
+			// check global state for migrations count mismatch, avoid saving
+			// state if the count has changed when a migration may have been added
+			const current: MigrationContext[] = this.context.globalState.get(this.mementoToken) || [];
+			if (current.length === migrations.length) {
+				await this.context.globalState.update(this.mementoToken, migrations);
+			}
+		}
+
 		return result;
 	}
 
@@ -104,6 +124,8 @@ export class MigrationLocalStorage {
 			console.log(e);
 		}
 	}
+
+
 
 	public static async clearMigrations(): Promise<void> {
 		await this.context.globalState.update(this.mementoToken, ([] as MigrationContext[]));


### PR DESCRIPTION
adding a bug fix to help prevent a race condition where a new migration started in the background can be lost/deleted while the migrations list is refreshing.