### PR TITLE
Fix welcome page images

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -9,6 +9,8 @@ import { localize } from 'vs/nls';
 
 const previewImgDescription = escape(localize('welcomePage.previewBody', "This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development."));
 
+// Note - this content is passed through an HTML sanitizer defined in src\vs\base\browser\dom.ts (safeInnerHtml). If something
+// isn't rendering correctly make sure that the tags/attributes and schemas are all listed in the allowed lists.
 export default () => `
 <div class="welcomePageContainer">
 	<div class="welcomePage">

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1403,7 +1403,7 @@ export function safeInnerHtml(node: HTMLElement, value: string): void {
 			'span': ['data-command', 'role'],
 			'textarea': ['name', 'placeholder', 'required'],
 		},
-		allowedSchemes: ['http', 'https', 'command', 'file'] // {{SQL CARBON EDIT}} Add allowed schema for welcome page support
+		allowedSchemes: ['http', 'https', 'command', 'vscode-file'] // {{SQL CARBON EDIT}} Add allowed schema for welcome page support
 	}, ['class', 'id', 'role', 'tabindex']);
 
 	const html = _ttpSafeInnerHtml?.createHTML(value, options) ?? insane(value, options);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/18002

With the protocol schema changes these changed from being file:// URIs to vscode-file://

![image](https://user-images.githubusercontent.com/28519865/151460624-1dd01b29-098d-4d0e-a648-079701b75f03.png)
