### PR TITLE
vbump STS

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.165",
+	"version": "3.0.0-release.168",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",


### PR DESCRIPTION
bring in the fix for the sql variant column handling.

![image](https://user-images.githubusercontent.com/13777222/145258096-b64b8d1d-5996-40c0-9184-da6ee0810d43.png)

@smartguest please confirm your XELite changes are also good to go for the release branch.
