### PR TITLE
Fix Mac signing

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
@@ -17,6 +17,13 @@ steps:
       mv azuredatastudio-darwin-unsigned.zip azuredatastudio-darwin.zip
     displayName: 'Rename the file'
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core sdk for signing'
+    inputs:
+      packageType: sdk
+      version: 2.1.x
+      installationPath: $(Agent.ToolsDirectory)/dotnet
+
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'ESRP CodeSigning'
     inputs:

--- a/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
@@ -18,9 +18,9 @@ steps:
     displayName: 'Rename the file'
 
   - task: UseDotNet@2
-    displayName: 'Install .NET Core sdk for signing'
+    displayName: 'Install .NET Core runtime for signing'
     inputs:
-      packageType: sdk
+      packageType: runtime
       version: 2.1.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
 

--- a/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
@@ -21,7 +21,7 @@ steps:
     displayName: 'Install .NET Core runtime for signing'
     inputs:
       packageType: runtime
-      version: 2.1.x
+      version: 2.1.0
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
@@ -18,10 +18,10 @@ steps:
     displayName: 'Rename the file'
 
   - task: UseDotNet@2
-    displayName: 'Install .NET Core runtime for signing'
+    displayName: 'Install .NET Core sdk for signing'
     inputs:
-      packageType: runtime
-      version: 2.1.0
+      packageType: sdk
+      version: 2.1.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1


### PR DESCRIPTION
.NET 2.1 is being removed from all hosted agents 

https://github.com/actions/virtual-environments/issues/4871

This is currently required for the signing task and so install it manually for now until the signing task can be updated to not require 2.1. Note that this is only required for Macs though - the other OSes have been updated to use .NET 6 per https://marketplace.visualstudio.com/items?itemName=SFP.build-tasks&targetId=465e99f0-a0f9-4257-95e0-04c716327b00

```
11/29/2021 (CodeSign task v1.9.101, ScanTask v1.6.90)

Add .net core 6 support (not include Mac OS)
```
