### PR TITLE
Fixed color contrast for error message in connect a dc window.

### DIFF
--- a/extensions/arc/src/test/ui/components/radioOptionsGroup.test.ts
+++ b/extensions/arc/src/test/ui/components/radioOptionsGroup.test.ts
@@ -52,8 +52,6 @@ describe('radioOptionsGroup', function (): void {
 		const label = radioOptionsGroup.items[0] as azdata.TextComponent;
 		should(label.value).not.be.undefined();
 		label.value!.should.deepEqual(loc.loadingClusterContextsError(loadingError));
-		should(label.CSSStyles).not.be.undefined();
-		should(label.CSSStyles!.color).not.be.undefined();
 	});
 
 	describe('getters and setters', async () => {

--- a/extensions/arc/src/test/ui/components/radioOptionsGroup.test.ts
+++ b/extensions/arc/src/test/ui/components/radioOptionsGroup.test.ts
@@ -54,7 +54,6 @@ describe('radioOptionsGroup', function (): void {
 		label.value!.should.deepEqual(loc.loadingClusterContextsError(loadingError));
 		should(label.CSSStyles).not.be.undefined();
 		should(label.CSSStyles!.color).not.be.undefined();
-		label.CSSStyles!.color.should.equal('Red');
 	});
 
 	describe('getters and setters', async () => {

--- a/extensions/arc/src/ui/components/radioOptionsGroup.ts
+++ b/extensions/arc/src/ui/components/radioOptionsGroup.ts
@@ -67,7 +67,7 @@ export class RadioOptionsGroup {
 			this.component().loadingCompletedText = this._loadingCompleteMessage;
 		}
 		catch (e) {
-			const errorLabel = this._modelBuilder.text().withProps({ value: loc.loadingClusterContextsError(e), CSSStyles: { 'color': 'Red' } }).component();
+			const errorLabel = this._modelBuilder.text().withProps({ value: loc.loadingClusterContextsError(e), textType: azdata.TextType.Error }).component();
 			this._divContainer.addItem(errorLabel);
 			this.component().loadingCompletedText = this._loadingCompleteErrorMessage(e);
 		}


### PR DESCRIPTION
Fixes the color contrast accessibility bug as seen here: https://github.com/microsoft/azuredatastudio/issues/15776
Now looks like:
![image](https://user-images.githubusercontent.com/22386690/154213364-46a3760c-4702-4121-9da5-34f7af9506f2.png)

This PR fixes #15776