### PR TITLE
Add option to not publish source maps

### DIFF
--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -93,6 +93,7 @@ steps:
     AZURE_STORAGE_ACCESS_KEY="$(sourcemap-storage-key)" \
       node build/azure-pipelines/upload-sourcemaps
   displayName: Upload sourcemaps
+  condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'))
 
 - script: |
     set -e

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -180,6 +180,7 @@ declare module 'azdata' {
 		rows: DbCellValue[][];
 	}
 
+	//
 	export interface SerializeDataResult {
 		messages?: string;
 		succeeded: boolean;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -180,7 +180,6 @@ declare module 'azdata' {
 		rows: DbCellValue[][];
 	}
 
-	//
 	export interface SerializeDataResult {
 		messages?: string;
 		succeeded: boolean;


### PR DESCRIPTION
This was something VS Code added a while back that we didn't bring over to our pipelines. There's no reason we should be publishing source maps for every build - adhoc runs and PR validation runs for example shouldn't. 