### PR TITLE
Have sql db proj publish command return publishing promise

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -324,7 +324,7 @@ export class ProjectsController {
 
 			return publishDatabaseDialog.waitForClose();
 		} else {
-			void this.publishDatabase(project);
+			return this.publishDatabase(project);
 		}
 	}
 


### PR DESCRIPTION
Right now the command is returning immediately - but callers should be able to wait on completion of the command to know when the publish is actually finished. 