### PR TITLE
Updated package.json for arc and azcli extensions to version 1.0.0

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,13 +2,13 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "0.12.0",
+  "version": "1.0.0",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.32.0"
+    "azdata": ">=1.35.0"
   },
   "activationEvents": [
     "onCommand:arc.connectToController",

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -2,13 +2,13 @@
   "name": "azcli",
   "displayName": "%azcli.arc.displayName%",
   "description": "%azcli.arc.description%",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.26.0"
+    "azdata": ">=1.35.0"
   },
   "activationEvents": [
     "*"


### PR DESCRIPTION
- Updates version of arc to 1.0.0
- Updates version of azcli to 1.0.0
- Updates min required azdata for both extensions to be 1.35

Closes https://github.com/microsoft/azuredatastudio/issues/18521