### PR TITLE
Fix some more images not loading

### DIFF
--- a/extensions/data-workspace/src/dialogs/projectDashboard.ts
+++ b/extensions/data-workspace/src/dialogs/projectDashboard.ts
@@ -169,10 +169,12 @@ export class ProjectDashboard {
 			.component();
 		header.addItem(locationLabel, { CSSStyles: { 'padding-left': '34px', 'padding-top': '15px', 'padding-bottom': '50px', 'font-size': '16px' } });
 
-		const image = this.projectProvider!.image;		// background image added at the bottom right of the header
+		const backgroundImage = this.projectProvider!.image; // background image added at the bottom right of the header
+		// Files need to have the vscode-file scheme to be loaded by ADS
+		const backgroundUri = vscode.Uri.file(backgroundImage!.light.toString()).with({ scheme: 'vscode-file' });
 		headerContainer.addItem(header, {
 			CSSStyles: {
-				'background-image': `url(${vscode.Uri.file(image!.light.toString())})`,
+				'background-image': `url(${backgroundUri})`,
 				'background-repeat': 'no-repeat',
 				'background-position': '85% bottom',
 				'background-size': '10%',

--- a/extensions/machine-learning/src/views/widgets/dashboardWidget.ts
+++ b/extensions/machine-learning/src/views/widgets/dashboardWidget.ts
@@ -38,10 +38,11 @@ export class DashboardWidget {
 				}).component();
 				const header = await this.createHeader(view);
 				const footerContainer = this.createFooter(view);
+				const backgroundImageUri = vscode.Uri.file(this.asAbsolutePath('images/background.svg')).with({ scheme: 'vscode-file' });
 				container.addItem(header, {
 					CSSStyles: {
 						'background-image': `
-							url(${vscode.Uri.file(this.asAbsolutePath('images/background.svg'))}),
+							url(${backgroundImageUri}),
 							linear-gradient(0deg, rgba(0,0,0,0.09) 0%, rgba(0,0,0,0) 100%)
 						`,
 						'background-repeat': 'no-repeat',
@@ -300,9 +301,11 @@ export class DashboardWidget {
 				await this._apiWrapper.openExternal(vscode.Uri.parse(linkMetaData.link));
 			}
 		});
+		// Files need to have the vscode-file scheme to be loaded by ADS
+		const imageUri = vscode.Uri.file(this.asAbsolutePath(linkMetaData.iconPath?.light as string || '')).with({ scheme: 'vscode-file' });
 		videosContainer.addItem(video1Container, {
 			CSSStyles: {
-				'background-image': `url(${vscode.Uri.file(this.asAbsolutePath(linkMetaData.iconPath?.light as string || ''))})`,
+				'background-image': `url(${imageUri})`,
 				'background-repeat': 'no-repeat',
 				'background-position': 'top',
 				'width': `${maxWidth}px`,

--- a/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
+++ b/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
@@ -81,10 +81,12 @@ export class DashboardWidget {
 			}).component();
 
 			const header = this.createHeader(view);
+			// Files need to have the vscode-file scheme to be loaded by ADS
+			const watermarkUri = vscode.Uri.file(<string>IconPathHelper.migrationDashboardHeaderBackground.light).with({ scheme: 'vscode-file' });
 			container.addItem(header, {
 				CSSStyles: {
 					'background-image': `
-						url(${vscode.Uri.file(<string>IconPathHelper.migrationDashboardHeaderBackground.light)}),
+						url(${watermarkUri}),
 						linear-gradient(0deg, rgba(0, 0, 0, 0.05) 0%, rgba(0, 0, 0, 0) 100%)
 					`,
 					'background-repeat': 'no-repeat',


### PR DESCRIPTION
With latest VS Code merge files loaded by ADS are required to use the vscode-file scheme, not the file scheme.

Having extensions contribute CSS like this directly isn't something that VS Code supports hence why there isn't any built in functionality for this - and in general it's not something we should be encouraging people to do so I'm not planning on adding any helper functionality for this. The fix is easy enough to do on a one-off basis as needed.

I checked all our extensions and these were the only ones that I found that did this - although if anyone knows of any others please let me know!

Before:
![image](https://user-images.githubusercontent.com/28519865/156817421-7bab0d71-202d-4225-bb13-9fe0c8692c41.png)
After:
![image](https://user-images.githubusercontent.com/28519865/156817473-fd958e27-7749-4598-9666-daee41d43034.png)

Before:
![image](https://user-images.githubusercontent.com/28519865/156817563-e5d1f461-7a2b-40d5-ac95-e997e2023cc8.png)
After:
![image](https://user-images.githubusercontent.com/28519865/156817523-a238dbaa-f401-4a2a-ac04-633f947320ce.png)

Before:
![image](https://user-images.githubusercontent.com/28519865/156818466-0e931514-5878-4fda-ae2d-533302c8f18b.png)
After:
![image](https://user-images.githubusercontent.com/28519865/156818498-a2744b07-6aae-4d06-a4e2-d221f35612d5.png)

