### PR TITLE
Fix images in Notebook not showing

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -9,6 +9,7 @@ import * as path from 'vs/base/common/path';
 import * as turndownPluginGfm from 'sql/workbench/contrib/notebook/browser/turndownPluginGfm';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { findPathRelativeToContent, NotebookLinkHandler } from 'sql/workbench/contrib/notebook/browser/notebookLinkHandler';
+import { FileAccess } from 'vs/base/common/network';
 
 // These replacements apply only to text. Here's how it's handled from Turndown:
 // if (node.nodeType === 3) {
@@ -121,9 +122,11 @@ export class HTMLMarkdownConverter {
 			filter: 'img',
 			replacement: (content, node) => {
 				if (node?.src) {
-					let imgPath = URI.parse(node.src);
+					// Image URIs are converted to vscode-file URIs for the underlying HTML so that they can be loaded by ADS,
+					// but we want to convert them back to their file URI when converting back to markdown for displaying to the user
+					let imgUri = FileAccess.asFileUri(URI.parse(node.src));
 					const notebookFolder: string = this.notebookUri ? path.join(path.dirname(this.notebookUri.fsPath), path.sep) : '';
-					let relativePath = findPathRelativeToContent(notebookFolder, imgPath);
+					let relativePath = findPathRelativeToContent(notebookFolder, imgUri);
 					if (relativePath) {
 						return `![${node.alt}](${relativePath})`;
 					}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -17,7 +17,7 @@ import { IMarkdownStringWithCellAttachments, MarkdownRenderOptionsWithCellAttach
 import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { useNewMarkdownRendererKey } from 'sql/workbench/contrib/notebook/common/notebookCommon';
-import { FileAccess } from 'vs/base/common/network';
+import { FileAccess, Schemas } from 'vs/base/common/network';
 
 // Based off of HtmlContentRenderer
 export class NotebookMarkdownRenderer {
@@ -103,7 +103,11 @@ export class NotebookMarkdownRenderer {
 				// first. Since the href here can be either a file path, an HTTP/S link or embedded data though we first
 				// check if it's any of the others and if so then don't need to do anything.
 				let uri = URI.parse(href);
-				if (!(uri.scheme === 'https' || uri.scheme === 'http' || uri.scheme === 'data')) {
+				if (!(uri.scheme === Schemas.https ||
+					uri.scheme === Schemas.http ||
+					uri.scheme === Schemas.data ||
+					uri.scheme === Schemas.attachment ||
+					uri.scheme === Schemas.vscodeFileResource)) {
 					uri = FileAccess.asBrowserUri(URI.file(href));
 				}
 				attributes.push(`src="${uri.toString(true)}"`);

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -17,6 +17,7 @@ import { IMarkdownStringWithCellAttachments, MarkdownRenderOptionsWithCellAttach
 import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { useNewMarkdownRendererKey } from 'sql/workbench/contrib/notebook/common/notebookCommon';
+import { FileAccess } from 'vs/base/common/network';
 
 // Based off of HtmlContentRenderer
 export class NotebookMarkdownRenderer {
@@ -98,7 +99,14 @@ export class NotebookMarkdownRenderer {
 			}
 			let attributes: string[] = [];
 			if (href) {
-				attributes.push(`src="${href}"`);
+				// VS Code blocks loading directly from the file protocol - we have to transform it to a vscode-file URI
+				// first. Since the href here can be either a file path, an HTTP/S link or embedded data though we first
+				// check if it's any of the others and if so then don't need to do anything.
+				let uri = URI.parse(href);
+				if (!(uri.scheme === 'https' || uri.scheme === 'http' || uri.scheme === 'data')) {
+					uri = FileAccess.asBrowserUri(URI.file(href));
+				}
+				attributes.push(`src="${uri.toString(true)}"`);
 			}
 			if (text) {
 				attributes.push(`alt="${text}"`);

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -18,7 +18,7 @@ suite('NotebookMarkdownRenderer', () => {
 		const imageFromMarked = marked(markdown.value, {
 			sanitize: true,
 			renderer
-		}).trim();
+		}).trim().replace('someimageurl', 'vscode-file://vscode-app/someimageurl');
 		assert.strictEqual(result.innerHTML, imageFromMarked);
 	});
 
@@ -26,26 +26,26 @@ suite('NotebookMarkdownRenderer', () => {
 		const markdown = { value: `![image](someimageurl)` };
 		const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown(markdown);
 		const renderer = new marked.Renderer();
-		const imageFromMarked = marked(markdown.value, {
+		let imageFromMarked = marked(markdown.value, {
 			sanitize: true,
 			renderer
-		}).trim();
+		}).trim().replace('someimageurl', 'vscode-file://vscode-app/someimageurl');
 		assert.strictEqual(result.innerHTML, imageFromMarked);
 	});
 
 	test('image width from title params', () => {
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![image](someimageurl|width=100 'caption')` });
-		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" width="100"></p>`);
+		assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/someimageurl" alt="image" title="caption" width="100"></p>`);
 	});
 
 	test('image height from title params', () => {
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![image](someimageurl|height=100 'caption')` });
-		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" height="100"></p>`);
+		assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/someimageurl" alt="image" title="caption" height="100"></p>`);
 	});
 
 	test('image width and height from title params', () => {
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![image](someimageurl|height=200,width=100 'caption')` });
-		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" width="100" height="200"></p>`);
+		assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/someimageurl" alt="image" title="caption" width="100" height="200"></p>`);
 	});
 
 	test('link from local file path', () => {
@@ -99,10 +99,38 @@ suite('NotebookMarkdownRenderer', () => {
 		assert.strictEqual(result.innerHTML, `<p><img src="attachment:ads.png" alt="altText"></p>`, 'Cell attachment name not found failed');
 
 		result = notebookMarkdownRenderer.renderMarkdown({ value: `![altText](attachments:ads.png)`, isTrusted: true }, { cellAttachments: JSON.parse('{"ads2.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}') });
-		assert.strictEqual(result.innerHTML, `<p><img src="attachments:ads.png" alt="altText"></p>`, 'Cell attachment scheme mismatch failed');
+		assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/attachments:ads.png" alt="altText"></p>`, 'Cell attachment scheme mismatch failed');
 
 		result = notebookMarkdownRenderer.renderMarkdown({ value: `![altText](attachment:ads.png)`, isTrusted: true }, { cellAttachments: JSON.parse('{"ads2.png":"image/png"}') });
 		assert.strictEqual(result.innerHTML, `<p><img src="attachment:ads.png" alt="altText"></p>`, 'Cell attachment no image data failed');
+	});
+
+	suite('Schema validation', function () {
+		test('https', () => {
+			const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![](https://example.com)` });
+			assert.strictEqual(result.innerHTML, `<p><img src="https://example.com/"></p>`, 'HTTPS schema link should not be modified');
+		});
+		test('http', () => {
+			const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![](http://example.com)` });
+			assert.strictEqual(result.innerHTML, `<p><img src="http://example.com/"></p>`, 'HTTP schema link should not be modified');
+		});
+		test('attachment & data', () => {
+			const result = notebookMarkdownRenderer.renderMarkdown({ value: `![altText](attachment:ads.png)`, isTrusted: false }, { cellAttachments: JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}') });
+			assert.strictEqual(result.innerHTML, `<p><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAggg==" alt="altText"></p>`, 'Cell with attachment should have attachment URI not be modified');
+		});
+		test('vscode-file', () => {
+			const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![](vscode-file://vscode-app/mypath)` });
+			assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/mypath"></p>`, 'vscode-file schema link should not be modified');
+		});
+		test('file', () => {
+			const filePath = URI.parse(__filename).fsPath;
+			const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![](${filePath})` });
+			assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/${filePath.replace(/\\/g, '/')}"></p>`, 'file links should have vscode-file schema added');
+		});
+		test('unknown', () => {
+			const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![](unknown://some/path)` });
+			assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/unknown://some/path"></p>`, 'vscode-file schema link should not be modified');
+		});
 	});
 
 	test('table followed by blank line with space and then header renders correctly (#16245)', function (): void {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -125,11 +125,14 @@ suite('NotebookMarkdownRenderer', () => {
 		test('file', () => {
 			const filePath = URI.parse(__filename).fsPath;
 			const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![](${filePath})` });
-			assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/${filePath.replace(/\\/g, '/')}"></p>`, 'file links should have vscode-file schema added');
+			let renderedPath = filePath.replace(/\\/g, '/');
+			// Unix filesystems start with / which is deduplicated in the final src URI - so just remove that now if it exists
+			renderedPath = renderedPath.startsWith('/') ? renderedPath.slice(1) : renderedPath;
+			assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/${renderedPath}"></p>`, 'file links should have vscode-file schema added');
 		});
 		test('unknown', () => {
 			const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![](unknown://some/path)` });
-			assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/unknown://some/path"></p>`, 'vscode-file schema link should not be modified');
+			assert.strictEqual(result.innerHTML, `<p><img src="vscode-file://vscode-app/unknown://some/path"></p>`, 'unknown schema should be treated like a path and have vscode-file schema added');
 		});
 	});
 

--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -46,6 +46,8 @@ export namespace Schemas {
 
 	export const data = 'data';
 
+	export const attachment = 'attachment'; // {{SQL CARBON EDIT}} "Scheme" used for Notebook cell attachment data (not really a scheme but formatted like one...)
+
 	export const command = 'command';
 
 	export const vscodeRemote = 'vscode-remote';


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/18062

The issue here is that VS Code changed it so that all direct file:// access is blocked - images have to be loaded using the vscode-file protocol now. So the fix here is to use `asBrowserUri` to transform the URI into one that we can load when the URI is a file on disk.

See https://github.com/microsoft/vscode/issues/80352 for a similiar-ish issue in their own markdown renderer

Notebook with local, web and embedded images : 
![image](https://user-images.githubusercontent.com/28519865/151085345-f23858a7-589d-4e0a-8947-d50242f8377d.png)
