### PR TITLE
Removing extra toUrl call

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour.ts
@@ -161,8 +161,7 @@ export class GuidedTour extends Disposable {
 			exitButton.classList.add('ads-tour-btn-exit');
 			exitButton.innerText = 'x';
 			const img = document.createElement('img');
-			const gif = require.toUrl(popupImage);
-			img.src = require.toUrl(gif);
+			img.src = require.toUrl(popupImage);
 			img.classList.add('ads-tour-img');
 			flexContainer.classList.add(...flexClasses);
 			container.classList.add('ads-tour-popup');


### PR DESCRIPTION
This PR fixes #18490 

The URL that was generated due to double require.toUrl calls was 
```
vscode-file://vscode-app/c:/src/azuredatastudio/out/vscode-file://vscode-app/c:/src/azuredatastudio/out/sql/workbench/contrib/welcome/gettingStarted/media/connections.png
```

I fixed the issue by making it a single require.toUrl call.