### PR TITLE
Fix untitled notebook save opening as JSON

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -37,8 +37,12 @@ import { INotebookInput } from 'sql/workbench/services/notebook/browser/interfac
 import { EditorModel } from 'vs/workbench/common/editor/editorModel';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { LocalContentManager } from 'sql/workbench/services/notebook/common/localContentManager';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions as LanguageAssociationExtensions, ILanguageAssociationRegistry } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
+import { NotebookLanguage } from 'sql/workbench/common/constants';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
+const languageAssociationRegistry = Registry.as<ILanguageAssociationRegistry>(LanguageAssociationExtensions.LanguageAssociations);
 
 export class NotebookEditorModel extends EditorModel {
 	private _dirty: boolean;
@@ -322,14 +326,16 @@ export abstract class NotebookInput extends EditorInput implements INotebookInpu
 		await this.updateModel();
 		let input = await this.textInput.save(groupId, options);
 		await this.setTrustForNewEditor(input);
-		return input;
+		const langAssociation = languageAssociationRegistry.getAssociationForLanguage(NotebookLanguage.Ipynb);
+		return langAssociation.convertInput(input);
 	}
 
 	override async saveAs(group: number, options?: ITextFileSaveOptions): Promise<IEditorInput | undefined> {
 		await this.updateModel();
 		let input = await this.textInput.saveAs(group, options);
 		await this.setTrustForNewEditor(input);
-		return input;
+		const langAssociation = languageAssociationRegistry.getAssociationForLanguage(NotebookLanguage.Ipynb);
+		return langAssociation.convertInput(input);
 	}
 
 	private async setTrustForNewEditor(newInput: IEditorInput | undefined): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/18097

In the VS Code merge the code path for saving/replacing editors change significantly. The change that broke this was that the code now picks the editor ID from the input - which for the basic `FileEditorInput` (that we use as the underlying input for Notebooks) is [default](https://github.com/microsoft/azuredatastudio/blob/main/src/vs/workbench/contrib/files/browser/editors/fileEditorInput.ts#L42). Previously the editor ID was passed in explicitly and so was undefined, which meant it went through the editor resolver logic and picked the correct input based on the extension. But now since the input passes in a specific editor ID it skips that and just chooses the default text editor (which displays as the raw JSON).

I looked into whether this was an actual bug that was fixed in VS Code in later commits but it looks like the behavior is the same - and by looking at other inputs that VS Code creates it seems like the expected method is that save/saveAs should be creating the actual inputs they want instead of returning a basic text input and relying on the resolver to "fix" it. 

So the solution is simple - just use our input conversion logic to create the actual Notebook input we want and pass that in.

I looked at other inputs we create and none of them seem to have this issue (query editor already makes its own for example) so we should be fine

Test cases created : 
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_workitems/edit/9626
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_workitems/edit/9627
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_workitems/edit/9628
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_workitems/edit/9629