### PR TITLE
Arc and Azure CLI extensions GA + bug fix for SQL MIAA update

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -4,7 +4,7 @@
   "description": "%arc.description%",
   "version": "0.11.0",
   "publisher": "Microsoft",
-  "preview": true,
+  "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,9 +2,8 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publisher": "Microsoft",
-  "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -13,7 +13,7 @@
 	"command.estimateCostSqlMiaa.title": "Estimate Cost of SQL Managed Instance - Azure Arc",
 	"arc.openDashboard": "Manage",
 
-	"resource.type.azure.arc.display.name": "Azure Arc data controller (preview)",
+	"resource.type.azure.arc.display.name": "Azure Arc data controller",
 	"resource.type.azure.arc.description": "Creates an Azure Arc data controller",
 	"arc.data.controller.new.wizard.title": "Create Azure Arc data controller",
 	"arc.data.controller.cluster.environment.title": "What is your target existing Kubernetes cluster environment?",

--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -8,9 +8,9 @@ import { getErrorMessage } from './common/utils';
 const localize = nls.loadMessageBundle();
 
 export const arcDeploymentDeprecation = localize('arc.arcDeploymentDeprecation', "The Arc Deployment extension has been replaced by the Arc extension and has been uninstalled.");
-export function arcControllerDashboard(name: string): string { return localize('arc.controllerDashboard', "Azure Arc Data Controller Dashboard (Preview) - {0}", name); }
-export function miaaDashboard(name: string): string { return localize('arc.miaaDashboard', "SQL managed instance - Azure Arc Dashboard (Preview) - {0}", name); }
-export function postgresDashboard(name: string): string { return localize('arc.postgresDashboard', "PostgreSQL Hyperscale - Azure Arc Dashboard (Preview) - {0}", name); }
+export function arcControllerDashboard(name: string): string { return localize('arc.controllerDashboard', "Azure Arc Data Controller Dashboard - {0}", name); }
+export function miaaDashboard(name: string): string { return localize('arc.miaaDashboard', "SQL managed instance - Azure Arc Dashboard - {0}", name); }
+export function postgresDashboard(name: string): string { return localize('arc.postgresDashboard', "PostgreSQL Hyperscale - Azure Arc Dashboard - {0}", name); }
 
 export const dataControllersType = localize('arc.dataControllersType', "Azure Arc Data Controller");
 export const pgSqlType = localize('arc.pgSqlType', "PostgreSQL Hyperscale - Azure Arc");

--- a/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as azExt from 'az-ext';
 import * as loc from '../../../localizedConstants';
-import { IconPathHelper, cssStyles } from '../../../constants';
+import { IconPathHelper, cssStyles, ConnectionMode } from '../../../constants';
 import { DashboardPage } from '../../components/dashboardPage';
 import { MiaaModel, RPModel, DatabaseModel, systemDbs } from '../../../models/miaaModel';
 import { ControllerModel } from '../../../models/controllerModel';
