### PR TITLE
Fixing init value of custom zoom widget in query Plan 

### DIFF
--- a/src/sql/workbench/contrib/queryplan2/browser/widgets/customZoomWidget.ts
+++ b/src/sql/workbench/contrib/queryplan2/browser/widgets/customZoomWidget.ts
@@ -37,7 +37,7 @@ export class CustomZoomWidget extends QueryPlanWidgetBase {
 		});
 		attachInputBoxStyler(this.customZoomInputBox, this.themeService);
 
-		const currentZoom = queryPlanView.azdataGraphDiagram.graph.view.getScale();
+		const currentZoom = queryPlanView.azdataGraphDiagram.graph.view.getScale() * 100;
 
 		// Setting initial value to graph's current zoom
 		this.customZoomInputBox.value = Math.round(currentZoom).toString();


### PR DESCRIPTION
Multiplying the scale factor by 100 to remove decimals manipulation in custom zoom widget. 
Pic of where this feature is present in query plan 
![image](https://user-images.githubusercontent.com/6816294/153662888-eab111bd-46c5-4765-9ec1-2789b4513554.png)
![image](https://user-images.githubusercontent.com/6816294/153662844-829e04c1-f8a8-4136-8c55-cd4dacf865cc.png)
