### PR TITLE
Add language picker to notebook cells.

### DIFF
--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -1798,10 +1798,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-parse@1.5.8, url-parse@~1.4.3:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.8.tgz#3f8090e4d6f80053eb861ec496049849f700337e"
-  integrity sha512-9JZ5zDrn9wJoOy/t+rH00HHejbU8dq9VsOYVu272TYDrCiyVAgHKUSpPh3ruZIpv8PMVR+NXLZvfRPJv8xAcQw==
+url-parse@^1.5.8, url-parse@~1.4.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
@@ -14,7 +14,7 @@
 		</div>
 		<div style="display: flex; flex-flow: row; justify-content: flex-end;">
 			<collapse-component *ngIf="cellModel.cellType === 'code' && cellModel.source && cellModel.source.length > 1" [cellModel]="cellModel" [activeCellId]="activeCellId"></collapse-component>
-			<button #cellLanguage class="cellLanguage" *ngIf="cellModel.cellType === 'code' && cellModel.language" (click)="onCellLanguageClick($event)">
+			<button #cellLanguage title="{{cellLanguageTitle}}" class="cellLanguage" *ngIf="cellModel.cellType === 'code' && cellModel.language" (click)="onCellLanguageClick($event)">
 				{{cellModel.displayLanguage}}
 			</button>
 		</div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
@@ -14,9 +14,9 @@
 		</div>
 		<div style="display: flex; flex-flow: row; justify-content: flex-end;">
 			<collapse-component *ngIf="cellModel.cellType === 'code' && cellModel.source && cellModel.source.length > 1" [cellModel]="cellModel" [activeCellId]="activeCellId"></collapse-component>
-			<div #cellLanguage class="cellLanguage" *ngIf="cellModel.cellType === 'code' && cellModel.language">
+			<button #cellLanguage class="cellLanguage" *ngIf="cellModel.cellType === 'code' && cellModel.language" (click)="onCellLanguageClick($event)">
 				{{cellModel.displayLanguage}}
-			</div>
+			</button>
 		</div>
 		<div #parameter class="parameter" *ngIf="cellModel.cellType === 'code' && cellModel.isParameter">
 			<span>{{parametersText}}</span>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
@@ -14,7 +14,7 @@
 		</div>
 		<div style="display: flex; flex-flow: row; justify-content: flex-end;">
 			<collapse-component *ngIf="cellModel.cellType === 'code' && cellModel.source && cellModel.source.length > 1" [cellModel]="cellModel" [activeCellId]="activeCellId"></collapse-component>
-			<button #cellLanguage title="{{cellLanguageTitle}}" class="cellLanguage" *ngIf="cellModel.cellType === 'code' && cellModel.language" (click)="onCellLanguageClick($event)">
+			<button #cellLanguage title="{{cellLanguageTitle}}" class="cellLanguage" *ngIf="cellModel.cellType === 'code' && cellModel.language" (click)="onCellLanguageClick()">
 				{{cellModel.displayLanguage}}
 			</button>
 		</div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -119,9 +119,6 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		this._register(this.themeService.onDidColorThemeChange(this.updateTheme, this));
 		this.updateTheme(this.themeService.getColorTheme());
 		this.initActionBar();
-		if (this.languageElement) {
-			(<HTMLElement>this.languageElement.nativeElement).title = localize('selectCellLanguage', "Select Cell Language Mode");
-		}
 	}
 
 	ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
@@ -150,6 +147,10 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 
 	public cellGuid(): string {
 		return this.cellModel.cellGuid;
+	}
+
+	get cellLanguageTitle(): string {
+		return localize('selectCellLanguage', "Select Cell Language Mode");
 	}
 
 	get parametersText(): string {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -492,7 +492,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 				description,
 				languageId: lang
 			};
-			if (lang === 'markdown' || lang === this._cellModel.language) {
+			if (lang === this._cellModel.language) {
 				topItems.push(item);
 			} else {
 				mainItems.push(item);

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -85,6 +85,10 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		this.cellModel.hover = value;
 	}
 
+	public onCellLanguageClick(event: any): void {
+		return;
+	}
+
 	protected _actionBar: Taskbar;
 	private readonly _minimumHeight = 30;
 	private readonly _maximumHeight = 4000;
@@ -115,6 +119,9 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		this._register(this.themeService.onDidColorThemeChange(this.updateTheme, this));
 		this.updateTheme(this.themeService.getColorTheme());
 		this.initActionBar();
+		if (this.languageElement) {
+			(<HTMLElement>this.languageElement.nativeElement).title = localize('selectCellLanguage', "Select Cell Language Mode");
+		}
 	}
 
 	ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
