### PR TITLE
Fix webmode build

### DIFF
--- a/build/lib/rollup.js
+++ b/build/lib/rollup.js
@@ -39,8 +39,8 @@ async function rollupModule(options) {
         });
         const result = generatedBundle.output[0];
         result.code = result.code + '\n//# sourceMappingURL=' + path.basename(outputMapName);
-        await fs.promises.writeFile(outputFilePath, JSON.stringify(result.code));
-        await fs.promises.writeFile(outputMapPath, JSON.stringify(result.map));
+        await fs.promises.writeFile(outputFilePath, result.code.toString());
+        await fs.promises.writeFile(outputMapPath, result.map ? result.map.toString() : '');
         return {
             name: moduleName,
             result: true

--- a/build/lib/rollup.js
+++ b/build/lib/rollup.js
@@ -40,7 +40,9 @@ async function rollupModule(options) {
         const result = generatedBundle.output[0];
         result.code = result.code + '\n//# sourceMappingURL=' + path.basename(outputMapName);
         await fs.promises.writeFile(outputFilePath, result.code.toString());
-        await fs.promises.writeFile(outputMapPath, result.map ? result.map.toString() : '');
+        if (result.map) {
+            await fs.promises.writeFile(outputMapPath, result.map.toString());
+        }
         return {
             name: moduleName,
             result: true

--- a/build/lib/rollup.js
+++ b/build/lib/rollup.js
@@ -39,8 +39,8 @@ async function rollupModule(options) {
         });
         const result = generatedBundle.output[0];
         result.code = result.code + '\n//# sourceMappingURL=' + path.basename(outputMapName);
-        await fs.promises.writeFile(outputFilePath, result.code);
-        await fs.promises.writeFile(outputMapPath, result.map);
+        await fs.promises.writeFile(outputFilePath, JSON.stringify(result.code));
+        await fs.promises.writeFile(outputMapPath, JSON.stringify(result.map));
         return {
             name: moduleName,
             result: true

--- a/build/lib/rollup.ts
+++ b/build/lib/rollup.ts
@@ -54,8 +54,9 @@ async function rollupModule(options: IRollupOptions) {
 		const result = generatedBundle.output[0];
 		result.code = result.code + '\n//# sourceMappingURL=' + path.basename(outputMapName);
 
-		await fs.promises.writeFile(outputFilePath, JSON.stringify(result.code));
-		await fs.promises.writeFile(outputMapPath, JSON.stringify(result.map));
+		await fs.promises.writeFile(outputFilePath, result.code.toString());
+		await fs.promises.writeFile(outputMapPath,
+			result.map ? result.map.toString() : '');
 
 		return {
 			name: moduleName,

--- a/build/lib/rollup.ts
+++ b/build/lib/rollup.ts
@@ -55,8 +55,9 @@ async function rollupModule(options: IRollupOptions) {
 		result.code = result.code + '\n//# sourceMappingURL=' + path.basename(outputMapName);
 
 		await fs.promises.writeFile(outputFilePath, result.code.toString());
-		await fs.promises.writeFile(outputMapPath,
-			result.map ? result.map.toString() : '');
+		if (result.map) {
+			await fs.promises.writeFile(outputMapPath, result.map.toString());
+		}
 
 		return {
 			name: moduleName,

--- a/build/lib/rollup.ts
+++ b/build/lib/rollup.ts
@@ -54,8 +54,8 @@ async function rollupModule(options: IRollupOptions) {
 		const result = generatedBundle.output[0];
 		result.code = result.code + '\n//# sourceMappingURL=' + path.basename(outputMapName);
 
-		await fs.promises.writeFile(outputFilePath, result.code);
-		await fs.promises.writeFile(outputMapPath, <any>result.map);
+		await fs.promises.writeFile(outputFilePath, JSON.stringify(result.code));
+		await fs.promises.writeFile(outputMapPath, JSON.stringify(result.map));
 
 		return {
 			name: moduleName,


### PR DESCRIPTION
Fix webmode build.  Changed previous PR to use toString instead of stringify, as I believe this is more compatible with previous behavior.  The web container is still broke at runtime for other issue that will be investigated separate from build break.