### PR TITLE
Fix split cell undo

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/cellEdit.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cellEdit.ts
@@ -36,11 +36,11 @@ export class SplitCellEdit implements IResourceUndoRedoElement {
 	resource = this.model.notebookUri;
 	private readonly cellOperation = { cell_operation: 'split_cell' };
 
-	constructor(private model: NotebookModel, private firstCell: ICellModel, private secondCell: ICellModel, private newLinesRemoved: string[]) {
+	constructor(private model: NotebookModel, private cells: ICellModel[], private newLinesRemoved: string[]) {
 	}
 
 	undo(): void {
-		this.model.mergeCells(this.firstCell, this.secondCell, this.newLinesRemoved);
+		this.model.mergeCells(this.cells, this.newLinesRemoved);
 		this.model.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.UndoCell, this.cellOperation);
 	}
 

--- a/src/sql/workbench/services/notebook/browser/models/cellEdit.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cellEdit.ts
@@ -5,7 +5,7 @@
 
 import { IResourceUndoRedoElement, UndoRedoElementType } from 'vs/platform/undoRedo/common/undoRedo';
 import { ICellModel, MoveDirection } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
-import { NotebookModel } from 'sql/workbench/services/notebook/browser/models/notebookModel';
+import { NotebookModel, SplitCell } from 'sql/workbench/services/notebook/browser/models/notebookModel';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { localize } from 'vs/nls';
 
@@ -36,11 +36,11 @@ export class SplitCellEdit implements IResourceUndoRedoElement {
 	resource = this.model.notebookUri;
 	private readonly cellOperation = { cell_operation: 'split_cell' };
 
-	constructor(private model: NotebookModel, private cells: ICellModel[], private newlinesBeforeTailCellContent: string) {
+	constructor(private model: NotebookModel, private cells: SplitCell[]) {
 	}
 
 	undo(): void {
-		this.model.mergeCells(this.cells, this.newlinesBeforeTailCellContent);
+		this.model.mergeCells(this.cells);
 		this.model.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.UndoCell, this.cellOperation);
 	}
 

--- a/src/sql/workbench/services/notebook/browser/models/cellEdit.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cellEdit.ts
@@ -36,11 +36,11 @@ export class SplitCellEdit implements IResourceUndoRedoElement {
 	resource = this.model.notebookUri;
 	private readonly cellOperation = { cell_operation: 'split_cell' };
 
-	constructor(private model: NotebookModel, private cells: ICellModel[], private newLinesRemoved: string[]) {
+	constructor(private model: NotebookModel, private cells: ICellModel[], private newlinesBeforeTailCellContent: string) {
 	}
 
 	undo(): void {
-		this.model.mergeCells(this.cells, this.newLinesRemoved);
+		this.model.mergeCells(this.cells, this.newlinesBeforeTailCellContent);
 		this.model.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.UndoCell, this.cellOperation);
 	}
 

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -683,23 +683,21 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	}
 
 	public mergeCells(cells: ICellModel[], newLinesRemoved: string[] | undefined): void {
-		let index = this._cells.findIndex(cell => cell.equals(cell));
-		if (index > -1) {
-			// Append the other cell sources to the first cell
-			for (let i = 1; i < cells.length; i++) {
-				cells[0].source = newLinesRemoved.length > 0 ? [...cells[0].source, ...newLinesRemoved, ...cells[i].source] : [...cells[0].source, ...cells[i].source];
-			}
-			cells[0].isEditMode = true;
-			// Set newly created cell as active cell
-			this.updateActiveCell(cells[0]);
-			this._contentChangedEmitter.fire({
-				changeType: NotebookChangeType.CellsModified,
-				cells: [cells[0]],
-				cellIndex: index
-			});
-			for (let i = 1; i < cells.length; i++) {
-				this.deleteCell(cells[i], false);
-			}
+		let firstCell = cells[0];
+		// Append the other cell sources to the first cell
+		for (let i = 1; i < cells.length; i++) {
+			firstCell.source = newLinesRemoved.length > 0 ? [...firstCell.source, ...newLinesRemoved, ...cells[i].source] : [...firstCell.source, ...cells[i].source];
+		}
+		firstCell.isEditMode = true;
+		// Set newly created cell as active cell
+		this.updateActiveCell(firstCell);
+		this._contentChangedEmitter.fire({
+			changeType: NotebookChangeType.CellsModified,
+			cells: [firstCell],
+			cellIndex: 0
+		});
+		for (let i = 1; i < cells.length; i++) {
+			this.deleteCell(cells[i], false);
 		}
 	}
 

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -579,7 +579,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				let newCellIndex = index;
 				let tailCellIndex = index;
 				let splitCells: SplitCell[] = [];
-				let newlinesBeforeTailCellContent: string;
 
 				// Save UI state
 				let showMarkdown = this.cells[index].showMarkdown;
@@ -652,6 +651,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						partialSource = source.slice(tailRange.startLineNumber - 1, tailRange.startLineNumber)[0].slice(tailRange.startColumn - 1);
 						tailSource.splice(0, 1, partialSource);
 					}
+					let newlinesBeforeTailCellContent: string;
 					//Remove the trailing empty line after the cursor
 					if (tailSource[0] === '\r\n' || tailSource[0] === '\n') {
 						newlinesBeforeTailCellContent = tailSource.splice(0, 1)[0];

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -574,7 +574,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				let newCellIndex = index;
 				let tailCellIndex = index;
 				let splitCells: ICellModel[] = [];
-				let newLinesRemoved: string[] = [];
+				let newlinesBeforeTailCellContent: string = '';
 
 				// Save UI state
 				let showMarkdown = this.cells[index].showMarkdown;
@@ -649,7 +649,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					}
 					//Remove the trailing empty line after the cursor
 					if (tailSource[0] === '\r\n' || tailSource[0] === '\n') {
-						newLinesRemoved = tailSource.splice(0, 1);
+						newlinesBeforeTailCellContent = tailSource.splice(0, 1)[0];
 					}
 					tailCell.source = tailSource;
 					tailCellIndex = newCellIndex + 1;
@@ -661,7 +661,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				let activeCellIndex = newCell ? newCellIndex : (headContent.length ? tailCellIndex : index);
 
 				if (addToUndoStack) {
-					this.undoService.pushElement(new SplitCellEdit(this, splitCells, newLinesRemoved));
+					this.undoService.pushElement(new SplitCellEdit(this, splitCells, newlinesBeforeTailCellContent));
 				}
 				//make new cell Active
 				this.updateActiveCell(activeCell);
@@ -682,11 +682,11 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return undefined;
 	}
 
-	public mergeCells(cells: ICellModel[], newLinesRemoved: string[] | undefined): void {
+	public mergeCells(cells: ICellModel[], newlinesBeforeTailCellContent: string): void {
 		let firstCell = cells[0];
 		// Append the other cell sources to the first cell
 		for (let i = 1; i < cells.length; i++) {
-			firstCell.source = newLinesRemoved.length > 0 ? [...firstCell.source, ...newLinesRemoved, ...cells[i].source] : [...firstCell.source, ...cells[i].source];
+			firstCell.source = newlinesBeforeTailCellContent.length > 0 ? [...firstCell.source, ...newlinesBeforeTailCellContent, ...cells[i].source] : [...firstCell.source, ...cells[i].source];
 		}
 		firstCell.isEditMode = true;
 		// Set newly created cell as active cell


### PR DESCRIPTION
This PR is for #17820 

Keep track of how we split the cells in an array. The first entry will always have the original cell and the subsequent cells will be the newly created cells.
To merge the cells we concatenate the sources from the other cells and attached them to the original cell.

https://user-images.githubusercontent.com/34872381/145117471-0b4ee8fe-5dfd-47ff-bcd2-9c1e6a83e709.mov