### PR TITLE
[SQL Migration] Add state check to target MI resource on target selection page

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -292,7 +292,7 @@ export function ACCOUNT_ACCESS_ERROR(account: AzureAccount, error: Error) {
 		error.message);
 }
 export function MI_NOT_READY_ERROR(miName: string, state: string): string {
-	return localize('sql.migration.mi.not.ready', "The Managed Instance '{0}' is currently unavailbable for migration because it is currently in the '{1}' state.", miName, state);
+	return localize('sql.migration.mi.not.ready', "The Managed Instance '{0}' is currently unavailable for migration because it is currently in the '{1}' state.", miName, state);
 }
 
 // database backup page

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -291,6 +291,9 @@ export function ACCOUNT_ACCESS_ERROR(account: AzureAccount, error: Error) {
 		`${account?.properties?.tenants[0]?.displayName} (${account?.properties?.tenants[0]?.userId})`,
 		error.message);
 }
+export function MI_NOT_READY_ERROR(miName: string, state: string): string {
+	return localize('sql.migration.mi.not.ready', "The Managed Instance '{0}' is currently unavailbable for migration because it is currently in the '{1}' state.", miName, state);
+}
 
 // database backup page
 export const DATABASE_BACKUP_PAGE_TITLE = localize('sql.migration.database.page.title', "Database backup");

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -1000,10 +1000,21 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			}
 
 			this._targetManagedInstances.forEach((managedInstance) => {
-				managedInstanceValues.push({
-					name: managedInstance.id,
-					displayName: `${managedInstance.name}`
-				});
+				let managedInstanceValue: azdata.CategoryValue;
+
+				if (managedInstance.properties.state === 'Ready') {
+					managedInstanceValue = {
+						name: managedInstance.id,
+						displayName: `${managedInstance.name}`
+					};
+				} else {
+					managedInstanceValue = {
+						name: managedInstance.id,
+						displayName: `(Unavailable) ${managedInstance.name}`
+					};
+				}
+
+				managedInstanceValues.push(managedInstanceValue);
 			});
 
 			if (managedInstanceValues.length === 0) {

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -403,6 +403,19 @@ export class TargetSelectionPage extends MigrationWizardPage {
 
 					case MigrationTargetType.SQLMI:
 						this.migrationStateModel._targetServerInstance = this.migrationStateModel.getManagedInstance(selectedIndex);
+
+						if (this.migrationStateModel._targetServerInstance.properties.state !== 'Ready') {
+							this.wizard.message = {
+								text: constants.MI_NOT_READY_ERROR(this.migrationStateModel._targetServerInstance.name, this.migrationStateModel._targetServerInstance.properties.state),
+								level: azdata.window.MessageLevel.Error
+							};
+						} else {
+							this.wizard.message = {
+								text: '',
+								level: azdata.window.MessageLevel.Error
+							};
+						}
+
 						break;
 				}
 			} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In this PR, we add a new state check to ensure that only MI resources in a Ready state are selected for migration. To do so, we:
1) prefix any non-Ready MI resource names with "(Unavailable)" in the dropdown on the target selection page
2) present an error message to the user when they try to select an MI in a non-Ready state, which contains the current state that the resource is in

<img width="900" alt="image" src="https://user-images.githubusercontent.com/11844501/157144983-c341a8a1-64db-472f-b042-129f10349b04.png">

Behavior is unchanged for MI targets that are in a Ready state:

<img width="901" alt="image" src="https://user-images.githubusercontent.com/11844501/157145071-f42e410c-e4eb-4834-9d57-12810bf6a57c.png">

