### PR TITLE
Remove connection error popup notification

### DIFF
--- a/src/sql/platform/connection/common/connectionStatusManager.ts
+++ b/src/sql/platform/connection/common/connectionStatusManager.ts
@@ -9,12 +9,9 @@ import { ConnectionProfile } from 'sql/platform/connection/common/connectionProf
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { StopWatch } from 'vs/base/common/stopwatch';
 import { ILogService } from 'vs/platform/log/common/log';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { join } from 'vs/base/common/path';
 import * as Utils from 'sql/platform/connection/common/utils';
 import * as azdata from 'azdata';
 import * as nls from 'vs/nls';
-import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { values } from 'vs/base/common/collections';
 import { Schemas } from 'vs/base/common/network';
 
@@ -24,9 +21,7 @@ export class ConnectionStatusManager {
 
 	constructor(
 		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService,
-		@ILogService private _logService: ILogService,
-		@IEnvironmentService private _environmentService: IEnvironmentService,
-		@INotificationService private _notificationService: INotificationService) {
+		@ILogService private _logService: ILogService) {
 		this._connections = {};
 	}
 

--- a/src/sql/platform/connection/common/connectionStatusManager.ts
+++ b/src/sql/platform/connection/common/connectionStatusManager.ts
@@ -143,10 +143,6 @@ export class ConnectionStatusManager {
 		let connection = this._connections[summary.ownerUri];
 		if (!connection) {
 			this._logService.error(`OnConnectionComplete but no connection found '${summary.ownerUri}' Connections = [${Object.keys(this._connections)}]`);
-			this._notificationService.notify({
-				severity: Severity.Error,
-				message: `An unexpected error occurred while connecting. Please [file an issue](command:workbench.action.openIssueReporter) with the title 'Unexpected Error Occurred while Connecting' and include the log file [${join(this._environmentService.logsPath, 'renderer1.log')}](command:workbench.action.openLogsFolder)`
-			});
 			// Bail out at this point - there's nothing else we can do since this is an unexpected state.
 			throw new Error('Unexpected error occurred while connecting.');
 		}

--- a/src/sql/platform/connection/test/node/connectionStatusManager.test.ts
+++ b/src/sql/platform/connection/test/node/connectionStatusManager.test.ts
@@ -10,12 +10,8 @@ import * as Utils from 'sql/platform/connection/common/utils';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
-import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { NullLogService } from 'vs/platform/log/common/log';
-import { NativeEnvironmentService } from 'vs/platform/environment/node/environmentService';
-import { parseArgs, OPTIONS } from 'vs/platform/environment/node/argv';
-import product from 'vs/platform/product/common/product';
 
 let connections: ConnectionStatusManager;
 let capabilitiesService: TestCapabilitiesService;
@@ -81,8 +77,7 @@ suite('SQL ConnectionStatusManager tests', () => {
 		capabilitiesService = new TestCapabilitiesService();
 		connectionProfileObject = new ConnectionProfile(capabilitiesService, connectionProfile);
 
-		const environmentService = new NativeEnvironmentService(parseArgs(process.argv, OPTIONS), { _serviceBrand: undefined, ...product });
-		connections = new ConnectionStatusManager(capabilitiesService, new NullLogService(), environmentService, new TestNotificationService());
+		connections = new ConnectionStatusManager(capabilitiesService, new NullLogService());
 		connection1Id = Utils.generateUri(connectionProfile);
 		connection2Id = 'connection2Id';
 		connection3Id = 'connection3Id';

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -29,7 +29,7 @@ import * as sinon from 'sinon';
 import { IConnectionProfileGroup, ConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { TestAccountManagementService } from 'sql/platform/accounts/test/common/testAccountManagementService';
-import { TestEnvironmentService, TestEditorService } from 'vs/workbench/test/browser/workbenchTestServices';
+import { TestEditorService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
@@ -94,7 +94,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		connectionDialogService = TypeMoq.Mock.ofType(TestConnectionDialogService);
 		connectionStore = TypeMoq.Mock.ofType(ConnectionStore, TypeMoq.MockBehavior.Loose, new TestStorageService());
 		workbenchEditorService = TypeMoq.Mock.ofType(TestEditorService);
-		connectionStatusManager = new ConnectionStatusManager(capabilitiesService, new NullLogService(), TestEnvironmentService, new TestNotificationService());
+		connectionStatusManager = new ConnectionStatusManager(capabilitiesService, new NullLogService());
 		mssqlConnectionProvider = TypeMoq.Mock.ofType(TestConnectionProvider);
 		let resourceProviderStub = new TestResourceProvider();
 		resourceProviderStubMock = TypeMoq.Mock.ofInstance(resourceProviderStub);


### PR DESCRIPTION
I added this a while back to try and figure out why we hit this occasionally but it hasn't really turned out to be useful for tracking anything down and generally when it happens isn't a critical error (when I've seen it it's because the connection was deleted before the onConnectionComplete handler was called which isn't necessarily unexpected).

Handling cases like that correctly will require some more investigation, but for the time being we should remove this since it doesn't provide useful information and often times isn't something that impacts the user. 