### PR TITLE
[SQL Migration] Fix overflow behavior on migration cutover dialog to avoid truncating backup file names

### DIFF
--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -814,8 +814,8 @@ export class MigrationCutoverDialog {
 				...styles.BODY_CSS,
 				'margin': '4px 0 12px',
 				'width': '100%',
-				'overflow': 'hidden',
-				'text-overflow': 'ellipses'
+				'overflow': 'visible',
+				'overflow-wrap': 'break-word'
 			}
 		}).component();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In this PR, we fix the CSS overflow behavior on the migration cutover dialog in order to avoid truncating fields such as the file names of the last applied backup files.

Previously, it looked like this, making it impossible for users to see the full file name if it was too long:

![image](https://user-images.githubusercontent.com/11844501/157347875-4a9ae99c-6249-4ecb-a8ed-efb8e625d49a.png)

Now, the fields will wrap properly, making it possible to read full file names:

![image](https://user-images.githubusercontent.com/11844501/157348172-c16ec642-632e-4d8c-9a79-fe1e2ffc8120.png)


