### PR TITLE
fix 'Read More' icon not visible issue

### DIFF
--- a/extensions/theme-carbon/themes/dark_carbon.json
+++ b/extensions/theme-carbon/themes/dark_carbon.json
@@ -53,6 +53,7 @@
 
 		//List and trees
 		"list.hoverBackground": "#444444",
+		"list.activeSelectionIconForeground": "#FFF",
 		"pickerGroup.border": "#0078d7",
 		"input.placeholderForeground": "#a6a6a6",
 		"editorGroupHeader.tabsBackground": "#444444",

--- a/extensions/theme-carbon/themes/light_carbon.json
+++ b/extensions/theme-carbon/themes/light_carbon.json
@@ -53,6 +53,7 @@
 
 		//List and tree
 		"list.hoverBackground": "#dcdcdc",
+		"list.activeSelectionIconForeground": "#FFF",
 		"pickerGroup.border": "#0078d7",
 
 		"editorGroupHeader.tabsBackground": "#f4f4f4",


### PR DESCRIPTION
This PR fixes #18528 

root cause: the color is not defined.
fix: copied the values from vscode theme files.

before:
![readmore-before](https://user-images.githubusercontent.com/13777222/155238492-b55cf079-d414-4f3d-b1d4-fb7f4112bafe.gif)

after:
![image](https://user-images.githubusercontent.com/13777222/155238433-8ff9fa19-8fac-4e76-8037-8ee0eba4719b.png)

![image](https://user-images.githubusercontent.com/13777222/155238472-c1512122-029d-4a82-81b5-01e66336ae40.png)

