### PR TITLE
Update arc to 0.11.0 and azcli to 0.3.0 - Insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.9.7",
-							"lastUpdated": "11/3/2021",
+							"version": "0.11.0",
+							"lastUpdated": "12/15/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-0.9.7.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-0.11.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4272,14 +4272,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.1.1",
-							"lastUpdated": "11/3/2021",
+							"version": "0.3.0",
+							"lastUpdated": "12/15/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-0.1.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-0.3.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Updated arc extension to 0.11.0 and azcli extension to 0.3.0 to go with the Azure Arc enabled Data Services release today.
I will merge in this PR after this one is approved and merged in to bump the version numbers of the extensions in their respective package.json: https://github.com/microsoft/azuredatastudio/pull/17932