### PR TITLE
highlight problematic property in the designer when error is selected

### DIFF
--- a/src/sql/workbench/browser/designer/designer.ts
+++ b/src/sql/workbench/browser/designer/designer.ts
@@ -139,7 +139,7 @@ export class Designer extends Disposable implements IThemable {
 			onDidChange: Event.None
 		}, Sizing.Distribute);
 		this._scriptTabbedPannel = new TabbedPanel(this._editorContainer);
-		this._messagesView = new DesignerMessagesTabPanelView();
+		this._messagesView = this._instantiationService.createInstance(DesignerMessagesTabPanelView);
 		this._register(this._messagesView.onMessageSelected((path) => {
 			this.selectProperty(path);
 		}));

--- a/src/sql/workbench/browser/designer/designer.ts
+++ b/src/sql/workbench/browser/designer/designer.ts
@@ -524,9 +524,7 @@ export class Designer extends Disposable implements IThemable {
 				tableComponent.setActiveCell(targetRow, targetCell);
 				tableComponent.grid.scrollCellIntoView(targetRow, targetCell, false);
 				if (path.length > 2) {
-					const propertyPaneObjectPath = path.slice(0, 2);
 					const relativePath = path.slice(2);
-					this.updatePropertiesPane(propertyPaneObjectPath);
 					this._propertiesPane.selectProperty(relativePath);
 				}
 			}

--- a/src/sql/workbench/browser/designer/designerMessagesTabPanelView.ts
+++ b/src/sql/workbench/browser/designer/designerMessagesTabPanelView.ts
@@ -8,30 +8,116 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import * as DOM from 'vs/base/browser/dom';
 import { DesignerPropertyPath, DesignerValidationError } from 'sql/workbench/browser/designer/interfaces';
 import { Emitter, Event } from 'vs/base/common/event';
