### PR TITLE
Remove extension dependency from VS Code data workspace

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -2,7 +2,7 @@
   "name": "data-workspace",
   "displayName": "Data Workspace",
   "description": "Additional common functionality for database projects",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/data-workspace/package.vscode.json
+++ b/extensions/data-workspace/package.vscode.json
@@ -1,7 +1,4 @@
 {
 	"name": "data-workspace-vscode",
-	"publisher": "ms-mssql",
-	"extensionDependencies": [
-		"ms-mssql.mssql"
-	]
+	"publisher": "ms-mssql"
 }


### PR DESCRIPTION
This was causing the MSSQL to extension to activate upon startup - even if the user wasn't using any of the features.

This has a couple negative side effects : 

1. Launch times for VS Code is increased - even if the user doesn't intend to use any features of the MSSQL extension
2. Our telemetry numbers are greatly increased since we currently use activation as a way to determine users of the extension. But now activation isn't really accurate for that count

Making the data-workspaces extension not activate on startup is another potential solution, but looking into that it gets tricky because we purposely hide the view until the extension can activate and determine if there's a project provider available (so we aren't showing it if we don't have anything that can contribute projects).

Since this extension doesn't directly rely on anything from the MSSQL extension this should be a much simpler way of fixing that.