### PR TITLE
add a project guid if a sql project doesn't have one

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -376,6 +376,7 @@ export const True = 'True';
 export const False = 'False';
 export const Private = 'Private';
 export const ProjectGuid = 'ProjectGuid';
+export const PropertyGroup = 'PropertyGroup';
 export const Type = 'Type';
 export const ExternalStreamingJob: string = 'ExternalStreamingJob';
 export const Sdk: string = 'Sdk';

--- a/extensions/sql-database-projects/src/test/baselines/baselines.ts
+++ b/extensions/sql-database-projects/src/test/baselines/baselines.ts
@@ -34,6 +34,7 @@ export let openSdkStyleSqlProjectBaseline: string;
 export let openSdkStyleSqlProjectWithFilesSpecifiedBaseline: string;
 export let openSdkStyleSqlProjectWithGlobsSpecifiedBaseline: string;
 export let openSdkStyleSqlProjectWithBuildRemoveBaseline: string;
+export let openSdkStyleSqlProjectNoProjectGuidBaseline: string;
 
 const baselineFolderPath = __dirname;
 
@@ -65,6 +66,7 @@ export async function loadBaselines() {
 	openSdkStyleSqlProjectWithFilesSpecifiedBaseline = await loadBaseline(baselineFolderPath, 'openSdkStyleSqlProjectWithFilesSpecifiedBaseline.xml');
 	openSdkStyleSqlProjectWithGlobsSpecifiedBaseline = await loadBaseline(baselineFolderPath, 'openSdkStyleSqlProjectWithGlobsSpecifiedBaseline.xml');
 	openSdkStyleSqlProjectWithBuildRemoveBaseline = await loadBaseline(baselineFolderPath, 'openSdkStyleSqlProjectWithBuildRemoveBaseline.xml');
+	openSdkStyleSqlProjectNoProjectGuidBaseline = await loadBaseline(baselineFolderPath, 'openSdkStyleSqlProjectNoProjectGuidBaseline.xml');
 }
 
 async function loadBaseline(baselineFolderPath: string, fileName: string): Promise<string> {

--- a/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectNoProjectGuidBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectNoProjectGuidBaseline.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build">
+  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <PropertyGroup>
+    <Name>TestProjectName</Name>
+    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>
+    <ModelCollation>1033, CI</ModelCollation>
+  </PropertyGroup>
+  <Target Name="BeforeBuild">
+    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
+  </Target>
+  <ItemGroup>
+    <SqlCmdVariable Include="ProdDatabaseName">
+      <DefaultValue>MyProdDatabase</DefaultValue>
+      <Value>$(SqlCmdVar__1)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="BackupDatabaseName">
+      <DefaultValue>MyBackupDatabase</DefaultValue>
+      <Value>$(SqlCmdVar__2)</Value>
+    </SqlCmdVariable>
+  </ItemGroup>
+  <ItemGroup>
+    <PreDeploy Include="Script.PreDeployment1.sql" />
+    <None Include="Script.PreDeployment2.sql" />
+  </ItemGroup>
+</Project>

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -1097,7 +1097,6 @@ describe('Project: sdk style project content operations', function (): void {
 		should(projFileText.includes('<Build Remove="folder1\\nestedFolder\\**" />')).equal(false, projFileText);
 	});
 
-
 	it('Should handle excluding nested glob included folders', async function (): Promise<void> {
 		const testFolderPath = await testUtils.generateTestFolderPath();
 		projFilePath = await testUtils.createTestSqlProjFile(baselines.openSdkStyleSqlProjectBaseline, testFolderPath);
@@ -1343,6 +1342,21 @@ describe('Project: sdk style project content operations', function (): void {
 
 		should(projFileText.includes('<Build Remove="folder1\\**" />')).equal(false, projFileText);
 		should(projFileText.includes('<Build Remove="folder2\\**" />')).equal(false, projFileText);
+	});
+
+	it('Should add a project guid if there is not one in the sqlproj', async function (): Promise<void> {
+		projFilePath = await testUtils.createTestSqlProjFile(baselines.openSdkStyleSqlProjectNoProjectGuidBaseline);
+		let projFileText = (await fs.readFile(projFilePath)).toString();
+
+		// verify no project guid
+		should(projFileText.includes(constants.ProjectGuid)).equal(false);
+
+		const project: Project = await Project.openProject(projFilePath);
+
+		// verify project guid was added
+		projFileText = (await fs.readFile(projFilePath)).toString();
+		should(project.projectGuid).not.equal(undefined);
+		should(projFileText.includes(constants.ProjectGuid)).equal(true);
 	});
 });
 


### PR DESCRIPTION
This PR fixes #17847. Instead of showing an error when opening a sql project without a project guid, the behavior is now the same as SSDT and a project guid is added to the sqlproj.
