### PR TITLE
Fix Notebook navigation key events triggering incorrectly

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -133,9 +133,17 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			}
 			return false;
 		}));
+	}
+
+	ngOnInit() {
+		// We currently have to hook this onto window because the Notebook component currently doesn't support having document focus
+		// on its elements (we have a "virtual" focus that is updated as users click or navigate through cells). So some of the keyboard
+		// events we care about are fired when the document focus is on something else - typically the root window.
 		this._register(DOM.addDisposableListener(window, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			let event = new StandardKeyboardEvent(e);
-			if (this.isActive() && this.model.activeCell) {
+			// Make sure that the current active element is an ancestor - this is to prevent us from handling events when the focus is
+			// on some other dialog or part of the app. 
+			if (DOM.isAncestor(this.container.nativeElement, document.activeElement) && this.isActive() && this.model.activeCell) {
+				const event = new StandardKeyboardEvent(e);
 				if (!this.model.activeCell?.isEditMode) {
 					if (event.keyCode === KeyCode.DownArrow) {
 						let next = (this.findCellIndex(this.model.activeCell) + 1) % this.cells.length;
@@ -167,9 +175,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 				}
 			}
 		}));
-	}
-
-	ngOnInit() {
 		this._register(this.themeService.onDidColorThemeChange(this.updateTheme, this));
 		this.updateTheme(this.themeService.getColorTheme());
 		this.initActionBar();


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/18269

This isn't what I'd consider an ideal fix - preferably the event handler would be in the Notebook component only and so if the focus wasn't on the Notebook then we wouldn't even get these events.

But to do that we'd need to make the Notebook and cell components focusable in the first place which is not only a big change to be making (and should go through a full design review) but also wasn't something I was able to easily set up since setting tabindex on the cell components alone wasn't enough (we also need to be tracking the focus so we can update the active cell based on that, but I was having issues doing that since the cell components are divs).

So I went with this approach, which is a bit of a brute force solution but is simple enough and should cover the main issue here well enough. 

Note I also moved the event handler into the init function - since we should only be handling events after the UI is initialized or we could end up with errors as some elements don't exist yet. 