### PR TITLE
Make python installation smoke test more stable

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -23,6 +23,9 @@ export class ConfigurePythonDialog extends Dialog {
 	}
 
 	async waitForPageOneLoaded(): Promise<void> {
+		const pageOne = 'div.wizardNavigation-container a[title="Configure Python Runtime"]';
+		await this.code.waitAndClick(pageOne);
+
 		// Wait up to 1 minute for the python install location to be loaded.
 		const pythonInstallLocationDropdownValue = `${ConfigurePythonDialog.dialogPageInView} option[value*="/azuredatastudio-python (Default)"]`;
 		try {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -13,7 +13,7 @@ import * as mkdirp from 'mkdirp';
 import { ncp } from 'ncp';
 import * as vscodetest from 'vscode-test';
 import fetch from 'node-fetch';
-import { Quality, ApplicationOptions, MultiLogger, Logger, ConsoleLogger, FileLogger, Application } from '../../automation';
+import { Quality, ApplicationOptions, MultiLogger, Logger, ConsoleLogger, FileLogger } from '../../automation';
 
 import { main as sqlMain, setup as sqlSetup } from './sql/main'; // {{SQL CARBON EDIT}}
 /*import { setup as setupDataMigrationTests } from './areas/workbench/data-migration.test';
@@ -361,18 +361,6 @@ after(async function () {
 });
 
 sqlMain(opts);
-
-if (screenshotsPath) {
-	afterEach(async function () {
-		if (this.currentTest!.state !== 'failed') {
-			return;
-		}
-		const app = this.app as Application;
-		const name = this.currentTest!.fullTitle().replace(/[^a-z0-9\-]/ig, '_');
-
-		await app.captureScreenshot(name);
-	});
-}
 
 if (!opts.web && opts['build'] && !opts['remote']) {
 	describe(`Stable vs Insiders Smoke Tests: This test MUST run before releasing`, () => {

--- a/test/smoke/src/utils.ts
+++ b/test/smoke/src/utils.ts
@@ -43,13 +43,17 @@ export function beforeSuite(opts: minimist.ParsedArgs, optionsTransform?: (opts:
 }
 
 export function afterSuite(opts: minimist.ParsedArgs) {
-	after(async function () {
+	afterEach(async function () {
 		const app = this.app as Application;
 
 		if (this.currentTest?.state === 'failed' && opts.screenshots) {
 			const name = this.currentTest!.fullTitle().replace(/[^a-z0-9\-]/ig, '_');
 			await app.captureScreenshot(name);
 		}
+	});
+
+	after(async function () {
+		const app = this.app as Application;
 
 		if (app) {
 			await app.stop();


### PR DESCRIPTION
Based on smoke logs, the Python test is waiting for the installation path on page 1 of the Configure Python wizard. But the screenshot from the test show that the wizard is already on page 2 (which is odd since based on the logs, the next button or enter key was never pressed).
To make the test more stable, I'm adding an extra step to click on the first page in the wizard navigation panel to make sure that the wizard is on page 1 when waiting for the install path.

Note: Also fixed the smoketest screenshots not being taken.