+import { IListAccessibilityProvider, List } from 'vs/base/browser/ui/list/listWidget';
+import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
+import { localize } from 'vs/nls';
+import { IColorTheme, ICssStyleCollector, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+import { attachListStyler } from 'vs/platform/theme/common/styler';
+import { problemsErrorIconForeground } from 'vs/platform/theme/common/colorRegistry';
+import { Codicon } from 'vs/base/common/codicons';
 
 export class DesignerMessagesTabPanelView extends Disposable implements IPanelView {
 	private _container: HTMLElement;
 	private _onMessageSelected = new Emitter<DesignerPropertyPath>();
+	private _messageList: List<DesignerValidationError>;
 
 	public readonly onMessageSelected: Event<DesignerPropertyPath> = this._onMessageSelected.event;
 
+	constructor(@IThemeService private _themeService: IThemeService) {
+		super();
+	}
+
 	render(container: HTMLElement): void {
 		this._container = container.appendChild(DOM.$('.messages-container'));
+		this._messageList = new List<DesignerValidationError>('designerMessageList', this._container, new DesignerMessageListDelegate(), [new TableFilterListRenderer()], {
+			multipleSelectionSupport: false,
+			keyboardSupport: true,
+			mouseSupport: true,
+			accessibilityProvider: new DesignerMessagesListAccessibilityProvider()
+		});
+		this._register(this._messageList.onDidChangeSelection((e) => {
+			if (e.elements && e.elements.length === 1) {
+				this._onMessageSelected.fire(e.elements[0].propertyPath);
+			}
+		}));
+		this._register(attachListStyler(this._messageList, this._themeService));
 	}
 
 	layout(dimension: DOM.Dimension): void {
+		this._messageList.layout(dimension.height, dimension.width);
 	}
 
 	updateMessages(errors: DesignerValidationError[]) {
-		if (this._container) {
-			DOM.clearNode(this._container);
-			errors?.forEach(error => {
-				const messageItem = this._container.appendChild(DOM.$('.message-item.codicon.error'));
-				messageItem.innerText = error.message;
-				messageItem.onclick = () => {
-					this._onMessageSelected.fire(error.propertyPath);
-				};
-			});
+		if (this._messageList) {
+			this._messageList.splice(0, this._messageList.length, errors);
 		}
+	}
+}
+
+registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
+	const errorForegroundColor = theme.getColor(problemsErrorIconForeground);
+	if (errorForegroundColor) {
+		collector.addRule(`
+		.designer-component .messages-container .message-item .message-icon {
+			color: ${errorForegroundColor};
+		}
+		`);
+	}
+});
+
+const DesignerMessageListTemplateId = 'DesignerMessageListTemplate';
+class DesignerMessageListDelegate implements IListVirtualDelegate<DesignerValidationError> {
+	getHeight(element: DesignerValidationError): number {
+		return 25;
+	}
+
+	getTemplateId(element: DesignerValidationError): string {
+		return DesignerMessageListTemplateId;
+	}
+}
+
+interface DesignerMessageListItemTemplate {
+	messageText: HTMLDivElement;
+}
+
+class TableFilterListRenderer implements IListRenderer<DesignerValidationError, DesignerMessageListItemTemplate> {
+	renderTemplate(container: HTMLElement): DesignerMessageListItemTemplate {
+		const data: DesignerMessageListItemTemplate = Object.create(null);
+		const messageItem = container.appendChild(DOM.$('.message-item'));
+		messageItem.appendChild(DOM.$(`.message-icon${Codicon.error.cssSelector}`));
+		data.messageText = messageItem.appendChild(DOM.$('.message-text'));
+		return data;
+	}
+
+	renderElement(element: DesignerValidationError, index: number, templateData: DesignerMessageListItemTemplate, height: number): void {
+		templateData.messageText.innerText = element.message;
+	}
+
+	disposeElement?(element: DesignerValidationError, index: number, templateData: DesignerMessageListItemTemplate, height: number): void {
+	}
+
+	public disposeTemplate(templateData: DesignerMessageListItemTemplate): void {
+	}
+
+	public get templateId(): string {
+		return DesignerMessageListTemplateId;
+	}
+}
+
+class DesignerMessagesListAccessibilityProvider implements IListAccessibilityProvider<DesignerValidationError> {
+	getAriaLabel(element: DesignerValidationError): string {
+		return element.message;
+	}
+
+	getWidgetAriaLabel(): string {
+		return localize('designer.MessageListAriaLabel', "Errors");
+	}
+
+	getWidgetRole() {
+		return 'listbox';
+	}
+
+	getRole(element: DesignerValidationError): string {
+		return 'option';
 	}
 }

--- a/src/sql/workbench/browser/designer/designerMessagesTabPanelView.ts
+++ b/src/sql/workbench/browser/designer/designerMessagesTabPanelView.ts
@@ -6,10 +6,14 @@
 import { IPanelView } from 'sql/base/browser/ui/panel/panel';
 import { Disposable } from 'vs/base/common/lifecycle';
 import * as DOM from 'vs/base/browser/dom';
-import { DesignerValidationError } from 'sql/workbench/browser/designer/interfaces';
+import { DesignerPropertyPath, DesignerValidationError } from 'sql/workbench/browser/designer/interfaces';
+import { Emitter, Event } from 'vs/base/common/event';
 
 export class DesignerMessagesTabPanelView extends Disposable implements IPanelView {
 	private _container: HTMLElement;
+	private _onMessageSelected = new Emitter<DesignerPropertyPath>();
+
+	public readonly onMessageSelected: Event<DesignerPropertyPath> = this._onMessageSelected.event;
 
 	render(container: HTMLElement): void {
 		this._container = container.appendChild(DOM.$('.messages-container'));
@@ -24,6 +28,9 @@ export class DesignerMessagesTabPanelView extends Disposable implements IPanelVi
 			errors?.forEach(error => {
 				const messageItem = this._container.appendChild(DOM.$('.message-item.codicon.error'));
 				messageItem.innerText = error.message;
+				messageItem.onclick = () => {
+					this._onMessageSelected.fire(error.propertyPath);
+				};
 			});
 		}
 	}

