### PR TITLE
Add select target platform to new project quickpick

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -54,6 +54,8 @@ export const LearnMore = localize('dataworkspace.learnMore', "Learn More");
 export const YesRecommended = localize('dataworkspace.yesRecommended', "Yes (Recommended)");
 export const No = localize('dataworkspace.no', "No");
 export const SdkLearnMorePlaceholder = localize('dataworkspace.sdkLearnMorePlaceholder', "Click \"Learn More\" button for more information about SDK-style projects");
+export const Default = localize('dataworkspace.default', "Default");
+export const SelectTargetPlatform = localize('dataworkspace.selectTargetPlatform', "Select Target Platform");
 
 //Open Existing Dialog
 export const OpenExistingDialogTitle = localize('dataworkspace.openExistingDialogTitle', "Open Existing Project");

--- a/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
@@ -98,7 +98,10 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 
 		if (projectType.defaultTargetPlatform) {
 			// move the default target platform to be the first one in the list
-			targetPlatforms.splice(targetPlatforms.findIndex(i => i.label === projectType.defaultTargetPlatform), 1);
+			const defaultIndex = targetPlatforms.findIndex(i => i.label === projectType.defaultTargetPlatform);
+			if (defaultIndex > -1) {
+				targetPlatforms.splice(defaultIndex, 1);
+			}
 
 			// add default next to the default target platform
 			targetPlatforms.unshift({ label: projectType.defaultTargetPlatform, description: constants.Default });

--- a/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
@@ -118,7 +118,7 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 
 	let sdkStyle;
 	if (projectType.sdkOption) {
-		// 3. SDK-style project or not
+		// 5. SDK-style project or not
 		const sdkLearnMoreButton: vscode.QuickInputButton = {
 			iconPath: new vscode.ThemeIcon('link-external'),
 			tooltip: constants.LearnMore

--- a/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
@@ -106,6 +106,7 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 
 		const selectedTargetPlatform = await vscode.window.showQuickPick(targetPlatforms, { title: constants.SelectTargetPlatform, ignoreFocusOut: true });
 		if (!selectedTargetPlatform) {
+			// User cancelled
 			return;
 		}
 


### PR DESCRIPTION
Selecting the target platform for new sql projects was added in #16091. This adds the same option to the new project quickpick in vscode. This step only shows if a template provides target platforms. If a default target platform is specified, then the default target platform is moved to the top of the list and has "Default" next to it like in the screenshot below.

![image](https://user-images.githubusercontent.com/31145923/158279027-c9f1a1a1-0cf7-47a3-9d2e-64fc3c905c54.png)
