### PR TITLE
Added undefined check to profiler

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -464,7 +464,7 @@ export class ProfilerEditor extends EditorPane {
 		let savedViewState = this._savedTableViewStates.get(input);
 
 		this._profilerEditorContextKey.set(true);
-		if (input instanceof ProfilerInput && input.matches(this.input)) {
+		if (input instanceof ProfilerInput && this.input !== undefined && input.matches(this.input)) {
 			if (savedViewState) {
 				this._profilerTableEditor.restoreViewState(savedViewState);
 			}


### PR DESCRIPTION
Adds in null check (which has been removed for editor inputs with the vscode-merge) for profiler input

This PR fixes #18023 
