### PR TITLE
Make SDK-style project a checkbox option instead of separate template

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -49,6 +49,8 @@ export const SelectProjectType = localize('dataworkspace.selectProjectType', "Se
 export const SelectProjectLocation = localize('dataworkspace.selectProjectLocation', "Select Project Location");
 export const NameCannotBeEmpty = localize('dataworkspace.nameCannotBeEmpty', "Name cannot be empty");
 export const TargetPlatform = localize('dataworkspace.targetPlatform', "Target Platform");
+export const SdkStyleProject = localize('dataworkspace.sdkStyleProject', "SDK-style project (Preview)");
+export const LearnMore = localize('dataworkspace.learnMore', "Learn More");
 
 //Open Existing Dialog
 export const OpenExistingDialogTitle = localize('dataworkspace.openExistingDialogTitle', "Open Existing Project");

--- a/extensions/data-workspace/src/common/interfaces.ts
+++ b/extensions/data-workspace/src/common/interfaces.ts
@@ -74,8 +74,9 @@ export interface IWorkspaceService {
 	 * @param location The location of the project
 	 * @param projectTypeId The project type id
 	 * @param projectTargetPlatform The target platform of the project
+	 * @param sdkStyleProject Whether or not the project is SDK-style
 	 */
-	createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetPlatform?: string): Promise<vscode.Uri>;
+	createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetPlatform?: string, sdkStyleProject?: boolean): Promise<vscode.Uri>;
 
 	/**
 	 * Clones git repository and adds projects to workspace

--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -137,14 +137,9 @@ declare module 'dataworkspace' {
 		readonly defaultTargetPlatform?: string;
 
 		/**
-		 * Link display value for a link at the end of the project description. linkLocation also needs to be set to use this
+		 * Location where clicking on the Learn More next to SDK style checkbox will go. sdkStyleOption needs to be set to true to use this
 		 */
-		readonly linkDisplayValue?: string;
-
-		/**
-		 * Location where clicking on the linkDisplayValue will go to
-		 */
-		readonly linkLocation?: string
+		readonly sdkStyleLearnMoreUrl?: string
 	}
 
 	/**

--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -67,8 +67,9 @@ declare module 'dataworkspace' {
 		 * @param location the parent directory of the project
 		 * @param projectTypeId the identifier of the selected project type
 		 * @param projectTargetPlatform the target platform of the project
+		 * @param sdkStyleProject whether or not a project is SDK-style
 		 */
-		createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetPlatform?: string): Promise<vscode.Uri>;
+		createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetPlatform?: string, sdkStyleProject?: boolean): Promise<vscode.Uri>;
 
 		/**
 		 * Gets the project data corresponding to the project file, to be placed in the dashboard container
@@ -124,6 +125,11 @@ declare module 'dataworkspace' {
 		  * Gets the target platforms that can be selected when creating a new project
 		 */
 		readonly targetPlatforms?: string[];
