### PR TITLE
Update mssql/sqltoolsservice for SKU recommendation changes

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.201",
+	"version": "3.0.0-release.202",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1038,6 +1038,50 @@ export namespace GetSqlMigrationAssessmentItemsRequest {
 	export const type = new RequestType<SqlMigrationAssessmentParams, mssql.AssessmentResult, void, void>('migration/getassessments');
 }
 
+export interface SqlMigrationSkuRecommendationsParams {
+	dataFolder: string;
+	perfQueryIntervalInSec: number;
+	targetPlatforms: string[];
+	targetSqlInstance: string;
+	targetPercentile: number;
+	scalingFactor: number;
+	startTime: string;
+	endTime: string;
+	includePreviewSkus: boolean;
+	databaseAllowList: string[];
+}
+
+export namespace GetSqlMigrationSkuRecommendationsRequest {
+	export const type = new RequestType<SqlMigrationSkuRecommendationsParams, mssql.SkuRecommendationResult, void, void>('migration/getskurecommendations');
+}
+
+export interface SqlMigrationStartPerfDataCollectionParams {
+	ownerUri: string,
+	dataFolder: string,
+	perfQueryIntervalInSec: number,
+	staticQueryIntervalInSec: number,
+	numberOfIterations: number
+}
+
+export namespace SqlMigrationStartPerfDataCollectionRequest {
+	export const type = new RequestType<SqlMigrationStartPerfDataCollectionParams, mssql.StartPerfDataCollectionResult, void, void>('migration/startperfdatacollection');
+}
+
+export interface SqlMigrationStopPerfDataCollectionParams {
+}
+
+export namespace SqlMigrationStopPerfDataCollectionRequest {
+	export const type = new RequestType<SqlMigrationStopPerfDataCollectionParams, mssql.StopPerfDataCollectionResult, void, void>('migration/stopperfdatacollection');
+}
+
+export interface SqlMigrationRefreshPerfDataCollectionParams {
+	lastRefreshTime: Date
+}
+
+export namespace SqlMigrationRefreshPerfDataCollectionRequest {
+	export const type = new RequestType<SqlMigrationRefreshPerfDataCollectionParams, mssql.RefreshPerfDataCollectionResult, void, void>('migration/refreshperfdatacollection');
+}
+
 // ------------------------------- <Sql Migration> -----------------------------
 
 // ------------------------------- < Table Designer > ------------------------------------

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -615,6 +615,285 @@ export interface AssessmentResult {
 	errors: ErrorModel[];
 }
 
