### PR TITLE
set mode explicitly to notebook

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -248,6 +248,9 @@ export abstract class NotebookInput extends EditorInput implements INotebookInpu
 		this._providersLoaded = this.assignProviders();
 		this._notebookEditorOpenedTimestamp = Date.now();
 		if (this._textInput) {
+			if (this._textInput instanceof UntitledTextEditorInput) {
+				this._textInput.setMode('notebook');
+			}
 			this.hookDirtyListener(this._textInput.onDidChangeDirty, () => this._onDidChangeDirty.fire());
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -248,9 +248,6 @@ export abstract class NotebookInput extends EditorInput implements INotebookInpu
 		this._providersLoaded = this.assignProviders();
 		this._notebookEditorOpenedTimestamp = Date.now();
 		if (this._textInput) {
-			if (this._textInput instanceof UntitledTextEditorInput) {
-				this._textInput.setMode('notebook');
-			}
 			this.hookDirtyListener(this._textInput.onDidChangeDirty, () => this._onDidChangeDirty.fire());
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
@@ -26,7 +26,8 @@ export class UntitledNotebookInput extends NotebookInput {
 		@IExtensionService extensionService: IExtensionService
 	) {
 		super(title, resource, textInput, true, textModelService, instantiationService, notebookService, extensionService);
-		this.setMode('notebook');
+		// Set the mode explicitly so that the auto language detection doesn't run and mark the model as being JSON
+		this.textInput.resolve().then(() => this.setMode('notebook'));
 	}
 
 	public override get textInput(): UntitledTextEditorInput {

--- a/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
@@ -27,7 +27,7 @@ export class UntitledNotebookInput extends NotebookInput {
 	) {
 		super(title, resource, textInput, true, textModelService, instantiationService, notebookService, extensionService);
 		// Set the mode explicitly so that the auto language detection doesn't run and mark the model as being JSON
-		this.textInput?.resolve().then(() => this.setMode('notebook'));
+		this.textInput.resolve().then(() => this.setMode('notebook'));
 	}
 
 	public override get textInput(): UntitledTextEditorInput {

--- a/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
@@ -27,7 +27,7 @@ export class UntitledNotebookInput extends NotebookInput {
 	) {
 		super(title, resource, textInput, true, textModelService, instantiationService, notebookService, extensionService);
 		// Set the mode explicitly so that the auto language detection doesn't run and mark the model as being JSON
-		this.textInput.resolve().then(() => this.setMode('notebook'));
+		this.textInput?.resolve().then(() => this.setMode('notebook'));
 	}
 
 	public override get textInput(): UntitledTextEditorInput {

--- a/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
@@ -26,6 +26,7 @@ export class UntitledNotebookInput extends NotebookInput {
 		@IExtensionService extensionService: IExtensionService
 	) {
 		super(title, resource, textInput, true, textModelService, instantiationService, notebookService, extensionService);
+		this.setMode('notebook');
 	}
 
 	public override get textInput(): UntitledTextEditorInput {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookInput.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookInput.test.ts
@@ -84,7 +84,7 @@ suite('Notebook Input', function (): void {
 		// Input title
 		assert.strictEqual(untitledNotebookInput.getTitle(), testTitle);
 
-		let noTitleInput = instantiationService.createInstance(UntitledNotebookInput, undefined, untitledUri, undefined);
+		let noTitleInput = instantiationService.createInstance(UntitledNotebookInput, undefined, untitledUri, untitledTextInput);
 		assert.strictEqual(noTitleInput.getTitle(), basenameOrAuthority(untitledUri));
 
 		// Text Input


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #18088 

VSCode added autodetectLanguage step whenever file content changes. And unless the file mode (language) is explicitly set, it tries to pick a language for the file.

Added setMode in notebookInput to explicitly set the language.
