### PR TITLE
Check error message to see if starting a notebook session failed.

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/clientSession.ts
+++ b/src/sql/workbench/services/notebook/browser/models/clientSession.ts
@@ -50,6 +50,8 @@ export class ClientSession implements IClientSession {
 	private _kernelConfigActions: ((kernelName: string) => Promise<any>)[] = [];
 	private _connectionId: string = '';
 
+	private readonly _jupyterNotImplementedError = 'Invalid response: 501 Not Implemented';
+
 	constructor(private options: IClientSessionOptions) {
 		this._notebookUri = options.notebookUri;
 		this._executeManager = options.executeManager;
@@ -62,7 +64,6 @@ export class ClientSession implements IClientSession {
 	public async initialize(): Promise<void> {
 		try {
 			this._serverLoadFinished = this.startServer(this.options.kernelSpec);
-			await this._serverLoadFinished;
 			await this.initializeSession();
 			await this.updateCachedKernelSpec();
 		} catch (err) {
@@ -116,8 +117,8 @@ export class ClientSession implements IClientSession {
 			session.defaultKernelLoaded = true;
 		} catch (err) {
 			// TODO move registration
-			if (err && err.response && err.response.status === 501) {
-				this.options.notificationService.warn(localize('kernelRequiresConnection', "Kernel {0} was not found. The default kernel will be used instead.", kernelSpec.name));
+			if (err?.response?.status === 501 || err?.message === this._jupyterNotImplementedError) {
+				this.options.notificationService.warn(localize('kernelRequiresConnection', "Kernel '{0}' was not found. The default kernel will be used instead.", kernelSpec.name));
 				session = await this._executeManager.sessionManager.startNew({
 					path: this.notebookUri.fsPath,
 					kernelName: undefined


### PR DESCRIPTION
When I was doing some testing with Interactive notebooks, I noticed that if the Interactive extension wasn't installed, then the notebook kernels would be stuck in a persistent loading state. This is because jupyter throws an error that the Interactive kernel in the ipynb file we're trying to use isn't supported, and we weren't handling this error correctly. We check the response code of the error to see if we need to restart with the default kernel, but in this case the error is being serialized and sent over RPC to the main thread without any of the additional error info. The serialized error object just has stuff like the message and the stack, and not anything Jupyter specific, so we have to check the error message instead to see if it's the 501 error we're looking for.

For reference, here's where the error serialization occurs: https://github.com/microsoft/azuredatastudio/blob/main/src/vs/base/common/errors.ts#L104