### PR TITLE
Update .NET 6 and DSCT extensions to latest

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4329,34 +4329,34 @@
 					},
 					"versions": [
 						{
-							"version": "0.1.0",
-							"lastUpdated": "10/1/2021",
+							"version": "1.0.0",
+							"lastUpdated": "12/20/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/net-6-runtime-0.1.0.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/net-6-runtime-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4455,34 +4455,34 @@
 					},
 					"versions": [
 						{
-							"version": "0.1.1",
-							"lastUpdated": "10/15/2021",
+							"version": "0.2.0",
+							"lastUpdated": "12/20/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/dsct-oracle-to-ms-sql-0.1.1.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/dsct-oracle-to-ms-sql-0.2.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/LICENSE.rtf"
 								}
 							],
 							"properties": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4321,34 +4321,34 @@
 					},
 					"versions": [
 						{
-							"version": "0.1.0",
-							"lastUpdated": "10/1/2021",
+							"version": "1.0.0",
+							"lastUpdated": "12/20/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/net-6-runtime-0.1.0.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/net-6-runtime-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21271.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4447,34 +4447,34 @@
 					},
 					"versions": [
 						{
-							"version": "0.1.1",
-							"lastUpdated": "10/15/2021",
+							"version": "0.2.0",
+							"lastUpdated": "12/20/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/dsct-oracle-to-ms-sql-0.1.1.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/dsct-oracle-to-ms-sql-0.2.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21288.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/LICENSE.rtf"
 								}
 							],
 							"properties": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- .NET 6: 0.1.0 -> 1.0.0 (use RTM runtime)
- DSCT (Oracle to MS SQL): 0.1.1 -> 0.2.0 (support user-defined data type mappings)