### PR TITLE
Revert oracle ext assets back

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4336,27 +4336,27 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/net-6-runtime-1.0.0.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/net-6-runtime-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4397,27 +4397,27 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/azuredatastudio-oracle-0.1.0.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/azuredatastudio-oracle-0.1.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4462,27 +4462,27 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/dsct-oracle-to-ms-sql-0.2.0.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/dsct-oracle-to-ms-sql-0.2.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/LICENSE.rtf"
 								}
 							],
 							"properties": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4328,27 +4328,27 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/net-6-runtime-1.0.0.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/net-6-runtime-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/net-6-runtime/1.0.0/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/21348.1/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4389,27 +4389,27 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/azuredatastudio-oracle-0.1.0.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/azuredatastudio-oracle-0.1.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuredatastudio-oracle/0.1.0/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/21279.2/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4454,27 +4454,27 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/dsct-oracle-to-ms-sql-0.2.0.vsix"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/dsct-oracle-to-ms-sql-0.2.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/icon.png"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/README.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/CHANGELOG.md"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/package.json"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/0.2.0/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/21351.1/LICENSE.rtf"
 								}
 							],
 							"properties": [

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -260,6 +260,12 @@ const hostedAssetTypes = new Set([
     'Microsoft.VisualStudio.Services.Content.Changelog',
     'Microsoft.VisualStudio.Code.Manifest']);
 
+const allowedHosts = [
+    'https://sqlopsextensions.blob.core.windows.net/',
+    'https://dsct.blob.core.windows.net/',
+    'https://raw.githubusercontent.com/'
+];
+
 /**
  * Validate an extension file blob according to
  * interface IRawGalleryExtensionFile {
@@ -279,7 +285,7 @@ async function validateExtensionFile(path, extensionName, extensionFileJson) {
     if (extensionName === 'vscode-wakatime' && extensionFileJson.assetType === 'Microsoft.SQLOps.DownloadPage') {
         return;
     }
-    if (hostedAssetTypes.has(extensionFileJson.assetType) && !(extensionFileJson.source.startsWith('https://sqlopsextensions.blob.core.windows.net/') || extensionFileJson.source.startsWith('https://raw.githubusercontent.com/'))) {
+    if (hostedAssetTypes.has(extensionFileJson.assetType) && !allowedHosts.find(host => extensionFileJson.source.startsWith(host))) {
         throw new Error(`${path} - ${extensionName} - The asset ${extensionFileJson.source} (${extensionFileJson.assetType}) is required to be hosted either on Github or by the Azure Data Studio team. If the asset is hosted on Github it must use a https://raw.githubusercontent.com/ URL. If the asset cannot be hosted on Github then please reply in the PR with links to the assets and a team member will handle moving them.`);
     }
 


### PR DESCRIPTION
Their storage account was updated to allow the vscode-file://vscode-app origin so adding them to the allowed list so they can continue to own their assets.

@nahk-ivanov FYI