### PR TITLE
Fixing telemetry

### DIFF
--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -12,7 +12,6 @@ import * as constants from '../constants/strings';
 import * as styles from '../constants/styles';
 import { WIZARD_INPUT_COMPONENT_WIDTH } from './wizardController';
 import { deepClone, findDropDownItemIndex, selectDropDownIndex } from '../api/utils';
-import { sendSqlMigrationActionEvent, TelemetryAction, TelemetryViews } from '../telemtery';
 
 export class TargetSelectionPage extends MigrationWizardPage {
 	private _view!: azdata.ModelView;

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -131,17 +131,6 @@ export class TargetSelectionPage extends MigrationWizardPage {
 
 	public async onPageLeave(pageChangeInfo: azdata.window.WizardPageChangeInfo): Promise<void> {
 		this.wizard.registerNavigationValidator((e) => {
-
-			sendSqlMigrationActionEvent(
-				TelemetryViews.MigrationWizardTargetSelectionPage,
-				TelemetryAction.OnPageLeave,
-				{
-					'sessionId': this.migrationStateModel?._sessionId,
-					'subscriptionId': this.migrationStateModel?._targetSubscription?.id,
-					'resourceGroup': this.migrationStateModel?._resourceGroup?.name,
-					'tenantId': this.migrationStateModel?._azureTenant?.id || this.migrationStateModel?._azureAccount?.properties?.tenants[0]?.id
-				}, {});
-
 			return true;
 		});
 	}

--- a/extensions/sql-migration/src/wizard/wizardController.ts
+++ b/extensions/sql-migration/src/wizard/wizardController.ts
@@ -165,6 +165,7 @@ export class WizardController {
 			'subscriptionId': this._model._targetSubscription?.id,
 			'resourceGroup': this._model._resourceGroup?.name,
 			'targetType': this._model._targetType,
+			'tenantId': this._model?._azureAccount?.properties?.tenants[0]?.id
 		};
 	}
 }


### PR DESCRIPTION
The telemetry event to get subscriptionid, tenantid and other information was not working at 'OnPageLeave' event of target selection page. I noticed we already collect similar information at page clicks. To avoid duplicating same telemetry event removing telemetry from 'onpageleave' and adding 'tenantid' to 'PageButtonClick'. This event takes care of all possible clicks (prev/next) similar to 'OnPageLeave'.
Tested locally using latest -
![image](https://user-images.githubusercontent.com/16827327/156476148-40d7153b-3b0a-4697-b1a8-54fa10d6c26c.png)
