### PR TITLE
Disable next button on Python wizard creation

### DIFF
--- a/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
@@ -119,6 +119,7 @@ export class ConfigurePythonWizard {
 			return true;
 		});
 
+		this._wizard.nextButton.enabled = false;
 		this._wizard.generateScriptButton.hidden = true;
 		this._wizard.pages = [page0, page1];
 		await this._wizard.open();

--- a/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
@@ -99,6 +99,10 @@ export class ConfigurePythonWizard {
 		});
 
 		this._wizard.registerNavigationValidator(async (info) => {
+			// The pages have not been registered yet
+			if (pages.size === 0) {
+				return false;
+			}
 			let lastPage = pages.get(info.lastPage);
 			let newPage = pages.get(info.newPage);
 
@@ -119,7 +123,6 @@ export class ConfigurePythonWizard {
 			return true;
 		});
 
-		this._wizard.nextButton.enabled = false;
 		this._wizard.generateScriptButton.hidden = true;
 		this._wizard.pages = [page0, page1];
 		await this._wizard.open();


### PR DESCRIPTION
This PR adds a check in the wizard navigation validator to return false when the pages have not been registered yet. Previously, a user can click next before the installation path is loaded on the first page and the wizard ends up in this weird state where it goes to the second page but the kernel dependencies never load and the previous button does not work. 

![Screen Shot 2022-01-13 at 10 00 23 AM](https://user-images.githubusercontent.com/23462877/149394116-c8f0f997-f8e1-43f3-90bc-66ad45e06dba.png)


I think this is what is happening during the Python smoke test that fails occasionally. Although it is still not clear what is causing the next button to be clicked (logs don’t show any clicks or enter key pressed) - I will continue to investigate that.