### PR TITLE
fix pre/post deploy scripts getting double counted in the files for sdk style projects

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -122,13 +122,15 @@ export class Project implements ISqlProject {
 		// check if this is an sdk style project https://docs.microsoft.com/en-us/dotnet/core/project-sdk/overview
 		this._isSdkStyleProject = this.CheckForSdkStyleProject();
 
+		// get pre and post deploy scripts specified in the sqlproj
+		this._preDeployScripts = this.readPreDeployScripts();
+		this._postDeployScripts = this.readPostDeployScripts();
+		this._noneDeployScripts = this.readNoneDeployScripts();
+
 		// get files and folders
 		this._files = await this.readFilesInProject();
 		this.files.push(...await this.readFolders());
 
-		this._preDeployScripts = this.readPreDeployScripts();
-		this._postDeployScripts = this.readPostDeployScripts();
-		this._noneDeployScripts = this.readNoneDeployScripts();
 		this._databaseReferences = this.readDatabaseReferences();
 		this._importedTargets = this.readImportedTargets();
 
@@ -164,6 +166,11 @@ export class Project implements ISqlProject {
 				globFiles.forEach(f => {
 					filesSet.add(utils.convertSlashesForSqlProj(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(f))));
 				});
+
+				// remove any pre/post deploy scripts that were specified in the sqlproj so they aren't counted twice
+				this.preDeployScripts.forEach(f => filesSet.delete(f.relativePath));
+				this.postDeployScripts.forEach(f => filesSet.delete(f.relativePath));
+				this.noneDeployScripts.forEach(f => filesSet.delete(f.relativePath));
 			} catch (e) {
 				console.error(utils.getErrorMessage(e));
 			}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -228,7 +228,7 @@ export class Project implements ISqlProject {
 		}
 
 		if (this.isSdkStyleProject) {
-			// remove any pre/post deploy scripts that were specified in the sqlproj so they aren't counted twice
+			// remove any pre/post/none deploy scripts that were specified in the sqlproj so they aren't counted twice
 			this.preDeployScripts.forEach(f => filesSet.delete(f.relativePath));
 			this.postDeployScripts.forEach(f => filesSet.delete(f.relativePath));
 			this.noneDeployScripts.forEach(f => filesSet.delete(f.relativePath));

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -166,11 +166,6 @@ export class Project implements ISqlProject {
 				globFiles.forEach(f => {
 					filesSet.add(utils.convertSlashesForSqlProj(utils.trimUri(Uri.file(this.projectFilePath), Uri.file(f))));
 				});
-
-				// remove any pre/post deploy scripts that were specified in the sqlproj so they aren't counted twice
-				this.preDeployScripts.forEach(f => filesSet.delete(f.relativePath));
-				this.postDeployScripts.forEach(f => filesSet.delete(f.relativePath));
-				this.noneDeployScripts.forEach(f => filesSet.delete(f.relativePath));
 			} catch (e) {
 				console.error(utils.getErrorMessage(e));
 			}
@@ -230,6 +225,13 @@ export class Project implements ISqlProject {
 				void window.showErrorMessage(constants.errorReadingProject(constants.BuildElements, this.projectFilePath));
 				console.error(utils.getErrorMessage(e));
 			}
+		}
+
+		if (this.isSdkStyleProject) {
+			// remove any pre/post deploy scripts that were specified in the sqlproj so they aren't counted twice
+			this.preDeployScripts.forEach(f => filesSet.delete(f.relativePath));
+			this.postDeployScripts.forEach(f => filesSet.delete(f.relativePath));
+			this.noneDeployScripts.forEach(f => filesSet.delete(f.relativePath));
 		}
 
 		// create a FileProjectEntry for each file

--- a/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectWithGlobsSpecifiedBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectWithGlobsSpecifiedBaseline.xml
@@ -21,6 +21,13 @@
     <Build Include="folder1\*.sql" />
   </ItemGroup>
   <ItemGroup>
+    <PreDeploy Include="..\other\folder2\Script.PreDeployment1.sql" />
+  </ItemGroup>
+   <ItemGroup>
+    <PostDeploy Include="..\other\folder2\Script.PostDeployment1.sql" />
+    <None Include="..\other\folder2\Script.PostDeployment2.sql" />
+  </ItemGroup>
+  <ItemGroup>
     <ArtifactReference Condition="'$(NetCoreBuild)' == 'true'" Include="$(NETCoreTargetsPath)\SystemDacpacs\150\master.dacpac">
       <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
       <DatabaseVariableLiteralValue>master</DatabaseVariableLiteralValue>

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -883,7 +883,7 @@ describe('Project: sdk style project content operations', function (): void {
 		should(project.files.filter(f => f.relativePath === 'folder1\\').length).equal(1);
 	});
 
