### PR TITLE
table keyboard focus

### DIFF
--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -142,12 +142,14 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 		this.mapMouseEvent(this._grid.onDblClick, this._onDoubleClick);
 		this._grid.onColumnsResized.subscribe(() => this._onColumnResize.fire());
 		this._grid.onRendered.subscribe(() => {
-			// When the grid is rerendered (e.g. view switching), the active cell information is kept but the cell will become not keyboard focusable (tabindex changed from 0 to -1).
-			// we need to set the container's tabindex to 0 to go through the focus redirection logic.
+			// When there are data present and no cells are keyboard focusable, the container should be set to keyboard focusable to
+			// leverage the focus redirection logic.
 			this._container.tabIndex = this._container.querySelector('[tabindex = "0"]') || this._data.getLength() === 0 ? -1 : 0;
 		});
 		this._grid.onActiveCellChanged.subscribe((e, data) => {
 			// When the active cell is changed, a cell will become focusable and we can make the container not focusable by user.
+			// later when the grid is rerendered (e.g. view switching), the active cell information is kept but the cell will become not keyboard focusable (tabindex changed from 0 to -1).
+			// we need to check and reset the tabIndex of the container in the onRendered handler.
 			this._container.tabIndex = -1;
 		});
 	}

--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -82,11 +82,8 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 		this._register(DOM.addDisposableListener(this._container, DOM.EventType.FOCUS, (e: FocusEvent) => {
 			// Focus redirection should only happen when the event target is the container (using keyboard navigation)
 			if (e.target && this._container === e.target && this._data.getLength() > 0) {
-				let cellToFocus = undefined;
-				if (this.grid.getActiveCell()) {
-					// When the table receives focus with an active cell, we should set the focus to the active cell.
-					cellToFocus = this.grid.getActiveCell();
-				} else {
+				let cellToFocus = this.grid.getActiveCell();
+				if (!cellToFocus) {
 					// When the table receives focus and there are currently no active cell, the focus should go to the first focusable cell.
 					for (let col = 0; col < this.columns.length; col++) {
 						// some cells are not keyboard focusable (e.g. row number column), we need to find the first focusable cell.

--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -80,10 +80,11 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 		this._container = document.createElement('div');
 		this._container.className = 'monaco-table';
 		this._register(DOM.addDisposableListener(this._container, DOM.EventType.FOCUS, (e: FocusEvent) => {
-			// the focus redirection should only happen when the event target is the container (using keyboard navigation)
+			// Focus redirection should only happen when the event target is the container (using keyboard navigation)
 			if (e.target && this._container === e.target && this._data.getLength() > 0) {
 				let cellToFocus = undefined;
 				if (this.grid.getActiveCell()) {
+					// When the table receives focus with an active cell, we should set the focus to the active cell.
 					cellToFocus = this.grid.getActiveCell();
 				} else {
 					// When the table receives focus and there are currently no active cell, the focus should go to the first focusable cell.
@@ -144,11 +145,12 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 		this.mapMouseEvent(this._grid.onDblClick, this._onDoubleClick);
 		this._grid.onColumnsResized.subscribe(() => this._onColumnResize.fire());
 		this._grid.onRendered.subscribe(() => {
-			// When the grid is rerendered (e.g. view switching), the active cell information is kept but the tabindex attribute will be set to -1 on the active cell.
-			// we need to set the container's tabindex to 0 so that the focus redirection can happen, otherwise the table won't be reachable by keyboard navigation.
+			// When the grid is rerendered (e.g. view switching), the active cell information is kept but the cell will become not keyboard focusable (tabindex changed from 0 to -1).
+			// we need to set the container's tabindex to 0 to go through the focus redirection logic.
 			this._container.tabIndex = this._container.querySelector('[tabindex = "0"]') || this._data.getLength() === 0 ? -1 : 0;
 		});
 		this._grid.onActiveCellChanged.subscribe((e, data) => {
+			// When the active cell is changed, a cell will become focusable and we can make the container not focusable by user.
 			this._container.tabIndex = -1;
 		});
 	}


### PR DESCRIPTION
This PR fixes #17898 
(I have run the command "Toggle Tab Key Moves Focus" while recording the following images)

**Before** 
The table is not keyboard focusable after tab switching, the focus goes from tab header to the 'Save as CSV' button directly.
![before-table-keyboard](https://user-images.githubusercontent.com/13777222/145866152-741e85b7-f040-4f95-b703-e13a29a09f70.gif)


after:
![after-table-keyboard](https://user-images.githubusercontent.com/13777222/145866169-45bb71bf-d848-4ddf-a658-a921f7b4c7c6.gif)

