### PR TITLE
Enable check-param-names

### DIFF
--- a/.eslintrc.sql.ts.json
+++ b/.eslintrc.sql.ts.json
@@ -16,6 +16,7 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		"jsdoc/check-param-names": "error"
 	}
 }

--- a/extensions/.eslintrc.json
+++ b/extensions/.eslintrc.json
@@ -1,5 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 2
+		"no-cond-assign": 2,
+		"jsdoc/check-param-names": "error"
 	}
 }

--- a/extensions/admin-tool-ext-win/src/main.ts
+++ b/extensions/admin-tool-ext-win/src/main.ts
@@ -47,7 +47,7 @@ function registerCommands(context: vscode.ExtensionContext): void {
 
 /**
  * Handler for command to launch SSMS Server Properties dialog
- * @param connectionId The connection context from the command
+ * @param connectionContext The connection context from the command
  */
 async function handleLaunchSsmsMinPropertiesDialogCommand(connectionContext?: azdata.ObjectExplorerContext): Promise<void> {
 	if (!connectionContext) {
@@ -75,7 +75,7 @@ async function handleLaunchSsmsMinPropertiesDialogCommand(connectionContext?: az
 
 /**
  * Handler for command to launch SSMS "Generate Script Wizard" dialog
- * @param connectionId The connection context from the command
+ * @param connectionContext The connection context from the command
  */
 async function handleLaunchSsmsMinGswDialogCommand(connectionContext?: azdata.ObjectExplorerContext): Promise<void> {
 	const action = 'GenerateScripts';
@@ -92,8 +92,7 @@ async function handleLaunchSsmsMinGswDialogCommand(connectionContext?: azdata.Ob
 /**
  * Launches SsmsMin with parameters from the specified connection
  * @param action The action to launch
- * @param params The params used to construct the command
- * @param urn The URN to pass to SsmsMin
+ * @param connectionContext The connection context from the command
  */
 async function launchSsmsDialog(action: string, connectionContext: azdata.ObjectExplorerContext): Promise<void> {
 	if (!connectionContext.connectionProfile) {

--- a/extensions/arc/src/common/utils.ts
+++ b/extensions/arc/src/common/utils.ts
@@ -105,8 +105,8 @@ export function getDatabaseStateDisplayText(state: string): string {
 
 /**
  * Opens an input box prompting and validating the user's input.
- * @param options Options for the input box
  * @param title An optional title for the input box
+ * @param options Options for the input box
  * @returns Promise resolving to the user's input if it passed validation,
  * or undefined if the input box was closed for any other reason
  */

--- a/extensions/azcli/src/common/childProcess.ts
+++ b/extensions/azcli/src/common/childProcess.ts
@@ -82,7 +82,6 @@ export async function executeCommand(command: string, args: string[], additional
  * Executes a command with admin privileges. The user will be prompted to enter credentials for invocation of
  * this function. The exact prompt is platform-dependent.
  * @param command The command to execute
- * @param args The additional args
  */
 export async function executeSudoCommand(command: string): Promise<ProcessOutput> {
 	return new Promise((resolve, reject) => {

--- a/extensions/azurecore/src/account-provider/auths/azureAuthCodeGrant.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuthCodeGrant.ts
@@ -69,9 +69,6 @@ export class AzureAuthCodeGrant extends AzureAuth {
 	 *
 	 * @param tenant
 	 * @param resource
-	 * @param authCode
-	 * @param redirectUri
-	 * @param codeVerifier
 	 */
 	private async getTokenWithAuthorizationCode(tenant: Tenant, resource: Resource, { authCode, redirectUri, codeVerifier }: AuthCodeResponse): Promise<OAuthTokenResponse | undefined> {
 		const postData: AuthorizationCodePostData = {

--- a/extensions/big-data-cluster/src/bigDataCluster/utils.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/utils.ts
@@ -117,7 +117,7 @@ export function getStateDisplayText(state?: string): string {
 
 /**
  * Gets the localized text to display for a corresponding endpoint
- * @param serviceName The endpoint name to get the display text for
+ * @param endpointName The endpoint name to get the display text for
  * @param description The backup description to use if we don't have our own
  */
 export function getEndpointDisplayText(endpointName?: string, description?: string): string {

--- a/extensions/integration-tests/src/test/utils.ts
+++ b/extensions/integration-tests/src/test/utils.ts
@@ -276,8 +276,8 @@ export async function assertFileGenerationResult(filepath: string, retryCount: n
 
 /**
  *
- * @param tableName table to look for
  * @param schema schema to look for
+ * @param tableName table to look for
  * @param ownerUri owner uri
  * @param retryCount number of times to retry with a 5 second wait between each try
  * @param checkForData whether or not to check if the table has data

--- a/extensions/machine-learning/src/common/utils.ts
+++ b/extensions/machine-learning/src/common/utils.ts
@@ -220,7 +220,9 @@ export function getScriptWithDBChange(currentDb: string, databaseName: string, s
 
 /**
  * Returns full name of model registration table
- * @param config config
+ * @param db
+ * @param table
+ * @param schema
  */
 export function getRegisteredModelsThreePartsName(db: string, table: string, schema: string) {
 	const dbName = doubleEscapeSingleBrackets(db);
@@ -231,7 +233,8 @@ export function getRegisteredModelsThreePartsName(db: string, table: string, sch
 
 /**
  * Returns full name of model registration table
- * @param config config object
+ * @param table
+ * @param schema
  */
 export function getRegisteredModelsTwoPartsName(table: string, schema: string) {
 	const schemaName = doubleEscapeSingleBrackets(schema);

--- a/extensions/machine-learning/src/modelManagement/deployedModelService.ts
+++ b/extensions/machine-learning/src/modelManagement/deployedModelService.ts
@@ -155,7 +155,6 @@ export class DeployedModelService {
 	/**
 	 * Verifies if the given table name is valid to be used as import table. If table doesn't exist returns true to create new table
 	 * Otherwise verifies the schema and returns true if the schema is supported
-	 * @param connection database connection
 	 * @param table config table name
 	 */
 	public async verifyConfigTable(table: DatabaseTable): Promise<boolean> {

--- a/extensions/machine-learning/src/modelManagement/queries.ts
+++ b/extensions/machine-learning/src/modelManagement/queries.ts
@@ -29,8 +29,7 @@ export function getDeployedModelsQuery(table: DatabaseTable): string {
 
 /**
  * Verifies config table has the expected schema
- * @param databaseName
- * @param tableName
+ * @param table
  */
 export function getConfigTableVerificationQuery(table: DatabaseTable): string {
 	let tableName = table.tableName;

--- a/extensions/machine-learning/src/packageManagement/packageManagementService.ts
+++ b/extensions/machine-learning/src/packageManagement/packageManagementService.ts
@@ -45,7 +45,6 @@ export class PackageManagementService {
 	/**
 	 * Updates external script config
 	 * @param connection SQL Connection
-	 * @param enable if true external script will be enabled
 	 */
 	public async enableExternalScriptConfig(connection: azdata.connection.ConnectionProfile): Promise<boolean> {
 		let current = await this._queryRunner.isMachineLearningServiceEnabled(connection);

--- a/extensions/machine-learning/src/packageManagement/sqlPythonPackageManageProvider.ts
+++ b/extensions/machine-learning/src/packageManagement/sqlPythonPackageManageProvider.ts
@@ -57,8 +57,9 @@ export class SqlPythonPackageManageProvider extends SqlPackageManageProviderBase
 
 	/**
 	 * Execute a script to install or uninstall a python package inside current SQL Server connection
-	 * @param packageDetails Packages to install or uninstall
 	 * @param scriptMode can be 'install' or 'uninstall'
+	 * @param packageDetails Packages to install or uninstall
+	 * @param databaseName
 	 */
 	protected async executeScripts(scriptMode: ScriptMode, packageDetails: nbExtensionApis.IPackageDetails, databaseName: string): Promise<void> {
 		let connection = await this.getCurrentConnection();

--- a/extensions/machine-learning/src/packageManagement/sqlRPackageManageProvider.ts
+++ b/extensions/machine-learning/src/packageManagement/sqlRPackageManageProvider.ts
@@ -60,8 +60,9 @@ export class SqlRPackageManageProvider extends SqlPackageManageProviderBase impl
 
 	/**
 	 * Execute a script to install or uninstall a r package inside current SQL Server connection
-	 * @param packageDetails Packages to install or uninstall
 	 * @param scriptMode can be 'install' or 'uninstall'
+	 * @param packageDetails Packages to install or uninstall
+	 * @param databaseName
 	 */
 	protected async executeScripts(scriptMode: ScriptMode, packageDetails: nbExtensionApis.IPackageDetails, databaseName: string): Promise<void> {
 		let connection = await this.getCurrentConnection();

--- a/extensions/machine-learning/src/views/models/modelManagementController.ts
+++ b/extensions/machine-learning/src/views/models/modelManagementController.ts
@@ -47,6 +47,7 @@ export class ModelManagementController extends ControllerBase {
 
 	/**
 	 * Opens the dialog for model import
+	 * @param importTable
 	 * @param parent parent if the view is opened from another view
 	 * @param controller controller
 	 * @param apiWrapper apiWrapper

--- a/extensions/machine-learning/src/views/models/modelViewBase.ts
+++ b/extensions/machine-learning/src/views/models/modelViewBase.ts
@@ -176,7 +176,7 @@ export abstract class ModelViewBase extends ViewBase {
 
 	/**
 	 * registers local model
-	 * @param localFilePath local file path
+	 * @param models
 	 */
 	public async importLocalModel(models: ModelViewData[]): Promise<void> {
 		return await this.sendDataRequest(RegisterLocalModelEventName, models);
@@ -192,7 +192,7 @@ export abstract class ModelViewBase extends ViewBase {
 
 	/**
 	 * download azure model
-	 * @param args azure resource
+	 * @param resource azure resource
 	 */
 	public async downloadAzureModel(resource: AzureModelResource | undefined): Promise<string> {
 		return await this.sendDataRequest(DownloadAzureModelEventName, resource);
@@ -207,7 +207,7 @@ export abstract class ModelViewBase extends ViewBase {
 
 	/**
 	 * registers azure model
-	 * @param args azure resource
+	 * @param models
 	 */
 	public async importAzureModel(models: ModelViewData[]): Promise<void> {
 		return await this.sendDataRequest(RegisterAzureModelEventName, models);
@@ -229,7 +229,9 @@ export abstract class ModelViewBase extends ViewBase {
 
 	/**
 	 * registers azure model
-	 * @param args azure resource
+	 * @param model
+	 * @param filePath
+	 * @param params
 	 */
 	public async generatePredictScript(model: ImportedModel | undefined, filePath: string | undefined, params: PredictParameters | undefined): Promise<void> {
 		const args: PredictModelEventArgs = Object.assign({}, params, {

--- a/extensions/machine-learning/src/views/models/modelsDetailsTableComponent.ts
+++ b/extensions/machine-learning/src/views/models/modelsDetailsTableComponent.ts
@@ -111,7 +111,6 @@ export class ModelsDetailsTableComponent extends ModelViewBase implements IDataC
 
 	/**
 	 * Load data in the component
-	 * @param workspaceResource Azure workspace
 	 */
 	public async loadData(): Promise<void> {
 

--- a/extensions/machine-learning/src/views/models/prediction/columnsTable.ts
+++ b/extensions/machine-learning/src/views/models/prediction/columnsTable.ts
@@ -158,7 +158,8 @@ export class ColumnsTable extends ModelViewBase implements IDataComponent<Predic
 
 	/**
 	 * Load data in the component
-	 * @param workspaceResource Azure workspace
+	 * @param modelParameters
+	 * @param table
 	 */
 	public async loadInputs(modelParameters: ModelParameters | undefined, table: DatabaseTable): Promise<void> {
 		await this.onLoading();

--- a/extensions/mssql/src/dashboard/serviceEndpoints.ts
+++ b/extensions/mssql/src/dashboard/serviceEndpoints.ts
@@ -142,7 +142,7 @@ export enum Endpoint {
 
 /**
  * Gets the localized text to display for a corresponding endpoint
- * @param serviceName The endpoint name to get the display text for
+ * @param endpointName The endpoint name to get the display text for
  * @param description The backup description to use if we don't have our own
  */
 function getEndpointDisplayText(endpointName?: string, description?: string): string {

--- a/extensions/mssql/src/hdfs/fileStatus.ts
+++ b/extensions/mssql/src/hdfs/fileStatus.ts
@@ -34,12 +34,17 @@ export function hdfsFileTypeToFileType(hdfsFileType: HdfsFileType | undefined): 
 export class FileStatus {
 	/**
 	 *
-	 * @param owner The ACL entry object for the owner permissions
+	 * @param accessTime
+	 * @param blockSize
 	 * @param group The ACL entry object for the group permissions
-	 * @param other The ACL entry object for the other permissions
-	 * @param stickyBit The sticky bit status for the object. If true the owner/root are
-	 * the only ones who can delete the resource or its contents (if a folder)
-	 * @param aclEntries The ACL entries defined for the object
+	 * @param length
+	 * @param modificationTime
+	 * @param owner The ACL entry object for the owner permissions
+	 * @param pathSuffix
+	 * @param permission
+	 * @param replication
+	 * @param snapshotEnabled
+	 * @param type
 	 */
 	constructor(
 		/**

--- a/extensions/mssql/src/hdfs/webhdfs.ts
+++ b/extensions/mssql/src/hdfs/webhdfs.ts
@@ -108,7 +108,6 @@ export class WebHDFS {
 	 * Gets status message from response
 	 *
 	 * @param response response object
-	 * @param strict If set true then RemoteException must be present in the body
 	 * @returns Error message interpreted by status code
 	 */
 	private getStatusMessage(response: request.Response): string {
@@ -211,6 +210,7 @@ export class WebHDFS {
 	 * Send a request to WebHDFS REST API
 	 *
 	 * @param method HTTP method
+	 * @param urlValue
 	 * @param opts Options for request
 	 * @returns void
 	 */
@@ -319,8 +319,10 @@ export class WebHDFS {
 	/**
 	 * Change file owner
 	 *
+	 * @param path
 	 * @param userId User name
 	 * @param groupId Group name
+	 * @param callback
 	 * @returns void
 	 */
 	public chown(path: string, userId: string, groupId: string, callback: (error: HdfsError) => void): void {
@@ -511,7 +513,7 @@ export class WebHDFS {
 	 * Set ACL for the given path. The owner, group and other fields are required - other entries are optional.
 	 * @param path The path to the file/folder to set the ACL on
 	 * @param fileType The type of file we're setting to determine if defaults should be applied. Use undefined if type is unknown
-	 * @param ownerEntry The status containing the permissions to set
+	 * @param permissionStatus The status containing the permissions to set
 	 * @param callback Callback to handle the response
 	 */
 	public setAcl(path: string, fileType: FileType | undefined, permissionStatus: PermissionStatus, callback: (error: HdfsError) => void): void {
@@ -592,7 +594,11 @@ export class WebHDFS {
 	/**
 	 * Write data to the file
 	 *
+	 * @param path
+	 * @param data
 	 * @param append If set to true then append data to the file
+	 * @param opts
+	 * @param callback
 	 */
 	public writeFile(path: string, data: string | Buffer, append: boolean, opts: object,
 		callback: (error: HdfsError) => void): fs.WriteStream {
@@ -663,8 +669,9 @@ export class WebHDFS {
 	 * Create writable stream for given path
 	 *
 	 * @fires WebHDFS#finish
-	 * @param [append] If set to true then append data to the file
-	 *
+	 * @param path
+	 * @param append If set to true then append data to the file
+	 * @param opts
 	 * @example
 	 * let hdfs = WebHDFS.createClient();
 	 *

--- a/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
@@ -379,8 +379,7 @@ class HdfsFileSource implements IFileSource {
 	 * Sets the ACL status for given path
 	 * @param path The path to the file/folder to set the ACL on
 	 * @param fileType The type of file we're setting to determine if defaults should be applied. Use undefined if type is unknown
-	 * @param ownerEntry The status containing the permissions to set
-	 * @param aclEntries The ACL entries to set
+	 * @param permissionStatus The permissions to set
 	 */
 	public setAcl(path: string, fileType: FileType | undefined, permissionStatus: PermissionStatus): Promise<void> {
 		return new Promise((resolve, reject) => {

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -42,7 +42,6 @@ export function getAppDataPath() {
 /**
  * Get a file name that is not already used in the target directory
  * @param filePath source notebook file name
- * @param fileExtension file type
  */
 export function findNextUntitledEditorName(filePath: string): string {
 	const fileExtension = path.extname(filePath);

--- a/extensions/notebook/src/book/bookModel.ts
+++ b/extensions/notebook/src/book/bookModel.ts
@@ -345,6 +345,7 @@ export class BookModel {
 
 	/**
 	 * Recursively parses out a section of a Jupyter Book.
+	 * @param version
 	 * @param section The input data to parse
 	 */
 	public parseJupyterSections(version: string, section: any[]): JupyterBookSection[] {

--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -325,7 +325,7 @@ export class BookTocManager implements IBookTocManager {
 	 * Moves a section to a book top level or another book's section. If there's a target section we add the the targetSection directory if it has one and append it to the
 	 * notebook's path. The overwrite option is set to false to prevent any issues with duplicated file names.
 	 * @param section The section that's been moved.
-	 * @param book The target book.
+	 * @param bookItem The target book.
 	*/
 	async moveSectionFiles(section: BookTreeItem, bookItem: BookTreeItem): Promise<void> {
 		const uri = path.posix.join(path.posix.sep, path.relative(section.rootContentPath, section.book.contentPath));
@@ -369,8 +369,8 @@ export class BookTocManager implements IBookTocManager {
 	/**
 	 * Moves a file to a book top level or a book's section. If there's a target section we add the the targetSection directory if it has one and append it to the
 	 * files's path. The overwrite option is set to false to prevent any issues with duplicated file names.
-	 * @param element Notebook, Markdown File, or book's notebook that will be added to the book.
-	 * @param targetBook Book that will be modified.
+	 * @param file Notebook, Markdown File, or book's notebook that will be added to the book.
+	 * @param book Book that will be modified.
 	*/
 	async moveFile(file: BookTreeItem, book: BookTreeItem): Promise<void> {
 		const rootPath = book.rootContentPath;

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -330,7 +330,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	 * were able to successfully parse it.
 	 * @param bookPath The path to the book folder to create the model for
 	 * @param isNotebook A boolean value to know we are creating a model for a notebook or a book
-	 * @param notebookBookRoot For pinned notebooks we need to know if the notebook is part of a book or it's a standalone notebook
+	 * @param notebookDetails
 	 */
 	private async createAndAddBookModel(bookPath: string, isNotebook: boolean, notebookDetails?: IPinnedNotebook): Promise<void> {
 		if (!this.books.find(x => x.bookPath === bookPath)) {

--- a/extensions/notebook/src/intellisense/text.ts
+++ b/extensions/notebook/src/intellisense/text.ts
@@ -45,8 +45,6 @@ export function jsIndexToCharIndex(jsIdx: number, text: string): number {
 /**
  * Get the diff between pure character count and JS-based count with 2 chars per surrogate pair.
  *
- * @param charIdx - The index in unicode characters
- *
  * @param text - The text in which the offset is calculated
  *
  * @returns The js-native index

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -168,8 +168,9 @@ type AzureComponent = azdata.InputBoxComponent | azdata.DropDownComponent;
 /**
  * Creates an inputBox using the properties defined in context.fieldInfo object
  *
- * @param context - the fieldContext object for this field
- * @param inputBoxType - the type of inputBox
+ * @param root
+ * @param root.context - the fieldContext object for this field
+ * @param root.inputBoxType - the type of inputBox
  */
 function createInputBoxField({ context, inputBoxType = 'text' }: { context: FieldContext; inputBoxType?: azdata.InputBoxInputType; }) {
 	const label = createLabel(context.view, { text: context.fieldInfo.label, description: context.fieldInfo.description, required: context.fieldInfo.required, width: context.fieldInfo.labelWidth, cssStyles: context.fieldInfo.labelCSSStyles });
@@ -930,8 +931,8 @@ function processEvaluatedTextField(context: FieldContext): ReadOnlyFieldInputs {
  *
  * Only variables in the current model starting with {@see NoteBookEnvironmentVariablePrefix} are replaced.
  *
- * @param inputValue
  * @param inputComponents
+ * @param inputValue
  */
 async function substituteVariableValues(inputComponents: InputComponents, inputValue?: string): Promise<string | undefined> {
 	await Promise.all(Object.keys(inputComponents)

--- a/extensions/sql-database-projects/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-database-projects/src/common/azureFunctionsUtils.ts
@@ -73,7 +73,7 @@ export async function setLocalAppSetting(projectFolder: string, key: string, val
 
 /**
  * Gets the Azure Functions project that contains the given file if the project is open in one of the workspace folders
- * @param filePath file that the containing project needs to be found for
+ * @param fileUri file that the containing project needs to be found for
  * @returns uri of project or undefined if project couldn't be found
  */
 export async function getAFProjectContainingFile(fileUri: vscode.Uri): Promise<vscode.Uri | undefined> {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -150,9 +150,7 @@ export class ProjectsController {
 
 	/**
 	 * Creates a new folder with the project name in the specified location, and places the new .sqlproj inside it
-	 * @param newProjName
-	 * @param folderUri
-	 * @param projectGuid
+	 * @param creationParams
 	 */
 	public async createNewProject(creationParams: NewProjectParams): Promise<string> {
 		TelemetryReporter.createActionEvent(TelemetryViews.ProjectController, TelemetryActions.createNewProject)
@@ -266,7 +264,8 @@ export class ProjectsController {
 
 	/**
 	 * Publishes a project to docker container
-	 * @param treeNode a treeItem in a project's hierarchy, to be used to obtain a Project
+	 * @param context a treeItem in a project's hierarchy, to be used to obtain a Project or the Project itself
+	 * @param deployProfile
 	 */
 	public async publishToDockerContainer(context: Project | dataworkspace.WorkspaceTreeItem, deployProfile: IDeployProfile): Promise<void> {
 		const project: Project = this.getProjectFromContext(context);
@@ -795,7 +794,7 @@ export class ProjectsController {
 
 	/**
 	 * Reloads the given project. Throws an error if given project is not a valid open project.
-	 * @param projectFileUri the uri of the project to be reloaded
+	 * @param context
 	 */
 	public async reloadProject(context: dataworkspace.WorkspaceTreeItem): Promise<void> {
 		const project = this.getProjectFromContext(context);

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceQuickpick.ts
@@ -21,7 +21,6 @@ interface DbServerValues {
 
 /**
  * Create flow for adding a database reference using only VS Code-native APIs such as QuickPick
- * @param connectionInfo Optional connection info to use instead of prompting the user for a connection
  */
 export async function addDatabaseReferenceQuickpick(project: Project): Promise<AddDatabaseReferenceSettings | undefined> {
 

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -740,7 +740,7 @@ export class Project implements ISqlProject {
 
 	/**
 	 * Set the target platform of the project
-	 * @param newTargetPlatform compat level of project
+	 * @param compatLevel compat level of project
 	 */
 	public async changeTargetPlatform(compatLevel: string): Promise<void> {
 		if (this.getProjectTargetVersion() !== compatLevel) {
@@ -863,8 +863,6 @@ export class Project implements ISqlProject {
 
 	/**
 	 * Adds reference to a dacpac to the project
-	 * @param uri Uri of the dacpac
-	 * @param databaseName name of the database
 	 */
 	public async addDatabaseReference(settings: IDacpacReferenceSettings): Promise<void> {
 		const databaseReferenceEntry = new DacpacReferenceProjectEntry(settings);
@@ -879,8 +877,6 @@ export class Project implements ISqlProject {
 
 	/**
 	 * Adds reference to a another project in the workspace
-	 * @param uri Uri of the dacpac
-	 * @param databaseName name of the database
 	 */
 	public async addProjectReference(settings: IProjectReferenceSettings): Promise<void> {
 		const projectReferenceEntry = new SqlProjectReferenceProjectEntry(settings);

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -22,7 +22,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 
 	/**
 	 * Gets the project tree data provider
-	 * @param projectFile The project file Uri
+	 * @param projectFilePath The project file Uri
 	 */
 	async getProjectTreeDataProvider(projectFilePath: vscode.Uri): Promise<vscode.TreeDataProvider<BaseProjectTreeItem>> {
 		const provider = new SqlDatabaseProjectTreeViewProvider();

--- a/extensions/sql-database-projects/src/tools/packageHelper.ts
+++ b/extensions/sql-database-projects/src/tools/packageHelper.ts
@@ -38,7 +38,7 @@ export class PackageHelper {
 	/**
 	 * Runs dotnet add package to add a package reference to the specified project. If the project already has a package reference
 	 * for this package version, the project file won't get updated
-	 * @param projectPath uri of project to add package to
+	 * @param projectUri uri of project to add package to
 	 * @param packageName name of package
 	 * @param packageVersion optional version of package. If none, latest will be pulled in
 	 */
@@ -53,7 +53,7 @@ export class PackageHelper {
 
 	/**
 	 * Adds specified package to Azure Functions project the specified file is a part of
-	 * @param filePath uri of file to find the containing AF project of to add package reference to
+	 * @param fileUri uri of file to find the containing AF project of to add package reference to
 	 * @param packageName package to add reference to
 	 * @param packageVersion optional version of package. If none, latest will be pulled in
 	 */

--- a/src/sql/platform/connection/common/connectionStatusManager.ts
+++ b/src/sql/platform/connection/common/connectionStatusManager.ts
@@ -182,7 +182,6 @@ export class ConnectionStatusManager {
 	 * Only if the db name in the original uri is different when connection is complete, we need to use the original uri
 	 * Returns the generated ownerUri for the connection profile if not existing connection found
 	 * @param ownerUri connection owner uri to find an existing connection
-	 * @param purpose purpose for the connection
 	 */
 	public getOriginalOwnerUri(ownerUri: string): string {
 		let ownerUriToReturn: string = ownerUri;

--- a/src/sql/platform/connection/common/connectionStore.ts
+++ b/src/sql/platform/connection/common/connectionStore.ts
@@ -106,7 +106,7 @@ export class ConnectionStore {
 	 * Password values are stored to a separate credential store if the "savePassword" option is true
 	 *
 	 * @param profile the profile to save
-	 * @param whether the plaintext password should be written to the settings file
+	 * @param forceWritePlaintextPassword whether the plaintext password should be written to the settings file
 	 * @returns a Promise that returns the original profile, for help in chaining calls
 	 */
 	public async saveProfile(profile: IConnectionProfile, forceWritePlaintextPassword?: boolean, matcher?: ProfileMatcher): Promise<IConnectionProfile> {
@@ -192,7 +192,6 @@ export class ConnectionStore {
 	 * Password values are stored to a separate credential store if the "savePassword" option is true
 	 *
 	 * @param conn the connection to add
-	 * @param addToMru Whether to add this connection to the MRU
 	 * @returns a Promise that returns when the connection was saved
 	 */
 	public addRecentConnection(conn: IConnectionProfile): Promise<void> {

--- a/src/sql/platform/telemetry/common/adsTelemetryService.ts
+++ b/src/sql/platform/telemetry/common/adsTelemetryService.ts
@@ -157,7 +157,8 @@ export class AdsTelemetryService implements IAdsTelemetryService {
 
 	/**
 	 * Sends a Metrics event. This is used to log measurements taken.
-	 * @param measurements The metrics to send
+	 * @param metrics The metrics to send
+	 * @param groupName The name of the group these metrics belong to
 	 */
 	public sendMetricsEvent(metrics: ITelemetryEventMeasures, groupName: string = ''): void {
 		this.createMetricsEvent(metrics, groupName).send();
@@ -169,7 +170,6 @@ export class AdsTelemetryService implements IAdsTelemetryService {
 	 * @param name The friendly name of the error
 	 * @param errorCode The error code returned
 	 * @param errorType The specific type of error
-	 * @param properties Optional additional properties
 	 */
 	public createErrorEvent(view: string, name: string, errorCode: string = '', errorType: string = ''): ITelemetryEvent {
 		return new TelemetryEventImpl(this.telemetryService, this.logService, EventName.Error, {

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -172,6 +172,13 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Constructor for modal
 	 * @param _title Title of the modal, if undefined, the title section is not rendered
 	 * @param _name Name of the modal, used for telemetry
+	 * @param _telemetryService
+	 * @param layoutService
+	 * @param _clipboardService
+	 * @param _themeService
+	 * @param logService
+	 * @param textResourcePropertiesService
+	 * @param _contextKeyService
 	 * @param options Modal options
 	 */
 	constructor(
@@ -530,7 +537,6 @@ export abstract class Modal extends Disposable implements IThemable {
 	/**
 	 * Returns a footer button matching the provided label
 	 * @param label Label to show on the button
-	 * @param onSelect The callback to call when the button is selected
 	 */
 	protected findFooterButton(label: string): Button | undefined {
 		return this._footerButtons.find(e => {

--- a/src/sql/workbench/browser/taskUtilities.ts
+++ b/src/sql/workbench/browser/taskUtilities.ts
@@ -14,6 +14,9 @@ import { DashboardInput } from 'sql/workbench/browser/editor/profiler/dashboardI
  * is focused or there is no such editor, in which case it comes from the OE selection. Returns
  * undefined when there is no such connection.
  *
+ * @param objectExplorerService
+ * @param connectionManagementService
+ * @param workbenchEditorService
  * @param topLevelOnly If true, only return top-level (i.e. connected) Object Explorer connections instead of database connections when appropriate
 */
 export function getCurrentGlobalConnection(objectExplorerService: IObjectExplorerService, connectionManagementService: IConnectionManagementService, workbenchEditorService: IEditorService, topLevelOnly: boolean = false): IConnectionProfile | undefined {

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper.ts
@@ -93,7 +93,6 @@ export function initExtensionConfigs(configurations: WidgetConfig[]): Array<Widg
 
 /**
  * Add provider to the passed widgets and returns the new widgets
- * @param widgets Array of widgets to add provider onto
  */
 export function addProvider<T extends { connectionManagementService: SingleConnectionManagementService }>(config: WidgetConfig[], collection: T): Array<WidgetConfig> {
 	const provider = collection.connectionManagementService.connectionInfo.providerId;
@@ -107,7 +106,6 @@ export function addProvider<T extends { connectionManagementService: SingleConne
 
 /**
  * Adds the edition to the passed widgets and returns the new widgets
- * @param widgets Array of widgets to add edition onto
  */
 export function addEdition<T extends { connectionManagementService: SingleConnectionManagementService }>(config: WidgetConfig[], collection: T): Array<WidgetConfig> {
 	const connectionInfo: ConnectionManagementInfo = collection.connectionManagementService.connectionInfo;
@@ -126,7 +124,6 @@ export function addEdition<T extends { connectionManagementService: SingleConnec
 
 /**
  * Adds the context to the passed widgets and returns the new widgets
- * @param widgets Array of widgets to add context to
  */
 export function addContext(config: WidgetConfig[], collection: any, context: string): Array<WidgetConfig> {
 	return config.map((item) => {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -349,7 +349,6 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 
 	/**
 	 * Instantiate modal for use as callout when inserting Link or Image into markdown.
-	 * @param calloutStyle Style of callout passed in to determine which callout is rendered.
 	 * Returns markup created after user enters values and submits the callout.
 	 */
 	private async createCallout(type: MarkdownButtonType, triggerElement: HTMLElement): Promise<ILinkCalloutDialogOptions> {

--- a/src/sql/workbench/contrib/notebook/browser/markdownToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/markdownToolbarActions.ts
@@ -173,6 +173,7 @@ export class MarkdownTextTransformer {
 	 * @param endRange range for end text that was inserted
 	 * @param type MarkdownButtonType
 	 * @param editorControl code editor widget
+	 * @param editorModel
 	 * @param noSelection controls whether there was no previous selection in the editor
 	 */
 	private setEndSelection(endRange: IRange, type: MarkdownButtonType, editorControl: CodeEditorWidget, editorModel: TextModel, noSelection: boolean, isUndo: boolean): void {

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -362,6 +362,7 @@ export class RunQueryShortcutAction extends Action {
 	 * Runs one of the optionally registered query shortcuts. This will lookup the shortcut's stored procedure
 	 * reference from the settings, and if found will execute it plus any
 	 *
+	 * @param editor
 	 * @param shortcutIndex which shortcut should be run?
 	 */
 	public runQueryShortcut(editor: QueryEditor, shortcutIndex: number): Thenable<void> {

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -207,6 +207,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	/**
 	 * Opens the connection dialog
 	 * @param params Include the uri, type of connection
+	 * @param options
 	 * @param model the existing connection profile to create a new one from
 	 */
 	public showConnectionDialog(params?: INewConnectionParams, options?: IConnectionCompletionOptions, model?: Partial<interfaces.IConnectionProfile>, connectionResult?: IConnectionResult): Promise<void> {
@@ -287,7 +288,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 	/**
 	 * Loads the  password and try to connect. If fails, shows the dialog so user can change the connection
-	 * @param Connection Profile
+	 * @param connection Profile
 	 * @param owner of the connection. Can be the editors
 	 * @param options to use after the connection is complete
 	 */
@@ -361,7 +362,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 	/**
 	 * Load the password and opens a new connection
-	 * @param Connection Profile
+	 * @param connection Profile
 	 * @param uri assigned to the profile (used only when connecting from an editor)
 	 * @param options to be used after the connection is completed
 	 * @param callbacks to call after the connection is completed
@@ -761,7 +762,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 *
 	 * @param uri the URI of the resource whose language has changed
 	 * @param language the base language
-	 * @param flavor the specific language flavor that's been set
+	 * @param provider
 	 * @throws {Error} if the provider is not in the list of registered providers
 	 */
 	public doChangeLanguageFlavor(uri: string, language: string, provider: string): void {

--- a/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
@@ -92,6 +92,12 @@ export class TreeSelectionHandler {
 
 	/**
 	 *
+	 * @param connectionManagementService
+	 * @param objectExplorerService
+	 * @param isDoubleClick
+	 * @param isKeyboard
+	 * @param selection
+	 * @param tree
 	 * @param connectionCompleteCallback A function that gets called after a connection is established due to the selection, if needed
 	 */
 	private handleTreeItemSelected(connectionManagementService: IConnectionManagementService, objectExplorerService: IObjectExplorerService, isDoubleClick: boolean, isKeyboard: boolean, selection: any[], tree: AsyncServerTree | ITree, connectionCompleteCallback: () => void): void {

--- a/src/sql/workbench/services/query/common/dataService.ts
+++ b/src/sql/workbench/services/query/common/dataService.ts
@@ -135,9 +135,6 @@ export class DataService {
 
 	/**
 	 * send request to save the selected result set as csv
-	 * @param uri of the calling document
-	 * @param batchId The batch id of the batch with the result to save
-	 * @param resultId The id of the result to save as csv
 	 */
 	sendSaveRequest(saveRequest: ISaveRequest): void {
 		let serializer = this._instantiationService.createInstance(ResultSerializer);

--- a/src/sql/workbench/test/electron-browser/api/extHostModelView.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostModelView.test.ts
@@ -446,6 +446,7 @@ suite('ExtHostModelView Validation Tests', () => {
  * Helper function that creates a simple declarative table. Supports just a single column
  * of data.
  * @param modelView The ModelView used to create the component
+ * @param dataType
  * @param data The rows of data
  */
 function createDeclarativeTable(modelView: azdata.ModelView, dataType: DeclarativeDataType, data?: any[]): azdata.DeclarativeTableComponent {


### PR DESCRIPTION
Trying to reduce the amount of stuff that often gets called out in PRs

https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-param-names

`Ensures that parameter names in JSDoc match those in the function declaration.`

Not enabling this for all core code since a ton of the VS Code stuff fails this check currently.

Will be following up with other rules, such as https://github.com/gajus/eslint-plugin-jsdoc#require-param to require that all params are included (this rule just checks that if they are declared they actually exist in the function)