### PR TITLE
update commandline handler

### DIFF
--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -132,14 +132,11 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 				this._notificationService.status(localize('connectingLabel', "Connecting: {0}", profile.serverName), { hideAfter: 2500 });
 			}
 			try {
-				await this._connectionManagementService.connectIfNotConnected(profile, 'connection', true);
+				await this._connectionManagementService.connectIfNotConnected(profile, args.showDashboard ? 'dashboard' : 'connection', true);
 				// Before sending to extensions, we should a) serialize to IConnectionProfile or things will fail,
 				// and b) use the latest version of the profile from the service so most fields are filled in.
 				let updatedProfile = this._connectionManagementService.getConnectionProfileById(profile.id);
 				connectedContext = { connectionProfile: new ConnectionProfile(this._capabilitiesService, updatedProfile).toIConnectionProfile() };
-				if (args.showDashboard) {
-					this._connectionManagementService.showDashboard(updatedProfile);
-				}
 			} catch (err) {
 				this.logService.warn('Failed to connect due to error' + getErrorMessage(err));
 			}


### PR DESCRIPTION
requested by a partner team.


1. the partner team do not have query provider support right now, we shouldn't assume it is and directly open query editor
2. ability to open the dashboard after connection is made. 