### PR TITLE
Fixing smoke tests in import where the status bar text was not found.

### DIFF
--- a/test/automation/src/statusbar.ts
+++ b/test/automation/src/statusbar.ts
@@ -35,9 +35,9 @@ export class StatusBar {
 		return this.code.waitForTextContent(this.getSelector(StatusBarElement.EOL_STATUS), eol);
 	}
 
-	// {{SQL CARBON EDIT}} Add retryCount
-	async waitForStatusbarText(title: string, text: string, retryCount?: number): Promise<void> {
-		await this.code.waitForTextContent(`${this.mainSelector} .statusbar-item[title="${title}"]`, text, undefined, retryCount);
+	// {{SQL CARBON EDIT}} Add retryCount, selecting status bar text with id instead of title.
+	async waitForStatusbarText(id: string, text: string, retryCount?: number): Promise<void> {
+		await this.code.waitForTextContent(`${this.mainSelector} .statusbar-item[id="${id}"]`, text, undefined, retryCount);
 	}
 
 	private getSelector(element: StatusBarElement): string {

--- a/test/smoke/src/sql/areas/import/import.test.ts
+++ b/test/smoke/src/sql/areas/import/import.test.ts
@@ -16,7 +16,7 @@ export function setup(opts: minimist.ParsedArgs) {
 			const app = this.app as Application;
 			await app.workbench.quickaccess.runCommand('Flat File Import: Import Wizard');
 			// Wait for the service to be downloaded and installed. This can take a while so set timeout to 5min (retryInterval default is 100ms)
-			await app.workbench.statusbar.waitForStatusbarText('', 'Flat File Import Service Started', 5 * 60 * 10);
+			await app.workbench.statusbar.waitForStatusbarText('Microsoft.import', 'Flat File Import Service Started', 5 * 60 * 10);
 			await app.workbench.connectionDialog.waitForConnectionDialog();
 		});
 	});


### PR DESCRIPTION
The waitForStatubarText function was not able to find the status message. 

Element looked like this 
```
<div id="Microsoft.import" class="statusbar-item left last-visible-item" aria-label="Flat File Import Service Started"><a tabindex="-1" role="button" aria-label="Flat File Import Service Started" class="disabled">Flat File Import Service Started</a></div>
```
It seemed the best way to select element over here is to provide the id for the element. 

There are other example of this being done in statusbar.ts

https://github.com/microsoft/azuredatastudio/blob/153f7be4f90680776c9b6ea5c7be5e64222249bb/test/automation/src/statusbar.ts#L46


