### PR TITLE
Show/hide azure recommendation components based on data collection source and status

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -92,6 +92,7 @@ export function RECOMMENDATIONS_TITLE(targetType: string): string {
 }
 export const RECOMMENDED_CONFIGURATION = localize('sql.migration.sku.recommendedConfiguration', "Recommended configuration");
 export const GET_AZURE_RECOMMENDATION = localize('sql.migration.sku.getAzureRecommendation', "Get Azure recommendation");
+export const REFRESH_AZURE_RECOMMENDATION = localize('sql.migration.sku.refresh.recommendation', "Refresh recommendation");
 export const STOP_PERFORMANCE_COLLECTION = localize('sql.migration.sku.stop.performance.collection', "Stop collection");
 export const AZURE_RECOMMENDATION_CARD_NOT_ENABLED = localize('sql.migration.sku.card.azureRecommendation.notEnabled', "Azure recommendation is not available. Click “Start” button below to get started.");
 export const AZURE_RECOMMENDATION_CARD_IN_PROGRESS = localize('sql.migration.sku.card.azureRecommendation.inProgress', "Azure recommendation will be displayed once data collection is complete.");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -92,13 +92,16 @@ export function RECOMMENDATIONS_TITLE(targetType: string): string {
 }
 export const RECOMMENDED_CONFIGURATION = localize('sql.migration.sku.recommendedConfiguration', "Recommended configuration");
 export const GET_AZURE_RECOMMENDATION = localize('sql.migration.sku.getAzureRecommendation', "Get Azure recommendation");
+export const GET_AZURE_RECOMMENDATION_AGAIN = localize('sql.migration.sku.getAzureRecommendation.again', "Get Azure recommendation again");
 export const REFRESH_AZURE_RECOMMENDATION = localize('sql.migration.sku.refresh.recommendation', "Refresh recommendation");
 export const STOP_PERFORMANCE_COLLECTION = localize('sql.migration.sku.stop.performance.collection', "Stop collection");
-export const AZURE_RECOMMENDATION_CARD_NOT_ENABLED = localize('sql.migration.sku.card.azureRecommendation.notEnabled', "Azure recommendation is not available. Click “Start” button below to get started.");
+export const AZURE_RECOMMENDATION_CARD_NOT_ENABLED = localize('sql.migration.sku.card.azureRecommendation.notEnabled', "Azure recommendation is not available. Click “Get Azure recommendation” button below");
 export const AZURE_RECOMMENDATION_CARD_IN_PROGRESS = localize('sql.migration.sku.card.azureRecommendation.inProgress', "Azure recommendation will be displayed once data collection is complete.");
 export const AZURE_RECOMMENDATION_STATUS_NOT_ENABLED = localize('sql.migration.sku.azureRecommendation.status.notEnabled', "Azure recommendation requires performance data to be collected from the SQL server instance.");
 export const AZURE_RECOMMENDATION_STATUS_IN_PROGRESS = localize('sql.migration.sku.azureRecommendation.status.inProgress', "Data collection in progress. Generating first set of recommendations...");
 export const AZURE_RECOMMENDATION_STATUS_REFINING = localize('sql.migration.sku.azureRecommendation.status.refining', "Data collection in progress. Refining existing recommendations...");
+export const AZURE_RECOMMENDATION_STATUS_STOPPED = localize('sql.migration.sku.azureRecommendation.status.stopped', "Data collection for Azure recommendations has been stopped.");
+export const AZURE_RECOMMENDATION_STATUS_DATA_IMPORTED = localize('sql.migration.sku.azureRecommendation.status.imported', "Azure recommendation has been applied using provided data. Import more data for a more refined recommendation.");
 
 export const AZURE_RECOMMENDATION_START = localize('sql.migration.sku.azureRecommendation.start', "Start");
 export const AZURE_RECOMMENDATION_DESCRIPTION = localize('sql.migration.sku.azureRecommendation.description', "Azure recommendation requires performance data of SQL server instance to provide target recommendation. Enable performance data collection to receive the target recommendation for the databases you want to migrate. The longer this will be enabled the better the recommendation. You can disable performance data collection at any time.");

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/getAzureRecommendationDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/getAzureRecommendationDialog.ts
@@ -101,6 +101,7 @@ export class GetAzureRecommendationDialog {
 				'flex-direction': 'row',
 				'width': 'fit-content',
 				'margin': '4px 0 16px',
+			}
 		}).component();
 
 		const collectDataButton = _view.modelBuilder.radioButton()
