### PR TITLE
Bump vscodeVersion

### DIFF
--- a/product.json
+++ b/product.json
@@ -36,7 +36,7 @@
 	"gettingStartedUrl": "https://go.microsoft.com/fwlink/?linkid=862039",
 	"releaseNotesUrl": "https://go.microsoft.com/fwlink/?linkid=875578",
 	"documentationUrl": "https://go.microsoft.com/fwlink/?linkid=862277",
-	"vscodeVersion": "1.58.0",
+	"vscodeVersion": "1.59.0",
 	"commit": "9ca6200018fc206d67a47229f991901a8a453781",
 	"date": "2017-12-15T12:00:00.000Z",
 	"recommendedExtensions": [


### PR DESCRIPTION
Note that while the commit we merged up to is in August I decided not to bump this to 1.60.0 because we're still missing a bunch of stuff that VS Code got into their 1.60.0 release. It's fairly unlikely that would cause a huge problem for the stable APIs but wanted to err on the side of caution here (especially since most people aren't using the latest VS Code APIs in our stuff)