### PR TITLE
Fix for query-editor-boost date

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -2487,7 +2487,7 @@
 					"versions": [
 						{
 							"version": "0.4.1",
-							"lastUpdated": "12/14/2021",
+							"lastUpdated": "2/16/2020",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [


### PR DESCRIPTION
Reverts microsoft/azuredatastudio#18372 Accidentally changed date for query-editor-booster, need to merge this in ASAP