### PR TITLE
Add folder for SDK style sql projects

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -603,3 +603,26 @@ export function getFoldersToFile(startFolder: string, endFile: string): string[]
 
 	return folders;
 }
+
+/**
+ * Gets the folders between the startFolder and endFolder
+ * @param startFolder
+ * @param endFolder
+ * @returns array of folders between startFolder and endFolder
+ */
+export function getFoldersToFolder(startFolder: string, endFolder: string): string[] {
+	let folders: string[] = [];
+
+	const relativePath = convertSlashesForSqlProj(endFolder.substring(startFolder.length));
+	const pathSegments = trimChars(relativePath, ' \\').split(constants.SqlProjPathSeparator);
+	let folderPath = convertSlashesForSqlProj(startFolder) + constants.SqlProjPathSeparator;
+
+	for (let segment of pathSegments) {
+		if (segment) {
+			folderPath += segment + constants.SqlProjPathSeparator;
+			folders.push(getPlatformSafeFileEntryPath(folderPath));
+		}
+	}
+
+	return folders;
+}

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -610,7 +610,7 @@ export function getFoldersToFile(startFolder: string, endFile: string): string[]
  * @param endFolder
  * @returns array of folders between startFolder and endFolder
  */
-export function getFoldersToFolder(startFolder: string, endFolder: string): string[] {
+export function getFoldersAlongPath(startFolder: string, endFolder: string): string[] {
 	let folders: string[] = [];
 
 	const relativePath = convertSlashesForSqlProj(endFolder.substring(startFolder.length));

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -259,7 +259,7 @@ export class Project implements ISqlProject {
 			// If there are nested empty folders, there will only be a Folder entry for the inner most folder, so we need to add entries for the intermediate folders
 			sqlprojFolders.forEach(folder => {
 				const fullPath = path.join(utils.getPlatformSafeFileEntryPath(this.projectFolderPath), utils.getPlatformSafeFileEntryPath(folder));
-				const intermediateFolders = utils.getFoldersToFolder(this.projectFolderPath, utils.getPlatformSafeFileEntryPath(fullPath));
+				const intermediateFolders = utils.getFoldersAlongPath(this.projectFolderPath, utils.getPlatformSafeFileEntryPath(fullPath));
 				intermediateFolders.forEach(f => foldersSet.add(utils.convertSlashesForSqlProj(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(f)))));
 			});
 		}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -901,17 +901,19 @@ export class Project implements ISqlProject {
 			}
 		}
 		else {
-			// if there's a folder entry for the folder containing this file, remove it from the sqlproj because the folder will now be
-			// included by the glob that includes this file (same as how csproj does it)
-			const folders = await this.foldersListedInSqlproj();
-			folders.forEach(folder => {
-				const trimmedUri = utils.trimUri(Uri.file(utils.getPlatformSafeFileEntryPath(folder)), Uri.file(utils.getPlatformSafeFileEntryPath(filePath)));
-				const basename = path.basename(utils.getPlatformSafeFileEntryPath(filePath));
-				if (trimmedUri === basename) {
-					// remove folder entry from sqlproj
-					this.removeFolderNode(folder);
-				}
-			});
+			if (this.isSdkStyleProject) {
+				// if there's a folder entry for the folder containing this file, remove it from the sqlproj because the folder will now be
+				// included by the glob that includes this file (same as how csproj does it)
+				const folders = await this.foldersListedInSqlproj();
+				folders.forEach(folder => {
+					const trimmedUri = utils.trimUri(Uri.file(utils.getPlatformSafeFileEntryPath(folder)), Uri.file(utils.getPlatformSafeFileEntryPath(filePath)));
+					const basename = path.basename(utils.getPlatformSafeFileEntryPath(filePath));
+					if (trimmedUri === basename) {
+						// remove folder entry from sqlproj
+						this.removeFolderNode(folder);
+					}
+				});
+			}
 
 			const currentFiles = await this.readFilesInProject();
 

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -1038,8 +1038,7 @@ describe('Project: sdk style project content operations', function (): void {
 		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(scriptPathTagged))?.sqlObjectType).equal(constants.ExternalStreamingJob);
 		should(newProject.files.find(f => f.type === EntryType.File && f.relativePath === convertSlashesForSqlProj(outsideFolderScriptPath))).not.equal(undefined);
 
-		// TODO: uncomment after add empty folder is updated
-		// should(newProject.files.find(f => f.type === EntryType.Folder && f.relativePath === convertSlashesForSqlProj(otherFolderPath))).not.equal(undefined);
+		should(newProject.files.find(f => f.type === EntryType.Folder && f.relativePath === convertSlashesForSqlProj(otherFolderPath))).not.equal(undefined);
 
 		// only the external streaming job and file outside of the project folder should have been added to the sqlproj
 		const projFileText = (await fs.readFile(projFilePath)).toString();
@@ -1131,10 +1130,51 @@ describe('Project: sdk style project content operations', function (): void {
 		// make sure both folders are removed from sqlproj and remove entry is added
 		const projFileText = (await fs.readFile(projFilePath)).toString();
 		should(projFileText.includes('<Folder Include="folder1" />')).equal(false, projFileText);
-		should(projFileText.includes('<Folder Include="folder2\" />')).equal(false, projFileText);
+		should(projFileText.includes('<Folder Include="folder2\\" />')).equal(false, projFileText);
 
 		should(projFileText.includes('<Build Remove="folder1\\**" />')).equal(true, projFileText);
 		should(projFileText.includes('<Build Remove="folder2\\**" />')).equal(true, projFileText);
+	});
+
+	it('Should handle adding empty folders and removing the Folder entry when the folder is no longer empty', async function (): Promise<void> {
+		const testFolderPath = await testUtils.generateTestFolderPath();
+		projFilePath = await testUtils.createTestSqlProjFile(baselines.openSdkStyleSqlProjectWithFilesSpecifiedBaseline, testFolderPath);
+		await testUtils.createDummyFileStructure(false, undefined, path.dirname(projFilePath));
+
+		const project: Project = await Project.openProject(projFilePath);
+
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(11);
+		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(2);
+		should(project.files.find(f => f.relativePath === 'folder1\\')!).not.equal(undefined);
+		should(project.files.find(f => f.relativePath === 'folder2\\')!).not.equal(undefined);
+
+		// try to add a new folder
+		await project.addFolderItem('folder3\\');
+
+		// try to add a new folder without trailing backslash
+		await project.addFolderItem('folder4');
+
+		// verify folders were added
+		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(4);
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(11);
+		should(project.files.find(f => f.relativePath === 'folder3\\')).not.equal(undefined);
+		should(project.files.find(f => f.relativePath === 'folder4\\')).not.equal(undefined);
+
+		// verify folders were added and the entries have a backslash in the sqlproj
+		let projFileText = (await fs.readFile(projFilePath)).toString();
+		should(projFileText.includes('<Folder Include="folder3\\" />')).equal(true, projFileText);
+		should(projFileText.includes('<Folder Include="folder4\\" />')).equal(true, projFileText);
+
+		// add file to folder3
+		await project.addScriptItem(path.join('folder3', 'test.sql'), 'fake contents');
+		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(4);
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(12);
+		should(project.files.find(f => f.relativePath === 'folder3\\test.sql')).not.equal(undefined);
+
+		// verify folder3 entry is no longer in sqlproj
+		projFileText = (await fs.readFile(projFilePath)).toString();
+		should(projFileText.includes('<Folder Include="folder3\\" />')).equal(false, projFileText);
+		should(projFileText.includes('<Folder Include="folder4\\" />')).equal(true, projFileText);
 	});
 });
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This fixes how add folder is handled for sdk style sql projects. This fixes the ADS sql projects implementation to match how csprojs are handled in VS when adding new folders. 

In the initial changes to handle SDK style projects, all folders in the project's folder were included by default. After taking a closer look at how csprojs handles it, there's actually a Folder entry added to the project file when a new folder is added, then the Folder entry is removed from the csproj when the folder is no longer empy, like when a file is added inside. Empty folders are not shown in the UI unless there's a Folder entry for it in the project file.

Examples of adding folders and how the project file gets updated:
sqlproj:
![nestedAddFolder](https://user-images.githubusercontent.com/31145923/146095910-cb56e131-1ade-4e07-b65c-47ae40b6fa1f.gif)

csproj:
![csprojNestedAddFolder](https://user-images.githubusercontent.com/31145923/146095926-49315d99-1035-44de-9b7d-de9b28b9bad1.gif)

