### PR TITLE
fix SDK style projects not being able to find system dacpacs

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -802,7 +802,8 @@ export class Project implements ISqlProject {
 
 	public getSystemDacpacUri(dacpac: string): Uri {
 		const versionFolder = this.getSystemDacpacFolderName();
-		return Uri.parse(path.join('$(NETCoreTargetsPath)', 'SystemDacpacs', versionFolder, dacpac));
+		const systemDacpacLocation = this.isSdkStyleProject ? '$(SystemDacpacsLocation)' : '$(NETCoreTargetsPath)';
+		return Uri.parse(path.join(systemDacpacLocation, 'SystemDacpacs', versionFolder, dacpac));
 	}
 
 	public getSystemDacpacSsdtUri(dacpac: string): Uri {

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -83,8 +83,12 @@ export class BuildHelper {
 	public constructBuildArguments(projectPath: string, buildDirPath: string, isSdkStyleProject: boolean): string {
 		projectPath = utils.getQuotedPath(projectPath);
 		buildDirPath = utils.getQuotedPath(buildDirPath);
+
+		// Right now SystemDacpacsLocation and NETCoreTargetsPath get set to the same thing, but separating them out for if we move
+		// the system dacpacs somewhere else and also so that the variable name makes more sense if building from the commandline,
+		// since SDK style projects don't to specify the targets path, just where the system dacpacs are
 		if (isSdkStyleProject) {
-			return ` build ${projectPath} /p:NetCoreBuild=true`;
+			return ` build ${projectPath} /p:NetCoreBuild=true /p:SystemDacpacsLocation=${buildDirPath}`;
 		} else {
 			return ` build ${projectPath} /p:NetCoreBuild=true /p:NETCoreTargetsPath=${buildDirPath}`;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/18040 so system dacpac references aren't broken while we figure out if system dacpacs can be included in the SDK. This changes the name of the variable for the location of system dacpacs for SDK projects (NETCoreTargetsPath didn't really make sense since the path is only being used for the system dacpacs) and updates the build command to pass in the location for this new variable.


