### PR TITLE
[SQL Migration] Add more help text to database backup page

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -295,6 +295,7 @@ export function ACCOUNT_ACCESS_ERROR(account: AzureAccount, error: Error) {
 // database backup page
 export const DATABASE_BACKUP_PAGE_TITLE = localize('sql.migration.database.page.title', "Database backup");
 export const DATABASE_BACKUP_PAGE_DESCRIPTION = localize('sql.migration.database.page.description', "Select the location of the database backups to use during migration.");
+export const DATABASE_BACKUP_CHECKSUM_INFO_TEXT = localize('sql.migration.database.checksum.info.text', "Ensure that your backups were taken with the WITH CHECKSUM option.");
 export const DATABASE_BACKUP_NC_NETWORK_SHARE_RADIO_LABEL = localize('sql.migration.nc.network.share.radio.label', "My database backups are on a network share");
 export const DATABASE_BACKUP_NC_BLOB_STORAGE_RADIO_LABEL = localize('sql.migration.nc.blob.storage.radio.label', "My database backups are in an Azure Storage Blob Container");
 export const DATABASE_BACKUP_NETWORK_SHARE_HEADER_TEXT = localize('sql.migration.network.share.header.text', "Network share details");
@@ -309,6 +310,7 @@ export const DATABASE_BACKUP_NETWORK_SHARE_PASSWORD_LABEL = localize('sql.migrat
 export const DATABASE_BACKUP_NETWORK_SHARE_PASSWORD_PLACEHOLDER = localize('sql.migration.network.share.password.placeholder', "Enter password.");
 export const DATABASE_BACKUP_NETWORK_SHARE_AZURE_ACCOUNT_HEADER = localize('sql.migration.network.share.azure.header', "Storage account details");
 export const DATABASE_BACKUP_NETWORK_SHARE_AZURE_ACCOUNT_HELP = localize('sql.migration.network.share.azure.help', "Provide the Azure Storage account where the backups will be uploaded to.");
+export const DATABASE_BACKUP_PRIVATE_ENDPOINT_INFO_TEXT = localize('sql.migration.database.private.endpoint.info.text', "You can't use an Azure Storage account that has a private endpoint with Azure Database Migration Service.");
 export const DUPLICATE_NAME_ERROR = localize('sql.migration.unique.name', "Select a unique name for this target database");
 export function DATABASE_ALREADY_EXISTS_MI(dbName: string, targetName: string): string {
 	return localize('sql.migration.database.already.exists', "Database '{0}' already exists on the target managed instance '{1}'.", dbName, targetName);

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -310,7 +310,7 @@ export const DATABASE_BACKUP_NETWORK_SHARE_PASSWORD_LABEL = localize('sql.migrat
 export const DATABASE_BACKUP_NETWORK_SHARE_PASSWORD_PLACEHOLDER = localize('sql.migration.network.share.password.placeholder', "Enter password.");
 export const DATABASE_BACKUP_NETWORK_SHARE_AZURE_ACCOUNT_HEADER = localize('sql.migration.network.share.azure.header', "Storage account details");
 export const DATABASE_BACKUP_NETWORK_SHARE_AZURE_ACCOUNT_HELP = localize('sql.migration.network.share.azure.help', "Provide the Azure Storage account where the backups will be uploaded to.");
-export const DATABASE_BACKUP_PRIVATE_ENDPOINT_INFO_TEXT = localize('sql.migration.database.private.endpoint.info.text', "You can't use an Azure Storage account that has a private endpoint with Azure Database Migration Service.");
+export const DATABASE_BACKUP_PRIVATE_ENDPOINT_INFO_TEXT = localize('sql.migration.database.private.endpoint.info.text', "Ensure that the Azure Storage account does not use a private endpoint.");
 export const DUPLICATE_NAME_ERROR = localize('sql.migration.unique.name', "Select a unique name for this target database");
 export function DATABASE_ALREADY_EXISTS_MI(dbName: string, targetName: string): string {
 	return localize('sql.migration.database.already.exists', "Database '{0}' already exists on the target managed instance '{1}'.", dbName, targetName);

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -123,6 +123,15 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 			}
 		}).component();
 
+		const backupChecksumInfoBox = this._view.modelBuilder.infoBox().withProps({
+			text: constants.DATABASE_BACKUP_CHECKSUM_INFO_TEXT,
+			style: 'information',
+			width: WIZARD_INPUT_COMPONENT_WIDTH,
+			CSSStyles: {
+				...styles.BODY_CSS
+			}
+		}).component();
+
 		this._networkShareButton = this._view.modelBuilder.radioButton()
 			.withProps({
 				name: buttonGroup,
@@ -160,6 +169,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		const flexContainer = this._view.modelBuilder.flexContainer().withItems(
 			[
 				selectLocationText,
+				backupChecksumInfoBox,
 				this._networkShareButton,
 				this._blobContainerButton
 			]
@@ -457,6 +467,15 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 				}
 			}).component();
 
+		const azureStoragePrivateEndpointInfoBox = this._view.modelBuilder.infoBox().withProps({
+			text: constants.DATABASE_BACKUP_PRIVATE_ENDPOINT_INFO_TEXT,
+			style: 'information',
+			width: WIZARD_INPUT_COMPONENT_WIDTH,
+			CSSStyles: {
+				...styles.BODY_CSS
+			}
+		}).component();
+
 		this._networkShareTargetDatabaseNamesTable = this._view.modelBuilder.declarativeTable().withProps({
 			columns: [
 				{
@@ -560,6 +579,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		this._blobTableContainer = this._view.modelBuilder.flexContainer().withItems([
 			blobTableText,
 			allFieldsRequiredLabel,
+			azureStoragePrivateEndpointInfoBox,
 			this._blobContainerTargetDatabaseNamesTable
 		]).withProps({
 			CSSStyles: {
@@ -600,6 +620,15 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 					'margin-bottom': '12px'
 				}
 			}).component();
+
+		const azureStoragePrivateEndpointInfoBox = this._view.modelBuilder.infoBox().withProps({
+			text: constants.DATABASE_BACKUP_PRIVATE_ENDPOINT_INFO_TEXT,
+			style: 'information',
+			width: WIZARD_INPUT_COMPONENT_WIDTH,
+			CSSStyles: {
+				...styles.BODY_CSS
+			}
+		}).component();
 
 		const subscriptionLabel = this._view.modelBuilder.text()
 			.withProps({
@@ -728,6 +757,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		}).withItems([
 			azureAccountHeader,
 			azureAccountHelpText,
+			azureStoragePrivateEndpointInfoBox,
 			subscriptionLabel,
 			this._networkShareContainerSubscription,
 			locationLabel,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In this PR, we add new help text info boxes to the database backup page in the SQL migration extension, in two places:
1) at the top, when the user is prompted to select their backup location, they are now informed that backups must be taken with checksums enabled:

    <img width="552" alt="image" src="https://user-images.githubusercontent.com/11844501/157138967-699d53f7-fee8-4ddd-a22f-4432eb9aa31f.png">

    This is shown in all scenarios, for both network share and blob container storage, for both MI and VM targets, for both online and offline migrations.

2) further down the page, when the user is prompted to enter storage account details, they are now informed that they cannot use a storage account that has a private endpoint. The UI is a bit different depending on whether the backups are on a network share or in a blob container, but the same message is shown:
    
    Network share scenario:
    ![image](https://user-images.githubusercontent.com/11844501/157782675-da3423c8-4718-4050-aadf-763628190cca.png)

    Blob container scenario:
    ![image](https://user-images.githubusercontent.com/11844501/157782707-07047a02-9f87-43d2-951c-ce1a47d4a000.png)

    This is shown in all scenarios, for both network share and blob container storage, for both MI and VM targets, for both online and offline migrations.