### PR TITLE
Fix export results default save location

### DIFF
--- a/src/sql/platform/common/pathUtilities.ts
+++ b/src/sql/platform/common/pathUtilities.ts
@@ -9,14 +9,12 @@ import { URI } from 'vs/base/common/uri';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { Schemas } from 'vs/base/common/network';
 
-export const FILE_SCHEMA: string = 'file';
-
 export function resolveCurrentDirectory(uri: string, rootPath?: string): string | undefined {
 	let sqlUri = URI.parse(uri);
 	let currentDirectory: string | undefined;
 
 	// use current directory of the sql file if sql file is saved
-	if (sqlUri.scheme === FILE_SCHEMA) {
+	if (sqlUri.scheme === Schemas.file) {
 		currentDirectory = dirname(sqlUri.fsPath);
 	} else if (sqlUri.scheme === Schemas.untitled) {
 		// if sql file is unsaved/untitled but a workspace is open use workspace root

--- a/src/sql/workbench/services/query/common/resultSerializer.ts
+++ b/src/sql/workbench/services/query/common/resultSerializer.ts
@@ -107,9 +107,7 @@ export class ResultSerializer {
 			// then fall back to the system default
 			filepathPlaceHolder = (await this.fileDialogService.defaultFilePath(Schemas.file)).fsPath;
 		}
-		if (filepathPlaceHolder) {
-			filepathPlaceHolder = path.join(filepathPlaceHolder, this.getResultsDefaultFilename(format));
-		}
+		filepathPlaceHolder = path.join(filepathPlaceHolder, this.getResultsDefaultFilename(format));
 		const fileUri = await this.fileDialogService.showSaveDialog({
 			title: nls.localize('resultsSerializer.saveAsFileTitle', "Choose Results File"),
 			defaultUri: filepathPlaceHolder ? URI.file(filepathPlaceHolder) : undefined,

--- a/src/sql/workbench/services/query/common/resultSerializer.ts
+++ b/src/sql/workbench/services/query/common/resultSerializer.ts
@@ -19,6 +19,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IFileDialogService, FileFilter } from 'vs/platform/dialogs/common/dialogs';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
+import { Schemas } from 'vs/base/common/network';
 
 let prevSavePath: URI;
 
@@ -99,23 +100,25 @@ export class ResultSerializer {
 		return getRootPath(this._contextService);
 	}
 
-	private promptForFilepath(format: SaveFormat, resourceUri: string): Promise<URI | undefined> {
+	private async promptForFilepath(format: SaveFormat, resourceUri: string): Promise<URI | undefined> {
 		let filepathPlaceHolder = prevSavePath ? path.dirname(prevSavePath.fsPath) : resolveCurrentDirectory(resourceUri, this.rootPath);
+		if (!filepathPlaceHolder) {
+			// If we haven't saved previously and there isn't a file path associated with this resource (e.g. for untitled files)
+			// then fall back to the system default
+			filepathPlaceHolder = (await this.fileDialogService.defaultFilePath(Schemas.file)).fsPath;
+		}
 		if (filepathPlaceHolder) {
 			filepathPlaceHolder = path.join(filepathPlaceHolder, this.getResultsDefaultFilename(format));
 		}
-
-		return this.fileDialogService.showSaveDialog({
+		const fileUri = await this.fileDialogService.showSaveDialog({
 			title: nls.localize('resultsSerializer.saveAsFileTitle', "Choose Results File"),
 			defaultUri: filepathPlaceHolder ? URI.file(filepathPlaceHolder) : undefined,
 			filters: this.getResultsFileExtension(format)
-		}).then(filePath => {
-			if (filePath) {
-				prevSavePath = filePath;
-				return filePath;
-			}
-			return undefined;
 		});
+		if (fileUri) {
+			prevSavePath = fileUri;
+		}
+		return fileUri;
 	}
 
 	private getResultsDefaultFilename(format: SaveFormat): string {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/18115

For untitled files if we haven't previously saved something then the default file path was undefined since there wasn't a location for the resource. In that case we fall back to the system default so we always have a save location to then set the default save name for. 

(this also applies to query editor result grids as well)

I also did some cleanup with a duplicate schema name var. 