@@ -220,7 +221,7 @@ export class GetAzureRecommendationDialog {
 		const container = _view.modelBuilder.flexContainer().withProps({
 			CSSStyles: {
 				'flex-direction': 'column',
-				'display': 'inline',
+				'display': 'none',
 			}
 		}).component();
 

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/getAzureRecommendationDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/getAzureRecommendationDialog.ts
@@ -20,7 +20,7 @@ export class GetAzureRecommendationDialog {
 
 	private _disposables: vscode.Disposable[] = [];
 
-	private _skuRecommendationPerformanceDataSource!: PerformanceDataSourceOptions;
+	private _performanceDataSource!: PerformanceDataSourceOptions;
 
 	private _collectDataContainer!: azdata.FlexContainer;
 	private _collectDataFolderInput!: azdata.InputBoxComponent;
@@ -29,7 +29,7 @@ export class GetAzureRecommendationDialog {
 	private _openExistingFolderInput!: azdata.InputBoxComponent;
 
 	constructor(public skuRecommendationPage: SKURecommendationPage, public migrationStateModel: MigrationStateModel) {
-		this._skuRecommendationPerformanceDataSource = PerformanceDataSourceOptions.CollectData;
+		this._performanceDataSource = PerformanceDataSourceOptions.CollectData;
 	}
 
 	private async initializeDialog(dialog: azdata.window.Dialog): Promise<void> {
@@ -112,7 +112,7 @@ export class GetAzureRecommendationDialog {
 					...styles.BODY_CSS,
 					'margin': '0'
 				},
-				checked: this._skuRecommendationPerformanceDataSource === PerformanceDataSourceOptions.CollectData,
+				checked: this._performanceDataSource === PerformanceDataSourceOptions.CollectData,
 			}).component();
 		this._disposables.push(collectDataButton.onDidChangeCheckedState(async (e) => {
 			if (e) {
@@ -179,7 +179,7 @@ export class GetAzureRecommendationDialog {
 		}).component();
 
 		this._collectDataFolderInput = _view.modelBuilder.inputBox().withProps({
-			required: this._skuRecommendationPerformanceDataSource === PerformanceDataSourceOptions.CollectData,
+			required: this._performanceDataSource === PerformanceDataSourceOptions.CollectData,
 			placeHolder: constants.FOLDER_NAME,
 			CSSStyles: {
 				'margin-right': '12px'
@@ -241,7 +241,7 @@ export class GetAzureRecommendationDialog {
 		}).component();
 
 		this._openExistingFolderInput = _view.modelBuilder.inputBox().withProps({
-			required: this._skuRecommendationPerformanceDataSource === PerformanceDataSourceOptions.OpenExisting,
+			required: this._performanceDataSource === PerformanceDataSourceOptions.OpenExisting,
 			placeHolder: constants.FOLDER_NAME,
 			CSSStyles: {
 				'margin-right': '12px'
@@ -251,7 +251,6 @@ export class GetAzureRecommendationDialog {
 		}).component();
 		this._disposables.push(this._openExistingFolderInput.onTextChanged(async (value) => {
 			this.migrationStateModel._skuRecommendationPerformanceLocation = value.trim();
-			console.log('this.migrationStateModel._skuRecommendationPerformanceLocation', this.migrationStateModel._skuRecommendationPerformanceLocation);
 		}));
 
 		const openButton = _view.modelBuilder.button().withProps({
@@ -280,7 +279,7 @@ export class GetAzureRecommendationDialog {
 	}
 
 	private async switchDataSourceContainerFields(containerType: PerformanceDataSourceOptions): Promise<void> {
-		this._skuRecommendationPerformanceDataSource = containerType;
+		this._performanceDataSource = containerType;
 		await this._collectDataContainer.updateCssStyles({ 'display': (containerType === PerformanceDataSourceOptions.CollectData) ? 'inline' : 'none' });
 		await this._openExistingContainer.updateCssStyles({ 'display': (containerType === PerformanceDataSourceOptions.OpenExisting) ? 'inline' : 'none' });
 		this._collectDataFolderInput.required = containerType === PerformanceDataSourceOptions.CollectData;
@@ -306,9 +305,9 @@ export class GetAzureRecommendationDialog {
 
 	protected async execute() {
 		this._isOpen = false;
-		console.log('Start button');
 
-		switch (this._skuRecommendationPerformanceDataSource) {
+		this.migrationStateModel._skuRecommendationPerformanceDataSource = this._performanceDataSource;
+		switch (this.migrationStateModel._skuRecommendationPerformanceDataSource) {
 			case PerformanceDataSourceOptions.CollectData: {
 				// start data collection entry point
 				// TO-DO: expose the rest of these in the UI
@@ -350,7 +349,7 @@ export class GetAzureRecommendationDialog {
 			}
 		}
 
-		await this.skuRecommendationPage.refreshDataCollectionStatus();
+		await this.skuRecommendationPage.refreshSkuRecommendationComponents();
 	}
 
 	public get isOpen(): boolean {

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -187,6 +187,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 	public mementoString: string;
 
 	public _skuRecommendationResults!: SkuRecommendation;
+	public _skuRecommendationPerformanceDataSource!: PerformanceDataSourceOptions;
 	private _skuRecommendationApiResponse!: mssql.SkuRecommendationResult;
 	public _skuRecommendationPerformanceLocation!: string;
 	private _startPerfDataCollectionApiResponse!: mssql.StartPerfDataCollectionResult;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR 
- adds logic to show/hide content based on the performance data source scenarios / performance data collection status.
- only exposes "Edit parameters" section when user has started data collection or imported existing data.

![image](https://user-images.githubusercontent.com/14362577/153130818-c66a8eb4-459b-4049-ae0c-68b1f8d2d212.png)

1. Collect Data
![image](https://user-images.githubusercontent.com/14362577/153130832-17191f62-2c96-44d4-be3b-9b09770abc61.png)
![image](https://user-images.githubusercontent.com/14362577/153130882-be2acd91-306b-494b-8345-0a2f70d57ffc.png)


2. Open Existing - give user option to get azure recommendations again
![image](https://user-images.githubusercontent.com/14362577/153130891-ee32920b-cde7-4c8d-ae38-1ff42fb065d5.png)
