### PR TITLE
update Microsoft.Build.Sql version to 0.1.3-preview in templates

### DIFF
--- a/extensions/sql-database-projects/resources/templates/newSdkSqlProjectTemplate.xml
+++ b/extensions/sql-database-projects/resources/templates/newSdkSqlProjectTemplate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="0.1.1-alpha" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
   <PropertyGroup>
     <Name>@@PROJECT_NAME@@</Name>
     <ProjectGuid>{@@PROJECT_GUID@@}</ProjectGuid>

--- a/extensions/sql-database-projects/src/test/baselines/newSdkStyleSqlProjectSdkImportAttributeBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/newSdkStyleSqlProjectSdkImportAttributeBaseline.xml
@@ -9,6 +9,6 @@
   <Target Name="BeforeBuild">
     <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>
-  <Import Project="Sdk.props" Sdk="Microsoft.Build.Sql" Version="1.0.0" />
-  <Import Project="Sdk.targets" Sdk="Microsoft.Build.Sql" Version="1.0.0" />
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.Sql" Version="0.1.3-preview" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.Sql" Version="0.1.3-preview" />
 </Project>

--- a/extensions/sql-database-projects/src/test/baselines/newSdkStyleSqlProjectSdkNodeBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/newSdkStyleSqlProjectSdkNodeBaseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
   <PropertyGroup>
     <Name>TestProjectName</Name>
     <ProjectGuid>{2C283C5D-9E4A-4313-8FF9-4E0CEE20B063}</ProjectGuid>

--- a/extensions/sql-database-projects/src/test/baselines/newSdkStyleSqlProjectSdkProjectAttributeBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/newSdkStyleSqlProjectSdkProjectAttributeBaseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" Sdk="Microsoft.Build.Sql/1.0.0">
+<Project DefaultTargets="Build" Sdk="Microsoft.Build.Sql/0.1.3-preview">
   <PropertyGroup>
     <Name>TestProjectName</Name>
     <ProjectGuid>{2C283C5D-9E4A-4313-8FF9-4E0CEE20B063}</ProjectGuid>

--- a/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectBaseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
   <PropertyGroup>
     <Name>TestProjectName</Name>
     <ProjectGuid>{2C283C5D-9E4A-4313-8FF9-4E0CEE20B063}</ProjectGuid>

--- a/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectNoProjectGuidBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectNoProjectGuidBaseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
   <PropertyGroup>
     <Name>TestProjectName</Name>
     <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>

--- a/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectWithBuildRemoveBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectWithBuildRemoveBaseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
   <PropertyGroup>
     <Name>TestProjectName</Name>
     <ProjectGuid>{2C283C5D-9E4A-4313-8FF9-4E0CEE20B063}</ProjectGuid>

--- a/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectWithFilesSpecifiedBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectWithFilesSpecifiedBaseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
   <PropertyGroup>
     <Name>TestProjectName</Name>
     <ProjectGuid>{2C283C5D-9E4A-4313-8FF9-4E0CEE20B063}</ProjectGuid>

--- a/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectWithGlobsSpecifiedBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSdkStyleSqlProjectWithGlobsSpecifiedBaseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
   <PropertyGroup>
     <Name>TestProjectName</Name>
     <ProjectGuid>{2C283C5D-9E4A-4313-8FF9-4E0CEE20B063}</ProjectGuid>


### PR DESCRIPTION
This updates the new SDK project template to have the latest Microsoft.Build.Sql SDK version and also updates the test templates to reference a valid version of the SDK. The tests using those templates weren't failing since they weren't actually building the projects, but it's still good to update them to reference a valid SDK version.
