### PR TITLE
Fix drag and drop for columns

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -23,8 +23,8 @@ export function supportsNodeNameDrop(nodeId: string): boolean {
 
 /**
  * Whether the specified node supports having a schema
- * @param node
- * @returns
+ * @param node The node being dragged
+ * @returns True if the node supports having the schema appended to its name, false if not
  */
 function supportsSchema(node: TreeNode): boolean {
 	// Currently the tree node created by SQL Tools Service will set the schema for a node to the schema

--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -21,6 +21,19 @@ export function supportsNodeNameDrop(nodeId: string): boolean {
 	return false;
 }
 
+/**
+ * Whether the specified node supports having a schema
+ * @param node
+ * @returns
+ */
+function supportsSchema(node: TreeNode): boolean {
+	// Currently the tree node created by SQL Tools Service will set the schema for a node to the schema
+	// of its parent node if it doesn't have one itself. While it's not clear why this is being done
+	// changing it at this point would be risky so instead just doing a check here so that we don't
+	// accidently put a schema on an element that doesn't support it
+	return node.nodeTypeId === 'Column' ? false : true;
+}
+
 export function supportsFolderNodeNameDrop(nodeId: string, label: string): boolean {
 	if (nodeId === 'Folder' && label === 'Columns') {
 		return true;
@@ -95,9 +108,9 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 		let escapedSchema, escapedName, finalString;
 		TreeUpdateUtils.isInDragAndDrop = true;
 		const data = dragAndDropData.getData();
-		const element = data[0];
+		const element = data[0] as TreeNode;
 		if (supportsNodeNameDrop(element.nodeTypeId)) {
-			escapedSchema = escapeString(element.metadata.schema);
+			escapedSchema = supportsSchema(element) ? escapeString(element.metadata.schema) : undefined;
 			escapedName = escapeString(element.metadata.name);
 			let providerName = this.getProviderNameFromElement(element);
 			if (providerName === 'KUSTO') {
@@ -116,7 +129,7 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 			let returnString = '';
 			let providerName = this.getProviderNameFromElement(element);
 			for (let child of element.children) {
-				escapedSchema = escapeString(child.metadata.schema);
+				escapedSchema = supportsSchema(child) ? escapeString(child.metadata.schema) : undefined;
 				escapedName = escapeString(child.metadata.name);
 				if (providerName === mssqlProviderName) {
 					finalString = escapedSchema ? `[${escapedSchema}].[${escapedName}]` : `[${escapedName}]`;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/18004

The root issue is that STS is for some reason setting the schema of a node to the schema of its parent if it doesn't have a schema itself : 

https://github.com/microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNode.cs#L86

So for columns (which don't belong directly to a schema themselves) we were seeing that it had a schema in the metadata and adding that.

Doing the check here isn't my favorite option - but I'm worried that if I change the behavior in STS that it'll break other things so probably best to leave it alone for now unless we find other places that are broken by this. 