@@ -220,9 +220,23 @@ export class MiaaBackupsPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token): Promise<void> => {
-								await this._azApi.az.sql.miarc.edit(
-									this._miaaModel.info.name, this._saveArgs, this._miaaModel.controllerModel.info.namespace, this._miaaModel.controllerModel.azAdditionalEnvVars);
-
+								if (this._miaaModel.controllerModel.info.connectionMode === ConnectionMode.direct) {
+									await this._azApi.az.sql.miarc.update(
+										this._miaaModel.info.name,
+										this._saveArgs,
+										this._miaaModel.controllerModel.info.resourceGroup,
+										undefined, // Indirect mode argument - namespace
+										undefined, // Indirect mode argument - usek8s
+										this._miaaModel.controllerModel.azAdditionalEnvVars);
+								} else {
+									await this._azApi.az.sql.miarc.update(
+										this._miaaModel.info.name,
+										this._saveArgs,
+										undefined, // Direct mode argument - resourceGroup
+										this._miaaModel.controllerModel.info.namespace,
+										true,
+										this._miaaModel.controllerModel.azAdditionalEnvVars);
+								}
 								try {
 									await this._miaaModel.refresh();
 								} catch (error) {

--- a/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as azExt from 'az-ext';
 import * as loc from '../../../localizedConstants';
-import { IconPathHelper, cssStyles } from '../../../constants';
+import { IconPathHelper, cssStyles, ConnectionMode } from '../../../constants';
 import { DashboardPage } from '../../components/dashboardPage';
 import { convertToGibibyteString } from '../../../common/utils';
 import { MiaaModel } from '../../../models/miaaModel';
@@ -130,8 +130,23 @@ export class MiaaComputeAndStoragePage extends DashboardPage {
 						},
 						async (_progress, _token): Promise<void> => {
 							try {
-								await this._azApi.az.sql.miarc.edit(
-									this._miaaModel.info.name, this.saveArgs, this._miaaModel.controllerModel.info.namespace, this._miaaModel.controllerModel.azAdditionalEnvVars);
+								if (this._miaaModel.controllerModel.info.connectionMode === ConnectionMode.direct) {
+									await this._azApi.az.sql.miarc.update(
+										this._miaaModel.info.name,
+										this.saveArgs,
+										this._miaaModel.controllerModel.info.resourceGroup,
+										undefined, // Indirect mode argument - namespace
+										undefined, // Indirect mode argument - usek8s
+										this._miaaModel.controllerModel.azAdditionalEnvVars);
+								} else {
+									await this._azApi.az.sql.miarc.update(
+										this._miaaModel.info.name,
+										this.saveArgs,
+										undefined, // Direct mode argument - resourceGroup
+										this._miaaModel.controllerModel.info.namespace,
+										true,
+										this._miaaModel.controllerModel.azAdditionalEnvVars);
+								}
 							} catch (err) {
 								this.saveButton!.enabled = true;
 								throw err;

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -2,9 +2,8 @@
   "name": "azcli",
   "displayName": "%azcli.arc.displayName%",
   "description": "%azcli.arc.description%",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "Microsoft",
-  "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -4,7 +4,7 @@
   "description": "%azcli.arc.description%",
   "version": "0.3.0",
   "publisher": "Microsoft",
-  "preview": true,
+  "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {

--- a/extensions/azcli/src/api.ts
+++ b/extensions/azcli/src/api.ts
@@ -116,7 +116,7 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 					validateAz(azToolService.localAz);
 					return azToolService.localAz!.sql.miarc.show(name, namespace, additionalEnvVars);
 				},
-				edit: async (
+				update: async (
 					name: string,
 					args: {
 						coresLimit?: string;
@@ -130,7 +130,7 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 				) => {
 					await localAzDiscovered;
 					validateAz(azToolService.localAz);
-					return azToolService.localAz!.sql.miarc.edit(name, args, namespace, additionalEnvVars);
+					return azToolService.localAz!.sql.miarc.update(name, args, namespace, additionalEnvVars);
 				}
 			},
 			midbarc: {

--- a/extensions/azcli/src/api.ts
+++ b/extensions/azcli/src/api.ts
@@ -125,12 +125,17 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 						memoryRequest?: string;
 						noWait?: boolean;
 					},
-					namespace: string,
+					// Direct mode arguments
+					resourceGroup?: string,
+					// Indirect mode arguments
+					namespace?: string,
+					usek8s?: boolean,
+					// Additional arguments
 					additionalEnvVars?: azExt.AdditionalEnvVars
 				) => {
 					await localAzDiscovered;
 					validateAz(azToolService.localAz);
-					return azToolService.localAz!.sql.miarc.update(name, args, namespace, additionalEnvVars);
+					return azToolService.localAz!.sql.miarc.update(name, args, resourceGroup, namespace, usek8s, additionalEnvVars);
 				}
 			},
 			midbarc: {

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -164,16 +164,24 @@ export class AzTool implements azExt.IAzApi {
 					noWait?: boolean,
 					retentionDays?: string
 				},
-				namespace: string,
+				// Direct mode arguments
+				resourceGroup?: string,
+				// Indirect mode arguments
+				namespace?: string,
+				usek8s?: boolean,
+				// Additional arguments
 				additionalEnvVars?: azExt.AdditionalEnvVars
 			): Promise<azExt.AzOutput<void>> => {
-				const argsArray = ['sql', 'mi-arc', 'update', '-n', name, '--k8s-namespace', namespace, '--use-k8s'];
+				const argsArray = ['sql', 'mi-arc', 'update', '-n', name];
 				if (args.coresLimit) { argsArray.push('--cores-limit', args.coresLimit); }
 				if (args.coresRequest) { argsArray.push('--cores-request', args.coresRequest); }
 				if (args.memoryLimit) { argsArray.push('--memory-limit', args.memoryLimit); }
 				if (args.memoryRequest) { argsArray.push('--memory-request', args.memoryRequest); }
 				if (args.noWait) { argsArray.push('--no-wait'); }
 				if (args.retentionDays) { argsArray.push('--retention-days', args.retentionDays); }
+				if (resourceGroup) { argsArray.push('--resource-group', resourceGroup); }
+				if (namespace) { argsArray.push('--k8s-namespace', namespace); }
+				if (usek8s) { argsArray.push('--use-k8s'); }
 				return this.executeCommand<void>(argsArray, additionalEnvVars);
 			}
 		},

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -154,7 +154,7 @@ export class AzTool implements azExt.IAzApi {
 			show: (name: string, namespace: string, additionalEnvVars?: azExt.AdditionalEnvVars): Promise<azExt.AzOutput<azExt.SqlMiShowResult>> => {
 				return this.executeCommand<azExt.SqlMiShowResult>(['sql', 'mi-arc', 'show', '-n', name, '--k8s-namespace', namespace, '--use-k8s'], additionalEnvVars);
 			},
-			edit: (
+			update: (
 				name: string,
 				args: {
 					coresLimit?: string,
@@ -167,7 +167,7 @@ export class AzTool implements azExt.IAzApi {
 				namespace: string,
 				additionalEnvVars?: azExt.AdditionalEnvVars
 			): Promise<azExt.AzOutput<void>> => {
-				const argsArray = ['sql', 'mi-arc', 'edit', '-n', name, '--k8s-namespace', namespace, '--use-k8s'];
+				const argsArray = ['sql', 'mi-arc', 'update', '-n', name, '--k8s-namespace', namespace, '--use-k8s'];
 				if (args.coresLimit) { argsArray.push('--cores-limit', args.coresLimit); }
 				if (args.coresRequest) { argsArray.push('--cores-request', args.coresRequest); }
 				if (args.memoryLimit) { argsArray.push('--memory-limit', args.memoryLimit); }

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -338,7 +338,12 @@ declare module 'az-ext' {
 						noWait?: boolean, //true
 						retentionDays?: string, //5
 					},
+					// Direct mode arguments
+					resourceGroup?: string,
+					// Indirect mode arguments
 					namespace?: string,
+					usek8s?: boolean,
+					// Additional arguments
 					additionalEnvVars?: AdditionalEnvVars
 				): Promise<AzOutput<void>>
 			},

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -328,7 +328,7 @@ declare module 'az-ext' {
 				delete(name: string, namespace?: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzOutput<void>>,
 				list(namespace?: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzOutput<SqlMiListResult[]>>,
 				show(name: string, namespace?: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzOutput<SqlMiShowResult>>,
-				edit(
+				update(
 					name: string,
 					args: {
 						coresLimit?: string, //2


### PR DESCRIPTION
- Releasing the arc and azcli extensions out of preview and into GA.
- Updated the az command "edit" to be "update", in line with new Azure CLI arcdata extension commands
- Azure CLI arcdata SQL MIAA update now works for both direct and indirect modes (bug fix)
- Azure CLI arcdata SQL MIAA backup now works for both direct and indirect modes (bug fix)