### PR TITLE
fix move editor group issue

### DIFF
--- a/src/sql/workbench/browser/designer/designerScriptEditor.ts
+++ b/src/sql/workbench/browser/designer/designerScriptEditor.ts
@@ -64,6 +64,7 @@ export class DesignerScriptEditor extends BaseTextEditor implements DesignerText
 		this.setInput(this._editorInput, undefined, undefined).catch(onUnexpectedError);
 		this._editorInput.resolve().then((model) => {
 			this._editorModel = model.textEditorModel;
+			this.updateEditor();
 		});
 	}
 
@@ -111,8 +112,14 @@ export class DesignerScriptEditor extends BaseTextEditor implements DesignerText
 
 	set content(val: string) {
 		this._content = val;
-		this._modelService.updateModel(this._editorModel, this._content);
-		this._untitledTextEditorModel.setDirty(false);
-		this.layout(new DOM.Dimension(this._container.clientWidth, this._container.clientHeight));
+		this.updateEditor();
+	}
+
+	private updateEditor(): void {
+		if (this._editorModel) {
+			this._modelService.updateModel(this._editorModel, this._content);
+			this._untitledTextEditorModel.setDirty(false);
+			this.layout(new DOM.Dimension(this._container.clientWidth, this._container.clientHeight));
+		}
 	}
 }


### PR DESCRIPTION
This PR fixes #18232 

there is a race condition when moving table designer from one editor group to another, the editor model might not be ready when the content is set.

the fix is to call updateEditor() at both places.