### PR TITLE
Disable smoke tests in web build

### DIFF
--- a/build/azure-pipelines/web/sql-product-build-web.yml
+++ b/build/azure-pipelines/web/sql-product-build-web.yml
@@ -104,14 +104,15 @@ steps:
     yarn gulp compile-extensions
   displayName: Compile Extensions
 
-- script: |
-    set -e
-    node ./node_modules/playwright/install.js
-    APP_ROOT=$(Agent.BuildDirectory)/vscode-reh-web-linux-x64
-    xvfb-run yarn smoketest --build "$(Agent.BuildDirectory)/vscode-reh-web-linux-x64" --web --headless --screenshots "$(Build.ArtifactStagingDirectory)/smokeshots" --log "$(Build.ArtifactStagingDirectory)/logs/web/smoke.log"
-  displayName: Run smoke tests (Browser)
-  continueOnError: true
-  condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+# disable smoke tests (karlb 3/2/2022)
+# - script: |
+#     set -e
+#     node ./node_modules/playwright/install.js
+#     APP_ROOT=$(Agent.BuildDirectory)/vscode-reh-web-linux-x64
+#     xvfb-run yarn smoketest --build "$(Agent.BuildDirectory)/vscode-reh-web-linux-x64" --web --headless --screenshots "$(Build.ArtifactStagingDirectory)/smokeshots" --log "$(Build.ArtifactStagingDirectory)/logs/web/smoke.log"
+#   displayName: Run smoke tests (Browser)
+#   continueOnError: true
+#   condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
 # - script: |
 #     set -e


### PR DESCRIPTION
The smoke tests have been failing in the web builds recently due to non-product bug.  This disables this step of build pipeline until we have time to investigate and fix.
