### PR TITLE
Remove Extra Split Cell Action in Notebook Cell Taskbar

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
@@ -106,7 +106,6 @@ export class CellToolbarComponent {
 			);
 		}
 		taskbarContent.push(
-			{ action: splitCellButton },
 			{ element: addCellDropdownContainer },
 			{ action: moveCellDownButton },
 			{ action: moveCellUpButton },


### PR DESCRIPTION
Fixes #18019, which i assume is just a result of a merge conflict issue from the merge.