### PR TITLE
[Table Designer] Add "New Table" menu to Tables node in OE

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -503,6 +503,11 @@
           "command": "mssql.designTable",
           "when": "connectionProvider == MSSQL && nodeType == Table && config.tableDesigner.enableFeature",
           "group": "0_query@3"
+        },
+        {
+          "command": "mssql.newTable",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && nodeLabel == Tables && config.tableDesigner.enableFeature",
+          "group": "0_query@1"
         }
       ],
       "notebook/toolbar": [


### PR DESCRIPTION
This PR adds "New Table" context menu to Tables node in OE.
![Screen Shot 2022-01-10 at 01 15 02](https://user-images.githubusercontent.com/21186993/148816671-d56af1e3-b8da-4fd2-8539-6a7284f01f98.png)

The end-to-end workflow to add a new table and persist the table to db works fine. (Along with my changes to DacFx)
![image](https://user-images.githubusercontent.com/21186993/148818345-348ff1e7-b1c3-4bf8-aef8-09621610fbd6.png)
![image](https://user-images.githubusercontent.com/21186993/148818378-1236a6db-d000-4ff1-b39a-606b4f70bac9.png)

