### PR TITLE
fix double click issue in browse connections

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -248,7 +248,7 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 				if (selectedNode.element.payload) {
 					this._onSelectedConnectionChanged.fire(
 						{
-							connectionProfile: selectedNode.element.payload,
+							connectionProfile: new ConnectionProfile(this.capabilitiesService, selectedNode.element.payload),
 							connect: connect,
 							source: 'azure'
 						});


### PR DESCRIPTION
the connection profile object passed in only contains data (from extension), we need to create a ConnectionProfile object from it just like other places.

This PR fixes #18029

this only happens for double click scenario, surprisingly, no customer has reported this issue :)