### PR TITLE
Add AzureAccount service

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -212,6 +212,7 @@
 				"restrictions": [
 					"vs/nls",
 					"azdata",
+					"azurecore",
 					"**/{vs,sql}/base/common/**",
 					"**/{vs,sql}/base/parts/*/common/**",
 					"**/{vs,sql}/platform/*/common/**"
@@ -472,6 +473,7 @@
 				"restrictions": [
 					"vscode",
 					"azdata",
+					"azurecore",
 					"vs/nls",
 					"**/{vs,sql}/base/common/**",
 					"**/{vs,sql}/platform/*/common/**",
@@ -577,6 +579,7 @@
 					"vs/nls",
 					"vs/css!./**/*",
 					"azdata",
+					"azurecore",
 					"vscode",
 					"**/{vs,sql}/base/**/{common,browser,worker}/**",
 					"**/{vs,sql}/platform/**/{common,browser}/**",

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -263,6 +263,12 @@ declare module 'azurecore' {
 	}
 
 	export interface IExtension {
+		/**
+		 * Gets the list of subscriptions for the specified AzureAccount
+		 * @param account The account to get the subscriptions for
+		 * @param ignoreErrors If true any errors are not thrown and instead collected and returned as part of the result
+		 * @param selectedOnly Whether to only list subscriptions the user has selected to filter to for this account
+		 */
 		getSubscriptions(account?: AzureAccount, ignoreErrors?: boolean, selectedOnly?: boolean): Promise<GetSubscriptionsResult>;
 		getResourceGroups(account?: AzureAccount, subscription?: azureResource.AzureResourceSubscription, ignoreErrors?: boolean): Promise<GetResourceGroupsResult>;
 		getLocations(account?: AzureAccount, subscription?: azureResource.AzureResourceSubscription, ignoreErrors?: boolean): Promise<GetLocationsResult>;

--- a/src/sql/platform/azureAccount/common/azureAccountService.ts
+++ b/src/sql/platform/azureAccount/common/azureAccountService.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as azurecore from 'azurecore';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+export const SERVICE_ID = 'azureAccountService';
+
+export const IAzureAccountService = createDecorator<IAzureAccountService>(SERVICE_ID);
+
+export interface IAzureAccountService {
+	_serviceBrand: undefined;
+	getSubscriptions(account: azurecore.AzureAccount): Promise<azurecore.GetSubscriptionsResult>;
+}
+

--- a/src/sql/workbench/api/browser/extensionHost.contribution.ts
+++ b/src/sql/workbench/api/browser/extensionHost.contribution.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './mainThreadAzureAccount';
 import './mainThreadAccountManagement';
 import './mainThreadBackgroundTaskManagement';
 import './mainThreadConnectionManagement';

--- a/src/sql/workbench/api/browser/mainThreadAzureAccount.ts
+++ b/src/sql/workbench/api/browser/mainThreadAzureAccount.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as azurecore from 'azurecore';
+import { Disposable } from 'vs/base/common/lifecycle';
+import {
+	ExtHostAzureAccountShape,
+	MainThreadAzureAccountShape,
+	SqlExtHostContext,
+	SqlMainContext
+} from 'sql/workbench/api/common/sqlExtHost.protocol';
+import { IExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
+import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
+import { IAzureAccountService } from 'sql/platform/azureAccount/common/azureAccountService';
+import { AzureAccountService } from 'sql/workbench/services/azureAccount/browser/azureAccountService';
+
+@extHostNamedCustomer(SqlMainContext.MainThreadAzureAccount)
+export class MainThreadAzureAccount extends Disposable implements MainThreadAzureAccountShape {
+	private _proxy: ExtHostAzureAccountShape;
+	public _serviceBrand: undefined;
+
+	constructor(
+		extHostContext: IExtHostContext,
+		@IAzureAccountService azureAccountService: IAzureAccountService
+	) {
+		super();
+		this._proxy = extHostContext.getProxy(SqlExtHostContext.ExtHostAzureAccount);
+		(azureAccountService as AzureAccountService).registerProxy(this);
+	}
+
+	public async getSubscriptions(account: azurecore.AzureAccount, ignoreErrors?: boolean, selectedOnly?: boolean): Promise<azurecore.GetSubscriptionsResult> {
+		return this._proxy.$getSubscriptions(account, ignoreErrors, selectedOnly);
+	}
+
+}

--- a/src/sql/workbench/api/common/extHostAzureAccount.ts
+++ b/src/sql/workbench/api/common/extHostAzureAccount.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azurecore from 'azurecore';
+import { ExtHostAzureAccountShape } from 'sql/workbench/api/common/sqlExtHost.protocol';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { IExtHostExtensionService } from 'vs/workbench/api/common/extHostExtensionService';
+
+export class ExtHostAzureAccount extends ExtHostAzureAccountShape {
+
+	constructor(@IExtHostExtensionService private _extHostExtensionService: IExtHostExtensionService,) {
+		super();
+	}
+
+	public override $getSubscriptions(account: azurecore.AzureAccount, ignoreErrors?: boolean, selectedOnly?: boolean): Thenable<azurecore.GetSubscriptionsResult> {
+		const api = this._extHostExtensionService.getExtensionExports(new ExtensionIdentifier(azurecore.extension.name)) as azurecore.IExtension;
+		return api.getSubscriptions(account, ignoreErrors, selectedOnly);
+	}
+}
+

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -37,6 +37,8 @@ import { ExtHostWorkspace } from 'sql/workbench/api/common/extHostWorkspace';
 import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitDataService';
 import { URI } from 'vs/base/common/uri';
 import { ITelemetryEventProperties } from 'sql/platform/telemetry/common/telemetry';
+import { ExtHostAzureAccount } from 'sql/workbench/api/common/extHostAzureAccount';
+import { IExtHostExtensionService } from 'vs/workbench/api/common/extHostExtensionService';
 
 export interface IAzdataExtensionApiFactory {
 	(extension: IExtensionDescription): typeof azdata;
@@ -77,6 +79,7 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 
 	// Addressable instances
 	const extHostAccountManagement = rpcProtocol.set(SqlExtHostContext.ExtHostAccountManagement, new ExtHostAccountManagement(rpcProtocol));
+	rpcProtocol.set(SqlExtHostContext.ExtHostAzureAccount, new ExtHostAzureAccount(accessor.get(IExtHostExtensionService)));
 	const extHostConnectionManagement = rpcProtocol.set(SqlExtHostContext.ExtHostConnectionManagement, new ExtHostConnectionManagement(rpcProtocol));
 	const extHostCredentialManagement = rpcProtocol.set(SqlExtHostContext.ExtHostCredentialManagement, new ExtHostCredentialManagement(rpcProtocol));
 	const extHostDataProvider = rpcProtocol.set(SqlExtHostContext.ExtHostDataProtocol, new ExtHostDataProtocol(rpcProtocol, uriTransformer));

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -13,6 +13,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 
 import type * as azdata from 'azdata';
 import type * as vscode from 'vscode';
+import type * as azurecore from 'azurecore';
 
 import { ITreeComponentItem } from 'sql/workbench/common/views';
 import { ITaskHandlerDescription } from 'sql/workbench/services/tasks/common/tasks';
@@ -29,6 +30,10 @@ import { IQueryEvent } from 'sql/workbench/services/query/common/queryModel';
 import { EditorViewColumn } from 'vs/workbench/api/common/shared/editor';
 import { TreeDataTransferDTO } from 'vs/workbench/api/common/shared/treeDataTransfer';
 import { ITelemetryEventProperties } from 'sql/platform/telemetry/common/telemetry';
+
+export abstract class ExtHostAzureAccountShape {
+	public $getSubscriptions(account: azurecore.AzureAccount, ignoreErrors?: boolean, selectedOnly?: boolean): Thenable<azurecore.GetSubscriptionsResult> { throw ni(); }
+}
 
 export abstract class ExtHostAccountManagementShape {
 	$autoOAuthCancelled(handle: number): Thenable<void> { throw ni(); }
@@ -603,6 +608,10 @@ export interface MainThreadAccountManagementShape extends IDisposable {
 	$getAccountsForProvider(providerId: string): Thenable<azdata.Account[]>;
 }
 
+export interface MainThreadAzureAccountShape extends IDisposable {
+
+}
+
 export interface MainThreadResourceProviderShape extends IDisposable {
 	$registerResourceProvider(providerMetadata: azdata.ResourceProviderMetadata, handle: number): Thenable<any>;
 	$unregisterResourceProvider(handle: number): Thenable<any>;
@@ -688,6 +697,7 @@ function ni() { return new Error('Not implemented'); }
 export const SqlMainContext = {
 	// SQL entries
 	MainThreadAccountManagement: createMainId<MainThreadAccountManagementShape>('MainThreadAccountManagement'),
+	MainThreadAzureAccount: createMainId<MainThreadAzureAccountShape>('MainThreadAzureAccount'),
 	MainThreadConnectionManagement: createMainId<MainThreadConnectionManagementShape>('MainThreadConnectionManagement'),
 	MainThreadCredentialManagement: createMainId<MainThreadCredentialManagementShape>('MainThreadCredentialManagement'),
 	MainThreadDataProtocol: createMainId<MainThreadDataProtocolShape>('MainThreadDataProtocol'),
@@ -709,6 +719,7 @@ export const SqlMainContext = {
 
 export const SqlExtHostContext = {
 	ExtHostAccountManagement: createExtId<ExtHostAccountManagementShape>('ExtHostAccountManagement'),
+	ExtHostAzureAccount: createExtId<ExtHostAzureAccountShape>('ExtHostAzureAccount'),
 	ExtHostConnectionManagement: createExtId<ExtHostConnectionManagementShape>('ExtHostConnectionManagement'),
 	ExtHostCredentialManagement: createExtId<ExtHostCredentialManagementShape>('ExtHostCredentialManagement'),
 	ExtHostDataProtocol: createExtId<ExtHostDataProtocolShape>('ExtHostDataProtocol'),

--- a/src/sql/workbench/services/azureAccount/browser/azureAccountService.ts
+++ b/src/sql/workbench/services/azureAccount/browser/azureAccountService.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as azurecore from 'azurecore';
+import { IAzureAccountService } from 'sql/platform/azureAccount/common/azureAccountService';
+import { MainThreadAzureAccount } from 'sql/workbench/api/browser/mainThreadAzureAccount';
+
+/**
+ * Service that provides access to the azurecore extension capabilities (such as getting subscriptions
+ * for an Azure account)
+ */
+export class AzureAccountService implements IAzureAccountService {
+
+	public _serviceBrand: undefined;
+	private _proxy: MainThreadAzureAccount;
+
+	/**
+	 * Internal use only, do not call! This is called once on startup by the proxy object used
+	 * to communicate with the extension host once it's been created.
+	 * @param proxy The proxy to use to communicate with the azurecore extension
+	 */
+	public registerProxy(proxy: MainThreadAzureAccount) {
+		this._proxy = proxy;
+	}
+
+	/**
+	 * Gets the list of subscriptions for the specified AzureAccount
+	 * @param account The account to get the subscriptions for
+	 * @param ignoreErrors If true any errors are not thrown and instead collected and returned as part of the result
+	 * @param selectedOnly Whether to only list subscriptions the user has selected to filter to for this account
+	 */
+	public getSubscriptions(account: azurecore.AzureAccount, ignoreErrors?: boolean, selectedOnly?: boolean): Promise<azurecore.GetSubscriptionsResult> {
+		this.checkProxy();
+		return this._proxy.getSubscriptions(account, ignoreErrors, selectedOnly);
+	}
+
+	private checkProxy(): void {
+		if (!this._proxy) {
+			throw new Error('Azure Account proxy not initialized');
+		}
+	}
+}
+

--- a/src/typings/refs.d.ts
+++ b/src/typings/refs.d.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference path='../../extensions/azurecore/src/azurecore.d.ts' />

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -84,10 +84,13 @@ import { IClipboardService as sqlIClipboardService } from 'sql/platform/clipboar
 import { ClipboardService as sqlClipboardService } from 'sql/platform/clipboard/electron-browser/clipboardService';
 import { IQueryHistoryService } from 'sql/workbench/services/queryHistory/common/queryHistoryService';
 import { QueryHistoryService } from 'sql/workbench/services/queryHistory/common/queryHistoryServiceImpl';
+import { IAzureAccountService } from 'sql/platform/azureAccount/common/azureAccountService';
+import { AzureAccountService } from 'sql/workbench/services/azureAccount/browser/azureAccountService';
 
 registerSingleton(ISqlOAuthService, SqlOAuthService);
 registerSingleton(sqlIClipboardService, sqlClipboardService);
 registerSingleton(IQueryHistoryService, QueryHistoryService);
+registerSingleton(IAzureAccountService, AzureAccountService);
 // {{SQL CARBON EDIT}} - End
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
@nemanja-milovancevic FYI

Initial implementation of service for core ADS to be able to query for Azure resources from the azurecore extension.

More types of resources can be added later - this is just the first bit to keep it focused on the bits required to hook everything up. 