### PR TITLE
Enable VS Code extension APIs for getting opened notebook documents

### DIFF
--- a/src/sql/workbench/api/common/vscodeNotebookEditor.ts
+++ b/src/sql/workbench/api/common/vscodeNotebookEditor.ts
@@ -5,21 +5,25 @@
 
 import type * as vscode from 'vscode';
 import type * as azdata from 'azdata';
+import { VSCodeNotebookDocument } from 'sql/workbench/api/common/vscodeNotebookDocument';
 
 export class VSCodeNotebookEditor implements vscode.NotebookEditor {
+	private readonly _document: vscode.NotebookDocument;
+
 	constructor(editor: azdata.nb.NotebookEditor) {
+		this._document = new VSCodeNotebookDocument(editor.document);
 	}
 
 	public get document(): vscode.NotebookDocument {
-		return undefined;
+		return this._document;
 	}
 
 	public get selections(): vscode.NotebookRange[] {
-		return undefined;
+		return [];
 	}
 
 	public get visibleRanges(): vscode.NotebookRange[] {
-		return undefined;
+		return [];
 	}
 
 	public get viewColumn(): vscode.ViewColumn | undefined {
@@ -27,14 +31,14 @@ export class VSCodeNotebookEditor implements vscode.NotebookEditor {
 	}
 
 	public revealRange(range: vscode.NotebookRange, revealType?: vscode.NotebookEditorRevealType): void {
-		throw new Error('Method not implemented.');
+		return; // No-op
 	}
 
 	public edit(callback: (editBuilder: vscode.NotebookEditorEdit) => void): Thenable<boolean> {
-		throw new Error('Method not implemented.');
+		return Promise.resolve(false);
 	}
 
 	public setDecorations(decorationType: vscode.NotebookEditorDecorationType, range: vscode.NotebookRange): void {
-		throw new Error('Method not implemented.');
+		return; // No-op
 	}
 }

--- a/src/sql/workbench/api/common/vscodeNotebookEditor.ts
+++ b/src/sql/workbench/api/common/vscodeNotebookEditor.ts
@@ -6,6 +6,7 @@
 import type * as vscode from 'vscode';
 import type * as azdata from 'azdata';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/vscodeNotebookDocument';
+import { functionalityNotSupportedError } from 'sql/base/common/locConstants';
 
 export class VSCodeNotebookEditor implements vscode.NotebookEditor {
 	private readonly _document: vscode.NotebookDocument;
@@ -19,26 +20,26 @@ export class VSCodeNotebookEditor implements vscode.NotebookEditor {
 	}
 
 	public get selections(): vscode.NotebookRange[] {
-		return [];
+		throw new Error(functionalityNotSupportedError);
 	}
 
 	public get visibleRanges(): vscode.NotebookRange[] {
-		return [];
+		throw new Error(functionalityNotSupportedError);
 	}
 
 	public get viewColumn(): vscode.ViewColumn | undefined {
-		return undefined;
+		throw new Error(functionalityNotSupportedError);
 	}
 
 	public revealRange(range: vscode.NotebookRange, revealType?: vscode.NotebookEditorRevealType): void {
-		return; // No-op
+		throw new Error(functionalityNotSupportedError);
 	}
 
-	public edit(callback: (editBuilder: vscode.NotebookEditorEdit) => void): Thenable<boolean> {
-		return Promise.resolve(false);
+	public edit(callback: (editBuilder: vscode.NotebookEditorEdit) => void): Promise<boolean> {
+		return Promise.reject(functionalityNotSupportedError);
 	}
 
 	public setDecorations(decorationType: vscode.NotebookEditorDecorationType, range: vscode.NotebookRange): void {
-		return; // No-op
+		throw new Error(functionalityNotSupportedError);
 	}
 }

--- a/src/sql/workbench/api/common/vscodeNotebookEditor.ts
+++ b/src/sql/workbench/api/common/vscodeNotebookEditor.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+import type * as azdata from 'azdata';
+
+export class VSCodeNotebookEditor implements vscode.NotebookEditor {
+	constructor(editor: azdata.nb.NotebookEditor) {
+	}
+
+	public get document(): vscode.NotebookDocument {
+		return undefined;
+	}
+
+	public get selections(): vscode.NotebookRange[] {
+		return undefined;
+	}
+
+	public get visibleRanges(): vscode.NotebookRange[] {
+		return undefined;
+	}
+
+	public get viewColumn(): vscode.ViewColumn | undefined {
+		return undefined;
+	}
+
+	public revealRange(range: vscode.NotebookRange, revealType?: vscode.NotebookEditorRevealType): void {
+		throw new Error('Method not implemented.');
+	}
+
+	public edit(callback: (editBuilder: vscode.NotebookEditorEdit) => void): Thenable<boolean> {
+		throw new Error('Method not implemented.');
+	}
+
+	public setDecorations(decorationType: vscode.NotebookEditorDecorationType, range: vscode.NotebookRange): void {
+		throw new Error('Method not implemented.');
+	}
+}

--- a/src/sql/workbench/test/electron-browser/api/vscodeNotebookApi.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/vscodeNotebookApi.test.ts
@@ -455,11 +455,12 @@ suite('Notebook Serializer', () => {
 
 		// We only need the document field for VSCodeNotebookEditor, so the other
 		// fields should be non-functional
-		assert.deepStrictEqual(vscodeEditor.selections, []);
-		assert.deepStrictEqual(vscodeEditor.visibleRanges, []);
-		assert.deepStrictEqual(vscodeEditor.viewColumn, undefined);
-		let editStatus = await vscodeEditor.edit(() => undefined);
-		assert.strictEqual(editStatus, false, 'Edit promise should have returned false.');
+		assert.throws(() => vscodeEditor.selections);
+		assert.throws(() => vscodeEditor.visibleRanges);
+		assert.throws(() => vscodeEditor.viewColumn);
+		assert.throws(() => vscodeEditor.revealRange(undefined));
+		assert.throws(() => vscodeEditor.setDecorations(undefined, undefined));
+		await assert.rejects(() => vscodeEditor.edit(() => undefined));
 	});
 });
 

