### PR TITLE
Update zone.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "xterm-headless": "4.14.0-beta.11",
     "yauzl": "^2.9.2",
     "yazl": "^2.4.3",
-    "zone.js": "^0.8.4"
+    "zone.js": "^0.11.4"
   },
   "devDependencies": {
     "7zip": "0.0.6",

--- a/remote/package.json
+++ b/remote/package.json
@@ -57,7 +57,7 @@
     "xterm-headless": "4.14.0-beta.11",
     "yauzl": "^2.9.2",
     "yazl": "^2.4.3",
-    "zone.js": "^0.8.4"
+    "zone.js": "^0.11.4"
   },
   "optionalDependencies": {
     "vscode-windows-registry": "1.0.3",

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -898,6 +898,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tslib@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 turndown-plugin-gfm@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz#6f8678a361f35220b2bdf5619e6049add75bf1c7"
@@ -1037,7 +1042,9 @@ zone.js@0.7.6:
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.6.tgz#fbbc39d3e0261d0986f1ba06306eb3aeb0d22009"
   integrity sha1-+7w50+AmHQmG8boGMG6zrrDSIAk=
 
-zone.js@^0.8.4:
-  version "0.8.29"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.29.tgz#8dce92aa0dd553b50bc5bfbb90af9986ad845a12"
-  integrity sha512-mla2acNCMkWXBD+c+yeUrBUrzOxYMNFdQ6FGfigGGtEVBPJx07BQeJekjt9DmH1FtZek4E9rE1eRR9qQpxACOQ==
+zone.js@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.11.4.tgz#0f70dcf6aba80f698af5735cbb257969396e8025"
+  integrity sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==
+  dependencies:
+    tslib "^2.0.0"

--- a/src/sql/setup.js
+++ b/src/sql/setup.js
@@ -18,11 +18,24 @@ define(['require', 'exports'], function (require) {
 	require.__$__nodeRequire('gridstack/dist/h5/gridstack-dd-native');
 	require.__$__nodeRequire('html-to-image/dist/html-to-image.js');
 	require.__$__nodeRequire('reflect-metadata');
+	require.__$__nodeRequire('chart.js');
+	// VS Code uses an AMD loader for its own files (and ours) but Node.JS normally uses commonjs. For modules that
+	// support UMD this may cause some issues since it will appear to them that AMD exists and so depending on the order
+	// they check support for the two types they may end up using either commonjs or AMD. If commonjs is first this is
+	// the expected method and so nothing needs to be done - but if it's AMD then the VS Code loader will throw an error
+	// (Can only have one anonymous define call per script file) since it only expects to be loading its own files.
+
+	// In order to make packages like zone.js load correctly we need to temporarily set AMD to false so that the modules
+	// load using commonjs before continuing.
+	const amd = define.amd;
+	define.amd = false;
 	require.__$__nodeRequire('zone.js/dist/zone');
 	require.__$__nodeRequire('zone.js/dist/zone-error');
-	require.__$__nodeRequire('chart.js');
+	define.amd = amd;
+
 	window['Zone']['__zone_symbol__ignoreConsoleErrorUncaughtError'] = true;
 	window['Zone']['__zone_symbol__unhandledPromiseRejectionHandler'] = e => setImmediate(() => {
 		window.dispatchEvent(new PromiseRejectionEvent('unhandledrejection', e));
 	}); // let window handle this
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11028,6 +11028,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
@@ -12221,7 +12226,9 @@ zone.js@0.7.6:
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.6.tgz#fbbc39d3e0261d0986f1ba06306eb3aeb0d22009"
   integrity sha1-+7w50+AmHQmG8boGMG6zrrDSIAk=
 
-zone.js@^0.8.4:
-  version "0.8.26"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.26.tgz#7bdd72f7668c5a7ad6b118148b4ea39c59d08d2d"
-  integrity sha512-W9Nj+UmBJG251wkCacIkETgra4QgBo/vgoEkb4a2uoLzpQG7qF9nzwoLXWU5xj3Fg2mxGvEDh47mg24vXccYjA==
+zone.js@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.11.4.tgz#0f70dcf6aba80f698af5735cbb257969396e8025"
+  integrity sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==
+  dependencies:
+    tslib "^2.0.0"


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/18084
Fixes https://github.com/microsoft/azuredatastudio/issues/18047

The core issue here is that older versions of zone.js don't support the newer Node runtimes (see https://github.com/stephanrauh/ngx-extended-pdf-viewer/issues/263 for a similar issue) that introduced things like Promise.allSettled.

In order to fix that we need to update to zone.js 10+, but this needed additional work since zone.js moved to support UMD in the newer versions which causes the `Can only have one anonymous define call per script file` we've seen with other modules. ([documented here](https://github.com/microsoft/azuredatastudio/wiki/Troubleshooting-Build-Issues#error-error-can-only-have-one-anonymous-define-call-per-script-file-when-launching))

This one was a bit different than the previous ones though since we were loading it directly using the Node require, so adding it to the list of amd modules didn't work (that path wasn't hit for native node module loading). I tried to get it to work with using import instead to force it through the VS Code/ADS normal module load path but was hitting other issues with then getting window.Zone to be defined correctly. So instead we just temporarily set amd to false so that zone.js loads as commonjs instead and then set it back right after. Not ideal but this was one of the things suggested by the VS Code dev I was talking to so should be safe enough for a (hopefully) one-off thing.