### PR TITLE
fix load publish profile not working

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -311,7 +311,9 @@ export class PublishDatabaseDialog {
 		this.targetDatabaseDropDown!.values?.push(<any>value);
 		this.targetDatabaseDropDown!.value = value;
 
-		this.targetDatabaseTextBox!.value = value;
+		if (this.targetDatabaseTextBox) {
+			this.targetDatabaseTextBox!.value = value;
+		}
 	}
 
 	public getBaseDockerImageName(): string {


### PR DESCRIPTION
Addresses https://github.com/microsoft/azuredatastudio/issues/17850. This got introduced with the publish to container changes in https://github.com/microsoft/azuredatastudio/pull/17495.

Load publish profile was failing when the radio buttons aren't toggled before loading the publish profile. The error was happening because the value of the database textbox is trying to get set, but that only gets created when the "Publish to new server in container" radio button is selected.
