### PR TITLE
Remove duplicate AzureResource enum

### DIFF
--- a/src/sql/platform/accounts/common/interfaces.ts
+++ b/src/sql/platform/accounts/common/interfaces.ts
@@ -47,22 +47,6 @@ export interface IAccountManagementService {
 	readonly updateAccountListEvent: Event<UpdateAccountListEventParams>;
 }
 
-// API sqlExtHostTypes.ts > AzureResource should also be updated
-// Enum matching the AzureResource enum from azdata.d.ts
-export enum AzureResource {
-	ResourceManagement = 0,
-	Sql = 1,
-	OssRdbms = 2,
-	AzureKeyVault = 3,
-	Graph = 4,
-	MicrosoftResourceManagement = 5,
-	AzureDevOps = 6,
-	MsGraph = 7,
-	AzureLogAnalytics = 8,
-	AzureStorage = 9,
-	AzureKusto = 10
-}
-
 export interface IAccountStore {
 	/**
 	 * Adds the provided account if the account doesn't exist. Updates the account if it already exists

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -430,7 +430,6 @@ export class TreeComponentItem extends vsExtTypes.TreeItem {
 	checked?: boolean;
 }
 
-// Accounts interfaces.ts > AzureResource should also be updated
 export enum AzureResource {
 	ResourceManagement = 0,
 	Sql = 1,

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -23,8 +23,8 @@ import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IResourceProviderService } from 'sql/workbench/services/resourceProvider/common/resourceProviderService';
 import { IAngularEventingService, AngularEventType } from 'sql/platform/angularEventing/browser/angularEventingService';
 import { Deferred } from 'sql/base/common/promise';
-import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
-import { IAccountManagementService, AzureResource } from 'sql/platform/accounts/common/interfaces';
+import { AzureResource, ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { IAccountManagementService } from 'sql/platform/accounts/common/interfaces';
 
 import * as azdata from 'azdata';
 

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController.ts
@@ -10,10 +10,11 @@ import * as azdata from 'azdata';
 
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { FirewallRuleDialog } from 'sql/workbench/services/resourceProvider/browser/firewallRuleDialog';
-import { IAccountManagementService, AzureResource } from 'sql/platform/accounts/common/interfaces';
+import { IAccountManagementService } from 'sql/platform/accounts/common/interfaces';
 import { IResourceProviderService } from 'sql/workbench/services/resourceProvider/common/resourceProviderService';
 import { Deferred } from 'sql/base/common/promise';
 import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMessageService';
+import { AzureResource } from 'sql/workbench/api/common/sqlExtHostTypes';
 
 export class FirewallRuleDialogController {
 

--- a/src/sql/workbench/test/electron-browser/api/extHostAccountManagement.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostAccountManagement.test.ts
@@ -12,9 +12,10 @@ import { TestInstantiationService } from 'vs/platform/instantiation/test/common/
 import { IRPCProtocol } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { SqlMainContext } from 'sql/workbench/api/common/sqlExtHost.protocol';
 import { MainThreadAccountManagement } from 'sql/workbench/api/browser/mainThreadAccountManagement';
-import { IAccountManagementService, AzureResource } from 'sql/platform/accounts/common/interfaces';
+import { IAccountManagementService } from 'sql/platform/accounts/common/interfaces';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { TestRPCProtocol } from 'vs/workbench/test/browser/api/testRPCProtocol';
+import { AzureResource } from 'sql/workbench/api/common/sqlExtHostTypes';
 
 const IRPCProtocol = createDecorator<IRPCProtocol>('rpcProtocol');
 


### PR DESCRIPTION
We already have this defined in https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/api/common/sqlExtHostTypes.ts#L434 - there's no reason to have it duplicated like this. 