### PR TITLE
Remove sdk style project template

### DIFF
--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -36,17 +36,6 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 */
 	get supportedProjectTypes(): dataworkspace.IProjectType[] {
 		return [{
-			id: constants.emptySqlDatabaseSdkProjectTypeId,
-			projectFileExtension: constants.sqlprojExtension.replace(/\./g, ''),
-			displayName: constants.emptySdkProjectTypeDisplayName,
-			description: constants.emptySdkProjectTypeDescription,
-			icon: IconPathHelper.colorfulSqlProject,
-			targetPlatforms: Array.from(constants.targetPlatformToVersion.keys()),
-			defaultTargetPlatform: constants.defaultTargetPlatform,
-			linkDisplayValue: constants.learnMore,
-			linkLocation: 'https://github.com/microsoft/DacFx/tree/main/src/Microsoft.Build.Sql'
-		},
-		{
 			id: constants.emptySqlDatabaseProjectTypeId,
 			projectFileExtension: constants.sqlprojExtension.replace(/\./g, ''),
 			displayName: constants.emptyProjectTypeDisplayName,


### PR DESCRIPTION
Removing the SDK style template for before the release branch snaps so a new version of sql database projects can be released in vscode for other changes. Will add back later for insiders release.