### PR TITLE
Wait for Azure accounts to be loaded by ADS before enabling the Add Account Button in Azure Tab.

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -253,7 +253,7 @@
       "view/title": [
         {
           "command": "azure.resource.signin",
-          "when": "view == azureResourceExplorer",
+          "when": "view == azureResourceExplorer && azurecore:accountsLoaded",
           "group": "navigation@1"
         },
         {

--- a/extensions/azurecore/src/azureResource/tree/treeProvider.ts
+++ b/extensions/azurecore/src/azureResource/tree/treeProvider.ts
@@ -34,7 +34,7 @@ export class AzureResourceTreeProvider implements vscode.TreeDataProvider<TreeNo
 			// the onDidChangeAccounts event will trigger in many cases where the accounts didn't actually change
 			// the notifyNodeChanged event triggers a refresh which triggers a getChildren which can trigger this callback
 			// this below check short-circuits the infinite callback loop
-			this.setSystemInitialized();
+			await this.setSystemInitialized();
 			if (!equals(accounts, this.accounts)) {
 				this.accounts = accounts;
 				this.notifyNodeChanged(undefined);
@@ -69,17 +69,19 @@ export class AzureResourceTreeProvider implements vscode.TreeDataProvider<TreeNo
 		try {
 			this.accounts = await azdata.accounts.getAllAccounts();
 			// System has been initialized
-			this.setSystemInitialized();
+			await this.setSystemInitialized();
 			this._onDidChangeTreeData.fire(undefined);
 		} catch (err) {
 			// Skip for now, we can assume that the accounts changed event will eventually notify instead
 			this.isSystemInitialized = false;
+			await vscode.commands.executeCommand('setContext', 'azurecore:accountsLoaded', this.isSystemInitialized);
 		}
 	}
 
-	private setSystemInitialized(): void {
+	private async setSystemInitialized(): Promise<void> {
 		this.isSystemInitialized = true;
 		this.loadingAccountsPromise = undefined;
+		await vscode.commands.executeCommand('setContext', 'azurecore:accountsLoaded', this.isSystemInitialized);
 	}
 
 	public get onDidChangeTreeData(): vscode.Event<TreeNode> {


### PR DESCRIPTION
This PR adds a wait flag in Azurecore so that the state of accounts is loaded first before attempting to add a new account, this will ensure the add new account window loads with valid data. 

This PR addresses #18584 

See #17853 for screenshots of this issue happening.