### PR TITLE
Fix search experience in notebooks

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -146,46 +146,48 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			// For Escape - the focused element is the div.notebook-preview or textarea.inputarea of the cell, so we need to make sure that it is a descendant of the current active cell
 			//  on the current active editor.
 			const activeCellElement = this.container.nativeElement.querySelector(`.editor-group-container.active .notebook-cell.active`);
+			const findWidgetVisible = document.querySelector(`.editor-widget.find-widget.visible`);
 			let handled = false;
-			if (DOM.isAncestor(this.container.nativeElement, document.activeElement) && this.isActive() && this.model.activeCell) {
-				const event = new StandardKeyboardEvent(e);
-				if (!this.model.activeCell?.isEditMode) {
-					if (event.keyCode === KeyCode.DownArrow) {
-						let next = (this.findCellIndex(this.model.activeCell) + 1) % this.cells.length;
+			if (isUndefinedOrNull(findWidgetVisible)) {
+				if (DOM.isAncestor(this.container.nativeElement, document.activeElement) && this.isActive() && this.model.activeCell) {
+					const event = new StandardKeyboardEvent(e);
+					if (!this.model.activeCell?.isEditMode) {
+						if (event.keyCode === KeyCode.DownArrow) {
+							let next = (this.findCellIndex(this.model.activeCell) + 1) % this.cells.length;
 
-						this.navigateToCell(this.cells[next]);
-						handled = true;
-					} else if (event.keyCode === KeyCode.UpArrow) {
-						let index = this.findCellIndex(this.model.activeCell);
-						if (index === 0) {
-							index = this.cells.length;
+							this.navigateToCell(this.cells[next]);
+							handled = true;
+						} else if (event.keyCode === KeyCode.UpArrow) {
+							let index = this.findCellIndex(this.model.activeCell);
+							if (index === 0) {
+								index = this.cells.length;
+							}
+							this.navigateToCell(this.cells[--index]);
+							handled = true;
 						}
-						this.navigateToCell(this.cells[--index]);
-						handled = true;
+						else if (event.keyCode === KeyCode.Enter) {
+							this.toggleEditMode();
+							handled = true;
+						}
+						else if (event.keyCode === KeyCode.Escape) {
+							// unselects active cell and removes the focus from code cells
+							this.unselectActiveCell();
+							(document.activeElement as HTMLElement).blur();
+							handled = true;
+						}
 					}
-					else if (event.keyCode === KeyCode.Enter) {
+				} else if (DOM.isAncestor(document.activeElement, activeCellElement) && this.isActive() && this.model.activeCell) {
+					const event = new StandardKeyboardEvent(e);
+					if (event.keyCode === KeyCode.Escape) {
+						// first time hitting escape removes the cursor from code cell and changes toolbar in text cells and changes edit mode to false
 						this.toggleEditMode();
 						handled = true;
 					}
-					else if (event.keyCode === KeyCode.Escape) {
-						// unselects active cell and removes the focus from code cells
-						this.unselectActiveCell();
-						(document.activeElement as HTMLElement).blur();
-						handled = true;
-					}
 				}
-			} else if (DOM.isAncestor(document.activeElement, activeCellElement) && this.isActive() && this.model.activeCell) {
-				const event = new StandardKeyboardEvent(e);
-				if (event.keyCode === KeyCode.Escape) {
-					// first time hitting escape removes the cursor from code cell and changes toolbar in text cells and changes edit mode to false
-					this.toggleEditMode();
-					handled = true;
+				if (handled) {
+					DOM.EventHelper.stop(e);
 				}
 			}
-			if (handled) {
-				DOM.EventHelper.stop(e);
-			}
-
 		}));
 		this._register(this.themeService.onDidColorThemeChange(this.updateTheme, this));
 		this.updateTheme(this.themeService.getColorTheme());
@@ -317,7 +319,9 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			selectedCell = this.codeCells.find(c => c.cellModel.id === this.activeCellId);
 		}
 		selectedCell.toggleEditMode();
-		this.setActiveCellEditActionMode(selectedCell.cellModel.isEditMode);
+		if (this.model.activeCell.cellType !== CellTypes.Code) {
+			this.setActiveCellEditActionMode(selectedCell.cellModel.isEditMode);
+		}
 	}
 
 	//Saves scrollTop value on scroll change

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -450,6 +450,7 @@ export class NotebookEditor extends EditorPane implements IFindNotebookControlle
 				this.setSelection(p);
 				this._updateFinderMatchState();
 				this._setCurrentFindMatch(p);
+				this._finder.focusFindInput();
 			}
 		} catch (er) {
 			onUnexpectedError(er);

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -436,6 +436,7 @@ export class NotebookEditor extends EditorPane implements IFindNotebookControlle
 				this.setSelection(p);
 				this._updateFinderMatchState();
 				this._setCurrentFindMatch(p);
+				this._finder.focusFindInput();
 			}
 		} catch (er) {
 			onUnexpectedError(er);


### PR DESCRIPTION
This PR is for #18472

- Check that the findWidget is undefined before handling notebook cell events. 
- When hitting enter for the next result, the find widget loses focus and we cannot longer go to the next result. Focusing on the findInput, when searching next result fixes the issue.