--- a/src/sql/workbench/browser/designer/designerPropertiesPane.ts
+++ b/src/sql/workbench/browser/designer/designerPropertiesPane.ts
@@ -3,14 +3,15 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Table } from 'sql/base/browser/ui/table/table';
 import { CreateComponentsFunc, DesignerUIComponent, SetComponentValueFunc } from 'sql/workbench/browser/designer/designer';
-import { DesignerViewModel, DesignerDataPropertyInfo, DesignerEditPath } from 'sql/workbench/browser/designer/interfaces';
+import { DesignerViewModel, DesignerDataPropertyInfo, DesignerPropertyPath } from 'sql/workbench/browser/designer/interfaces';
 import * as DOM from 'vs/base/browser/dom';
 import { equals } from 'vs/base/common/objects';
 import { localize } from 'vs/nls';
 
 export interface ObjectInfo {
-	path: DesignerEditPath;
+	path: DesignerPropertyPath;
 	type: string;
 	components: DesignerDataPropertyInfo[];
 	viewModel: DesignerViewModel;
@@ -19,7 +20,7 @@ export interface ObjectInfo {
 export class DesignerPropertiesPane {
 	private _titleElement: HTMLElement;
 	private _contentElement: HTMLElement;
-	private _objectPath: DesignerEditPath;
+	private _objectPath: DesignerPropertyPath;
 	private _componentMap = new Map<string, { defintion: DesignerDataPropertyInfo, component: DesignerUIComponent }>();
 	private _groupHeaders: HTMLElement[] = [];
 
@@ -48,7 +49,7 @@ export class DesignerPropertiesPane {
 		return this._componentMap;
 	}
 
-	public get objectPath(): DesignerEditPath {
+	public get objectPath(): DesignerPropertyPath {
 		return this._objectPath;
 	}
 
@@ -93,5 +94,22 @@ export class DesignerPropertiesPane {
 			this._setComponentValue(value.defintion, value.component, item.viewModel);
 		});
 		this._descriptionContainer.style.display = 'none';
+	}
+
+	public selectProperty(path: DesignerPropertyPath): void {
+		const componentInfo = this.componentMap.get(<string>path[0]);
+		if (componentInfo.defintion.componentType !== 'table') {
+			componentInfo.component.focus();
+			return;
+		}
+
+		const table = componentInfo.component as Table<Slick.SlickData>;
+		const row = path[1] as number;
+		let cell = 0;
+		if (path.length === 3) {
+			const colName = path[2] as string;
+			cell = table.columns.findIndex(c => c.field === colName);
+		}
+		table.setActiveCell(row, cell);
 	}
 }

--- a/src/sql/workbench/browser/designer/designerPropertiesPane.ts
+++ b/src/sql/workbench/browser/designer/designerPropertiesPane.ts
@@ -111,5 +111,6 @@ export class DesignerPropertiesPane {
 			cell = table.columns.findIndex(c => c.field === colName);
 		}
 		table.setActiveCell(row, cell);
+		table.grid.scrollCellIntoView(row, cell, false);
 	}
 }

