### PR TITLE
fix issue with profiler and table designer editor

### DIFF
--- a/src/sql/workbench/browser/designer/designerScriptEditor.ts
+++ b/src/sql/workbench/browser/designer/designerScriptEditor.ts
@@ -33,6 +33,8 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 class DesignerCodeEditor extends CodeEditorWidget {
 }
 
+let DesignerScriptEditorInstanceId = 0;
+
 export class DesignerScriptEditor extends BaseTextEditor implements DesignerTextEditor {
 	private _content: string;
 	private _contentChangeEventEmitter: Emitter<string> = new Emitter<string>();
@@ -57,7 +59,7 @@ export class DesignerScriptEditor extends BaseTextEditor implements DesignerText
 		super(DesignerScriptEditor.ID, telemetryService, instantiationService, storageService, configurationService, themeService, editorService, editorGroupService);
 		this.create(this._container);
 		this.setVisible(true);
-		this._untitledTextEditorModel = this.instantiationService.createInstance(UntitledTextEditorModel, URI.from({ scheme: Schemas.untitled }), false, undefined, 'sql', undefined);
+		this._untitledTextEditorModel = this.instantiationService.createInstance(UntitledTextEditorModel, URI.from({ scheme: Schemas.untitled, path: `DesignerScriptEditor-${DesignerScriptEditorInstanceId++}` }), false, undefined, 'sql', undefined);
 		this._editorInput = this.instantiationService.createInstance(UntitledTextEditorInput, this._untitledTextEditorModel);
 		this.setInput(this._editorInput, undefined, undefined).catch(onUnexpectedError);
 		this._editorInput.resolve().then((model) => {

--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -117,6 +117,8 @@ export interface IDetailData {
 	value: string;
 }
 
+let ProfilerEditorInstanceId = 0;
+
 export class ProfilerEditor extends EditorPane {
 	public static readonly ID: string = 'workbench.editor.profiler';
 
@@ -449,7 +451,7 @@ export class ProfilerEditor extends EditorPane {
 		editorContainer.className = 'profiler-editor';
 		this._editor.create(editorContainer);
 		this._editor.setVisible(true);
-		this._untitledTextEditorModel = this._instantiationService.createInstance(UntitledTextEditorModel, URI.from({ scheme: Schemas.untitled }), false, undefined, 'sql', undefined);
+		this._untitledTextEditorModel = this._instantiationService.createInstance(UntitledTextEditorModel, URI.from({ scheme: Schemas.untitled, path: `ProfilerTextEditor-${ProfilerEditorInstanceId++}` }), false, undefined, 'sql', undefined);
 		this._editorInput = this._instantiationService.createInstance(UntitledTextEditorInput, this._untitledTextEditorModel);
 		this._editor.setInput(this._editorInput, undefined, undefined);
 		this._editorInput.resolve().then(model => this._editorModel = model.textEditorModel);


### PR DESCRIPTION
Noticed this issue during my testing, scenarios will run into this problem:
1. open a profiler editor and drag it to a different editor group
2. open a profiler editor and then open a table designer
3. open a table designer editor and drag it to a different editor group

When creating UntitledTextEditorModel, we have to make sure the URI is unique. I think this is introduced by recent vscode merge, I remembered I tested the multiple editor group scenario for table designer before.

I searched in the code base and the other places like Notebook code cell is handling this correctly.

![image](https://user-images.githubusercontent.com/13777222/149234198-4424e02c-3ecf-4888-8226-20e6a9656080.png)