+// SKU recommendation interfaces, mirrored from Microsoft.SqlServer.Migration.SkuRecommendation
+export interface AzureSqlSkuCategory {
+	sqlTargetPlatform: AzureSqlTargetPlatform;
+	computeTier: ComputeTier;
+}
+
+export interface AzureSqlSkuPaaSCategory extends AzureSqlSkuCategory {
+	sqlPurchasingModel: AzureSqlPurchasingModel;
+	sqlServiceTier: AzureSqlPaaSServiceTier;
+	hardwareType: AzureSqlPaaSHardwareType;
+}
+
+export interface AzureSqlSkuIaaSCategory extends AzureSqlSkuCategory {
+	virtualMachineFamilyType: VirtualMachineFamilyType;
+}
+
+export interface AzureManagedDiskSku {
+	tier: AzureManagedDiskTier;
+	size: string;
+	caching: AzureManagedDiskCaching;
+}
+
+export interface AzureVirtualMachineSku {
+	virtualMachineFamily: VirtualMachineFamily;
+	sizeName: string;
+	computeSize: number;
+	azureSkuName: string;
+	vCPUsAvailable: number;
+}
+
+export interface AzureSqlSkuMonthlyCost {
+	computeCost: number;
+	storageCost: number;
+	totalCost: number;
+}
+
+export interface AzureSqlSku {
+	category: AzureSqlSkuPaaSCategory | AzureSqlSkuIaaSCategory;
+	computeSize: number;
+	predictedDataSizeInMb: number;
+	predictedLogSizeInMb: number;
+}
+
+export interface AzureSqlPaaSSku extends AzureSqlSku {
+	category: AzureSqlSkuPaaSCategory;
+	storageMaxSizeInMb: number;
+}
+
+export interface AzureSqlIaaSSku extends AzureSqlSku {
+	category: AzureSqlSkuIaaSCategory;
+	virtualMachineSize: AzureVirtualMachineSku;
+	dataDiskSizes: AzureManagedDiskSku[];
+	logDiskSizes: AzureManagedDiskSku[];
+	tempDbDiskSizes: AzureManagedDiskSku[];
+}
+
+export interface SkuRecommendationResultItem {
+	sqlInstanceName: string;
+	databaseName: string;
+	targetSku: AzureSqlIaaSSku | AzureSqlPaaSSku;
+	monthlyCost: AzureSqlSkuMonthlyCost;
+	ranking: number;
+	positiveJustifications: string[];
+	negativeJustifications: string[];
+}
+
+export interface SqlInstanceRequirements {
+	cpuRequirementInCores: number;
+	dataStorageRequirementInMB: number;
+	logStorageRequirementInMB: number;
+	memoryRequirementInMB: number;
+	dataIOPSRequirement: number;
+	logIOPSRequirement: number;
+	ioLatencyRequirementInMs: number;
+	ioThroughputRequirementInMBps: number;
+	tempDBSizeInMB: number;
+	dataPointsStartTime: string;
+	dataPointsEndTime: string;
+	aggregationTargetPercentile: number;
+	perfDataCollectionIntervalInSeconds: number;
+	databaseLevelRequirements: SqlDatabaseRequirements[];
+	numberOfDataPointsAnalyzed: number;
+}
+
+export interface SqlDatabaseRequirements {
+	cpuRequirementInCores: number;
+	dataIOPSRequirement: number;
+	logIOPSRequirement: number;
+	ioLatencyRequirementInMs: number;
+	ioThroughputRequirementInMBps: number;
+	dataStorageRequirementInMB: number;
+	logStorageRequirementInMB: number;
+	databaseName: string;
+	memoryRequirementInMB: number;
+	cpuRequirementInPercentageOfTotalInstance: number;
+	numberOfDataPointsAnalyzed: number;
+	fileLevelRequirements: SqlFileRequirements[];
+}
+
+export interface SqlFileRequirements {
+	fileName: string;
+	fileType: DatabaseFileType;
+	sizeInMB: number;
+	readLatencyInMs: number;
+	writeLatencyInMs: number;
+	iopsRequirement: number;
+	ioThroughputRequirementInMBps: number;
+	numberOfDataPointsAnalyzed: number;
+}
+
+export interface PaaSSkuRecommendationResultItem extends SkuRecommendationResultItem {
+	targetSku: AzureSqlPaaSSku;
+}
+
+export interface IaaSSkuRecommendationResultItem extends SkuRecommendationResultItem {
+	targetSku: AzureSqlIaaSSku;
+}
+
+export interface SkuRecommendationResult {
+	sqlDbRecommendationResults: PaaSSkuRecommendationResultItem[];
+	sqlMiRecommendationResults: PaaSSkuRecommendationResultItem[];
+	sqlVmRecommendationResults: IaaSSkuRecommendationResultItem[];
+	instanceRequirements: SqlInstanceRequirements;
+}
+
+// SKU recommendation enums, mirrored from Microsoft.SqlServer.Migration.SkuRecommendation
+export const enum DatabaseFileType {
+	Rows = 0,
+	Log = 1,
+	Filestream = 2,
+	NotSupported = 3,
+	Fulltext = 4
+}
+
+export const enum AzureSqlTargetPlatform {
+	AzureSqlDatabase = 0,
+	AzureSqlManagedInstance = 1,
+	AzureSqlVirtualMachine = 2
+}
+
+export const enum ComputeTier {
+	Provisioned = 0,
+	ServerLess = 1
+}
+
+export const enum AzureManagedDiskTier {
+	Standard = 0,
+	Premium = 1,
+	Ultra = 2
+}
+
+export const enum AzureManagedDiskCaching {
+	NotApplicable = 0,
+	None = 1,
+	ReadOnly = 2,
+	ReadWrite = 3
+}
+
+export const enum AzureSqlPurchasingModel {
+	vCore = 0,
+}
+
+export const enum AzureSqlPaaSServiceTier {
+	GeneralPurpose = 0,
+	BusinessCritical,
+	HyperScale,
+}
+
+export const enum AzureSqlPaaSHardwareType {
+	Gen5 = 0,
+	PremiumSeries,
+	PremiumSeriesMemoryOptimized
+}
+
+export const enum VirtualMachineFamilyType {
+	GeneralPurpose,
+	ComputeOptimized,
+	MemoryOptimized,
+	StorageOptimized,
+	GPU,
+	HighPerformanceCompute
+}
+
+export const enum VirtualMachineFamily {
+	basicAFamily,
+	standardA0_A7Family,
+	standardAv2Family,
+	standardBSFamily,
+	standardDFamily,
+	standardDv2Family,
+	standardDv2PromoFamily,
+	standardDADSv5Family,
+	standardDASv4Family,
+	standardDASv5Family,
+	standardDAv4Family,
+	standardDDSv4Family,
+	standardDDSv5Family,
+	standardDDv4Family,
+	standardDDv5Family,
+	standardDSv3Family,
+	standardDSv4Family,
+	standardDSv5Family,
+	standardDv3Family,
+	standardDv4Family,
+	standardDv5Family,
+	standardDCADSv5Family,
+	standardDCASv5Family,
+	standardDCSv2Family,
+	standardDSFamily,
+	standardDSv2Family,
+	standardDSv2PromoFamily,
+	standardEIDSv5Family,
+	standardEIDv5Family,
+	standardEISv5Family,
+	standardEIv5Family,
+	standardEADSv5Family,
+	standardEASv4Family,
+	standardEASv5Family,
+	standardEDSv4Family,
+	standardEDSv5Family,
+	standardEBDSv5Family,
+	standardESv3Family,
+	standardESv4Family,
+	standardESv5Family,
+	standardEBSv5Family,
+	standardEAv4Family,
+	standardEDv4Family,
+	standardEDv5Family,
+	standardEv3Family,
+	standardEv4Family,
+	standardEv5Family,
+	standardEISv3Family,
+	standardEIv3Family,
+	standardXEIDSv4Family,
+	standardXEISv4Family,
+	standardECADSv5Family,
+	standardECASv5Family,
+	standardECIADSv5Family,
+	standardECIASv5Family,
+	standardFFamily,
+	standardFSFamily,
+	standardFSv2Family,
+	standardGFamily,
+	standardGSFamily,
+	standardHFamily,
+	standardHPromoFamily,
+	standardLSFamily,
+	standardLSv2Family,
+	standardMSFamily,
+	standardMDSMediumMemoryv2Family,
+	standardMSMediumMemoryv2Family,
+	standardMIDSMediumMemoryv2Family,
+	standardMISMediumMemoryv2Family,
+	standardMSv2Family,
+	standardNCSv3Family,
+	StandardNCASv3_T4Family,
+	standardNVSv2Family,
+	standardNVSv3Family,
+	standardNVSv4Family
+}
+
+export interface StartPerfDataCollectionResult {
+	dateTimeStarted: Date;
+}
+
+export interface StopPerfDataCollectionResult {
+	dateTimeStopped: Date;
+}
+
+export interface RefreshPerfDataCollectionResult {
+	messages: string[];
+	errors: string[];
+	refreshTime: Date;
+}
+
 export interface ISqlMigrationService {
 	getAssessments(ownerUri: string, databases: string[]): Promise<AssessmentResult | undefined>;
+	getSkuRecommendations(dataFolder: string, perfQueryIntervalInSec: number, targetPlatforms: string[], targetSqlInstance: string, targetPercentile: number, scalingFactor: number, startTime: string, endTime: string, includePreviewSkus: boolean, databaseAllowList: string[]): Promise<SkuRecommendationResult | undefined>;
+	startPerfDataCollection(ownerUri: string, dataFolder: string, perfQueryIntervalInSec: number, staticQueryIntervalInSec: number, numberOfIterations: number): Promise<StartPerfDataCollectionResult | undefined>;
+	stopPerfDataCollection(): Promise<StopPerfDataCollectionResult | undefined>;
+	refreshPerfDataCollection(lastRefreshedTime: Date): Promise<RefreshPerfDataCollectionResult | undefined>;
 }

