### PR TITLE
Fix gallery workflow errors from external contributors

### DIFF
--- a/.github/workflows/update-galleries-list-reminder.yml
+++ b/.github/workflows/update-galleries-list-reminder.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - release/extensions
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should fix the errors we see running this workflow when external contributors open a PR. PRs from forks are locked down on purpose so have to specify the types of permissions a workflow should have. (we still have control over approving the workflow to run in the first place too)