-	it('Should handle pre/post deploy scripts outside of project folder', async function (): Promise<void> {
+	it('Should handle pre/post/none deploy scripts outside of project folder', async function (): Promise<void> {
 		const testFolderPath = await testUtils.generateTestFolderPath();
 		const mainProjectPath =  path.join(testFolderPath, 'project');
 		const otherFolderPath = path.join(testFolderPath, 'other');
@@ -896,7 +896,7 @@ describe('Project: sdk style project content operations', function (): void {
 
 		const project: Project = await Project.openProject(projFilePath);
 
-		// Files and folders
+		// verify files, folders, pre/post/none deploy scripts were loaded correctly
 		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(2);
 		should(project.files.filter(f => f.type === EntryType.File).length).equal(18);
 		should(project.preDeployScripts.length).equal(1);

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -844,7 +844,7 @@ describe('Project: sdk style project content operations', function (): void {
 
 		// Files and folders
 		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(3);
-		should(project.files.filter(f => f.type === EntryType.File).length).equal(17);
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(13);
 
 		// SqlCmdVariables
 		should(Object.keys(project.sqlCmdVariables).length).equal(2);
@@ -1056,15 +1056,17 @@ describe('Project: sdk style project content operations', function (): void {
 
 		const project: Project = await Project.openProject(projFilePath);
 
-		should(project.files.filter(f => f.type === EntryType.File).length).equal(17);
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(13);
 		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(3);
+		should(project.noneDeployScripts.length).equal(2);
 
 		// try to exclude a glob included folder
 		await project.exclude(project.files.find(f => f.relativePath === 'folder1\\')!);
 
 		// verify folder and contents are excluded
 		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(1);
-		should(project.files.filter(f => f.type === EntryType.File).length).equal(9);
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(6);
+		should(project.noneDeployScripts.length).equal(1, 'Script.PostDeployment2.sql should have been excluded');
 		should(project.files.find(f => f.relativePath === 'folder1\\')).equal(undefined);
 
 		// verify sqlproj has glob exclude for folder, but not for files and inner folder
@@ -1082,7 +1084,7 @@ describe('Project: sdk style project content operations', function (): void {
 
 		const project: Project = await Project.openProject(projFilePath);
 
-		should(project.files.filter(f => f.type === EntryType.File).length).equal(17);
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(13);
 		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(3);
 
 		// try to exclude a glob included folder
@@ -1090,7 +1092,7 @@ describe('Project: sdk style project content operations', function (): void {
 
 		// verify folder and contents are excluded
 		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(2);
-		should(project.files.filter(f => f.type === EntryType.File).length).equal(15);
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(11);
 		should(project.files.find(f => f.relativePath === 'folder1\\nestedFolder\\')).equal(undefined);
 
 		// verify sqlproj has glob exclude for folder, but not for files

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -883,6 +883,27 @@ describe('Project: sdk style project content operations', function (): void {
 		should(project.files.filter(f => f.relativePath === 'folder1\\').length).equal(1);
 	});
 
+	it('Should handle pre/post deploy scripts outside of project folder', async function (): Promise<void> {
+		const testFolderPath = await testUtils.generateTestFolderPath();
+		const mainProjectPath =  path.join(testFolderPath, 'project');
+		const otherFolderPath = path.join(testFolderPath, 'other');
+		projFilePath = await testUtils.createTestSqlProjFile(baselines.openSdkStyleSqlProjectWithGlobsSpecifiedBaseline, mainProjectPath);
+		await testUtils.createDummyFileStructure(false, undefined, path.dirname(projFilePath));
+
+		// create files outside of project folder that are included in the project file
+		await fs.mkdir(otherFolderPath);
+		await testUtils.createOtherDummyFiles(otherFolderPath);
+
+		const project: Project = await Project.openProject(projFilePath);
+
+		// Files and folders
+		should(project.files.filter(f => f.type === EntryType.Folder).length).equal(2);
+		should(project.files.filter(f => f.type === EntryType.File).length).equal(18);
+		should(project.preDeployScripts.length).equal(1);
+		should(project.postDeployScripts.length).equal(1);
+		should(project.noneDeployScripts.length).equal(1);
+	});
+
 	it('Should handle globbing patterns listed in sqlproj', async function (): Promise<void> {
 		const testFolderPath = await testUtils.generateTestFolderPath();
 		const mainProjectPath =  path.join(testFolderPath, 'project');

--- a/extensions/sql-database-projects/src/test/testUtils.ts
+++ b/extensions/sql-database-projects/src/test/testUtils.ts
@@ -198,6 +198,9 @@ export async function createListOfFiles(filePath?: string): Promise<Uri[]> {
  *	 	- folder2
  * 			-file1.sql
  * 			-file2.sql
+ * 			- Script.PreDeployment1.sql
+ * 			- Script.PostDeployment1.sql
+ * 			- Script.PostDeployment2.sql
  *
  */
 export async function createOtherDummyFiles(testFolderPath: string): Promise<string> {
@@ -221,5 +224,13 @@ export async function createOtherDummyFiles(testFolderPath: string): Promise<str
 	const testLongerName = path.join(testFolderPath, 'folder1', 'testLongerName.sql');
 	await fs.writeFile(testLongerName, '');
 
+	const preDeploymentScript = path.join(testFolderPath, 'folder2', 'Script.PreDeployment1.sql');
+	await fs.writeFile(preDeploymentScript, '');
+
+	const postDeploymentScript1 = path.join(testFolderPath, 'folder2', 'Script.PostDeployment1.sql');
+	await fs.writeFile(postDeploymentScript1, '');
+
+	const postDeploymentScript2 = path.join(testFolderPath, 'folder2', 'Script.PostDeployment2.sql');
+	await fs.writeFile(postDeploymentScript2, '');
 	return testFolderPath;
 }


### PR DESCRIPTION
I realized the pre and post deploy scripts were getting counted twice (in files and in the pre/post/none deploy script arrays) while implementing delete for sdk style projects when the pre and post deploy scripts were trying to get deleted twice. The pre and post deploy scripts were getting picked up by the file globbing, so they need to be removed from the list of files so that they're only kept track of in the pre/post/none deploy script arrays.  