### PR TITLE
fix focus when opening publish dialog

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -181,8 +181,6 @@ export class PublishDatabaseDialog {
 
 			let formModel = this.formBuilder.component();
 			await view.initializeModel(formModel);
-
-			await this.loadProfileTextBox!.focus();
 		});
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/17869. The focus should be on the first enabled component, which used to be the publish profile input box but is now the radio buttons. Alan made a change a while ago that automatically sets the focus on the first enabled component, so we don't need to explicitly set the focus anymore.

