### PR TITLE
Bumped versions of arc and azcli to 1.0.0 for GA

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -8,7 +8,7 @@
   "icon": "images/extension.png",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.32.0"
+    "azdata": ">=1.35.0"
   },
   "activationEvents": [
     "onCommand:arc.connectToController",

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,7 +2,7 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "0.12.0",
+  "version": "1.0.0",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -8,7 +8,7 @@
   "icon": "images/extension.png",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.26.0"
+    "azdata": ">=1.35.0"
   },
   "activationEvents": [
     "*"

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -2,7 +2,7 @@
   "name": "azcli",
   "displayName": "%azcli.arc.displayName%",
   "description": "%azcli.arc.description%",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",


### PR DESCRIPTION
- Bumped arc to 1.0.0 and azcli to 1.0.0 for GA for Feb release
- Bumped azdata version requirement to 1.35