### PR TITLE
Improve logic used to wait for standard kernel registration

### DIFF
--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -661,6 +661,7 @@ export class NotebookService extends Disposable implements INotebookService {
 					instance = await this.waitOnExecuteProviderAvailability(providerDescriptor, timeout);
 				}
 
+				// Even if we have an execute provider, we still need standard kernels to be able to use it
 				if (instance && !kernelDescriptor.instance) {
 					let kernels = await this.waitOnStandardKernelsAvailability(kernelDescriptor, timeout);
 					if (!kernels) {

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -692,7 +692,9 @@ export class NotebookService extends Disposable implements INotebookService {
 		let promises: Promise<ISerializationProvider | undefined>[] = [
 			providerDescriptor.instanceReady,
 			new Promise<ISerializationProvider | undefined>((resolve, reject) => setTimeout(() => {
-				onUnexpectedError(localize('serializationProviderTimeout', 'Waiting for Serialization Provider availability timed out for notebook provider \'{0}\'', providerDescriptor.providerId));
+				if (!providerDescriptor.instance) {
+					onUnexpectedError(localize('serializationProviderTimeout', 'Waiting for Serialization Provider availability timed out for notebook provider \'{0}\'', providerDescriptor.providerId));
+				}
 				resolve(undefined);
 			}, timeout))
 		];
@@ -705,7 +707,9 @@ export class NotebookService extends Disposable implements INotebookService {
 		let promises: Promise<IExecuteProvider | undefined>[] = [
 			providerDescriptor.instanceReady,
 			new Promise<IExecuteProvider | undefined>((resolve, reject) => setTimeout(() => {
-				onUnexpectedError(localize('executeProviderTimeout', 'Waiting for Execute Provider availability timed out for notebook provider \'{0}\'', providerDescriptor.providerId));
+				if (!providerDescriptor.instance) {
+					onUnexpectedError(localize('executeProviderTimeout', 'Waiting for Execute Provider availability timed out for notebook provider \'{0}\'', providerDescriptor.providerId));
+				}
 				resolve(undefined);
 			}, timeout))
 		];
@@ -718,7 +722,9 @@ export class NotebookService extends Disposable implements INotebookService {
 		let promises: Promise<nb.IStandardKernel[] | undefined>[] = [
 			kernelsDescriptor.instanceReady,
 			new Promise<nb.IStandardKernel[] | undefined>((resolve, reject) => setTimeout(() => {
-				onUnexpectedError(localize('standardKernelsTimeout', 'Waiting for Standard Kernels availability timed out for notebook provider \'{0}\'', kernelsDescriptor.providerId));
+				if (!kernelsDescriptor.instance) {
+					onUnexpectedError(localize('standardKernelsTimeout', 'Waiting for Standard Kernels availability timed out for notebook provider \'{0}\'', kernelsDescriptor.providerId));
+				}
 				resolve(undefined);
 			}, timeout))
 		];


### PR DESCRIPTION
When we wait for kernels to be registered (as well as for execute and serialization providers), we run 2 promises in parallel: one for the actual registration completion, and a timeout promise that emits an error to the log. The registration was always completing successfully, but that timeout promise was still running in the background, and was then adding a faulty error to the log. The fix for that is to check if the provider instance exists when that timeout promise finishes. In addition, I improved some of the waiting logic to reduce the number of times we queue up those racing promises in the first place.

Fixes #18022