@@ -269,6 +276,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		this._register(this.cellModel.onLanguageChanged(language => {
 			let nativeElement = <HTMLElement>this.languageElement.nativeElement;
 			nativeElement.innerText = this.cellModel.displayLanguage;
+			nativeElement.ariaLabel = this.cellModel.displayLanguage;
 			this.updateLanguageMode();
 			this._changeRef.detectChanges();
 		}));

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -460,7 +460,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 	}
 
 	public onCellLanguageClick(event: any): void {
-		this._notebookService.getSupportedLanguagesForProvider(this._model.providerId)
+		this._notebookService.getSupportedLanguagesForProvider(this._model.providerId, this._model.selectedKernelDisplayName)
 			.then(languages => this.pickCellLanguage(languages))
 			.then(selection => {
 				if (selection?.languageId) {
@@ -485,12 +485,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 				description = localize('cellLanguageDescriptionConfigured', "({0})", lang);
 			}
 
-			const languageName = this._modeService.getLanguageName(lang);
-			if (!languageName) {
-				// Notebook has unrecognized language
-				return;
-			}
-
+			const languageName = this._modeService.getLanguageName(lang) ?? lang;
 			const item = <ILanguagePickInput>{
 				label: languageName,
 				iconClasses: getIconClasses(this._modelService, this._modeService, this.getFakeResource(languageName, this._modeService)),

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -22,7 +22,7 @@ import { IModelService } from 'vs/editor/common/services/modelService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Event, Emitter } from 'vs/base/common/event';
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
-import { OVERRIDE_EDITOR_THEMING_SETTING } from 'sql/workbench/services/notebook/browser/notebookService';
+import { INotebookService, OVERRIDE_EDITOR_THEMING_SETTING } from 'sql/workbench/services/notebook/browser/notebookService';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
@@ -36,6 +36,11 @@ import { notebookConstants } from 'sql/workbench/services/notebook/browser/inter
 import { tryMatchCellMagic } from 'sql/workbench/services/notebook/browser/utils';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { localize } from 'vs/nls';
+import { IQuickInputService, QuickPickInput } from 'vs/platform/quickinput/common/quickInput';
+import { onUnexpectedError } from 'vs/base/common/errors';
+import { getIconClasses } from 'vs/editor/common/services/getIconClasses';
+import { URI } from 'vs/base/common/uri';
+import { ILanguagePickInput } from 'vs/workbench/contrib/notebook/browser/contrib/coreActions';
 
 export const CODE_SELECTOR: string = 'code-component';
 const MARKDOWN_CLASS = 'markdown';
@@ -85,10 +90,6 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		this.cellModel.hover = value;
 	}
 
-	public onCellLanguageClick(event: any): void {
-		return;
-	}
-
 	protected _actionBar: Taskbar;
 	private readonly _minimumHeight = 30;
 	private readonly _maximumHeight = 4000;
@@ -106,7 +107,9 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		@Inject(IModeService) private _modeService: IModeService,
 		@Inject(IConfigurationService) private _configurationService: IConfigurationService,
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
-		@Inject(ILogService) private readonly logService: ILogService
+		@Inject(ILogService) private readonly logService: ILogService,
+		@Inject(IQuickInputService) private _quickInputService: IQuickInputService,
+		@Inject(INotebookService) private _notebookService: INotebookService,
 	) {
 		super();
 		this._register(Event.debounce(this._layoutEmitter.event, (l, e) => e, 250, /*leading=*/false)
@@ -454,5 +457,81 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 				(document.activeElement as HTMLElement).blur();
 			}
 		}
+	}
+
+	public onCellLanguageClick(event: any): void {
+		this._notebookService.getSupportedLanguagesForProvider(this._model.providerId)
+			.then(languages => this.pickCellLanguage(languages))
+			.then(selection => {
+				if (selection?.languageId) {
+					this._cellModel.setOverrideLanguage(selection.label);
+				}
+			})
+			.catch(err => onUnexpectedError(err));
+	}
+
+	private pickCellLanguage(languages: string[]): Promise<ILanguagePickInput | undefined> {
+		if (languages.length === 0) {
+			languages = [this._cellModel.language];
+		}
+
+		const topItems: ILanguagePickInput[] = [];
+		const mainItems: ILanguagePickInput[] = [];
+		languages.forEach(lang => {
+			let description: string;
+			if (lang === this._cellModel.language) {
+				description = localize('cellLanguageDescription', "({0}) - Current Language", lang);
+			} else {
+				description = localize('cellLanguageDescriptionConfigured', "({0})", lang);
+			}
+
+			const languageName = this._modeService.getLanguageName(lang);
+			if (!languageName) {
+				// Notebook has unrecognized language
+				return;
+			}
+
+			const item = <ILanguagePickInput>{
+				label: languageName,
+				iconClasses: getIconClasses(this._modelService, this._modeService, this.getFakeResource(languageName, this._modeService)),
+				description,
+				languageId: lang
+			};
+			if (lang === 'markdown' || lang === this._cellModel.language) {
+				topItems.push(item);
+			} else {
+				mainItems.push(item);
+			}
+		});
+
+		mainItems.sort((a, b) => {
+			return a.description.localeCompare(b.description);
+		});
+
+		const picks: QuickPickInput[] = [
+			...topItems,
+			{ type: 'separator' },
+			...mainItems
+		];
+		return this._quickInputService.pick(picks, { placeHolder: this.cellLanguageTitle, canPickMany: false }) as Promise<ILanguagePickInput | undefined>;
+	}
+
+	/**
+	 * Copied from coreActions.ts
+	 */
+	private getFakeResource(lang: string, modeService: IModeService): URI | undefined {
+		let fakeResource: URI | undefined;
+
+		const extensions = modeService.getExtensions(lang);
+		if (extensions?.length) {
+			fakeResource = URI.file(extensions[0]);
+		} else {
+			const filenames = modeService.getFilenames(lang);
+			if (filenames?.length) {
+				fakeResource = URI.file(filenames[0]);
+			}
+		}
+
+		return fakeResource;
 	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -464,7 +464,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			.then(languages => this.pickCellLanguage(languages))
 			.then(selection => {
 				if (selection?.languageId) {
-					this._cellModel.setOverrideLanguage(selection.label);
+					this._cellModel.setOverrideLanguage(selection.languageId);
 				}
 			})
 			.catch(err => onUnexpectedError(err));

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -459,7 +459,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		}
 	}
 
