### PR TITLE
Adds Operational Cost to Query Plan Vertex Labels.

### DIFF
--- a/src/sql/workbench/contrib/queryplan2/browser/queryPlan.ts
+++ b/src/sql/workbench/contrib/queryplan2/browser/queryPlan.ts
@@ -283,14 +283,7 @@ export class QueryPlan2 implements ISashLayoutProvider {
 	}
 
 	private populate(node: InternalExecutionPlanNode, diagramNode: any): any {
-		diagramNode.label = '';
-		node.subtext.forEach((str, index) => {
-			diagramNode.label += str;
-
-			if (index < node.subtext.length - 1) {
-				diagramNode.label += this.textResourcePropertiesService.getEOL(undefined);
-			}
-		});
+		diagramNode.label = node.subtext.join(this.textResourcePropertiesService.getEOL(undefined));
 		const nodeId = this.createGraphElementId();
 		diagramNode.id = nodeId;
 		node.id = nodeId;

--- a/src/sql/workbench/contrib/queryplan2/browser/queryPlan.ts
+++ b/src/sql/workbench/contrib/queryplan2/browser/queryPlan.ts
@@ -38,6 +38,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { URI } from 'vs/base/common/uri';
+import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
 
 let azdataGraph = azdataGraphModule();
 
@@ -165,7 +166,8 @@ export class QueryPlan2 implements ISashLayoutProvider {
 		@IContextMenuService private _contextMenuService: IContextMenuService,
 		@IFileDialogService public fileDialogService: IFileDialogService,
 		@IFileService public fileService: IFileService,
-		@IWorkspaceContextService public workspaceContextService: IWorkspaceContextService
+		@IWorkspaceContextService public workspaceContextService: IWorkspaceContextService,
+		@ITextResourcePropertiesService private readonly textResourcePropertiesService: ITextResourcePropertiesService,
 	) {
 		// parent container for query plan.
 		this._container = DOM.$('.query-plan');
@@ -281,7 +283,14 @@ export class QueryPlan2 implements ISashLayoutProvider {
 	}
 
 	private populate(node: InternalExecutionPlanNode, diagramNode: any): any {
-		diagramNode.label = node.name;
+		diagramNode.label = '';
+		node.subtext.forEach((str, index) => {
+			diagramNode.label += str;
+
+			if (index < node.subtext.length - 1) {
+				diagramNode.label += this.textResourcePropertiesService.getEOL(undefined);
+			}
+		});
 		const nodeId = this.createGraphElementId();
 		diagramNode.id = nodeId;
 		node.id = nodeId;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #18374, which allows us to include cost information to graph cells in ADS. An example of this cost information appearing is seen here: 
![image](https://user-images.githubusercontent.com/87730006/154381675-ecd98b4e-8142-4260-a123-d4b50e9f7e14.png)


