### PR TITLE
remove update project from database in vscode

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -198,13 +198,13 @@
         },
         {
           "command": "sqlDatabaseProjects.updateProjectFromDatabase",
-          "when": "view == dataworkspace.views.main",
+          "when": "view == dataworkspace.views.main && azdataAvailable",
           "group": "1_currentWorkspace@2"
         },
         {
           "command": "sqlDatabaseProjects.generateProjectFromOpenApiSpec",
           "when": "view == dataworkspace.views.main",
-          "group": "1_currentWorkspace@2"
+          "group": "1_currentWorkspace@3"
         }
       ],
       "commandPalette": [


### PR DESCRIPTION
This PR fixes #18123. There isn't quickpick support for this yet, so this should be hidden in vscode. 