--- a/src/sql/workbench/browser/designer/designerPropertyPathValidator.ts
+++ b/src/sql/workbench/browser/designer/designerPropertyPathValidator.ts
@@ -6,6 +6,13 @@
 import { DesignerPropertyPath, DesignerTableProperties, DesignerViewModel } from 'sql/workbench/browser/designer/interfaces';
 
 export class DesignerPropertyPathValidator {
+
+	/**
+	 * Validate the path property, detail of the path can be found in the azdata typings file.
+	 * @param path path of the property.
+	 * @param viewModel the view model.
+	 * @returns Whether the path is valid.
+	 */
 	static validate(path: DesignerPropertyPath, viewModel: DesignerViewModel): boolean {
 		// the path must have items and currently we support up to 5 items in the path.
 		if (!path || path.length === 0 || path.length > 5) {

--- a/src/sql/workbench/browser/designer/designerPropertyPathValidator.ts
+++ b/src/sql/workbench/browser/designer/designerPropertyPathValidator.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DesignerPropertyPath, DesignerTableProperties, DesignerViewModel } from 'sql/workbench/browser/designer/interfaces';
+
+export class DesignerPropertyPathValidator {
+	static validate(path: DesignerPropertyPath, viewModel: DesignerViewModel): boolean {
+		// the path must have items and currently we support up to 5 items in the path.
+		if (!path || path.length === 0 || path.length > 5) {
+			return false;
+		}
+
+		for (let index = 0; index < path.length; index++) {
+			const expectingNumber = (index % 2) !== 0;
+			if (expectingNumber && typeof path[index] !== 'number') {
+				return false;
+			}
+
+			if (!expectingNumber && typeof path[index] !== 'string') {
+				return false;
+			}
+		}
+		let currentObject = viewModel;
+		for (let index = 0; index < path.length;) {
+			const propertyName = <string>path[index];
+			if (Object.keys(currentObject).indexOf(propertyName) === -1) {
+				return false;
+			}
+			if (index === path.length - 1) {
+				break;
+			}
+			index++;
+			const tableData = <DesignerTableProperties>currentObject[propertyName];
+			const objectIndex = <number>path[index];
+			if (!tableData.data || tableData.data.length - 1 < objectIndex) {
+				return false;
+			}
+			currentObject = tableData.data[objectIndex];
+			index++;
+		}
+		return true;
+	}
+}

--- a/src/sql/workbench/browser/designer/designerPropertyPathValidator.ts
+++ b/src/sql/workbench/browser/designer/designerPropertyPathValidator.ts
@@ -14,7 +14,19 @@ export class DesignerPropertyPathValidator {
 	 * @returns Whether the path is valid.
 	 */
 	static validate(path: DesignerPropertyPath, viewModel: DesignerViewModel): boolean {
-		// the path must have items and currently we support up to 5 items in the path.
+		/**
+		 * Path specification for all supported scenarios:
+		 * 1. 'Add' scenario
+		 *     a. ['propertyName1']. Example: add a column to the columns property: ['columns'].
+		 *     b. ['propertyName1',index-1,'propertyName2']. Example: add a column mapping to the first foreign key: ['foreignKeys',0,'mappings'].
+		 * 2. 'Update' scenario
+		 *     a. ['propertyName1']. Example: update the name of the table: ['name'].
+		 *     b. ['propertyName1',index-1,'propertyName2']. Example: update the name of a column: ['columns',0,'name'].
+		 *     c. ['propertyName1',index-1,'propertyName2',index-2,'propertyName3']. Example: update the source column of an entry in a foreign key's column mapping table: ['foreignKeys',0,'mappings',0,'source'].
+		 * 3. 'Remove' scenario
+		 *     a. ['propertyName1',index-1]. Example: remove a column from the columns property: ['columns',0'].
+		 *     b. ['propertyName1',index-1,'propertyName2',index-2]. Example: remove a column mapping from a foreign key's column mapping table: ['foreignKeys',0,'mappings',0].
+		 */
 		if (!path || path.length === 0 || path.length > 5) {
 			return false;
 		}

--- a/src/sql/workbench/browser/designer/interfaces.ts
+++ b/src/sql/workbench/browser/designer/interfaces.ts
@@ -81,7 +81,8 @@ export interface DesignerComponentInput {
 }
 
 export interface DesignerUIState {
-	activeTabId: PanelTabIdentifier;
+	activeContentTabId: PanelTabIdentifier;
+	activeScriptTabId: PanelTabIdentifier;
 }
 
 export type DesignerAction = 'publish' | 'initialize' | 'processEdit' | 'generateScript' | 'generateReport';
@@ -180,7 +181,6 @@ export interface DesignerTableProperties extends ComponentProperties {
 	 * Whether user can add new rows to the table. The default value is true.
 	 */
 	canAddRows?: boolean;
-
 	/**
 	 * Whether user can remove rows from the table. The default value is true.
 	 */
@@ -208,14 +208,14 @@ export enum DesignerEditType {
 
 export interface DesignerEdit {
 	type: DesignerEditType;
-	path: DesignerEditPath;
+	path: DesignerPropertyPath;
 	value?: any;
 }
 
-export type DesignerEditPath = (string | number)[];
-export const DesignerRootObjectPath: DesignerEditPath = [];
+export type DesignerPropertyPath = (string | number)[];
+export const DesignerRootObjectPath: DesignerPropertyPath = [];
 
-export type DesignerValidationError = { message: string, property?: DesignerEditPath };
+export type DesignerValidationError = { message: string, propertyPath?: DesignerPropertyPath };
 
 export interface DesignerEditResult {
 	isValid: boolean;

--- a/src/sql/workbench/browser/designer/media/designer.css
+++ b/src/sql/workbench/browser/designer/media/designer.css
@@ -30,18 +30,23 @@
 }
 
 .designer-component .messages-container {
-	overflow: scroll;
+	overflow: hidden;
 	height: 100%;
 	width: 100%;
 }
 
 .designer-component .messages-container .message-item {
-	padding: 0px 5px 0px 25px;
-	background-position: 5px center;
-	background-size: 16px 16px;
-	user-select: text;
+	display: flex;
+}
+
+.designer-component .messages-container .message-item .message-icon {
+	margin: 0px 6px;
+	flex: 0 0 auto;
 	line-height: 25px;
-	cursor: pointer;
+}
+
+.designer-component .messages-container .message-item .message-text {
+	flex: 1 1 auto;
 }
 
 .designer-component .tabbed-panel-container {

--- a/src/sql/workbench/browser/designer/media/designer.css
+++ b/src/sql/workbench/browser/designer/media/designer.css
@@ -41,6 +41,7 @@
 	background-size: 16px 16px;
 	user-select: text;
 	line-height: 25px;
+	cursor: pointer;
 }
 
 .designer-component .tabbed-panel-container {

--- a/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
+++ b/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
-import { DesignerViewModel, DesignerEdit, DesignerComponentInput, DesignerView, DesignerTab, DesignerDataPropertyInfo, DropDownProperties, DesignerTableProperties, DesignerEditProcessedEventArgs, DesignerAction, DesignerStateChangedEventArgs, DesignerEditPath, DesignerValidationError } from 'sql/workbench/browser/designer/interfaces';
+import { DesignerViewModel, DesignerEdit, DesignerComponentInput, DesignerView, DesignerTab, DesignerDataPropertyInfo, DropDownProperties, DesignerTableProperties, DesignerEditProcessedEventArgs, DesignerAction, DesignerStateChangedEventArgs, DesignerPropertyPath, DesignerValidationError } from 'sql/workbench/browser/designer/interfaces';
 import { TableDesignerProvider } from 'sql/workbench/services/tableDesigner/common/interface';
 import { localize } from 'vs/nls';
 import { designers } from 'sql/workbench/api/common/sqlExtHostTypes';
@@ -658,7 +658,7 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 			b. ['propertyName1',index-1,'proper
 		The return values would be the propertyNames followed by slashes in level order. Eg.: propertyName1/propertyName2/...
 	 */
-	private getObjectTypeFromPath(path: DesignerEditPath): string {
+	private getObjectTypeFromPath(path: DesignerPropertyPath): string {
 		let typeArray = [];
 		for (let i = 0; i < path.length; i++) {
 			if (i % 2 === 0) {


### PR DESCRIPTION
This PR fixes #18511 

1. replace the error list implementation with the accessible solution (using list component).
2. when error item is selected, bring the problematic item into view and then highlight it (make it easier to visually spot it).
3. fix some accessibility issues.

![error-navigation-light](https://user-images.githubusercontent.com/13777222/155017274-a4339620-9cdb-4c1e-80bf-8c2b230aea73.gif)
![error-navigation-dark](https://user-images.githubusercontent.com/13777222/155017279-2ba4dab6-ee62-4e8c-a379-c25642df1280.gif)
