### PR TITLE
Do not show add section command

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -425,6 +425,10 @@
           "when": "false"
         },
         {
+          "command": "notebook.command.addSection",
+          "when": "false"
+        },
+        {
           "command": "notebook.command.addMarkdown",
           "when": "false"
         },


### PR DESCRIPTION
Add Section command should only be visible by right clicking a book tree item.