### PR TITLE
[PORT] Clear account tokens before refresh (#18452)

### DIFF
--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -172,6 +172,11 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 	}
 
 	refresh(account: AzureAccount): Thenable<AzureAccount | azdata.PromptFailedResult> {
+		return this._refresh(account);
+	}
+
+	private async _refresh(account: AzureAccount): Promise<AzureAccount | azdata.PromptFailedResult> {
+		await this._clear(account.key);
 		return this.prompt();
 	}
 

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -418,6 +418,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 				if (account) {
 					await this._accountManagementService.refreshAccount(account);
 					await this.fillInAzureAccountOptions();
+					this.updateRefreshCredentialsLink();
 				}
 			}));
 		}


### PR DESCRIPTION
Fix to clear the azure account tokens from the cache before refreshing for new tokens

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses https://github.com/microsoft/azuredatastudio/issues/12637 https://github.com/microsoft/azuredatastudio/issues/14159
