### PR TITLE
fix grid actionbar

### DIFF
--- a/src/sql/workbench/contrib/query/browser/media/gridPanel.css
+++ b/src/sql/workbench/contrib/query/browser/media/gridPanel.css
@@ -18,3 +18,7 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
+
+.grid-panel.action-bar.vertical .action-item .action-label {
+	padding: 0px;
+}


### PR DESCRIPTION
#17833 

in previous vscode merge, vscode added default padding for action-label and as a result the size of the action bar items was changed and it is taking more space now, the fix is to add a grid specific rule to make sure it is compact.

I've updated the query editor test case to include a "one row" test.

https://github.com/microsoft/azuredatastudio/pull/15681/files?file-filters%5B%5D=.css&hide-deleted-files=true#diff-addd7132dee13457b17c0ce8af86416722108e69b8a60d63a865f524a8323f5fR50
![image](https://user-images.githubusercontent.com/13777222/145085668-6caec0b5-910f-4db7-abf5-ae7396258944.png)


before:

![image](https://user-images.githubusercontent.com/13777222/144970155-919bce3f-a821-494a-9385-671f1d437cde.png)

after:

![image](https://user-images.githubusercontent.com/13777222/145084159-226c1703-d46f-4532-981c-7aaf6bd87fce.png)
