### PR TITLE
check for encoded components

### DIFF
--- a/src/sql/base/common/network.ts
+++ b/src/sql/base/common/network.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+* Checks if the specified URL is already URI-encoded by checking if there are any unencoded reserved URI component characters
+* (such as ?, =, &, /, etc.) in the URL. See https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent for more details.
+* @returns true if the URL contains encoded URI component reserved characters
+*/
+export function containsEncodedUriComponentReservedCharacters(url: string): boolean {
+	// ie ?,=,&,/ etc
+	return (decodeURI(url) !== decodeURIComponent(url));
+}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -28,6 +28,7 @@ import { NotebookLinkHandler } from 'sql/workbench/contrib/notebook/browser/note
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { FileAccess } from 'vs/base/common/network';
+import { getEncodedLinkUrl } from 'sql/workbench/contrib/notebook/browser/utils';
 
 export const MARKDOWN_TOOLBAR_SELECTOR: string = 'markdown-toolbar-component';
 const linksRegex = /\[(?<text>.+)\]\((?<url>[^ ]+)(?: "(?<title>.+)")?\)/;
@@ -278,8 +279,8 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
 				// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-				let encodedLinkURL = notebookLink.getEncodedLinkUrl(linkUrl);
-				document.execCommand('insertHTML', false, `<a href="${encodedLinkURL}" title="${encodedLinkURL}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
+				let encodedLinkURL = getEncodedLinkUrl(linkUrl);
+				document.execCommand('insertHTML', false, `<a href="${encodedLinkURL}" title="${linkUrl}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}
 		} else if (type === MarkdownButtonType.IMAGE_PREVIEW) {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -28,7 +28,6 @@ import { NotebookLinkHandler } from 'sql/workbench/contrib/notebook/browser/note
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { FileAccess } from 'vs/base/common/network';
-import { getEncodedLinkUrl } from 'sql/workbench/contrib/notebook/browser/utils';
 
 export const MARKDOWN_TOOLBAR_SELECTOR: string = 'markdown-toolbar-component';
 const linksRegex = /\[(?<text>.+)\]\((?<url>[^ ]+)(?: "(?<title>.+)")?\)/;
@@ -279,7 +278,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
 				// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-				let encodedLinkURL = getEncodedLinkUrl(linkUrl);
+				let encodedLinkURL = notebookLink.getEncodedLinkUrl();
 				document.execCommand('insertHTML', false, `<a href="${encodedLinkURL}" title="${linkUrl}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -278,7 +278,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
 				// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-				let encodedLinkURL = encodeURI(linkUrl);
+				let encodedLinkURL = notebookLink.getEncodedLinkUrl(linkUrl);
 				document.execCommand('insertHTML', false, `<a href="${encodedLinkURL}" title="${encodedLinkURL}" is-encoded="true" is-absolute=${notebookLink.isAbsolutePath}>${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -118,6 +118,20 @@ export class NotebookLinkHandler {
 		}
 	}
 
+	public getEncodedLinkUrl(linkUrl: string): string {
+		// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
+		// skip encoding it if it's already encoded
+		if (!this.containsEncodedComponents(linkUrl)) {
+			return encodeURI(linkUrl);
+		}
+		return linkUrl;
+	}
+
+	public containsEncodedComponents(url) {
+		// ie ?,=,&,/ etc
+		return (decodeURI(url) !== decodeURIComponent(url));
+	}
+
 	/**
 	 * Creates a URI for for a link with a anchor (#)
 	 * @param node is the HTMLAnchorElement of the target notebook

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -8,6 +8,7 @@ import * as path from 'vs/base/common/path';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 import { isWindows } from 'vs/base/common/platform';
+import { containsEncodedUriComponentReservedCharacters } from 'sql/base/common/network';
 
 const useAbsolutePathConfigName = 'notebook.useAbsoluteFilePaths';
 
@@ -119,31 +120,21 @@ export class NotebookLinkHandler {
 	}
 
 	/**
-	* Function to get encoded url,
-	* checks the url if it's already encoded before encoding it
+	* Function to get encoded url, Gets the link URI-encoded link URL
+	* (https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)
 	* @returns the encoded url
 	*/
 	public getEncodedLinkUrl(): string | undefined {
-		// since we only handle strings that come from call out dialogs
 		if (typeof this._link === 'string') {
 			// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
 			// skip encoding it if it's already encoded
-			if (!this.containsEncodedComponents(this._link)) {
+			if (!containsEncodedUriComponentReservedCharacters(this._link)) {
 				return encodeURI(this._link);
 			}
 			return this._link;
 		}
+		// since we only handle strings that come from call out dialogs
 		return undefined;
-	}
-
-	/**
-	* Function to check if a string url has encoded characters
-	* space gets encoded as %20 and ;,/?:@&=+$ -> %3B%2C%2F%3F%3A%40%26%3D%2B%24
-	* @returns true if the passed in url has encoded strings:
-	*/
-	containsEncodedComponents(url): boolean {
-		// ie ?,=,&,/ etc
-		return (decodeURI(url) !== decodeURIComponent(url));
 	}
 
 	/**

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -118,10 +118,16 @@ export class NotebookLinkHandler {
 		}
 	}
 
+	/**
+	* Function to get encoded url,
+	* checks the url if it's already encoded before encoding it
+	* @returns the encoded url
+	*/
 	public getEncodedLinkUrl(): string | undefined {
-		// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-		// skip encoding it if it's already encoded
+		// since we only handle strings that come from call out dialogs
 		if (typeof this._link === 'string') {
+			// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
+			// skip encoding it if it's already encoded
 			if (!this.containsEncodedComponents(this._link)) {
 				return encodeURI(this._link);
 			}
@@ -130,8 +136,11 @@ export class NotebookLinkHandler {
 		return undefined;
 	}
 
-	// returns true if the passed in url has encoded strings:
-	// space gets encoded as %20 and ;,/?:@&=+$ -> %3B%2C%2F%3F%3A%40%26%3D%2B%24
+	/**
+	* Function to check if a string url has encoded characters
+	* space gets encoded as %20 and ;,/?:@&=+$ -> %3B%2C%2F%3F%3A%40%26%3D%2B%24
+	* @returns true if the passed in url has encoded strings:
+	*/
 	containsEncodedComponents(url): boolean {
 		// ie ?,=,&,/ etc
 		return (decodeURI(url) !== decodeURIComponent(url));

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -118,6 +118,25 @@ export class NotebookLinkHandler {
 		}
 	}
 
+	public getEncodedLinkUrl(): string | undefined {
+		// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
+		// skip encoding it if it's already encoded
+		if (typeof this._link === 'string') {
+			if (!this.containsEncodedComponents(this._link)) {
+				return encodeURI(this._link);
+			}
+			return this._link;
+		}
+		return undefined;
+	}
+
+	// returns true if the passed in url has encoded strings:
+	// space gets encoded as %20 and ;,/?:@&=+$ -> %3B%2C%2F%3F%3A%40%26%3D%2B%24
+	containsEncodedComponents(url): boolean {
+		// ie ?,=,&,/ etc
+		return (decodeURI(url) !== decodeURIComponent(url));
+	}
+
 	/**
 	 * Creates a URI for for a link with a anchor (#)
 	 * @param node is the HTMLAnchorElement of the target notebook

--- a/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookLinkHandler.ts
@@ -118,20 +118,6 @@ export class NotebookLinkHandler {
 		}
 	}
 
-	public getEncodedLinkUrl(linkUrl: string): string {
-		// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-		// skip encoding it if it's already encoded
-		if (!this.containsEncodedComponents(linkUrl)) {
-			return encodeURI(linkUrl);
-		}
-		return linkUrl;
-	}
-
-	public containsEncodedComponents(url) {
-		// ie ?,=,&,/ etc
-		return (decodeURI(url) !== decodeURIComponent(url));
-	}
-
 	/**
 	 * Creates a URI for for a link with a anchor (#)
 	 * @param node is the HTMLAnchorElement of the target notebook

--- a/src/sql/workbench/contrib/notebook/browser/utils.ts
+++ b/src/sql/workbench/contrib/notebook/browser/utils.ts
@@ -43,19 +43,3 @@ export function highlightSelectedText(): void {
 		document.execCommand('hiliteColor', false, 'Yellow');
 	}
 }
-
-export function getEncodedLinkUrl(linkUrl: string): string {
-	// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
-	// skip encoding it if it's already encoded
-	if (!containsEncodedComponents(linkUrl)) {
-		return encodeURI(linkUrl);
-	}
-	return linkUrl;
-}
-
-// returns true if the passed in url has encoded strings:
-// space gets encoded as %20 and ;,/?:@&=+$ -> %3B%2C%2F%3F%3A%40%26%3D%2B%24
-export function containsEncodedComponents(url) {
-	// ie ?,=,&,/ etc
-	return (decodeURI(url) !== decodeURIComponent(url));
-}

--- a/src/sql/workbench/contrib/notebook/browser/utils.ts
+++ b/src/sql/workbench/contrib/notebook/browser/utils.ts
@@ -44,3 +44,18 @@ export function highlightSelectedText(): void {
 	}
 }
 
+export function getEncodedLinkUrl(linkUrl: string): string {
+	// Need to encode URI here in order for user to click the proper encoded link in WYSIWYG
+	// skip encoding it if it's already encoded
+	if (!containsEncodedComponents(linkUrl)) {
+		return encodeURI(linkUrl);
+	}
+	return linkUrl;
+}
+
+// returns true if the passed in url has encoded strings:
+// space gets encoded as %20 and ;,/?:@&=+$ -> %3B%2C%2F%3F%3A%40%26%3D%2B%24
+export function containsEncodedComponents(url) {
+	// ie ?,=,&,/ etc
+	return (decodeURI(url) !== decodeURIComponent(url));
+}

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
@@ -112,7 +112,7 @@ suite('Noteboook Link Handler', function (): void {
 
 		test('when given an already encoded URL with non-reserved characters', () => {
 			let notebookLinkHandler = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code', configurationService);
-			assert.strictEqual(notebookLinkHandler.getEncodedLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
+			assert.strictEqual(notebookLinkHandler.getEncodedLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link should not be encoded');
 		});
 
 		test('when given an unencoded URL with a space', () => {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
@@ -103,4 +103,15 @@ suite('Noteboook Link Handler', function (): void {
 		result = new NotebookLinkHandler(notebookUri, Object.assign(document.createElement('a'), { href: '/tmp/my%20stuff.png' }), configurationService);
 		assert.strictEqual(result.getLinkUrl(), `.${path.sep}my%2520stuff.png`, 'Basic link test with %20 filename failed');
 	});
+
+	test('Should return correctly encoded url/filePath', () => {
+		let result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code', configurationService);
+		assert.strictEqual(result.getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
+
+		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code', configurationService);
+		assert.strictEqual(result.getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
+
+		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft/azuredata studio)&type=Code', configurationService);
+		assert.strictEqual(result.getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
+	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
@@ -9,6 +9,7 @@ import { URI } from 'vs/base/common/uri';
 import { NotebookLinkHandler } from 'sql/workbench/contrib/notebook/browser/notebookLinkHandler';
 import { TestConfigurationService } from 'sql/platform/connection/test/common/testConfigurationService';
 import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
+import { getEncodedLinkUrl } from 'sql/workbench/contrib/notebook/browser/utils';
 
 suite('Noteboook Link Handler', function (): void {
 	let notebookUri = URI.file('/tmp/notebook.ipynb');
@@ -106,12 +107,12 @@ suite('Noteboook Link Handler', function (): void {
 
 	test('Should return correctly encoded url/filePath', () => {
 		let result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code', configurationService);
-		assert.strictEqual(result.getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
+		assert.strictEqual(getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
 
 		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code', configurationService);
-		assert.strictEqual(result.getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
+		assert.strictEqual(getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
 
 		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft/azuredata studio)&type=Code', configurationService);
-		assert.strictEqual(result.getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
+		assert.strictEqual(getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
@@ -105,14 +105,4 @@ suite('Noteboook Link Handler', function (): void {
 		assert.strictEqual(result.getLinkUrl(), `.${path.sep}my%2520stuff.png`, 'Basic link test with %20 filename failed');
 	});
 
-	test('Should return correctly encoded url/filePath', () => {
-		let result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code', configurationService);
-		assert.strictEqual(getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
-
-		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code', configurationService);
-		assert.strictEqual(getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
-
-		result = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft/azuredata studio)&type=Code', configurationService);
-		assert.strictEqual(getEncodedLinkUrl(result.getLinkUrl()), `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
-	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookLinkHandler.test.ts
@@ -9,7 +9,6 @@ import { URI } from 'vs/base/common/uri';
 import { NotebookLinkHandler } from 'sql/workbench/contrib/notebook/browser/notebookLinkHandler';
 import { TestConfigurationService } from 'sql/platform/connection/test/common/testConfigurationService';
 import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
-import { getEncodedLinkUrl } from 'sql/workbench/contrib/notebook/browser/utils';
 
 suite('Noteboook Link Handler', function (): void {
 	let notebookUri = URI.file('/tmp/notebook.ipynb');
@@ -105,4 +104,30 @@ suite('Noteboook Link Handler', function (): void {
 		assert.strictEqual(result.getLinkUrl(), `.${path.sep}my%2520stuff.png`, 'Basic link test with %20 filename failed');
 	});
 
+	test('Should return correctly encoded url/filePath', () => {
+		test('when given an already-encoded URL', () => {
+			let notebookLinkHandler = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code', configurationService);
+			assert.strictEqual(notebookLinkHandler.getEncodedLinkUrl(), `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link does not need encoding');
+		});
+
+		test('when given an already encoded URL with non-reserved characters', () => {
+			let notebookLinkHandler = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code', configurationService);
+			assert.strictEqual(notebookLinkHandler.getEncodedLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
+		});
+
+		test('when given an unencoded URL with a space', () => {
+			let notebookLinkHandler = new NotebookLinkHandler(notebookUri, 'https://github.com/search/advanced?q=test&r=(microsoft/azuredata studio)&type=Code', configurationService);
+			assert.strictEqual(notebookLinkHandler.getEncodedLinkUrl(), `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space in the url failed to be encoded');
+		});
+
+		test('when given file path with a space', () => {
+			let notebookLinkHandler = new NotebookLinkHandler(notebookUri, '/Notebooks/Test_Paths/My File.ipynb', configurationService);
+			assert.strictEqual(notebookLinkHandler.getEncodedLinkUrl(), `/Notebooks/Test_Paths/My%20File.ipynb`, 'space in file path failed to be encoded');
+		});
+
+		test('when given file path has special characters such as %', () => {
+			let notebookLinkHandler = new NotebookLinkHandler(notebookUri, '/Notebooks/Test_Paths/My%20File.ipynb', configurationService);
+			assert.strictEqual(notebookLinkHandler.getEncodedLinkUrl(), `/Notebooks/Test_Paths/My%2520File.ipynb`, '% in file path failed to be encoded');
+		});
+	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
@@ -13,7 +13,6 @@ import { NotebookServiceStub } from 'sql/workbench/contrib/notebook/test/stubs';
 import { tryMatchCellMagic, extractCellMagicCommandPlusArgs } from 'sql/workbench/services/notebook/browser/utils';
 import { RichTextEditStack } from 'sql/workbench/contrib/notebook/browser/cellViews/textCell.component';
 import { notebookConstants } from 'sql/workbench/services/notebook/browser/interfaces';
-import { getEncodedLinkUrl } from 'sql/workbench/contrib/notebook/browser/utils';
 
 suite('notebookUtils', function (): void {
 	const mockNotebookService = TypeMoq.Mock.ofType<INotebookService>(NotebookServiceStub);
@@ -324,23 +323,5 @@ suite('notebookUtils', function (): void {
 		stack.push('c');
 		assert.strictEqual(stack.count, maxStackSize);
 		assert.strictEqual(stack.peek(), 'c');
-	});
-
-	test('getEncodedLinkUrl should return correctly encoded url/filePath', () => {
-		let result = getEncodedLinkUrl('https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code');
-		assert.strictEqual(result, `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
-
-		result = getEncodedLinkUrl('https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code');
-		assert.strictEqual(result, `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
-
-		result = getEncodedLinkUrl('https://github.com/search/advanced?q=test&r=(microsoft/azuredata studio)&type=Code');
-		assert.strictEqual(result, `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
-
-		// test file paths
-		result = getEncodedLinkUrl('/Notebooks/Test_Paths/My%20File.ipynb');
-		assert.strictEqual(result, `/Notebooks/Test_Paths/My%2520File.ipynb`, '% failed to be encoded');
-
-		result = getEncodedLinkUrl('/Notebooks/Test_Paths/My File.ipynb');
-		assert.strictEqual(result, `/Notebooks/Test_Paths/My%20File.ipynb`, '% failed to be encoded');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
@@ -13,6 +13,7 @@ import { NotebookServiceStub } from 'sql/workbench/contrib/notebook/test/stubs';
 import { tryMatchCellMagic, extractCellMagicCommandPlusArgs } from 'sql/workbench/services/notebook/browser/utils';
 import { RichTextEditStack } from 'sql/workbench/contrib/notebook/browser/cellViews/textCell.component';
 import { notebookConstants } from 'sql/workbench/services/notebook/browser/interfaces';
+import { getEncodedLinkUrl } from 'sql/workbench/contrib/notebook/browser/utils';
 
 suite('notebookUtils', function (): void {
 	const mockNotebookService = TypeMoq.Mock.ofType<INotebookService>(NotebookServiceStub);
@@ -323,5 +324,23 @@ suite('notebookUtils', function (): void {
 		stack.push('c');
 		assert.strictEqual(stack.count, maxStackSize);
 		assert.strictEqual(stack.peek(), 'c');
+	});
+
+	test('getEncodedLinkUrl should return correctly encoded url/filePath', () => {
+		let result = getEncodedLinkUrl('https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code');
+		assert.strictEqual(result, `https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code`, 'HTTPS link encoding failed');
+
+		result = getEncodedLinkUrl('https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code');
+		assert.strictEqual(result, `https://github.com/search/advanced?q=test&r=(microsoft%2Fazuredatastudio)&type=Code`, '() in HTTP link failed to resolve');
+
+		result = getEncodedLinkUrl('https://github.com/search/advanced?q=test&r=(microsoft/azuredata studio)&type=Code');
+		assert.strictEqual(result, `https://github.com/search/advanced?q=test&r=(microsoft/azuredata%20studio)&type=Code`, 'space failed to be encoded failed');
+
+		// test file paths
+		result = getEncodedLinkUrl('/Notebooks/Test_Paths/My%20File.ipynb');
+		assert.strictEqual(result, `/Notebooks/Test_Paths/My%2520File.ipynb`, '% failed to be encoded');
+
+		result = getEncodedLinkUrl('/Notebooks/Test_Paths/My File.ipynb');
+		assert.strictEqual(result, `/Notebooks/Test_Paths/My%20File.ipynb`, '% failed to be encoded');
 	});
 });


### PR DESCRIPTION
This PR fixes #17662 

As the issue states if user enters an encoded url such as https://github.com/search/advanced?q=test&r=microsoft%2Fazuredatastudio&type=Code we re-encode it and show it as https://github.com/search/advanced?q=test&r=microsoft%252Fazuredatastudio&type=Code.

In this PR, I've added a check to see if the url has encoded components using an example method from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent .
