### PR TITLE
Stop existing data collection when leaving and starting a new migration + update timers

### DIFF
--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -420,16 +420,18 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 		numberOfIterations: number,
 		page: SKURecommendationPage): Promise<boolean> {
 		try {
-			const ownerUri = await azdata.connection.getUriForConnection(this.sourceConnectionId);
-			const response = await this.migrationService.startPerfDataCollection(ownerUri, dataFolder, perfQueryIntervalInSec, staticQueryIntervalInSec, numberOfIterations);
+			if (!this.performanceCollectionInProgress()) {
+				const ownerUri = await azdata.connection.getUriForConnection(this.sourceConnectionId);
+				const response = await this.migrationService.startPerfDataCollection(ownerUri, dataFolder, perfQueryIntervalInSec, staticQueryIntervalInSec, numberOfIterations);
 
-			this._startPerfDataCollectionApiResponse = response!;
-			this._perfDataCollectionStartDate = this._startPerfDataCollectionApiResponse.dateTimeStarted;
-			this._perfDataCollectionStopDate = undefined;
+				this._startPerfDataCollectionApiResponse = response!;
+				this._perfDataCollectionStartDate = this._startPerfDataCollectionApiResponse.dateTimeStarted;
+				this._perfDataCollectionStopDate = undefined;
 
-			void vscode.window.showInformationMessage(constants.AZURE_RECOMMENDATION_START_POPUP);
+				void vscode.window.showInformationMessage(constants.AZURE_RECOMMENDATION_START_POPUP);
 
-			await this.startSkuTimers(page, this.refreshPerfDataCollectionFrequency);
+				await this.startSkuTimers(page, this.refreshPerfDataCollectionFrequency);
+			}
 		}
 		catch (error) {
 			console.log(error);
@@ -488,7 +490,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 
 	public async refreshPerfDataCollection(): Promise<boolean> {
 		try {
-			const response = await this.migrationService.refreshPerfDataCollection(this._perfDataCollectionLastRefreshedDate);
+			const response = await this.migrationService.refreshPerfDataCollection(this._perfDataCollectionLastRefreshedDate ?? new Date());
 			this._refreshPerfDataCollectionApiResponse = response!;
 			this._perfDataCollectionLastRefreshedDate = this._refreshPerfDataCollectionApiResponse.refreshTime;
 			this._perfDataCollectionMessages = this._refreshPerfDataCollectionApiResponse.messages;

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -209,16 +209,16 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 	public _perfDataCollectionErrors!: string[];
 	public _perfDataCollectionIsCollecting!: boolean;
 
-	public readonly _performanceDataQueryIntervalInSeconds = 5;		// TO-DO: update value
-	public readonly _staticDataQueryIntervalInSeconds = 30;			// TO-DO: update value
-	public readonly _numberOfPerformanceDataQueryIterations = 11;	// TO-DO: update value
+	public readonly _performanceDataQueryIntervalInSeconds = 30;
+	public readonly _staticDataQueryIntervalInSeconds = 60;
+	public readonly _numberOfPerformanceDataQueryIterations = 19;
 	public readonly _defaultDataPointStartTime = '1900-01-01 00:00:00';
 	public readonly _defaultDataPointEndTime = '2200-01-01 00:00:00';
 	public readonly _recommendationTargetPlatforms = [MigrationTargetType.SQLDB, MigrationTargetType.SQLMI, MigrationTargetType.SQLVM];
 
-	public refreshPerfDataCollectionFrequency: SupportedAutoRefreshIntervals = 30000;
+	public refreshPerfDataCollectionFrequency = this._performanceDataQueryIntervalInSeconds * 1000;
 	private _autoRefreshPerfDataCollectionHandle!: NodeJS.Timeout;
-	public refreshGetSkuRecommendationFrequency: SupportedAutoRefreshIntervals = 60000;	// TO-DO: update value
+	public refreshGetSkuRecommendationFrequency = 600000;	// 10 minutes
 	private _autoRefreshGetSkuRecommendationHandle!: NodeJS.Timeout;
 
 	public _skuScalingFactor!: number;

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -14,7 +14,7 @@ import { MigrationLocalStorage } from './migrationLocalStorage';
 import * as nls from 'vscode-nls';
 import { v4 as uuidv4 } from 'uuid';
 import { sendSqlMigrationActionEvent, TelemetryAction, TelemetryViews } from '../telemtery';
-import { hashString, deepClone, SupportedAutoRefreshIntervals } from '../api/utils';
+import { hashString, deepClone } from '../api/utils';
 import { SKURecommendationPage } from '../wizard/skuRecommendationPage';
 const localize = nls.loadMessageBundle();
 

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -915,7 +915,6 @@ export class SKURecommendationPage extends MigrationWizardPage {
 		}).component();
 		this._disposables.push(this._skuStopDataCollectionButton.onDidClick(async (e) => {
 			await this.migrationStateModel.stopPerfDataCollection();
-			await this.migrationStateModel.getSkuRecommendations();
 			await this.refreshSkuRecommendationComponents();
 		}));
 

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -915,6 +915,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 		}).component();
 		this._disposables.push(this._skuStopDataCollectionButton.onDidClick(async (e) => {
 			await this.migrationStateModel.stopPerfDataCollection();
+			await this.migrationStateModel.getSkuRecommendations();
 			await this.refreshSkuRecommendationComponents();
 		}));
 

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -1154,14 +1154,12 @@ export class SKURecommendationPage extends MigrationWizardPage {
 
 			// initial state before "Get Azure recommendation" dialog
 			default: {
-				if (this.migrationStateModel.performanceCollectionNotStarted()) {
-					await this._skuGetRecommendationContainer.updateCssStyles({ 'display': 'block' });
-					await this._skuDataCollectionStatusContainer.updateCssStyles({ 'display': 'none' });
-					await this._skuEditParametersContainer.updateCssStyles({ 'display': 'none' });
-					await this._azureRecommendationSectionText.updateProperties({
-						description: constants.AZURE_RECOMMENDATION_TOOLTIP_NOT_STARTED
-					});
-				}
+				await this._skuGetRecommendationContainer.updateCssStyles({ 'display': 'block' });
+				await this._skuDataCollectionStatusContainer.updateCssStyles({ 'display': 'none' });
+				await this._skuEditParametersContainer.updateCssStyles({ 'display': 'none' });
+				await this._azureRecommendationSectionText.updateProperties({
+					description: constants.AZURE_RECOMMENDATION_TOOLTIP_NOT_STARTED
+				});
 				break;
 			}
 		}

--- a/extensions/sql-migration/src/wizard/wizardController.ts
+++ b/extensions/sql-migration/src/wizard/wizardController.ts
@@ -61,6 +61,13 @@ export class WizardController {
 
 		this._wizardObject.pages = pages.map(p => p.getwizardPage());
 
+		// kill existing data collection if user relaunches the wizard via new migration or retry existing migration
+		await this._model.refreshPerfDataCollection();
+		if ((!this._model.resumeAssessment || this._model.retryMigration) && this._model._perfDataCollectionIsCollecting) {
+			void this._model.stopPerfDataCollection();
+			void vscode.window.showInformationMessage(loc.AZURE_RECOMMENDATION_STOP_POPUP);
+		}
+
 		const wizardSetupPromises: Thenable<void>[] = [];
 		wizardSetupPromises.push(...pages.map(p => p.registerWizardContent()));
 		wizardSetupPromises.push(this._wizardObject.open());


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Changes:
- previously, we implemented the case where users would start data collection, save and quit, come back, and _continue_ their existing migration, which works as intended - data is still collected and the user picks up where they left off. However, the case where they start collection, save and quit, come back, and _start a new migration_, the new migration would start just fine except the old data collection would still be running and wouldn't have a way to be stopped. Now, whenever the user selects that they want to start a new migration, any existing data collection will be terminated.
- update the data collection / SKU recommendation timers to their production values - query every 30 seconds, generate SKUs after 10 minutes