### PR TITLE
fix adding nested items not being created in the correct location in the project

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "Enables users to develop and publish database schemas for MSSQL Databases",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -660,7 +660,10 @@ export class ProjectsController {
 		if (root && fileOrFolder) {
 			// use relative path and not tree paths for files and folder
 			const allFileEntries = project.files.concat(project.preDeployScripts).concat(project.postDeployScripts).concat(project.noneDeployScripts);
-			return allFileEntries.find(x => utils.getPlatformSafeFileEntryPath(x.relativePath) === utils.getPlatformSafeFileEntryPath(utils.trimUri(root.fileSystemUri, fileOrFolder.fileSystemUri)));
+
+			// trim trailing slash since folders with and without a trailing slash are allowed in a sqlproj
+			const trimmedUri = utils.trimChars(utils.getPlatformSafeFileEntryPath(utils.trimUri(root.fileSystemUri, fileOrFolder.fileSystemUri)), '/');
+			return allFileEntries.find(x => utils.trimChars(utils.getPlatformSafeFileEntryPath(x.relativePath), '/') === trimmedUri);
 		}
 		return project.files.find(x => utils.getPlatformSafeFileEntryPath(x.relativePath) === utils.getPlatformSafeFileEntryPath(utils.trimUri(context.root.projectUri, context.projectUri)));
 	}

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -115,7 +115,8 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 
 		for (const part of relativePathParts) {
 			if (current.fileChildren[part] === undefined) {
-				current.fileChildren[part] = new fileTree.FolderNode(vscode.Uri.file(path.join(path.dirname(this.project.projectFilePath), part)), current);
+				const parentPath = current instanceof ProjectRootTreeItem ? path.dirname(current.fileSystemUri.fsPath) : current.fileSystemUri.fsPath;
+				current.fileChildren[part] = new fileTree.FolderNode(vscode.Uri.file(path.join(parentPath, part)), current);
 			}
 
 			if (current.fileChildren[part] instanceof fileTree.FileNode) {

--- a/extensions/sql-database-projects/src/test/projectTree.test.ts
+++ b/extensions/sql-database-projects/src/test/projectTree.test.ts
@@ -108,11 +108,10 @@ describe('Project Tree tests', function (): void {
 			'/TestProj/Database References',
 			'/TestProj/someFolder1']);
 
-		// Why are we only matching names - https://github.com/microsoft/azuredatastudio/issues/11026
-		should(tree.children.find(x => x.projectUri.path === '/TestProj/someFolder1')?.children.map(y => path.basename(y.projectUri.path))).deepEqual([
-			'MyNestedFolder1',
-			'MyNestedFolder2',
-			'MyFile2.sql']);
+		should(tree.children.find(x => x.projectUri.path === '/TestProj/someFolder1')?.children.map(y => y.projectUri.path)).deepEqual([
+			'/TestProj/someFolder1/MyNestedFolder1',
+			'/TestProj/someFolder1/MyNestedFolder2',
+			'/TestProj/someFolder1/MyFile2.sql']);
 	});
 
 	it('Should be able to parse and include relative paths outside project folder', function (): void {


### PR DESCRIPTION
This PR fixes #17963. This was already fixed in main in #17826, but to minimize the changes, this PR only has the 2 line fix and test change. This looks related to this previous test issue that #11026 that wasn't investigated before because it was only failing in tests.

This wasn't a problem before because this line of code wasn't being hit in most cases. By default when created in VS or ADS, sqlprojs have the folders listed first before the files and the project loading logic would go through the ItemGroups in order so the folders would be loaded first. If the order is changed to have files first, then folders, this would also be a problem in the previous extension versions. The test was previously failing because the folder was added after the files.

This got exposed in recent changes because the order that the sqlproj is read changed so that files are loaded first, then folders(https://github.com/microsoft/azuredatastudio/pull/17637). The change in order is because files and folders don't need to listed in the sqlproj for SDK style projects. There's a default glob to include sql files in the same folder as the sqlproj. Empty folders aren't included, so the files need to be loaded first so that only the folders containing project files and folders explicitly listed in the sqlproj are shown in the project tree.

Also fixes https://github.com/microsoft/azuredatastudio/issues/17984, which was introduced now that the code in ProjectTreeItem.ts is getting hit.