### PR TITLE
Bringing back leftover changes for telemetry opt-out

### DIFF
--- a/src/vs/workbench/contrib/welcome/telemetryOptOut/electron-sandbox/telemetryOptOut.ts
+++ b/src/vs/workbench/contrib/welcome/telemetryOptOut/electron-sandbox/telemetryOptOut.ts
@@ -39,6 +39,6 @@ export class NativeTelemetryOptOut extends AbstractTelemetryOptOut {
 	}
 
 	protected getWindowCount(): Promise<number> {
-		return this.nativeHostService.getWindowCount();
+		return this.nativeHostService ? this.nativeHostService.getWindowCount() : Promise.resolve(0); // {{SQL CARBON EDIT}} Tests run without UI context so electronService is undefined in that case
 	}
 }


### PR DESCRIPTION
While diffing release 1.34 code to the main code I found out that this carbon edit was not ported back. 