### PR TITLE
Add option to disable running integration tests

### DIFF
--- a/build/azure-pipelines/win32/sql-product-test-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-test-win32.yml
@@ -51,7 +51,7 @@ steps:
     $AppNameShort = $AppProductJson.nameShort
     exec { $env:INTEGRATION_TEST_ELECTRON_PATH = "$AppRoot\$AppNameShort.exe"; $env:INTEGRATION_TEST_CLI_PATH = "$AppRoot\bin\$AppNameShort"; .\scripts\sql-test-integration.bat }
   continueOnError: false
-  condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+  condition: and(succeededOrFailed(), and(eq(variables['RUN_TESTS'], 'true'), ne(variables['RUN_INTEGRATION_TESTS'], 'false')))
   displayName: Run stable tests
   env:
     BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
@@ -75,7 +75,7 @@ steps:
     $AppNameShort = $AppProductJson.nameShort
     exec { $env:INTEGRATION_TEST_ELECTRON_PATH = "$AppRoot\$AppNameShort.exe"; .\scripts\sql-test-integration-unstable.bat }
   continueOnError: true
-  condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
+  condition: and(succeededOrFailed(), and(eq(variables['RUN_UNSTABLE_TESTS'], 'true'), ne(variables['RUN_INTEGRATION_TESTS'], 'false')))
   displayName: Run unstable integration tests
   env:
     BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
@@ -99,4 +99,4 @@ steps:
     mergeTestResults: true
     failTaskOnFailedTests: true
   continueOnError: true
-  condition: and(succeededOrFailed(), eq(variables['RUN_TESTS'], 'true'))
+  condition: and(succeededOrFailed(), and(eq(variables['RUN_TESTS'], 'true'), ne(variables['RUN_INTEGRATION_TESTS'], 'false')))

--- a/build/azure-pipelines/win32/sql-product-test-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-test-win32.yml
@@ -51,7 +51,7 @@ steps:
     $AppNameShort = $AppProductJson.nameShort
     exec { $env:INTEGRATION_TEST_ELECTRON_PATH = "$AppRoot\$AppNameShort.exe"; $env:INTEGRATION_TEST_CLI_PATH = "$AppRoot\bin\$AppNameShort"; .\scripts\sql-test-integration.bat }
   continueOnError: false
-  condition: and(succeededOrFailed(), and(eq(variables['RUN_TESTS'], 'true'), ne(variables['RUN_INTEGRATION_TESTS'], 'false')))
+  condition: and(succeeded(), and(eq(variables['RUN_TESTS'], 'true'), ne(variables['RUN_INTEGRATION_TESTS'], 'false')))
   displayName: Run stable tests
   env:
     BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
@@ -75,7 +75,7 @@ steps:
     $AppNameShort = $AppProductJson.nameShort
     exec { $env:INTEGRATION_TEST_ELECTRON_PATH = "$AppRoot\$AppNameShort.exe"; .\scripts\sql-test-integration-unstable.bat }
   continueOnError: true
-  condition: and(succeededOrFailed(), and(eq(variables['RUN_UNSTABLE_TESTS'], 'true'), ne(variables['RUN_INTEGRATION_TESTS'], 'false')))
+  condition: and(succeeded(), and(eq(variables['RUN_UNSTABLE_TESTS'], 'true'), ne(variables['RUN_INTEGRATION_TESTS'], 'false')))
   displayName: Run unstable integration tests
   env:
     BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)


### PR DESCRIPTION
Set up to explicitly require disabling integration tests (by setting RUN_INTEGRATION_TESTS to false) so that nothing changes by default. 

Porting to 1.35 directly for quick turnaround, will bring to main after this is in. 