+
+		/**
+		 * Whether or not sdk style project is an option
+		 */
+		readonly sdkStyleOption?: boolean;
 
 		/**
 		 * Gets the default target platform

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -197,10 +197,10 @@ export class WorkspaceService implements IWorkspaceService {
 		return ProjectProviderRegistry.getProviderByProjectExtension(projectType);
 	}
 
-	async createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetVersion?: string): Promise<vscode.Uri> {
+	async createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetVersion?: string, sdkStyleProject?: boolean): Promise<vscode.Uri> {
 		const provider = ProjectProviderRegistry.getProviderByProjectType(projectTypeId);
 		if (provider) {
-			const projectFile = await provider.createProject(name, location, projectTypeId, projectTargetVersion);
+			const projectFile = await provider.createProject(name, location, projectTypeId, projectTargetVersion, sdkStyleProject);
 			await this.addProjectsToWorkspace([projectFile]);
 			this._onDidWorkspaceProjectsChange.fire();
 			return projectFile;

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -154,7 +154,7 @@ export class ProjectsController {
 	 */
 	public async createNewProject(creationParams: NewProjectParams): Promise<string> {
 		TelemetryReporter.createActionEvent(TelemetryViews.ProjectController, TelemetryActions.createNewProject)
-			.withAdditionalProperties({ template: creationParams.projectTypeId })
+			.withAdditionalProperties({ template: creationParams.projectTypeId, sdkStyle: creationParams.sdkStyle!.toString() })
 			.send();
 
 		if (creationParams.projectGuid && !UUID.isUUID(creationParams.projectGuid)) {
@@ -171,7 +171,7 @@ export class ProjectsController {
 			'PROJECT_DSP': creationParams.targetPlatform ? constants.targetPlatformToVersion.get(creationParams.targetPlatform)! : constants.defaultDSP
 		};
 
-		let newProjFileContents = creationParams.projectTypeId === constants.emptySqlDatabaseSdkProjectTypeId ? templates.macroExpansion(templates.newSdkSqlProjectTemplate, macroDict) : templates.macroExpansion(templates.newSqlProjectTemplate, macroDict);
+		let newProjFileContents = creationParams.sdkStyle ? templates.macroExpansion(templates.newSdkSqlProjectTemplate, macroDict) : templates.macroExpansion(templates.newSqlProjectTemplate, macroDict);
 
 		let newProjFileName = creationParams.newProjName;
 
@@ -1111,7 +1111,8 @@ export class ProjectsController {
 			const newProjFilePath = await this.createNewProject({
 				newProjName: projectInfo.projectName,
 				folderUri: vscode.Uri.file(projectInfo.outputFolder),
-				projectTypeId: constants.emptySqlDatabaseProjectTypeId
+				projectTypeId: constants.emptySqlDatabaseProjectTypeId,
+				sdkStyle: false
 			});
 
 			const project = await Project.openProject(newProjFilePath);
@@ -1286,7 +1287,8 @@ export class ProjectsController {
 			const newProjFilePath = await this.createNewProject({
 				newProjName: model.projName,
 				folderUri: vscode.Uri.file(newProjFolderUri),
-				projectTypeId: model.sdkStyle ? constants.emptySqlDatabaseSdkProjectTypeId : constants.emptySqlDatabaseProjectTypeId
+				projectTypeId: model.sdkStyle ? constants.emptySqlDatabaseSdkProjectTypeId : constants.emptySqlDatabaseProjectTypeId,
+				sdkStyle: model.sdkStyle
 			});
 
 			model.filePath = path.dirname(newProjFilePath);
@@ -1498,6 +1500,7 @@ export interface NewProjectParams {
 	newProjName: string;
 	folderUri: vscode.Uri;
 	projectTypeId: string;
+	sdkStyle: boolean;
 	projectGuid?: string;
 	targetPlatform?: SqlTargetPlatform;
 }

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -381,7 +381,7 @@ export class CreateProjectFromDatabaseDialog {
 			filePath: this.projectLocationTextBox!.value!,
 			version: '1.0.0.0',
 			extractTarget: mapExtractTargetEnum(<string>this.folderStructureDropDown!.value),
-			sdkStyle: this.sdkStyleCheckbox?.checked
+			sdkStyle: this.sdkStyleCheckbox?.checked!
 		};
 
 		azdataApi!.window.closeDialog(this.dialog);

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseQuickpick.ts
@@ -139,6 +139,7 @@ export async function createNewProjectFromDatabaseWithQuickpick(connectionInfo?:
 		projName: projectName,
 		filePath: projectLocation,
 		version: '1.0.0.0',
-		extractTarget: mapExtractTargetEnum(folderStructure)
+		extractTarget: mapExtractTargetEnum(folderStructure),
+		sdkStyle: false // todo: add sdkstyle option to quickpick
 	};
 }

--- a/extensions/sql-database-projects/src/models/api/import.ts
+++ b/extensions/sql-database-projects/src/models/api/import.ts
@@ -18,5 +18,5 @@ export interface ImportDataModel {
 	filePath: string;
 	version: string;
 	extractTarget: ExtractTarget;
-	sdkStyle?: boolean;
+	sdkStyle: boolean;
 }

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -36,24 +36,14 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 */
 	get supportedProjectTypes(): dataworkspace.IProjectType[] {
 		return [{
-			id: constants.emptySqlDatabaseSdkProjectTypeId,
-			projectFileExtension: constants.sqlprojExtension.replace(/\./g, ''),
-			displayName: constants.emptySdkProjectTypeDisplayName,
-			description: constants.emptySdkProjectTypeDescription,
-			icon: IconPathHelper.colorfulSqlProject,
-			targetPlatforms: Array.from(constants.targetPlatformToVersion.keys()),
-			defaultTargetPlatform: constants.defaultTargetPlatform,
-			linkDisplayValue: constants.learnMore,
-			linkLocation: constants.sdkLearnMoreUrl
-		},
-		{
 			id: constants.emptySqlDatabaseProjectTypeId,
 			projectFileExtension: constants.sqlprojExtension.replace(/\./g, ''),
 			displayName: constants.emptyProjectTypeDisplayName,
 			description: constants.emptyProjectTypeDescription,
 			icon: IconPathHelper.colorfulSqlProject,
 			targetPlatforms: Array.from(constants.targetPlatformToVersion.keys()),
-			defaultTargetPlatform: constants.defaultTargetPlatform
+			defaultTargetPlatform: constants.defaultTargetPlatform,
+			sdkStyleOption: true
 		},
 		{
 			id: constants.edgeSqlDatabaseProjectTypeId,
@@ -71,12 +61,13 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 * @param projectTypeId the ID of the project/template
 	 * @returns Uri of the newly created project file
 	 */
-	async createProject(name: string, location: vscode.Uri, projectTypeId: string, targetPlatform?: sqldbproj.SqlTargetPlatform): Promise<vscode.Uri> {
+	async createProject(name: string, location: vscode.Uri, projectTypeId: string, targetPlatform?: sqldbproj.SqlTargetPlatform, sdkStyle: boolean = true): Promise<vscode.Uri> {
 		const projectFile = await this.projectController.createNewProject({
 			newProjName: name,
 			folderUri: location,
 			projectTypeId: projectTypeId,
-			targetPlatform: targetPlatform
+			targetPlatform: targetPlatform,
+			sdkStyle: sdkStyle
 		});
 
 		return vscode.Uri.file(projectFile);

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -43,14 +43,17 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 			icon: IconPathHelper.colorfulSqlProject,
 			targetPlatforms: Array.from(constants.targetPlatformToVersion.keys()),
 			defaultTargetPlatform: constants.defaultTargetPlatform,
-			sdkStyleOption: true
+			sdkStyleOption: true,
+			sdkStyleLearnMoreUrl: constants.sdkLearnMoreUrl
 		},
 		{
 			id: constants.edgeSqlDatabaseProjectTypeId,
 			projectFileExtension: constants.sqlprojExtension.replace(/\./g, ''),
 			displayName: constants.edgeProjectTypeDisplayName,
 			description: constants.edgeProjectTypeDescription,
-			icon: IconPathHelper.sqlEdgeProject
+			icon: IconPathHelper.sqlEdgeProject,
+			sdkStyleOption: true,
+			sdkStyleLearnMoreUrl: constants.sdkLearnMoreUrl
 		}];
 	}
 

--- a/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
@@ -36,7 +36,8 @@ describe('Publish Database Dialog', () => {
 			newProjName: 'TestProjectName',
 			folderUri: vscode.Uri.file(projFileDir),
 			projectTypeId: emptySqlDatabaseProjectTypeId,
-			projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575'
+			projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575',
+			sdkStyle: false
 		});
 
 		const project = new Project(projFilePath);
@@ -54,7 +55,8 @@ describe('Publish Database Dialog', () => {
 			newProjName: 'TestProjectName',
 			folderUri: vscode.Uri.file(projFileDir),
 			projectTypeId: emptySqlDatabaseProjectTypeId,
-			projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575'
+			projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575',
+			sdkStyle: false
 		});
 
 		const project = new Project(projFilePath);

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -59,7 +59,8 @@ describe('ProjectsController', function (): void {
 					newProjName: 'TestProjectName',
 					folderUri: vscode.Uri.file(projFileDir),
 					projectTypeId: constants.emptySqlDatabaseProjectTypeId,
-					projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575'
+					projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575',
+					sdkStyle: false
 				});
 
 				let projFileText = (await fs.readFile(projFilePath)).toString();
@@ -77,7 +78,8 @@ describe('ProjectsController', function (): void {
 					folderUri: vscode.Uri.file(projFileDir),
 					projectTypeId: constants.emptySqlDatabaseProjectTypeId,
 					projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575',
-					targetPlatform: projTargetPlatform
+					targetPlatform: projTargetPlatform,
+					sdkStyle: false
 				});
 
 				const project = await Project.openProject(projFilePath);
@@ -496,7 +498,8 @@ describe('ProjectsController', function (): void {
 					projName: 'testProject',
 					filePath: 'testLocation',
 					version: '1.0.0.0',
-					extractTarget: mssql.ExtractTarget['schemaObjectType']
+					extractTarget: mssql.ExtractTarget['schemaObjectType'],
+					sdkStyle: false
 				});
 
 				return Promise.resolve(undefined);
@@ -520,7 +523,7 @@ describe('ProjectsController', function (): void {
 			let folderPath = await testUtils.generateTestFolderPath();
 			let projectName = 'My Project';
 			let importPath;
-			let model: ImportDataModel = { connectionUri: 'My Id', database: 'My Database', projName: projectName, filePath: folderPath, version: '1.0.0.0', extractTarget: mssql.ExtractTarget['file'] };
+			let model: ImportDataModel = { connectionUri: 'My Id', database: 'My Database', projName: projectName, filePath: folderPath, version: '1.0.0.0', extractTarget: mssql.ExtractTarget['file'], sdkStyle: false };
 
 			const projController = new ProjectsController(testContext.outputChannel);
 			projController.setFilePath(model);
@@ -533,7 +536,7 @@ describe('ProjectsController', function (): void {
 			let folderPath = await testUtils.generateTestFolderPath();
 			let projectName = 'My Project';
 			let importPath;
-			let model: ImportDataModel = { connectionUri: 'My Id', database: 'My Database', projName: projectName, filePath: folderPath, version: '1.0.0.0', extractTarget: mssql.ExtractTarget['schemaObjectType'] };
+			let model: ImportDataModel = { connectionUri: 'My Id', database: 'My Database', projName: projectName, filePath: folderPath, version: '1.0.0.0', extractTarget: mssql.ExtractTarget['schemaObjectType'], sdkStyle: false };
 
 			const projController = new ProjectsController(testContext.outputChannel);
 			projController.setFilePath(model);


### PR DESCRIPTION
As discussed, this makes SDK-style project an option instead of being a separate template. With this change, SDK style is also an option for the edge template. For future project types added, they can specify whether or not SDK-style is an option for that template and if a url for the learn more link.

old (left) compared to new (right)
![image](https://user-images.githubusercontent.com/31145923/157790513-3818665c-997f-4053-9754-c81cad994104.png)

example of the SDK-style option being removed for a template that doesn't specify SDK-style as an option and the learn more link (this is just for demonstrating the behavior, but this PR adds SDK-style as an option for the edge template)
![sdkCheckbox](https://user-images.githubusercontent.com/31145923/157790799-1d71ac28-5c8c-4c1b-9560-6f2fd9b01710.gif)

