### PR TITLE
[SQL Migration] Fix SKU recommendations not working for named (non-default) instances

### DIFF
--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -351,13 +351,15 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 
 	public async getSkuRecommendations(): Promise<SkuRecommendation> {
 		try {
-			let fullInstanceName = (await this.getSourceConnectionProfile()).serverName;
+			const serverInfo = await azdata.connection.getServerInfo(this.sourceConnectionId);
+			const machineName = (<any>serverInfo)['machineName'];	// contains the correct machine name but not necessarily the correct instance name
+			const instanceName = (await this.getSourceConnectionProfile()).serverName;	// contains the correct instance name but not necessarily the correct machine name
 
-			if (fullInstanceName.includes('localhost')) {
-				const serverInfo = await azdata.connection.getServerInfo(this.sourceConnectionId);
-				const machineName = (<any>serverInfo)['machineName'];
-
-				fullInstanceName = fullInstanceName.replace('localhost', machineName);
+			let fullInstanceName: string;
+			if (instanceName.includes('\\')) {
+				fullInstanceName = machineName + '\\' + instanceName.substring(instanceName.indexOf('\\') + 1);
+			} else {
+				fullInstanceName = machineName;
 			}
 
 			const response = (await this.migrationService.getSkuRecommendations(

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -352,13 +352,15 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 	public async getSkuRecommendations(): Promise<SkuRecommendation> {
 		try {
 			const serverInfo = await azdata.connection.getServerInfo(this.sourceConnectionId);
-			const machineName = (<any>serverInfo)['machineName'];		// get actual machine name instead of whatever the user entered as the server name (e.g. DESKTOP-xxx instead of localhost)
+			// const machineName = (<any>serverInfo)['machineName'];		// get actual machine name instead of whatever the user entered as the server name (e.g. DESKTOP-xxx instead of localhost)
+
+			const instanceName = this._assessmentApiResponse.assessmentResult.name;
 
 			const response = (await this.migrationService.getSkuRecommendations(
 				this._skuRecommendationPerformanceLocation,
 				this._performanceDataQueryIntervalInSeconds,
 				this._recommendationTargetPlatforms.map(p => p.toString()),
-				machineName,
+				instanceName,
 				this._skuTargetPercentile,
 				this._skuScalingFactor,
 				this._defaultDataPointStartTime,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In this PR, we fix SKU recommendations not working for named (non-default) instances. As part of the API call made to request the generation of SKU recommendations, the instance name must be passed in order to construct the file names that the assessment NuGet expects when reading collected performance data. However, the previous approach(es) used to derive the instance name would only look at the _machine_ name:

![image](https://user-images.githubusercontent.com/11844501/157772222-10a1f75b-43c1-46b6-b580-dd7e610b1f1b.png)

(note that this named instance is actually named `RATRUONG-P330\MSSQLSERVER01`)

This would work for unnamed (default) instances since specifying the default instance name is optional, but when trying with named instances, this would result in an error implying that data was not collected, since the NuGet would be looking for the wrong file names (thinking it's an unnamed instance) and not be able to find the data files, even if the data collection worked properly:

![image](https://user-images.githubusercontent.com/11844501/157772341-2ea7297e-32ed-4c30-9c88-3aeac20a1563.png)

Now, we change it so that the full instance name is now constructed properly:
![image](https://user-images.githubusercontent.com/11844501/157771926-81275f7d-dcad-44d8-a2d1-89a4cb76a5b0.png)

SKU recommendation now works as expected for both named and unnamed instances.
