### PR TITLE
open database dashboard

### DIFF
--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -192,6 +192,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 	public cloneWithDatabase(databaseName: string): ConnectionProfile {
 		let instance = this.cloneWithNewId();
 		instance.databaseName = databaseName;
+		instance.originalDatabase = databaseName;
 		return instance;
 	}
 


### PR DESCRIPTION
for: https://github.com/microsoft/azuredatastudio/issues/17844

root cause:
in this PR: https://github.com/microsoft/azuredatastudio/pull/17266 a new option (originalDatabase) is added to the connection profile and used it to determine whether we are trying to open a database dashboard or server dashboard.

when we open database dashboard from OE, we are cloning the profile and set the database name, but the originalDatabase is not set, as a result it is being treated as request to open server dashboard.

fix:
when we clone the profile with a database name, we should also set the originalDatabase property.

P.S. I've been testing the database dashboard directly from the server dashboard, I've added a test case to the test plan to check this entry point as well.