### PR TITLE
add SDK style option to new project quickpick

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -51,8 +51,9 @@ export const NameCannotBeEmpty = localize('dataworkspace.nameCannotBeEmpty', "Na
 export const TargetPlatform = localize('dataworkspace.targetPlatform', "Target Platform");
 export const SdkStyleProject = localize('dataworkspace.sdkStyleProject', "SDK-style project (Preview)");
 export const LearnMore = localize('dataworkspace.learnMore', "Learn More");
-export const Yes = localize('dataworkspace.yes', "Yes");
+export const YesRecommended = localize('dataworkspace.yesRecommended', "Yes (Recommended)");
 export const No = localize('dataworkspace.no', "No");
+export const SdkLearnMorePlaceholder = localize('dataworkspace.sdkLearnMorePlaceholder', "Click \"Learn More\" button for more information about SDK-style projects");
 
 //Open Existing Dialog
 export const OpenExistingDialogTitle = localize('dataworkspace.openExistingDialogTitle', "Open Existing Project");

--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -51,6 +51,8 @@ export const NameCannotBeEmpty = localize('dataworkspace.nameCannotBeEmpty', "Na
 export const TargetPlatform = localize('dataworkspace.targetPlatform', "Target Platform");
 export const SdkStyleProject = localize('dataworkspace.sdkStyleProject', "SDK-style project (Preview)");
 export const LearnMore = localize('dataworkspace.learnMore', "Learn More");
+export const Yes = localize('dataworkspace.yes', "Yes");
+export const No = localize('dataworkspace.no', "No");
 
 //Open Existing Dialog
 export const OpenExistingDialogTitle = localize('dataworkspace.openExistingDialogTitle', "Open Existing Project");

--- a/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
@@ -19,8 +19,10 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 		return {
 			label: projType.displayName,
 			description: projType.description,
-			id: projType.id
-		} as vscode.QuickPickItem & { id: string };
+			id: projType.id,
+			sdkOption: projType.sdkStyleOption,
+			sdkLearnMoreUrl: projType.sdkStyleLearnMoreUrl
+		} as vscode.QuickPickItem & { id: string, sdkOption?: boolean, sdkLearnMoreUrl?: string };
 	});
 
 	// 1. Prompt for project type
@@ -87,5 +89,53 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 		continue;
 	}
 
-	await workspaceService.createProject(projectName, vscode.Uri.file(projectLocation), projectType.id, undefined);
+	let sdkStyle;
+	if (projectType.sdkOption) {
+		// 4. SDK-style project or not
+		const sdkLearnMoreButton: vscode.QuickInputButton = {
+			iconPath: new vscode.ThemeIcon('link-external'),
+			tooltip: constants.LearnMore
+		};
+		const quickPick = vscode.window.createQuickPick();
+		quickPick.items = [{ label: constants.Yes }, { label: constants.No }];
+		quickPick.title = constants.SdkStyleProject;
+		quickPick.ignoreFocusOut = true;
+		const disposables: vscode.Disposable[] = [];
+
+		try {
+			if (projectType.sdkLearnMoreUrl) {
+				// add button to open sdkLearnMoreUrl if it was provided
+				quickPick.buttons = [sdkLearnMoreButton];
+			}
+
+			let sdkStylePromise = new Promise<boolean | undefined>((resolve) => {
+				disposables.push(
+					quickPick.onDidHide(() => {
+						resolve(undefined);
+					}),
+					quickPick.onDidChangeSelection((item) => {
+						resolve(item[0].label === constants.Yes);
+					}));
+
+				if (projectType.sdkLearnMoreUrl) {
+					disposables.push(quickPick.onDidTriggerButton(async () => {
+						await vscode.env.openExternal(vscode.Uri.parse(projectType.sdkLearnMoreUrl!));
+					}));
+				}
+			});
+
+			quickPick.show();
+			sdkStyle = await sdkStylePromise;
+			quickPick.hide();
+		} finally {
+			disposables.forEach(d => d.dispose());
+		}
+
+		if (sdkStyle === undefined) {
+			// User cancelled
+			return;
+		}
+	}
+
+	await workspaceService.createProject(projectName, vscode.Uri.file(projectLocation), projectType.id, undefined, sdkStyle);
 }

--- a/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
@@ -97,7 +97,7 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 			tooltip: constants.LearnMore
 		};
 		const quickPick = vscode.window.createQuickPick();
-		quickPick.items = [{ label: constants.Yes }, { label: constants.No }];
+		quickPick.items = [{ label: constants.YesRecommended }, { label: constants.No }];
 		quickPick.title = constants.SdkStyleProject;
 		quickPick.ignoreFocusOut = true;
 		const disposables: vscode.Disposable[] = [];
@@ -106,6 +106,7 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 			if (projectType.sdkLearnMoreUrl) {
 				// add button to open sdkLearnMoreUrl if it was provided
 				quickPick.buttons = [sdkLearnMoreButton];
+				quickPick.placeholder = constants.SdkLearnMorePlaceholder;
 			}
 
 			let sdkStylePromise = new Promise<boolean | undefined>((resolve) => {
@@ -114,7 +115,7 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 						resolve(undefined);
 					}),
 					quickPick.onDidChangeSelection((item) => {
-						resolve(item[0].label === constants.Yes);
+						resolve(item[0].label === constants.YesRecommended);
 					}));
 
 				if (projectType.sdkLearnMoreUrl) {


### PR DESCRIPTION
This adds SDK-style as an option in the vscode new project quickpick if a template has specified it as an option. This was added to the new project dialog in ADS in https://github.com/microsoft/azuredatastudio/pull/18698.
![image](https://user-images.githubusercontent.com/31145923/158241186-5ae29f4a-2a36-4a0b-b293-db1e282d895b.png)
