### PR TITLE
Fix query editor diff compare

### DIFF
--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -530,7 +530,10 @@ export class QueryEditorOverrideContribution extends Disposable implements IWork
 					label: QueryEditor.LABEL,
 					priority: RegisteredEditorPriority.builtin
 				},
-				{},
+				{
+					// Fall back to using the normal text based diff editor - we don't want the query bar and related items showing up in the diff editor
+					canHandleDiff: () => false
+				},
 				(editorInput, group) => {
 					const fileInput = this._editorService.createEditorInput(editorInput) as FileEditorInput;
 					const langAssociation = languageAssociationRegistry.getAssociationForLanguage(lang);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/18049

Fall back to the default text diff editor for SQL files.

![image](https://user-images.githubusercontent.com/28519865/152587476-684ceb66-88e2-4919-9cab-6a9ffadf612a.png)
