### PR TITLE
Bump Electron to 13.5.0

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://electronjs.org/headers"
-target "13.1.8"
+target "13.5.0"
 runtime "electron"

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -60,12 +60,12 @@
 				"git": {
 					"name": "electron",
 					"repositoryUrl": "https://github.com/electron/electron",
-					"commitHash": "0436a27d4f0fd7d1cb8246137a07fa0c8eb9337e"
+					"commitHash": "d93629321e994031e27504ccada933fb13fedb5a"
 				}
 			},
 			"isOnlyProductionDependency": true,
 			"license": "MIT",
-			"version": "13.1.8"
+			"version": "13.5.0"
 		},
 		{
 			"component": {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "cssnano": "^4.1.11",
     "debounce": "^1.0.0",
     "deemon": "^1.4.0",
-    "electron": "13.1.8",
+    "electron": "13.5.0",
     "eslint": "6.8.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,10 +3680,10 @@ electron-to-chromium@^1.3.723:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.737.tgz#196f2e9656f4f3c31930750e1899c091b72d36b5"
   integrity sha512-P/B84AgUSQXaum7a8m11HUsYL8tj9h/Pt5f7Hg7Ty6bm5DxlFq+e5+ouHUoNQMsKDJ7u4yGfI8mOErCmSH9wyg==
 
-electron@13.1.8:
-  version "13.1.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.8.tgz#a6def6eca7cafc7b068a8f71a069e521ba803182"
-  integrity sha512-ei2ZyyG81zUOlvm5Zxri668TdH5GNLY0wF+XrC2FRCqa8AABAPjJIWTRkhFEr/H6PDVPNZjMPvSs3XhHyVVk2g==
+electron@13.5.0:
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.5.0.tgz#6f746ca55d6be4f20dd4b799a5bf42fcb1ea0587"
+  integrity sha512-s4+b1RFWkNKWp7WWrv2q60MuFljHUCbO7XAupBSCUz/NP1Hz4OenWbMPUt0H+fa8YZeN8CX3JDIA8Bet5uAJvw==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
The VS Code updates didn't seem to need to update anything in the core app so this should be safe to get in. I did some basic validation and things seem fine.

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=134859&view=results

Fixes a security issue with the version we got from the merge. I decided to update to the latest version VS Code is using since there weren't any major changes needed to do so.