### PR TITLE
fix section markdown and html link

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -57,7 +57,6 @@ export class LinkHandlerDirective {
 
 	private async handleLink(content: string): Promise<void> {
 		let uri: URI | undefined;
-		let fragment: string = '';
 		try {
 			uri = URI.parse(content);
 		} catch {
@@ -74,9 +73,8 @@ export class LinkHandlerDirective {
 			}
 		}
 		if (uri && this.openerService) {
-			if (uri.fragment !== '') {
-				fragment = uri.fragment;
-			}
+			// Store fragment before converting, since asFileUri removes the uri fragment
+			const fragment = uri.fragment;
 			// Convert vscode-file protocol URIs to file since that's what Notebooks expect to work with
 			uri = FileAccess.asFileUri(uri);
 			if (this.isSupportedLink(uri)) {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -57,6 +57,7 @@ export class LinkHandlerDirective {
 
 	private async handleLink(content: string): Promise<void> {
 		let uri: URI | undefined;
+		let fragment: string = '';
 		try {
 			uri = URI.parse(content);
 		} catch {
@@ -73,11 +74,14 @@ export class LinkHandlerDirective {
 			}
 		}
 		if (uri && this.openerService) {
+			if (uri.fragment !== '') {
+				fragment = uri.fragment;
+			}
 			// Convert vscode-file protocol URIs to file since that's what Notebooks expect to work with
 			uri = FileAccess.asFileUri(uri);
 			if (this.isSupportedLink(uri)) {
-				if (uri.fragment && uri.fragment.length > 0 && uri.fsPath === this.workbenchFilePath.fsPath) {
-					this.notebookService.navigateTo(this.notebookUri, uri.fragment);
+				if (fragment && fragment.length > 0 && uri.fsPath === this.workbenchFilePath.fsPath) {
+					this.notebookService.navigateTo(this.notebookUri, fragment);
 				} else {
 					if (uri.scheme === 'file') {
 						let exists = await this.fileService.exists(uri);


### PR DESCRIPTION
This PR is for #18477

The new vscode file parser removes the fragment from the uri and returns undefined.
