### PR TITLE
Notebooks: Add telemetry event for mime type renderer not found

### DIFF
--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -99,7 +99,8 @@ export const enum NbTelemetryAction {
 	KernelChanged = 'KernelChanged',
 	NewNotebookFromConnections = 'NewNotebookWithConnectionProfile',
 	UndoCell = 'UndoCell',
-	RedoCell = 'RedoCell'
+	RedoCell = 'RedoCell',
+	MIMETypeRendererNotFound = 'MIMETypeRendererNotFound'
 }
 
 export const enum TelemetryPropertyName {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
@@ -23,6 +23,7 @@ import { getErrorMessage } from 'vs/base/common/errors';
 import { CellView, findHighlightClass, findRangeSpecificClass } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
 import { INotebookService, NotebookRange } from 'sql/workbench/services/notebook/browser/notebookService';
 import { NotebookInput } from 'sql/workbench/contrib/notebook/browser/models/notebookInput';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 
 export const OUTPUT_SELECTOR: string = 'output-component';
 const USER_SELECT_CLASS = 'actionselect';
@@ -152,10 +153,11 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 		);
 		this.errorText = undefined;
 		if (!mimeType) {
+			const mimeTypesWithoutRenderer = Object.keys(options.data);
 			this.errorText = localize('noMimeTypeFound', "No {0}renderer could be found for output. It has the following MIME types: {1}",
 				options.trusted ? '' : localize('safe', "safe "),
-				Object.keys(options.data).join(', '));
-			return;
+				mimeTypesWithoutRenderer.join(', '));
+			this.cellModel?.notebookModel?.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.MIMETypeRendererNotFound, { mime_types: mimeTypesWithoutRenderer });
 		}
 		let selector = componentRegistry.getCtorFromMimeType(mimeType);
 		if (!selector) {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
@@ -158,6 +158,7 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 				options.trusted ? '' : localize('safe', "safe "),
 				mimeTypesWithoutRenderer.join(', '));
 			this.cellModel?.notebookModel?.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.MIMETypeRendererNotFound, { mime_types: mimeTypesWithoutRenderer });
+			return;
 		}
 		let selector = componentRegistry.getCtorFromMimeType(mimeType);
 		if (!selector) {


### PR DESCRIPTION
Adding a telemetry event to track when MIME renderers aren't found in notebook outputs.