### PR TITLE
Fix file links not opening in Notebooks on Mac

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -11,6 +11,7 @@ import { INotebookService } from 'sql/workbench/services/notebook/browser/notebo
 import { relative, resolve } from 'vs/base/common/path';
 import { IFileService } from 'vs/platform/files/common/files';
 import { isWeb } from 'vs/base/common/platform';
+import { FileAccess } from 'vs/base/common/network';
 
 const knownSchemes = new Set(['http', 'https', 'file', 'mailto', 'data', 'azuredatastudio', 'azuredatastudio-insiders', 'vscode', 'vscode-insiders', 'vscode-resource', 'onenote']);
 @Directive({
@@ -71,6 +72,9 @@ export class LinkHandlerDirective {
 				return;
 			}
 		}
+		// On Mac, the link href scheme is vscode-file. We want to convert the vscode-file URI to file URI
+		// so that notebooks get opened properly.
+		uri = FileAccess.asFileUri(uri);
 		if (uri && this.openerService && this.isSupportedLink(uri)) {
 			if (uri.fragment && uri.fragment.length > 0 && uri.fsPath === this.workbenchFilePath.fsPath) {
 				this.notebookService.navigateTo(this.notebookUri, uri.fragment);

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -72,8 +72,7 @@ export class LinkHandlerDirective {
 				return;
 			}
 		}
-		// On Mac, the link href scheme is vscode-file. We want to convert the vscode-file URI to file URI
-		// so that notebooks get opened properly.
+		// Convert vscode-file protocol URIs to file since that's what Notebooks expect to work with
 		uri = FileAccess.asFileUri(uri);
 		if (uri && this.openerService && this.isSupportedLink(uri)) {
 			if (uri.fragment && uri.fragment.length > 0 && uri.fsPath === this.workbenchFilePath.fsPath) {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -72,29 +72,31 @@ export class LinkHandlerDirective {
 				return;
 			}
 		}
-		// Convert vscode-file protocol URIs to file since that's what Notebooks expect to work with
-		uri = FileAccess.asFileUri(uri);
-		if (uri && this.openerService && this.isSupportedLink(uri)) {
-			if (uri.fragment && uri.fragment.length > 0 && uri.fsPath === this.workbenchFilePath.fsPath) {
-				this.notebookService.navigateTo(this.notebookUri, uri.fragment);
-			} else {
-				if (uri.scheme === 'file') {
-					let exists = await this.fileService.exists(uri);
-					if (!exists) {
-						let relPath = relative(this.workbenchFilePath.fsPath, uri.fsPath);
-						let path = resolve(this.notebookUri.fsPath, relPath);
-						try {
-							uri = URI.file(path);
-						} catch (error) {
-							onUnexpectedError(error);
+		if (uri && this.openerService) {
+			// Convert vscode-file protocol URIs to file since that's what Notebooks expect to work with
+			uri = FileAccess.asFileUri(uri);
+			if (this.isSupportedLink(uri)) {
+				if (uri.fragment && uri.fragment.length > 0 && uri.fsPath === this.workbenchFilePath.fsPath) {
+					this.notebookService.navigateTo(this.notebookUri, uri.fragment);
+				} else {
+					if (uri.scheme === 'file') {
+						let exists = await this.fileService.exists(uri);
+						if (!exists) {
+							let relPath = relative(this.workbenchFilePath.fsPath, uri.fsPath);
+							let path = resolve(this.notebookUri.fsPath, relPath);
+							try {
+								uri = URI.file(path);
+							} catch (error) {
+								onUnexpectedError(error);
+							}
 						}
 					}
-				}
-				if (this.forceOpenExternal(uri)) {
-					this.openerService.open(uri, { openExternal: true }).catch(onUnexpectedError);
-				}
-				else {
-					this.openerService.open(uri, { allowCommands: true }).catch(onUnexpectedError);
+					if (this.forceOpenExternal(uri)) {
+						this.openerService.open(uri, { openExternal: true }).catch(onUnexpectedError);
+					}
+					else {
+						this.openerService.open(uri, { allowCommands: true }).catch(onUnexpectedError);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/18021

The fix is similar to the fix for images not working https://github.com/microsoft/azuredatastudio/pull/18160.
We need to convert the vscode-file URI to file URI when opening. It is still not clear to me why the URI is vscode-file only on Mac and not Windows.