### PR TITLE
Update arc to 0.11.0 and azcli to 0.3.0 - Stable

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.10.0",
-							"lastUpdated": "11/5/2021",
+							"version": "0.11.0",
+							"lastUpdated": "12/15/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-0.10.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-0.11.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4264,14 +4264,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.2.0",
-							"lastUpdated": "11/5/2021",
+							"version": "0.3.0",
+							"lastUpdated": "12/15/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-0.2.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-0.3.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Updating extension gallery of stable build to have new arc-0.11.0 and azcli -0.3.0 for the Azure Arc enabled Data Services release today. 
I will merge in this PR after this one is approved and merged in to bump the version numbers of the extensions in their respective package.json: https://github.com/microsoft/azuredatastudio/pull/17932