-	public onCellLanguageClick(event: any): void {
+	public onCellLanguageClick(): void {
 		this._notebookService.getSupportedLanguagesForProvider(this._model.providerId, this._model.selectedKernelDisplayName)
 			.then(languages => this.pickCellLanguage(languages))
 			.then(selection => {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -118,7 +118,7 @@ code-component .cellLanguage {
 	padding: 2px 15px;
 	display: inline-block;
 	text-align: center;
-	font-size: 16px;
+	font-size: 12px;
 	border-style: none;
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -119,6 +119,11 @@ code-component .cellLanguage {
 	display: inline-block;
 	text-align: center;
 	font-size: 16px;
+	border-style: none;
+}
+
+code-component .cellLanguage:hover {
+	background-color: green;
 }
 
 code-component .parameter {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -120,10 +120,7 @@ code-component .cellLanguage {
 	text-align: center;
 	font-size: 12px;
 	border-style: none;
-}
-
-code-component .cellLanguage:hover {
-	background-color: green;
+	background-color: transparent;
 }
 
 code-component .parameter {

--- a/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
@@ -6,7 +6,7 @@ import 'vs/css!./notebook';
 
 import { registerThemingParticipant, IColorTheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
 import { SIDE_BAR_BACKGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND } from 'vs/workbench/common/theme';
-import { activeContrastBorder, contrastBorder, buttonBackground, textLinkForeground, textLinkActiveForeground, textPreformatForeground, textBlockQuoteBackground, textBlockQuoteBorder, buttonForeground } from 'vs/platform/theme/common/colorRegistry';
+import { activeContrastBorder, contrastBorder, buttonBackground, textLinkForeground, textLinkActiveForeground, textPreformatForeground, textBlockQuoteBackground, textBlockQuoteBorder, buttonForeground, foreground } from 'vs/platform/theme/common/colorRegistry';
 import { editorLineHighlight, editorLineHighlightBorder } from 'vs/editor/common/view/editorColorRegistry';
 import { cellBorder, notebookToolbarIcon, notebookToolbarLines, buttonMenuArrow, dropdownArrow, markdownEditorBackground, codeEditorBackground, codeEditorBackgroundActive, codeEditorLineNumber, codeEditorToolbarIcon, codeEditorToolbarBackground, codeEditorToolbarBorder, toolbarBackground, toolbarIcon, toolbarBottomBorder, notebookToolbarSelectBackground, splitBorder, notebookCellTagBackground, notebookCellTagForeground, notebookFindMatchHighlight, notebookFindRangeHighlight } from 'sql/platform/theme/common/colorRegistry';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -14,6 +14,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { BareResultsGridInfo, getBareResultsGridInfoStyles } from 'sql/workbench/contrib/query/browser/queryResultsEditor';
 import { getZoomLevel } from 'vs/base/browser/browser';
 import * as types from 'vs/base/common/types';
+import { cellStatusBarItemHover } from 'vs/workbench/contrib/notebook/browser/notebookEditorWidget';
 
 export function registerNotebookThemes(overrideEditorThemeSetting: boolean, configurationService: IConfigurationService): IDisposable {
 	return registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
@@ -179,6 +180,16 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean, conf
 		const notebookToolbarSelectBackgroundColor = theme.getColor(notebookToolbarSelectBackground);
 		if (notebookToolbarSelectBackgroundColor) {
 			collector.addRule(`.notebookEditor .notebook-cell.active cell-toolbar-component { background-color: ${notebookToolbarSelectBackgroundColor};}`);
+		}
+
+		// Cell language button
+		const textColor = theme.getColor(foreground);
+		if (textColor) {
+			collector.addRule(`code-component .cellLanguage { color: ${textColor}; }`);
+		}
+		const cellStatusBarHoverBg = theme.getColor(cellStatusBarItemHover);
+		if (cellStatusBarHoverBg) {
+			collector.addRule(`code-component .cellLanguage:hover { background-color: ${cellStatusBarHoverBg}; }`);
 		}
 
 		// Markdown editor toolbar

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -235,6 +235,9 @@ export class ServerManagerStub implements nb.ServerManager {
 }
 
 export class NotebookServiceStub implements INotebookService {
+	getSupportedLanguagesForProvider(provider: string): Promise<string[]> {
+		throw new Error('Method not implemented.');
+	}
 	createNotebookInput(options: INotebookShowOptions, resource?: UriComponents): Promise<IEditorInput> {
 		throw new Error('Method not implemented.');
 	}

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -235,7 +235,7 @@ export class ServerManagerStub implements nb.ServerManager {
 }
 
 export class NotebookServiceStub implements INotebookService {
-	getSupportedLanguagesForProvider(provider: string): Promise<string[]> {
+	getSupportedLanguagesForProvider(provider: string, kernelDisplayName?: string): Promise<string[]> {
 		throw new Error('Method not implemented.');
 	}
 	createNotebookInput(options: INotebookShowOptions, resource?: UriComponents): Promise<IEditorInput> {

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -418,6 +418,7 @@ export class CellModel extends Disposable implements ICellModel {
 		if (newLanguage !== this._language) {
 			this._language = newLanguage;
 			this._onLanguageChanged.fire(newLanguage);
+			this.sendChangeToNotebook(NotebookChangeType.CellMetadataUpdated);
 		}
 	}
 

--- a/src/sql/workbench/services/notebook/browser/notebookService.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookService.ts
@@ -76,6 +76,8 @@ export interface INotebookService {
 
 	getStandardKernelsForProvider(provider: string): Promise<azdata.nb.IStandardKernel[] | undefined>;
 
+	getSupportedLanguagesForProvider(provider: string): Promise<string[]>;
+
 	getOrCreateSerializationManager(providerId: string, uri: URI): Promise<ISerializationManager>;
 
 	getOrCreateExecuteManager(providerId: string, uri: URI): Thenable<IExecuteManager>;

--- a/src/sql/workbench/services/notebook/browser/notebookService.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookService.ts
@@ -76,7 +76,7 @@ export interface INotebookService {
 
 	getStandardKernelsForProvider(provider: string): Promise<azdata.nb.IStandardKernel[] | undefined>;
 
-	getSupportedLanguagesForProvider(provider: string): Promise<string[]>;
+	getSupportedLanguagesForProvider(provider: string, kernelDisplayName?: string): Promise<string[]>;
 
 	getOrCreateSerializationManager(providerId: string, uri: URI): Promise<ISerializationManager>;
 

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -494,6 +494,17 @@ export class NotebookService extends Disposable implements INotebookService {
 		return kernels;
 	}
 
+	public async getSupportedLanguagesForProvider(provider: string): Promise<string[]> {
+		let languages: string[] = [];
+		let kernels = await this.getStandardKernelsForProvider(provider);
+		kernels?.forEach(kernel => {
+			if (kernel.supportedLanguages) {
+				languages.push(...kernel.supportedLanguages);
+			}
+		});
+		return languages;
+	}
+
 	private shutdown(): void {
 		this._executeManagersMap.forEach(manager => {
 			manager.forEach(m => {

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -502,6 +502,8 @@ export class NotebookService extends Disposable implements INotebookService {
 				languages.push(...kernel.supportedLanguages);
 			}
 		});
+		// Remove duplicates
+		languages = [...new Set(languages)];
 		return languages;
 	}
 

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -494,9 +494,12 @@ export class NotebookService extends Disposable implements INotebookService {
 		return kernels;
 	}
 
-	public async getSupportedLanguagesForProvider(provider: string): Promise<string[]> {
+	public async getSupportedLanguagesForProvider(provider: string, kernelDisplayName?: string): Promise<string[]> {
 		let languages: string[] = [];
 		let kernels = await this.getStandardKernelsForProvider(provider);
+		if (kernelDisplayName && kernels) {
+			kernels = kernels.filter(kernel => kernel.displayName === kernelDisplayName);
+		}
 		kernels?.forEach(kernel => {
 			if (kernel.supportedLanguages) {
 				languages.push(...kernel.supportedLanguages);

--- a/src/vs/workbench/contrib/notebook/browser/contrib/coreActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/coreActions.ts
@@ -1647,7 +1647,7 @@ registerAction2(class ClearCellOutputsAction extends NotebookCellAction {
 	}
 });
 
-interface ILanguagePickInput extends IQuickPickItem {
+export interface ILanguagePickInput extends IQuickPickItem { // {{SQL CARBON EDIT}} Add export
 	languageId: string;
 	description: string;
 }

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -160,6 +160,25 @@ export function setup(opts: minimist.ParsedArgs) {
 				await verifyElementRendered(app, markdownString, imgSelector);
 			});
 		});
+
+		describe('Cell Actions', function () {
+			it('can change cell language', async function () {
+				const app = this.app as Application;
+				await app.workbench.sqlNotebook.newUntitledNotebook();
+				await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('SQL');
+				await app.workbench.sqlNotebook.addCellFromPlaceholder('Code');
+				await app.workbench.sqlNotebook.waitForPlaceholderGone();
+
+				const languagePickerButton = '.notebook-cell.active .cellLanguage';
+				await app.code.waitAndClick(languagePickerButton);
+
+				await app.workbench.quickinput.waitForQuickInputElements(names => names[0] === 'SQL');
+				await app.code.waitAndClick('.quick-input-widget .quick-input-list .monaco-list-row');
+
+				let element = await app.code.waitForElement(languagePickerButton);
+				assert.strictEqual(element.textContent?.trim(), 'SQL');
+			});
+		});
 	});
 }
 


### PR DESCRIPTION
In order to support polyglot notebooks (i.e. .NET Interactive) we need to be able to configure cell languages individually. So, this change adds a language picker to the lower right corner of the cell, similar to what VS Code has. Language lookup is based off of the current provider and kernel display name, so if we're using Interactive we get all of its languages, but when using the Python 3 kernel we only get Python as an option.

![CellLanguagePicker](https://user-images.githubusercontent.com/12820011/156232889-ff5efc7f-77ef-4434-88a3-605eef073a85.gif)
 