### PR TITLE
fix table focus issue

### DIFF
--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -79,8 +79,9 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 
 		this._container = document.createElement('div');
 		this._container.className = 'monaco-table';
-		this._register(DOM.addDisposableListener(this._container, DOM.EventType.FOCUS, () => {
-			if (!this.grid.getActiveCell() && this._data.getLength() > 0) {
+		this._register(DOM.addDisposableListener(this._container, DOM.EventType.FOCUS, (e: FocusEvent) => {
+			// the focus redirection should only happen when the event target is the container (using keyboard navigation)
+			if (e.target && this._container === e.target && !this.grid.getActiveCell() && this._data.getLength() > 0) {
 				// When the table receives focus and there are currently no active cell, the focus should go to the first focusable cell.
 				let cellToFocus = undefined;
 				for (let col = 0; col < this.columns.length; col++) {


### PR DESCRIPTION
This PR fixes #17808 

in my previous PR: https://github.com/microsoft/azuredatastudio/pull/16206 I fixed the table not getting focused issue by keyboard. there is a flaw in the implementation, I meant to only handle the keyboard scenario. in the case that user directly clicks the table, we shouldn't do focus redirection.
before:
![before-table](https://user-images.githubusercontent.com/13777222/145657491-55db39e4-1e9e-42b9-b491-4068a6cba281.gif)

after:
![after-table](https://user-images.githubusercontent.com/13777222/145657497-15c1c953-9e3b-435c-b2f1-fd5f3d1c6fb2.gif)

