### PR TITLE
Only update active cell if the cell isn't currently in edit mode.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -547,8 +547,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	private enableActiveCellEditOnDoubleClick() {
 		if (!this.isEditMode && this.doubleClickEditEnabled) {
 			this.toggleEditMode(true);
+			this._model.updateActiveCell(this.cellModel, true);
 		}
-		this._model.updateActiveCell(this.cellModel, true);
 	}
 }
 


### PR DESCRIPTION
Currently there's a bug in text cells where if you double click on text to highlight it, the highlight is cleared and the cursor is reset to the beginning of the editor. This is because we update the current cell to be the active cell when double clicking on it, regardless of whether it's already in edit mode. If a cell is already the active cell, then calling updateActiveCell on it clears its edit mode before enabling it again, and clearing the edit mode is what resets the cursor position.

This PR fixes #18493
