### PR TITLE
Fixing query editor smoke test

### DIFF
--- a/src/vs/workbench/contrib/welcome/telemetryOptOut/browser/telemetryOptOut.ts
+++ b/src/vs/workbench/contrib/welcome/telemetryOptOut/browser/telemetryOptOut.ts
@@ -41,7 +41,9 @@ export abstract class AbstractTelemetryOptOut implements IWorkbenchContribution 
 	}
 
 	protected async handleTelemetryOptOut(): Promise<void> {
-		if (this.productService.telemetryOptOutUrl && !this.storageService.get(AbstractTelemetryOptOut.TELEMETRY_OPT_OUT_SHOWN, StorageScope.GLOBAL)) {
+		if (this.productService.telemetryOptOutUrl &&
+			!this.storageService.get(AbstractTelemetryOptOut.TELEMETRY_OPT_OUT_SHOWN, StorageScope.GLOBAL) &&
+			!this.environmentService.disableTelemetry) {
 			const experimentId = 'telemetryOptOut';
 
 			const [count, experimentState] = await Promise.all([this.getWindowCount(), this.experimentService.getExperimentById(experimentId)]);

--- a/src/vs/workbench/contrib/welcome/telemetryOptOut/browser/telemetryOptOut.ts
+++ b/src/vs/workbench/contrib/welcome/telemetryOptOut/browser/telemetryOptOut.ts
@@ -43,7 +43,7 @@ export abstract class AbstractTelemetryOptOut implements IWorkbenchContribution 
 	protected async handleTelemetryOptOut(): Promise<void> {
 		if (this.productService.telemetryOptOutUrl &&
 			!this.storageService.get(AbstractTelemetryOptOut.TELEMETRY_OPT_OUT_SHOWN, StorageScope.GLOBAL) &&
-			!this.environmentService.disableTelemetry) {
+			!this.environmentService.disableTelemetry) { // {{SQL CARBON EDIT}} Adding check to disable opt out toast when this flag is set.
 			const experimentId = 'telemetryOptOut';
 
 			const [count, experimentState] = await Promise.all([this.getWindowCount(), this.experimentService.getExperimentById(experimentId)]);

--- a/test/smoke/src/sql/areas/queryEditor/queryEditor.test.ts
+++ b/test/smoke/src/sql/areas/queryEditor/queryEditor.test.ts
@@ -38,13 +38,6 @@ export function setupWeb(opts: minimist.ParsedArgs) {
 function setupCommonTests(opts: minimist.ParsedArgs): void {
 	beforeSuite(opts);
 	afterSuite(opts);
-
-	beforeEach(async function (): Promise<void> {
-		const app = this.app as Application;
-		// Clearing any toast notifications that popup when ADS is launched like Telemetry opt-out.
-		await app.workbench.notificationToast.closeNotificationToasts();
-	});
-
 	afterEach(async function (): Promise<void> {
 		const app = this.app as Application;
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');

--- a/test/smoke/src/sql/areas/queryEditor/queryEditor.test.ts
+++ b/test/smoke/src/sql/areas/queryEditor/queryEditor.test.ts
@@ -38,6 +38,13 @@ export function setupWeb(opts: minimist.ParsedArgs) {
 function setupCommonTests(opts: minimist.ParsedArgs): void {
 	beforeSuite(opts);
 	afterSuite(opts);
+
+	beforeEach(async function (): Promise<void> {
+		const app = this.app as Application;
+		// Clearing any toast notifications that popup when ADS is launched like Telemetry opt-out.
+		await app.workbench.notificationToast.closeNotificationToasts();
+	});
+
 	afterEach(async function (): Promise<void> {
 		const app = this.app as Application;
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');


### PR DESCRIPTION
The recent changes to the telemetry opt out feature have created a notification toast that is blocking the connect button thereby failing query editor smoke tests. This PR clears that toast notification before running those tests.
Example of the bug:
![image](https://user-images.githubusercontent.com/6816294/155194859-1842d33a-6a2d-4f2b-a943-0b559fca5e71.png)

This PR fixes #18515 and fixes https://github.com/microsoft/azuredatastudio/issues/18523