### PR TITLE
Bumped versions of azcli and arc in package.json

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,7 +2,7 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "0.9.7",
+  "version": "0.11.0",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -2,7 +2,7 @@
   "name": "azcli",
   "displayName": "%azcli.arc.displayName%",
   "description": "%azcli.arc.description%",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",


### PR DESCRIPTION
Bumped up the version numbers in the package.json of extensions:
- arc-0.11.0
- azcli-0.3.0

Stable and Insiders will have the same version. Updating extension galleries in an upcoming PR after this.