### PR TITLE
[Port] Bump url-parse (#18422)

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -774,7 +774,7 @@
     "@microsoft/vscodetestcover": "^1.2.0"
   },
   "resolutions": {
-    "url-parse": "^1.5.1"
+    "url-parse": "^1.5.6"
   },
   "enableProposedApi": true
 }

--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -1798,10 +1798,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-parse@^1.5.1, url-parse@~1.4.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862"
-  integrity sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==
+url-parse@^1.5.6, url-parse@~1.4.3:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.6.tgz#b2a41d5a233645f3c31204cc8be60e76a15230a2"
+  integrity sha512-xj3QdUJ1DttD1LeSfvJlU1eiF1RvBSBfUu8GplFGdUzSO28y5yUtEl7wb//PI4Af6qh0o/K8545vUmucRrfWsw==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
(cherry picked from commit 3dbd5ac2c1ec86910aea4103b648605595962467)

Fixes https://github.com/microsoft/azuredatastudio/issues/18423