### PR TITLE
Fix Notebook Tree View smoke tests

### DIFF
--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -15,12 +15,12 @@ export class Notebook {
 
 	public readonly notebookToolbar: NotebookToolbar;
 	public readonly textCellToolbar: TextCellToolbar;
-	public readonly view: NotebookView;
+	public readonly view: NotebookTreeView;
 
 	constructor(private code: Code, private quickAccess: QuickAccess, private quickInput: QuickInput, private editors: Editors) {
 		this.notebookToolbar = new NotebookToolbar(code);
 		this.textCellToolbar = new TextCellToolbar(code);
-		this.view = new NotebookView(code, quickAccess);
+		this.view = new NotebookTreeView(code, quickAccess);
 	}
 
 	async openFile(fileName: string): Promise<void> {
@@ -331,7 +331,7 @@ export class NotebookToolbar {
 	}
 }
 
-export class NotebookView {
+export class NotebookTreeView {
 	private static readonly inputBox = '.notebookExplorer-viewlet .search-widget .input-box';
 	private static searchResult = '.search-view .result-messages';
 	private static notebookTreeItem = '.split-view-view .tree-explorer-viewlet-tree-view .monaco-list-row';
@@ -355,7 +355,7 @@ export class NotebookView {
 	async searchInNotebook(expr: string): Promise<IElement> {
 		await this.waitForSetSearchValue(expr);
 		await this.code.dispatchKeybinding('enter');
-		let selector = NotebookView.searchResult;
+		let selector = NotebookTreeView.searchResult;
 		if (expr) {
 			selector += ' .message';
 		}
@@ -363,7 +363,7 @@ export class NotebookView {
 	}
 
 	async waitForSetSearchValue(text: string): Promise<void> {
-		const textArea = `${NotebookView.inputBox} textarea`;
+		const textArea = `${NotebookTreeView.inputBox} textarea`;
 		await this.code.waitForTypeInEditor(textArea, text);
 	}
 
@@ -372,7 +372,7 @@ export class NotebookView {
 	 * @returns tree item ids from Notebooks View
 	 */
 	async getNotebookTreeItemIds(): Promise<string[]> {
-		return (await this.code.waitForElements(NotebookView.notebookTreeItem, false)).map(item => item.attributes['id']);
+		return (await this.code.waitForElements(NotebookTreeView.notebookTreeItem, false)).map(item => item.attributes['id']);
 	}
 
 	/**
@@ -380,9 +380,9 @@ export class NotebookView {
 	 */
 	async pinNotebook(): Promise<void> {
 		const notebookIds = await this.getNotebookTreeItemIds();
-		// Pinning SQL notebook to prevent the Configure Python Wizard from showing, since Python is no longer set up when the NotebookView test suite starts
-		await this.code.waitAndDoubleClick(`${NotebookView.notebookTreeItem}[id="${notebookIds[1]}"]`);
-		await this.code.waitAndClick(`${NotebookView.notebookTreeItem}${NotebookView.selectedItem} .codicon-pinned`);
+		// Pinning SQL notebook to prevent the Configure Python Wizard from showing, since Python is no longer set up when the NotebookTreeView test suite starts
+		await this.code.waitAndDoubleClick(`${NotebookTreeView.notebookTreeItem}[id="${notebookIds[1]}"]`);
+		await this.code.waitAndClick(`${NotebookTreeView.notebookTreeItem}${NotebookTreeView.selectedItem} .codicon-pinned`);
 	}
 
 	/**
@@ -390,14 +390,14 @@ export class NotebookView {
 	 * Previously pinned by the pinNotebook method.
 	 */
 	async unpinNotebook(): Promise<void> {
-		await this.code.waitAndClick(NotebookView.pinnedNotebooksSelector);
-		await this.code.waitAndClick(`${NotebookView.pinnedNotebooksSelector} .actions a[title="Unpin Notebook"]`);
+		await this.code.waitAndClick(NotebookTreeView.pinnedNotebooksSelector);
+		await this.code.waitAndClick(`${NotebookTreeView.pinnedNotebooksSelector} .actions a[title="Unpin Notebook"]`);
 	}
 
 	/**
 	 * When pinning a notebook, the pinned notebook view will show.
 	 */
-	async waitForPinnedNotebookView(): Promise<void> {
-		await this.code.waitForElement(NotebookView.pinnedNotebooksSelector);
+	async waitForPinnedNotebookTreeView(): Promise<void> {
+		await this.code.waitForElement(NotebookTreeView.pinnedNotebooksSelector);
 	}
 }

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -376,12 +376,18 @@ export class NotebookTreeView {
 	}
 
 	/**
+	 * Helper function
+	 * @returns tree item ids from Pinned Notebooks View
+	 */
+	async getPinnedNotebookTreeItemIds(): Promise<string[]> {
+		return (await this.code.waitForElements(NotebookTreeView.pinnedNotebooksSelector, false)).map(item => item.attributes['id']);
+	}
+
+	/**
 	 * Pin the first notebook in the Notebooks View
 	 */
-	async pinNotebook(): Promise<void> {
-		const notebookIds = await this.getNotebookTreeItemIds();
-		// Pinning SQL notebook to prevent the Configure Python Wizard from showing, since Python is no longer set up when the NotebookTreeView test suite starts
-		await this.code.waitAndDoubleClick(`${NotebookTreeView.notebookTreeItem}[id="${notebookIds[1]}"]`);
+	async pinNotebook(notebookId: string): Promise<void> {
+		await this.code.waitAndDoubleClick(`${NotebookTreeView.notebookTreeItem}[id="${notebookId}"]`);
 		await this.code.waitAndClick(`${NotebookTreeView.notebookTreeItem}${NotebookTreeView.selectedItem} .codicon-pinned`);
 	}
 
@@ -389,9 +395,9 @@ export class NotebookTreeView {
 	 * Unpin the only pinned notebook.
 	 * Previously pinned by the pinNotebook method.
 	 */
-	async unpinNotebook(): Promise<void> {
+	async unpinNotebook(notebookId: string): Promise<void> {
 		await this.code.waitAndClick(NotebookTreeView.pinnedNotebooksSelector);
-		await this.code.waitAndClick(`${NotebookTreeView.pinnedNotebooksSelector} .actions a[title="Unpin Notebook"]`);
+		await this.code.waitAndClick(`${NotebookTreeView.pinnedNotebooksSelector}[id="${notebookId}"] .actions a[title="Unpin Notebook"]`);
 	}
 
 	/**

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -368,33 +368,26 @@ export class NotebookTreeView {
 	}
 
 	/**
-	 * Helper function
-	 * @returns tree item ids from Notebooks View
+	 * Gets tree items from Notebooks Tree View
+	 * @returns tree item from Notebooks View
 	 */
-	async getNotebookTreeItemIds(): Promise<string[]> {
-		return (await this.code.waitForElements(NotebookTreeView.notebookTreeItem, false)).map(item => item.attributes['id']);
+	async getNotebookTreeItems(): Promise<IElement[]> {
+		return this.code.waitForElements(NotebookTreeView.notebookTreeItem, false);
 	}
 
 	/**
-	 * Helper function
-	 * @returns tree item ids from Pinned Notebooks View
+	 * Gets tree items from Pinned Notebooks View
+	 * @returns tree item from Pinned Notebooks View
 	 */
-	async getPinnedNotebookTreeItemIds(): Promise<string[]> {
-		return (await this.code.waitForElements(NotebookTreeView.pinnedNotebooksSelector, false)).map(item => item.attributes['id']);
+	async getPinnedNotebookTreeItems(): Promise<IElement[]> {
+		return this.code.waitForElements(NotebookTreeView.pinnedNotebooksSelector, false);
 	}
 
-	/**
-	 * Pin the first notebook in the Notebooks View
-	 */
 	async pinNotebook(notebookId: string): Promise<void> {
 		await this.code.waitAndDoubleClick(`${NotebookTreeView.notebookTreeItem}[id="${notebookId}"]`);
 		await this.code.waitAndClick(`${NotebookTreeView.notebookTreeItem}${NotebookTreeView.selectedItem} .codicon-pinned`);
 	}
 
-	/**
-	 * Unpin the only pinned notebook.
-	 * Previously pinned by the pinNotebook method.
-	 */
 	async unpinNotebook(notebookId: string): Promise<void> {
 		await this.code.waitAndClick(NotebookTreeView.pinnedNotebooksSelector);
 		await this.code.waitAndClick(`${NotebookTreeView.pinnedNotebooksSelector}[id="${notebookId}"] .actions a[title="Unpin Notebook"]`);
@@ -405,5 +398,9 @@ export class NotebookTreeView {
 	 */
 	async waitForPinnedNotebookTreeView(): Promise<void> {
 		await this.code.waitForElement(NotebookTreeView.pinnedNotebooksSelector);
+	}
+
+	async waitForPinnedNotebookTreeViewGone(): Promise<void> {
+		await this.code.waitForElementGone(NotebookTreeView.pinnedNotebooksSelector);
 	}
 }

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -380,7 +380,8 @@ export class NotebookView {
 	 */
 	async pinNotebook(): Promise<void> {
 		const notebookIds = await this.getNotebookTreeItemIds();
-		await this.code.waitAndDoubleClick(`${NotebookView.notebookTreeItem}[id="${notebookIds[0]}"]`);
+		// Pinning SQL notebook to prevent the Configure Python Wizard from showing, since Python is no longer set up when the NotebookView test suite starts
+		await this.code.waitAndDoubleClick(`${NotebookView.notebookTreeItem}[id="${notebookIds[1]}"]`);
 		await this.code.waitAndClick(`${NotebookView.notebookTreeItem}${NotebookView.selectedItem} .codicon-pinned`);
 	}
 

--- a/test/smoke/src/sql/areas/notebook/notebookView.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebookView.test.ts
@@ -12,11 +12,12 @@ export function setup(opts: minimist.ParsedArgs) {
 	describe('NotebookTreeView', () => {
 		beforeSuite(opts);
 		afterSuite(opts);
-
+		// Name of the SQL notebook from azuredatastudio-smoke-test-repo
+		const SQL_NOTEBOOK = 'collapsed';
 		it('Pin notebook', async function () {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.view.focusNotebooksView();
-			const sqlNotebook = (await app.workbench.sqlNotebook.view.getNotebookTreeItems()).filter(n => n.textContent === 'collapsed');
+			const sqlNotebook = (await app.workbench.sqlNotebook.view.getNotebookTreeItems()).filter(n => n.textContent === SQL_NOTEBOOK);
 			// Pinning SQL notebook to prevent the Configure Python Wizard from showing, since Python is no longer set up when the NotebookTreeView test suite starts
 			await app.workbench.sqlNotebook.view.pinNotebook(sqlNotebook[0].attributes.id);
 			await app.workbench.sqlNotebook.view.waitForPinnedNotebookTreeView();
@@ -26,12 +27,14 @@ export function setup(opts: minimist.ParsedArgs) {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.view.focusPinnedNotebooksView();
 			let pinnedNotebooks = await app.workbench.sqlNotebook.view.getPinnedNotebookTreeItems();
-			const sqlNotebook = (pinnedNotebooks).filter(n => n.textContent === 'collapsed')[0];
+			const sqlNotebook = (pinnedNotebooks).filter(n => n.textContent === SQL_NOTEBOOK)[0];
 			await app.workbench.sqlNotebook.view.unpinNotebook(sqlNotebook.attributes.id);
-			pinnedNotebooks = await app.workbench.sqlNotebook.view.getPinnedNotebookTreeItems();
-			if (pinnedNotebooks.length > 0) {
-				// if theres multiple pinned notebooks check that the "collapsed" notebook is no longer in the Pinned Notebooks View
-				assert((await app.workbench.sqlNotebook.view.getPinnedNotebookTreeItems()).find(n => n.textContent === 'collapsed') === undefined);
+			// wait a second for unpinning to complete
+			await new Promise(c => setTimeout(c, 1000));
+			if (pinnedNotebooks.length > 1) {
+				// if theres multiple pinned notebooks check that the SQL notebook is no longer in the Pinned Notebooks View
+				pinnedNotebooks = await app.workbench.sqlNotebook.view.getPinnedNotebookTreeItems();
+				assert(pinnedNotebooks.find(n => n.textContent === SQL_NOTEBOOK) === undefined);
 			} else {
 				// check that the Pinned Notebook View is gone
 				await app.workbench.sqlNotebook.view.waitForPinnedNotebookTreeViewGone();

--- a/test/smoke/src/sql/areas/notebook/notebookView.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebookView.test.ts
@@ -9,7 +9,7 @@ import * as minimist from 'minimist';
 import { afterSuite, beforeSuite } from '../../../utils';
 
 export function setup(opts: minimist.ParsedArgs) {
-	describe('NotebookView', () => {
+	describe('NotebookTreeView', () => {
 		beforeSuite(opts);
 		afterSuite(opts);
 
@@ -17,7 +17,7 @@ export function setup(opts: minimist.ParsedArgs) {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.view.focusNotebooksView();
 			await app.workbench.sqlNotebook.view.pinNotebook();
-			await app.workbench.sqlNotebook.view.waitForPinnedNotebookView();
+			await app.workbench.sqlNotebook.view.waitForPinnedNotebookTreeView();
 		});
 
 		it('Unpin Notebook', async function () {

--- a/test/smoke/src/sql/areas/notebook/notebookView.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebookView.test.ts
@@ -16,14 +16,17 @@ export function setup(opts: minimist.ParsedArgs) {
 		it('Pin a notebook', async function () {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.view.focusNotebooksView();
-			await app.workbench.sqlNotebook.view.pinNotebook();
+			const notebookIds = await app.workbench.sqlNotebook.view.getNotebookTreeItemIds();
+			// Pinning SQL notebook to prevent the Configure Python Wizard from showing, since Python is no longer set up when the NotebookTreeView test suite starts
+			await app.workbench.sqlNotebook.view.pinNotebook(notebookIds[1]);
 			await app.workbench.sqlNotebook.view.waitForPinnedNotebookTreeView();
 		});
 
 		it('Unpin Notebook', async function () {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.view.focusPinnedNotebooksView();
-			await app.workbench.sqlNotebook.view.unpinNotebook();
+			const notebookIds = await app.workbench.sqlNotebook.view.getNotebookTreeItemIds();
+			await app.workbench.sqlNotebook.view.unpinNotebook(notebookIds[0]);
 		});
 
 		it('No search results if search query is empty', async function () {


### PR DESCRIPTION
ADS gets refreshed after each test suite, so we need to configure python every time. 

Pinning a SQL notebook to prevent the Configure Python Wizard from popping up.


