### PR TITLE
Add SDK style project option to create project from db dialog

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -257,8 +257,7 @@ export const WorkspaceFileExtension = '.code-workspace';
 export const browseEllipsisWithIcon = `$(folder) ${localize('browseEllipsis', "Browse...")}`;
 export const selectProjectLocation = localize('selectProjectLocation', "Select project location");
 export const sqlprojFormat = localize('sqlprojFormat', '.sqlproj format');
-export const sdk = localize('sdk', 'SDK');
-export const legacy = localize('legacy', 'Legacy');
+export const sdkStyleProject = localize('sdkStyleProject', 'SDK-style project');
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
 export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -256,6 +256,9 @@ export const folderStructureLabel = localize('folderStructureLabel', "Folder str
 export const WorkspaceFileExtension = '.code-workspace';
 export const browseEllipsisWithIcon = `$(folder) ${localize('browseEllipsis', "Browse...")}`;
 export const selectProjectLocation = localize('selectProjectLocation', "Select project location");
+export const sqlprojFormat = localize('sqlprojFormat', '.sqlproj format');
+export const sdk = localize('sdk', 'SDK');
+export const legacy = localize('legacy', 'Legacy');
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
 export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -256,7 +256,6 @@ export const folderStructureLabel = localize('folderStructureLabel', "Folder str
 export const WorkspaceFileExtension = '.code-workspace';
 export const browseEllipsisWithIcon = `$(folder) ${localize('browseEllipsis', "Browse...")}`;
 export const selectProjectLocation = localize('selectProjectLocation', "Select project location");
-export const sqlprojFormat = localize('sqlprojFormat', '.sqlproj format');
 export const sdkStyleProject = localize('sdkStyleProject', 'SDK-style project');
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
 export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1261,7 +1261,7 @@ export class ProjectsController {
 			const newProjFilePath = await this.createNewProject({
 				newProjName: model.projName,
 				folderUri: vscode.Uri.file(newProjFolderUri),
-				projectTypeId: constants.emptySqlDatabaseProjectTypeId
+				projectTypeId: model.sdkStyle ? constants.emptySqlDatabaseSdkProjectTypeId : constants.emptySqlDatabaseProjectTypeId
 			});
 
 			model.filePath = path.dirname(newProjFilePath);
@@ -1271,7 +1271,9 @@ export class ProjectsController {
 			await this.createProjectFromDatabaseApiCall(model); // Call ExtractAPI in DacFx Service
 			let fileFolderList: vscode.Uri[] = model.extractTarget === mssql.ExtractTarget.file ? [vscode.Uri.file(model.filePath)] : await this.generateList(model.filePath); // Create a list of all the files and directories to be added to project
 
-			await project.addToProject(fileFolderList); // Add generated file structure to the project
+			if (!model.sdkStyle) {
+				await project.addToProject(fileFolderList); // Add generated file structure to the project
+			}
 
 			// add project to workspace
 			const workspaceApi = utils.getDataWorkspaceExtensionApi();

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -26,6 +26,8 @@ export class CreateProjectFromDatabaseDialog {
 	public projectNameTextBox: azdataType.InputBoxComponent | undefined;
 	public projectLocationTextBox: azdataType.InputBoxComponent | undefined;
 	public folderStructureDropDown: azdataType.DropDownComponent | undefined;
+	public SdkStyleProjectRadioButton: azdataType.RadioButtonComponent | undefined;
+	public legacyStyleProjectRadioButton: azdataType.RadioButtonComponent | undefined;
 	private formBuilder: azdataType.FormBuilder | undefined;
 	private connectionId: string | undefined;
 	private toDispose: vscode.Disposable[] = [];
@@ -85,6 +87,8 @@ export class CreateProjectFromDatabaseDialog {
 			const createProjectSettingsFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
 			createProjectSettingsFormSection.addItems([folderStructureRow]);
 
+			const projectTypeRadioButtonsFlexModel = this.createProjectTypeRadioButtons(view);
+
 			this.formBuilder = <azdataType.FormBuilder>view.modelBuilder.formContainer()
 				.withFormItems([
 					{
@@ -108,6 +112,9 @@ export class CreateProjectFromDatabaseDialog {
 						components: [
 							{
 								component: createProjectSettingsFormSection,
+							},
+							{
+								component: projectTypeRadioButtonsFlexModel
 							}
 						]
 					}
@@ -341,6 +348,40 @@ export class CreateProjectFromDatabaseDialog {
 		return folderStructureRow;
 	}
 
+	private createProjectTypeRadioButtons(view: azdataType.ModelView): azdataType.Component {
+		const sqlprojFormat = view.modelBuilder.text().withProps({
+			value: constants.sqlprojFormat,
+			width: '100px'
+		}).component();
+
+		this.SdkStyleProjectRadioButton = view.modelBuilder.radioButton()
+			.withProps({
+				name: 'projectType',
+				label: constants.sdk
+			}).component();
+
+		this.SdkStyleProjectRadioButton.checked = true;
+
+		this.legacyStyleProjectRadioButton = view.modelBuilder.radioButton()
+			.withProps({
+				name: 'projectType',
+				label: constants.legacy
+			}).component();
+
+		const radioButtonContainer = view.modelBuilder.flexContainer()
+			.withLayout({ flexFlow: 'row' })
+			.withItems([this.SdkStyleProjectRadioButton, this.legacyStyleProjectRadioButton])
+			.withProps({ ariaRole: 'radiogroup' })
+			.component();
+
+		let flexRadioButtonsModel: azdataType.FlexContainer = view.modelBuilder.flexContainer()
+			.withLayout({ alignItems: 'baseline' })
+			.withItems([sqlprojFormat, radioButtonContainer])
+			.component();
+
+		return flexRadioButtonsModel;
+	}
+
 	// only enable Create button if all fields are filled
 	public tryEnableCreateButton(): void {
 		if (this.sourceConnectionTextBox!.value && this.sourceDatabaseDropDown!.value
@@ -360,7 +401,8 @@ export class CreateProjectFromDatabaseDialog {
 			projName: this.projectNameTextBox!.value!,
 			filePath: this.projectLocationTextBox!.value!,
 			version: '1.0.0.0',
-			extractTarget: mapExtractTargetEnum(<string>this.folderStructureDropDown!.value)
+			extractTarget: mapExtractTargetEnum(<string>this.folderStructureDropDown!.value),
+			sdkStyle: this.SdkStyleProjectRadioButton?.checked
 		};
 
 		azdataApi!.window.closeDialog(this.dialog);

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -26,8 +26,7 @@ export class CreateProjectFromDatabaseDialog {
 	public projectNameTextBox: azdataType.InputBoxComponent | undefined;
 	public projectLocationTextBox: azdataType.InputBoxComponent | undefined;
 	public folderStructureDropDown: azdataType.DropDownComponent | undefined;
-	public SdkStyleProjectRadioButton: azdataType.RadioButtonComponent | undefined;
-	public legacyStyleProjectRadioButton: azdataType.RadioButtonComponent | undefined;
+	public sdkStyleCheckbox: azdataType.CheckBoxComponent | undefined;
 	private formBuilder: azdataType.FormBuilder | undefined;
 	private connectionId: string | undefined;
 	private toDispose: vscode.Disposable[] = [];
@@ -87,7 +86,11 @@ export class CreateProjectFromDatabaseDialog {
 			const createProjectSettingsFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
 			createProjectSettingsFormSection.addItems([folderStructureRow]);
 
-			const projectTypeRadioButtonsFlexModel = this.createProjectTypeRadioButtons(view);
+			// could also potentially be radio buttons once there's a term to refer to "legacy" style sqlprojs
+			const sdkStyleCheckbox = view.modelBuilder.checkBox().withProps({
+				checked: true,
+				label: constants.sdkStyleProject
+			}).component();
 
 			this.formBuilder = <azdataType.FormBuilder>view.modelBuilder.formContainer()
 				.withFormItems([
@@ -114,7 +117,7 @@ export class CreateProjectFromDatabaseDialog {
 								component: createProjectSettingsFormSection,
 							},
 							{
-								component: projectTypeRadioButtonsFlexModel
+								component: sdkStyleCheckbox
 							}
 						]
 					}
@@ -348,40 +351,6 @@ export class CreateProjectFromDatabaseDialog {
 		return folderStructureRow;
 	}
 
-	private createProjectTypeRadioButtons(view: azdataType.ModelView): azdataType.Component {
-		const sqlprojFormat = view.modelBuilder.text().withProps({
-			value: constants.sqlprojFormat,
-			width: '100px'
-		}).component();
-
-		this.SdkStyleProjectRadioButton = view.modelBuilder.radioButton()
-			.withProps({
-				name: 'projectType',
-				label: constants.sdk
-			}).component();
-
-		this.SdkStyleProjectRadioButton.checked = true;
-
-		this.legacyStyleProjectRadioButton = view.modelBuilder.radioButton()
-			.withProps({
-				name: 'projectType',
-				label: constants.legacy
-			}).component();
-
-		const radioButtonContainer = view.modelBuilder.flexContainer()
-			.withLayout({ flexFlow: 'row' })
-			.withItems([this.SdkStyleProjectRadioButton, this.legacyStyleProjectRadioButton])
-			.withProps({ ariaRole: 'radiogroup' })
-			.component();
-
-		let flexRadioButtonsModel: azdataType.FlexContainer = view.modelBuilder.flexContainer()
-			.withLayout({ alignItems: 'baseline' })
-			.withItems([sqlprojFormat, radioButtonContainer])
-			.component();
-
-		return flexRadioButtonsModel;
-	}
-
 	// only enable Create button if all fields are filled
 	public tryEnableCreateButton(): void {
 		if (this.sourceConnectionTextBox!.value && this.sourceDatabaseDropDown!.value
@@ -402,7 +371,7 @@ export class CreateProjectFromDatabaseDialog {
 			filePath: this.projectLocationTextBox!.value!,
 			version: '1.0.0.0',
 			extractTarget: mapExtractTargetEnum(<string>this.folderStructureDropDown!.value),
-			sdkStyle: this.SdkStyleProjectRadioButton?.checked
+			sdkStyle: this.sdkStyleCheckbox?.checked
 		};
 
 		azdataApi!.window.closeDialog(this.dialog);

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -87,7 +87,7 @@ export class CreateProjectFromDatabaseDialog {
 			createProjectSettingsFormSection.addItems([folderStructureRow]);
 
 			// could also potentially be radio buttons once there's a term to refer to "legacy" style sqlprojs
-			const sdkStyleCheckbox = view.modelBuilder.checkBox().withProps({
+			this.sdkStyleCheckbox = view.modelBuilder.checkBox().withProps({
 				checked: true,
 				label: constants.sdkStyleProject
 			}).component();
@@ -117,7 +117,7 @@ export class CreateProjectFromDatabaseDialog {
 								component: createProjectSettingsFormSection,
 							},
 							{
-								component: sdkStyleCheckbox
+								component: this.sdkStyleCheckbox
 							}
 						]
 					}

--- a/extensions/sql-database-projects/src/models/api/import.ts
+++ b/extensions/sql-database-projects/src/models/api/import.ts
@@ -18,4 +18,5 @@ export interface ImportDataModel {
 	filePath: string;
 	version: string;
 	extractTarget: ExtractTarget;
+	sdkStyle?: boolean;
 }

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -61,6 +61,15 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 			displayName: constants.edgeProjectTypeDisplayName,
 			description: constants.edgeProjectTypeDescription,
 			icon: IconPathHelper.sqlEdgeProject
+		},
+		{
+			id: constants.emptySqlDatabaseSdkProjectTypeId,
+			projectFileExtension: constants.sqlprojExtension.replace(/\./g, ''),
+			displayName: constants.emptySdkProjectTypeDisplayName,
+			description: constants.emptySdkProjectTypeDescription,
+			icon: IconPathHelper.colorfulSqlProject,
+			targetPlatforms: Array.from(constants.targetPlatformToVersion.keys()),
+			defaultTargetPlatform: constants.defaultTargetPlatform
 		}];
 	}
 

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -61,15 +61,6 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 			displayName: constants.edgeProjectTypeDisplayName,
 			description: constants.edgeProjectTypeDescription,
 			icon: IconPathHelper.sqlEdgeProject
-		},
-		{
-			id: constants.emptySqlDatabaseSdkProjectTypeId,
-			projectFileExtension: constants.sqlprojExtension.replace(/\./g, ''),
-			displayName: constants.emptySdkProjectTypeDisplayName,
-			description: constants.emptySdkProjectTypeDescription,
-			icon: IconPathHelper.colorfulSqlProject,
-			targetPlatforms: Array.from(constants.targetPlatformToVersion.keys()),
-			defaultTargetPlatform: constants.defaultTargetPlatform
 		}];
 	}
 

--- a/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseDialog.test.ts
@@ -100,7 +100,8 @@ describe('Create Project From Database Dialog', () => {
 			projName: 'testProject',
 			filePath: 'testLocation',
 			version: '1.0.0.0',
-			extractTarget: mssql.ExtractTarget.schemaObjectType
+			extractTarget: mssql.ExtractTarget.schemaObjectType,
+			sdkStyle: true
 		};
 
 		dialog.createProjectFromDatabaseCallback = (m) => { model = m; };


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #18041. This adds a checkbox option for SDK style project to the create project from db dialog so that users have the option of creating an SDK style project from a db when sql projects gets updated in insiders. 

@dzsquared do we have terminology to distinguish between the new SDK style and old style sqlproj? Other options I considered for this were radio buttons or a dropdown to select between SDK style and "old" style sqlproj, but I wasn't sure how to refer to the old style sqlproj :/

![image](https://user-images.githubusercontent.com/31145923/152897122-90a8fedc-e129-4b30-9ab1-1a18db75b4d2.png)
