### PR TITLE
Benjin/project update bug

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -899,7 +899,6 @@ export class SchemaCompareMainWindow {
 				}
 
 				if (!result || !result.success) {
-
 					TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareApplyFailed', undefined, getTelemetryErrorType(result?.errorMessage))
 						.withAdditionalProperties({
 							'operationId': this.comparisonResult.operationId,
@@ -913,6 +912,12 @@ export class SchemaCompareMainWindow {
 					this.applyButton.enabled = true;
 					this.applyButton.title = loc.applyEnabledMessage;
 				}
+				else if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+					const workspaceApi = getDataWorkspaceExtensionApi();
+					workspaceApi.showProjectsView();
+
+					void vscode.window.showInformationMessage(loc.applySuccess);
+				}
 
 				TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareApplyEnded')
 					.withAdditionalProperties({
@@ -920,13 +925,6 @@ export class SchemaCompareMainWindow {
 						'operationId': this.comparisonResult.operationId,
 						'targetType': getSchemaCompareEndpointString(this.targetEndpointInfo.endpointType)
 					}).send();
-
-				if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
-					const workspaceApi = getDataWorkspaceExtensionApi();
-					workspaceApi.showProjectsView();
-
-					void vscode.window.showInformationMessage(loc.applySuccess);
-				}
 			}
 		});
 	}

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -898,7 +898,7 @@ export class SchemaCompareMainWindow {
 						throw new Error(`Unsupported SchemaCompareEndpointType: ${getSchemaCompareEndpointString(this.targetEndpointInfo.endpointType)}`);
 				}
 
-				if (!result || !result.success) {
+				if (!result || !result.success || result.errorMessage !== '') {
 					TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareApplyFailed', undefined, getTelemetryErrorType(result?.errorMessage))
 						.withAdditionalProperties({
 							'operationId': this.comparisonResult.operationId,
@@ -911,8 +911,7 @@ export class SchemaCompareMainWindow {
 					this.generateScriptButton.title = loc.generateScriptEnabledMessage;
 					this.applyButton.enabled = true;
 					this.applyButton.title = loc.applyEnabledMessage;
-				}
-				else if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+				} else if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
 					const workspaceApi = getDataWorkspaceExtensionApi();
 					workspaceApi.showProjectsView();
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -534,9 +534,7 @@ export class ProjectsController {
 
 		const result: mssql.SchemaComparePublishProjectResult = await service.schemaComparePublishProjectChanges(operationId, projectPath, fs, utils.getAzdataApi()!.TaskExecutionMode.execute);
 
-		result.success = result.success && result.errorMessage === '';
-
-		if (result.success) {
+		if (result.errorMessage === '') {
 			const project = await Project.openProject(projectFilePath);
 
 			let toAdd: vscode.Uri[] = [];

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -534,21 +534,25 @@ export class ProjectsController {
 
 		const result: mssql.SchemaComparePublishProjectResult = await service.schemaComparePublishProjectChanges(operationId, projectPath, fs, utils.getAzdataApi()!.TaskExecutionMode.execute);
 
-		const project = await Project.openProject(projectFilePath);
+		result.success = result.success && result.errorMessage === '';
 
-		let toAdd: vscode.Uri[] = [];
-		result.addedFiles.forEach((f: any) => toAdd.push(vscode.Uri.file(f)));
-		await project.addToProject(toAdd);
+		if (result.success) {
+			const project = await Project.openProject(projectFilePath);
 
-		let toRemove: vscode.Uri[] = [];
-		result.deletedFiles.forEach((f: any) => toRemove.push(vscode.Uri.file(f)));
+			let toAdd: vscode.Uri[] = [];
+			result.addedFiles.forEach((f: any) => toAdd.push(vscode.Uri.file(f)));
+			await project.addToProject(toAdd);
 
-		let toRemoveEntries: FileProjectEntry[] = [];
-		toRemove.forEach(f => toRemoveEntries.push(new FileProjectEntry(f, f.path.replace(projectPath + '\\', ''), EntryType.File)));
+			let toRemove: vscode.Uri[] = [];
+			result.deletedFiles.forEach((f: any) => toRemove.push(vscode.Uri.file(f)));
 
-		toRemoveEntries.forEach(async f => await project.exclude(f));
+			let toRemoveEntries: FileProjectEntry[] = [];
+			toRemove.forEach(f => toRemoveEntries.push(new FileProjectEntry(f, f.path.replace(projectPath + '\\', ''), EntryType.File)));
 
-		await this.buildProject(project);
+			toRemoveEntries.forEach(async f => await project.exclude(f));
+
+			await this.buildProject(project);
+		}
 
 		return result;
 	}


### PR DESCRIPTION
Fixes #18078.  My investigation found an underlying problem that I haven't been able to address yet, but this PR fixes some extension-level logic and adds a work-around for the base issue.

The underlying issue is:
* The `schemaComparePublishProjectChanges` task in Tools Service sends a task result with the `success` boolean set to false (correct)
* The ADS task displays that the task failed (correct)
* The `result` object returned by `service.schemaComparePublishProjectChanges` has its success boolean set to true (_incorrect_)

How ADS gets two different success statuses for the same task... I don't know.