### PR TITLE
Fix azure auth error display

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -103,11 +103,12 @@ export abstract class AzureAuth implements vscode.Disposable {
 			if (ex instanceof AzureAuthError) {
 				if (loginComplete) {
 					loginComplete.reject(ex);
+					Logger.error(ex);
 				} else {
-					void vscode.window.showErrorMessage(ex.getPrintableString());
+					void vscode.window.showErrorMessage(ex.displayableErrorMessage);
+					Logger.error(ex.originalMessageAndException);
 				}
 			}
-			Logger.error(ex);
 			return {
 				canceled: false
 			};
@@ -139,9 +140,11 @@ export abstract class AzureAuth implements vscode.Disposable {
 			return await this.hydrateAccount(tokenResult, this.getTokenClaims(tokenResult.token));
 		} catch (ex) {
 			if (ex instanceof AzureAuthError) {
-				void vscode.window.showErrorMessage(ex.getPrintableString());
+				void vscode.window.showErrorMessage(ex.displayableErrorMessage);
+				Logger.error(ex.originalMessageAndException);
+			} else {
+				Logger.error(ex);
 			}
-			Logger.error(ex);
 			account.isStale = true;
 			return account;
 		}
@@ -261,7 +264,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 		if (response.data.error) {
 			Logger.error('Response error!', response.data);
-			throw new AzureAuthError(localize('azure.responseError', "Token retrieval failed with an error. Open developer tools to view the error"), 'Token retrieval failed', undefined);
+			throw new AzureAuthError(localize('azure.responseError', "Token retrieval failed with an error. [Open developer tools](command:workbench.action.toggleDevTools) for more details."), 'Token retrieval failed', undefined);
 		}
 
 		const accessTokenString = response.data.access_token;

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -264,7 +264,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 		if (response.data.error) {
 			Logger.error('Response error!', response.data);
-			throw new AzureAuthError(localize('azure.responseError', "Token retrieval failed with an error. [Open developer tools](command:workbench.action.toggleDevTools) for more details."), 'Token retrieval failed', undefined);
+			throw new AzureAuthError(localize('azure.responseError', "Token retrieval failed with an error. [Open developer tools]({0}) for more details.", 'command:workbench.action.toggleDevTools'), 'Token retrieval failed', undefined);
 		}
 
 		const accessTokenString = response.data.access_token;

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -105,7 +105,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 					loginComplete.reject(ex);
 					Logger.error(ex);
 				} else {
-					void vscode.window.showErrorMessage(ex.displayableErrorMessage);
+					void vscode.window.showErrorMessage(ex.message);
 					Logger.error(ex.originalMessageAndException);
 				}
 			}
@@ -140,7 +140,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 			return await this.hydrateAccount(tokenResult, this.getTokenClaims(tokenResult.token));
 		} catch (ex) {
 			if (ex instanceof AzureAuthError) {
-				void vscode.window.showErrorMessage(ex.displayableErrorMessage);
+				void vscode.window.showErrorMessage(ex.message);
 				Logger.error(ex.originalMessageAndException);
 			} else {
 				Logger.error(ex);

--- a/extensions/azurecore/src/account-provider/auths/azureAuthError.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuthError.ts
@@ -3,19 +3,25 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as nls from 'vscode-nls';
+const localize = nls.loadMessageBundle();
+
 export class AzureAuthError extends Error {
-	private readonly _originalMessage: string;
-
-	constructor(localizedMessage: string, _originalMessage: string, private readonly originalException: any) {
+	constructor(localizedMessage: string, public readonly originalMessage: string, private readonly originalException: any) {
 		super(localizedMessage);
-
 	}
 
-	get originalMessage(): string {
-		return this._originalMessage;
+	/**
+	 * Localized message to display to the user describing this error.
+	 */
+	public get displayableErrorMessage(): string {
+		return localize('azureAuthError.fullErrorMessage', '{0} ({1})', this.message, this.originalMessage);
 	}
 
-	getPrintableString(): string {
+	/**
+	 * The original message and exception for displaying extra information
+	 */
+	public get originalMessageAndException(): string {
 		return JSON.stringify({
 			originalMessage: this.originalMessage,
 			originalException: this.originalException

--- a/extensions/azurecore/src/account-provider/auths/azureAuthError.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuthError.ts
@@ -3,19 +3,9 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as nls from 'vscode-nls';
-const localize = nls.loadMessageBundle();
-
 export class AzureAuthError extends Error {
 	constructor(localizedMessage: string, public readonly originalMessage: string, private readonly originalException: any) {
 		super(localizedMessage);
-	}
-
-	/**
-	 * Localized message to display to the user describing this error.
-	 */
-	public get displayableErrorMessage(): string {
-		return localize('azureAuthError.fullErrorMessage', '{0} ({1})', this.message, this.originalMessage);
 	}
 
 	/**


### PR DESCRIPTION
This started off as just fixing the error message displayed prompting the user to open the developer tools (I just added a command link) but then was finally able to figure out where the error displayed to the user as '`{}`' was coming from which has been an issue that pops up occasionally for a while now. 

The main issue is that we were never setting the `_originalMessage` property - it was passed into the constructor but then never assigned. So then the call to `getPrintableString` returned an empty object which was then displayed to the user.  

In fixing this though I didn't like the idea of us showing these values to the user when we already had a localized error message, so changed it so that was displayed to the user instead and then print the original error/exception in the console logs.

![image](https://user-images.githubusercontent.com/28519865/150004825-073a123c-7a9c-4e12-bec6-7bdf84478566.png)