### PR TITLE
vbumping sts to get latest execution plan changes

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.184",
+	"version": "3.0.0-release.192",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
These commits will also come with the vbump
![msedge_xPdnNAQKr7](https://user-images.githubusercontent.com/6816294/152246435-2ab7fc07-86d3-4199-aeb2-ab2118458b07.png)

@smartguest , does it look okay? 