--- a/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
+++ b/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
@@ -40,4 +40,90 @@ export class SqlMigrationService implements mssql.ISqlMigrationService {
 
 		return undefined;
 	}
+
+	async getSkuRecommendations(
+		dataFolder: string,
+		perfQueryIntervalInSec: number,
+		targetPlatforms: string[],
+		targetSqlInstance: string,
+		targetPercentile: number,
+		scalingFactor: number,
+		startTime: string,
+		endTime: string,
+		includePreviewSkus: boolean,
+		databaseAllowList: string[]): Promise<mssql.SkuRecommendationResult | undefined> {
+		let params: contracts.SqlMigrationSkuRecommendationsParams = {
+			dataFolder,
+			perfQueryIntervalInSec,
+			targetPlatforms,
+			targetSqlInstance,
+			targetPercentile,
+			scalingFactor,
+			startTime,
+			endTime,
+			includePreviewSkus,
+			databaseAllowList
+		};
+
+		try {
+			return this.client.sendRequest(contracts.GetSqlMigrationSkuRecommendationsRequest.type, params);
+		}
+		catch (e) {
+			this.client.logFailedRequest(contracts.GetSqlMigrationSkuRecommendationsRequest.type, e);
+		}
+
+		return undefined;
+	}
+
+	async startPerfDataCollection(
+		ownerUri: string,
+		dataFolder: string,
+		perfQueryIntervalInSec: number,
+		staticQueryIntervalInSec: number,
+		numberOfIterations: number): Promise<mssql.StartPerfDataCollectionResult | undefined> {
+		let params: contracts.SqlMigrationStartPerfDataCollectionParams = {
+			ownerUri,
+			dataFolder,
+			perfQueryIntervalInSec,
+			staticQueryIntervalInSec,
+			numberOfIterations
+		};
+
+		try {
+			return this.client.sendRequest(contracts.SqlMigrationStartPerfDataCollectionRequest.type, params);
+		}
+		catch (e) {
+			this.client.logFailedRequest(contracts.SqlMigrationStartPerfDataCollectionRequest.type, e);
+		}
+
+		return undefined;
+	}
+
+	async stopPerfDataCollection(): Promise<mssql.StopPerfDataCollectionResult | undefined> {
+		let params: contracts.SqlMigrationStopPerfDataCollectionParams = {};
+
+		try {
+			return this.client.sendRequest(contracts.SqlMigrationStopPerfDataCollectionRequest.type, params);
+		}
+		catch (e) {
+			this.client.logFailedRequest(contracts.SqlMigrationStopPerfDataCollectionRequest.type, e);
+		}
+
+		return undefined;
+	}
+
+	async refreshPerfDataCollection(lastRefreshedTime: Date): Promise<mssql.RefreshPerfDataCollectionResult | undefined> {
+		let params: contracts.SqlMigrationStopPerfDataCollectionParams = {
+			lastRefreshedTime
+		};
+
+		try {
+			return this.client.sendRequest(contracts.SqlMigrationRefreshPerfDataCollectionRequest.type, params);
+		}
+		catch (e) {
+			this.client.logFailedRequest(contracts.SqlMigrationRefreshPerfDataCollectionRequest.type, e);
+		}
+
+		return undefined;
+	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR includes several new changes in preparation for the new SKU recommendation feature in the SQL migration extension.

Changes include:
- updating sqltoolsservice to `3.0.0-release.202`, which includes an updated version of the assessment NuGet which enables the new SKU recommendation features
- defining new interfaces for the SKU recommendation functionality such as backend calls for generating SKU recommendations, as well as starting, stopping, and refreshing SQL performance data collection from ADS

See https://github.com/microsoft/azuredatastudio/pull/18252 and https://github.com/microsoft/sqltoolsservice/pull/1399 for corresponding changes.

Changes have been built and tested locally.