### PR TITLE
Add stop performance collection button on sql migration dashboard

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -92,6 +92,12 @@
 				"command": "sqlmigration.retry.migration",
 				"title": "%retry-migration-menu%",
 				"category": "%migration-context-menu-category%"
+			},
+      {
+        "command": "sqlmigration.stopSkuPerformanceDataCollection",
+				"title": "%stop-sku-performance-data-collection%",
+				"category": "%migration-command-category%",
+        "icon": "./images/cancel.svg"
 			}
 		],
 		"menu": {
@@ -131,6 +137,10 @@
         {
 					"command": "sqlmigration.retry.migration",
 					"when": "false"
+				},
+        {
+					"command": "sqlmigration.stopSkuPerformanceDataCollection",
+					"when": "false"
 				}
 			]
 		},
@@ -155,7 +165,8 @@
 								"tasks-widget": [
 									"sqlmigration.start",
 									"sqlmigration.newsupportrequest",
-									"sqlmigration.sendfeedback"
+									"sqlmigration.sendfeedback",
+                  "sqlmigration.stopSkuPerformanceDataCollection"
 								]
 							}
 						},

--- a/extensions/sql-migration/package.nls.json
+++ b/extensions/sql-migration/package.nls.json
@@ -15,5 +15,6 @@
 	"view-service-menu": "Database Migration Service details",
 	"copy-migration-menu": "Copy migration details",
 	"cancel-migration-menu": "Cancel migration",
-	"retry-migration-menu": "Retry migration"
+	"retry-migration-menu": "Retry migration",
+	"stop-sku-performance-data-collection": "Stop performance data collection"
 }

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -103,6 +103,8 @@ export const AZURE_RECOMMENDATION_OPEN_EXISTING_FOLDER = localize('sql.migration
 export const FOLDER_NAME = localize('sql.migration.azureRecommendation.folder.name', "Folder name");
 export const BROWSE = localize('sql.migration.azureRecommendation.browse', "Browse");
 export const OPEN = localize('sql.migration.azureRecommendation.open', "Open");
+export const STOP_PERFORMANCE_COLLECTION_CONFIRMATION = localize('sql.migration.sku.stopPerformanceCollection.confirmation', "Are you sure you want to stop collecting performance data?");
+export const NO_PERFORMANCE_COLLECTION_ERROR = localize('sql.migration.sku.stopPerformanceCollection.error', "There is no performance data collection to be stopped.");
 
 export const VIEW_DETAILS = localize('sql.migration.sku.viewDetails', "View details");
 export function ASSESSED_DBS(totalDbs: number): string {

--- a/extensions/sql-migration/src/main.ts
+++ b/extensions/sql-migration/src/main.ts
@@ -73,6 +73,9 @@ class SQLMigration {
 				};
 				return await vscode.commands.executeCommand(actionId, args);
 			}),
+			azdata.tasks.registerTask('sqlmigration.stopSkuPerformanceDataCollection', async () => {
+				await this.stopPerformanceCollection();
+			}),
 		];
 
 		this.context.subscriptions.push(...commandDisposables);
@@ -123,6 +126,18 @@ class SQLMigration {
 	async launchNewSupportRequest(): Promise<void> {
 		await vscode.env.openExternal(vscode.Uri.parse(
 			`https://portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/newsupportrequest`));
+	}
+
+	async stopPerformanceCollection(): Promise<void> {
+		if (this.stateModel && !!this.stateModel?.startPerfDataCollection) {
+			void vscode.window.showInformationMessage(loc.STOP_PERFORMANCE_COLLECTION_CONFIRMATION, { modal: true }, loc.YES, loc.NO).then(async (v) => {
+				if (v === loc.YES) {
+					await this.stateModel.stopPerfDataCollection();
+				}
+			});
+		} else {
+			void vscode.window.showInformationMessage(loc.NO_PERFORMANCE_COLLECTION_ERROR);
+		}
 	}
 
 	stop(): void {

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -1160,6 +1160,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 						this._sessionId
 					);
 					void vscode.window.showInformationMessage(localize("sql.migration.starting.migration.message", 'Starting migration for database {0} to {1} - {2}', this._migrationDbs[i], this._targetServerInstance.name, this._targetDatabaseNames[i]));
+					await this.stopPerfDataCollection();
 				}
 			} catch (e) {
 				void vscode.window.showErrorMessage(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

There isn't a way to hide/show this button based on if perf collection is happening in the background. When the user clicks on this button, I've added 2 popup scenarios:

1. There is no ongoing perf collection 
<img width="905" alt="image" src="https://user-images.githubusercontent.com/14362577/152865254-ed5ba2dc-d42b-4742-9dd2-99566859fc8e.png">

2. Perf collection is ongoing - ask user to confirm if they want to actually stop perf collection
<img width="858" alt="image" src="https://user-images.githubusercontent.com/14362577/152865691-d87a9076-b5a8-4076-9a5f-02c73be1cd74.png">