--- a/src/sql/workbench/test/electron-browser/api/vscodeNotebookApi.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/vscodeNotebookApi.test.ts
@@ -15,6 +15,7 @@ import { NBFORMAT, NBFORMAT_MINOR } from 'sql/workbench/common/constants';
 import { convertToVSCodeNotebookCell } from 'sql/workbench/api/common/vscodeExecuteProvider';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/vscodeNotebookDocument';
 import { URI } from 'vs/base/common/uri';
+import { VSCodeNotebookEditor } from 'sql/workbench/api/common/vscodeNotebookEditor';
 
 class MockNotebookSerializer implements vscode.NotebookSerializer {
 	deserializeNotebook(content: Uint8Array, token: vscode.CancellationToken): vscode.NotebookData | Thenable<vscode.NotebookData> {
@@ -366,6 +367,17 @@ suite('Notebook Serializer', () => {
 		validateCellRange: () => undefined
 	};
 
+	function validateDocsMatch(actualDoc: vscode.NotebookDocument, expectedDoc: vscode.NotebookDocument): void {
+		assert.deepStrictEqual(actualDoc.uri, expectedDoc.uri);
+		assert.strictEqual(actualDoc.notebookType, expectedDoc.notebookType);
+		assert.strictEqual(actualDoc.version, expectedDoc.version);
+		assert.strictEqual(actualDoc.isDirty, expectedDoc.isDirty);
+		assert.strictEqual(actualDoc.isUntitled, expectedDoc.isUntitled);
+		assert.strictEqual(actualDoc.isClosed, expectedDoc.isClosed);
+		assert.deepStrictEqual(actualDoc.metadata, expectedDoc.metadata);
+		assert.strictEqual(actualDoc.cellCount, expectedDoc.cellCount);
+	}
+
 	test('Convert ADS NotebookDocument into VS Code NotebookDocument', async () => {
 		let expectedDoc: vscode.NotebookDocument = {
 			get uri() { return testDoc.uri; },
@@ -382,14 +394,7 @@ suite('Notebook Serializer', () => {
 		};
 
 		let actualDoc = new VSCodeNotebookDocument(testDoc);
-		assert.deepStrictEqual(actualDoc.uri, expectedDoc.uri);
-		assert.strictEqual(actualDoc.notebookType, expectedDoc.notebookType);
-		assert.strictEqual(actualDoc.version, expectedDoc.version);
-		assert.strictEqual(actualDoc.isDirty, expectedDoc.isDirty);
-		assert.strictEqual(actualDoc.isUntitled, expectedDoc.isUntitled);
-		assert.strictEqual(actualDoc.isClosed, expectedDoc.isClosed);
-		assert.deepStrictEqual(actualDoc.metadata, expectedDoc.metadata);
-		assert.strictEqual(actualDoc.cellCount, expectedDoc.cellCount);
+		validateDocsMatch(actualDoc, expectedDoc);
 	});
 
 	// Have to validate cell fields manually since one of the NotebookCell fields is a function pointer,
@@ -439,6 +444,22 @@ suite('Notebook Serializer', () => {
 
 		secondCell = vsDoc.cellAt(10);
 		validateCellMatches(secondCell, expectedCells[1]);
+	});
+
+	test('VS Code NotebookEditor functionality', async () => {
+		let editor = <azdata.nb.NotebookEditor>{ document: testDoc };
+		let vscodeEditor = new VSCodeNotebookEditor(editor);
+		let expectedDoc = new VSCodeNotebookDocument(testDoc);
+
+		validateDocsMatch(vscodeEditor.document, expectedDoc);
+
+		// We only need the document field for VSCodeNotebookEditor, so the other
+		// fields should be non-functional
+		assert.deepStrictEqual(vscodeEditor.selections, []);
+		assert.deepStrictEqual(vscodeEditor.visibleRanges, []);
+		assert.deepStrictEqual(vscodeEditor.viewColumn, undefined);
+		let editStatus = await vscodeEditor.edit(() => undefined);
+		assert.strictEqual(editStatus, false, 'Edit promise should have returned false.');
 	});
 });
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -94,6 +94,7 @@ import { matchesScheme } from 'vs/platform/opener/common/opener';
 import { ExtHostNotebook } from 'sql/workbench/api/common/extHostNotebook';
 import { functionalityNotSupportedError } from 'sql/base/common/locConstants';
 import { ExtHostNotebookDocumentsAndEditors } from 'sql/workbench/api/common/extHostNotebookDocumentsAndEditors';
+import { VSCodeNotebookDocument } from 'sql/workbench/api/common/vscodeNotebookDocument';
 
 export interface IExtensionApiFactory {
 	(extension: IExtensionDescription, registry: ExtensionDescriptionRegistry, configProvider: ExtHostConfigProvider): typeof vscode;
@@ -884,9 +885,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor, ex
 				return extHostDocumentSaveParticipant.getOnWillSaveTextDocumentEvent(extension)(listener, thisArgs, disposables);
 			},
 			get notebookDocuments(): vscode.NotebookDocument[] {
-				// {{SQL CARBON EDIT}} Disable VS Code notebooks
-				throw new Error(functionalityNotSupportedError);
-				// return extHostNotebook.notebookDocuments.map(d => d.apiNotebook);
+				// {{SQL CARBON EDIT}} Use our own notebooks
+				return extHostNotebookDocumentsAndEditors.getAllDocuments().map(doc => new VSCodeNotebookDocument(doc.document));
 			},
 			async openNotebookDocument(uriOrType?: URI | string, content?: vscode.NotebookData) {
 				// {{SQL CARBON EDIT}} Disable VS Code notebooks

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -95,6 +95,7 @@ import { ExtHostNotebook } from 'sql/workbench/api/common/extHostNotebook';
 import { functionalityNotSupportedError } from 'sql/base/common/locConstants';
 import { ExtHostNotebookDocumentsAndEditors } from 'sql/workbench/api/common/extHostNotebookDocumentsAndEditors';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/vscodeNotebookDocument';
+import { VSCodeNotebookEditor } from 'sql/workbench/api/common/vscodeNotebookEditor';
 
 export interface IExtensionApiFactory {
 	(extension: IExtensionDescription, registry: ExtensionDescriptionRegistry, configProvider: ExtHostConfigProvider): typeof vscode;
@@ -717,10 +718,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor, ex
 				return extHostWebviewViews.registerWebviewViewProvider(extension, viewId, provider, options?.webviewOptions);
 			},
 			get activeNotebookEditor(): vscode.NotebookEditor | undefined {
-				// {{SQL CARBON EDIT}} Disable VS Code notebooks
-				throw new Error(functionalityNotSupportedError);
-				// checkProposedApiEnabled(extension);
-				// return extHostNotebook.activeNotebookEditor;
+				// {{SQL CARBON EDIT}} Use our own notebooks
+				return new VSCodeNotebookEditor(extHostNotebookDocumentsAndEditors.getActiveEditor());
 			},
 			onDidChangeActiveNotebookEditor(listener, thisArgs?, disposables?) {
 				// {{SQL CARBON EDIT}} Disable VS Code notebooks


### PR DESCRIPTION
This change adds support for the following VS Code extension APIs:
vscode.workspace.notebookDocuments
vscode.window.activeNotebookEditor

We already had our own version of these APIs, so the main part of this change was adding a class to convert between the azdata NotebookEditor class and vscode's. We also only need the **document** field from NotebookEditor for Interactive support, so the other methods in the conversion class are no-ops.
