### PR TITLE
Add missing onNotebook:* activation event for VS Code notebook compatibility.

### DIFF
--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -382,9 +382,10 @@ export class NotebookService extends Disposable implements INotebookService {
 
 		// Emit activation event if the provider is not one of the default options
 		if (p.id !== SQL_NOTEBOOK_PROVIDER && p.id !== JUPYTER_PROVIDER_ID) {
-			this._extensionService.whenInstalledExtensionsRegistered().then(() => {
-				this._extensionService.activateByEvent(`onNotebook:${p.id}`).catch(err => onUnexpectedError(err));
-			}).catch(err => onUnexpectedError(err));
+			this._extensionService.whenInstalledExtensionsRegistered()
+				.then(() => this._extensionService.activateByEvent(`onNotebook:${p.id}`))
+				.then(() => this._extensionService.activateByEvent(`onNotebook:*`))
+				.catch(err => onUnexpectedError(err));
 		}
 	}
 


### PR DESCRIPTION
VS Code emits a "onNotebook:*" activation event whenever a notebook is opened, in addition to a more specific one for the provider e.g. "onNotebook:jupyter-notebook". We were missing that previous general event, so I've added it in this PR.

For reference, this is where VS Code emits their events: https://github.com/microsoft/azuredatastudio/blob/main/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts#L483