### PR TITLE
Add rest of sql-bindings/azure funcs logic to sql bindings ext

### DIFF
--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -67,7 +67,6 @@
     "promisify-child-process": "^3.1.1",
     "vscode-nls": "^4.1.2",
     "vscode-languageclient": "5.2.1"
-
   },
   "devDependencies": {
     "@types/node": "^14.14.16",

--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -65,7 +65,9 @@
     "fast-glob": "^3.2.7",
     "jsonc-parser": "^2.3.1",
     "promisify-child-process": "^3.1.1",
-    "vscode-nls": "^4.1.2"
+    "vscode-nls": "^4.1.2",
+    "vscode-languageclient": "5.2.1"
+
   },
   "devDependencies": {
     "@types/node": "^14.14.16",

--- a/extensions/sql-bindings/src/contracts/azureFunctions/azureFunctionsContracts.ts
+++ b/extensions/sql-bindings/src/contracts/azureFunctions/azureFunctionsContracts.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AddSqlBindingParams, GetAzureFunctionsParams, GetAzureFunctionsResult, ResultStatus } from 'sqlbindings';
+import { RequestType } from 'vscode-languageclient';
+
+/**
+ * Adds a SQL Binding to a specified Azure function in a file
+ */
+export namespace AddSqlBindingRequest {
+	export const type = new RequestType<AddSqlBindingParams, ResultStatus, void, void>('azureFunctions/sqlBinding');
+}
+
+/**
+ * Gets the names of the Azure functions in a file
+ */
+export namespace GetAzureFunctionsRequest {
+	export const type = new RequestType<GetAzureFunctionsParams, GetAzureFunctionsResult, void, void>('azureFunctions/getAzureFunctions');
+}

--- a/extensions/sql-bindings/src/contracts/azureFunctions/azureFunctionsContracts.ts
+++ b/extensions/sql-bindings/src/contracts/azureFunctions/azureFunctionsContracts.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AddSqlBindingParams, GetAzureFunctionsParams, GetAzureFunctionsResult, ResultStatus } from 'sqlbindings';
+import { AddSqlBindingParams, GetAzureFunctionsParams, GetAzureFunctionsResult, ResultStatus } from 'sql-bindings';
 import { RequestType } from 'vscode-languageclient';
 
 /**

--- a/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
@@ -10,7 +10,7 @@ import * as constants from '../common/constants';
 import * as utils from '../common/utils';
 import * as azureFunctionsUtils from '../common/azureFunctionsUtils';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
-import { BindingType } from 'sqlbindings';
+import { BindingType } from 'sql-bindings';
 
 export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined): Promise<void> {
 	TelemetryReporter.sendActionEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.startAddSqlBinding);

--- a/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
@@ -5,11 +5,12 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { BindingType, ConnectionDetails, IConnectionInfo } from 'vscode-mssql';
+import { ConnectionDetails, IConnectionInfo } from 'vscode-mssql';
 import * as constants from '../common/constants';
 import * as utils from '../common/utils';
 import * as azureFunctionsUtils from '../common/azureFunctionsUtils';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
+import { BindingType } from 'sqlbindings';
 
 export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined): Promise<void> {
 	TelemetryReporter.sendActionEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.startAddSqlBinding);

--- a/extensions/sql-bindings/src/extension.ts
+++ b/extensions/sql-bindings/src/extension.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
 import { ITreeNodeInfo } from 'vscode-mssql';
-import { IExtension, BindingType } from 'sqlbindings';
+import { IExtension, BindingType } from 'sql-bindings';
 import { getAzdataApi, getVscodeMssqlApi } from './common/utils';
 import { launchAddSqlBindingQuickpick } from './dialogs/addSqlBindingQuickpick';
 import { addSqlBinding, createAzureFunction, getAzureFunctions } from './services/azureFunctionsService';

--- a/extensions/sql-bindings/src/extension.ts
+++ b/extensions/sql-bindings/src/extension.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
 import { ITreeNodeInfo } from 'vscode-mssql';
+import { IExtension, BindingType } from 'sqlbindings';
 import { getAzdataApi, getVscodeMssqlApi } from './common/utils';
 import { launchAddSqlBindingQuickpick } from './dialogs/addSqlBindingQuickpick';
-import { createAzureFunction } from './services/azureFunctionsService';
+import { addSqlBinding, createAzureFunction, getAzureFunctions } from './services/azureFunctionsService';
 
-export async function activate(context: vscode.ExtensionContext): Promise<void> {
+export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
 	const vscodeMssqlApi = await getVscodeMssqlApi();
 
 	void vscode.commands.executeCommand('setContext', 'azdataAvailable', !!getAzdataApi());
@@ -32,6 +33,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		const connectionString = await vscodeMssqlApi.getConnectionString(connectionDetails, false, false);
 		await createAzureFunction(connectionString, node.metadata.schema, node.metadata.name);
 	}));
+	return {
+		addSqlBinding: async (bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string) => {
+			return addSqlBinding(bindingType, filePath, functionName, objectName, connectionStringSetting);
+		},
+		getAzureFunctions: async (filePath: string) => {
+			return getAzureFunctions(filePath);
+		}
+	};
 }
 
 export function deactivate(): void {

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -132,7 +132,7 @@ export async function createAzureFunction(connectionString: string, schema: stri
  * @param functionName Name of the function where the SQL Binding is to be added
  * @param objectName Name of Object for the SQL Query
  * @param connectionStringSetting Setting for the connection string
- * @returns
+ * @returns Azure Function SQL binding
  */
 export async function addSqlBinding(
 	bindingType: BindingType,
@@ -140,7 +140,7 @@ export async function addSqlBinding(
 	functionName: string,
 	objectName: string,
 	connectionStringSetting: string
-): Promise<Thenable<ResultStatus>> {
+): Promise<ResultStatus> {
 	const params: AddSqlBindingParams = {
 		bindingType: bindingType,
 		filePath: filePath,

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as mssql from 'vscode-mssql';
 import * as path from 'path';
 import * as utils from '../common/utils';
 import * as azureFunctionUtils from '../common/azureFunctionsUtils';
 import * as constants from '../common/constants';
+import * as azureFunctionsContracts from '../contracts/azureFunctions/azureFunctionsContracts';
+import { AddSqlBindingParams, BindingType, GetAzureFunctionsParams, GetAzureFunctionsResult, ResultStatus } from 'sqlbindings';
 
 export const hostFileName: string = 'host.json';
 
@@ -86,14 +87,14 @@ export async function createAzureFunction(connectionString: string, schema: stri
 		}
 
 		// select input or output binding
-		const inputOutputItems: (vscode.QuickPickItem & { type: mssql.BindingType })[] = [
+		const inputOutputItems: (vscode.QuickPickItem & { type: BindingType })[] = [
 			{
 				label: constants.input,
-				type: mssql.BindingType.input
+				type: BindingType.input
 			},
 			{
 				label: constants.output,
-				type: mssql.BindingType.output
+				type: BindingType.output
 			}
 		];
 
@@ -122,4 +123,48 @@ export async function createAzureFunction(connectionString: string, schema: stri
 
 		azureFunctionUtils.overwriteAzureFunctionMethodBody(functionFile);
 	}
+}
+
+/**
+ * Adds a SQL Binding to a specified Azure function in a file
+ * @param bindingType Type of SQL Binding
+ * @param filePath Path of the file where the Azure Functions are
+ * @param functionName Name of the function where the SQL Binding is to be added
+ * @param objectName Name of Object for the SQL Query
+ * @param connectionStringSetting Setting for the connection string
+ * @returns
+ */
+export async function addSqlBinding(
+	bindingType: BindingType,
+	filePath: string,
+	functionName: string,
+	objectName: string,
+	connectionStringSetting: string
+): Promise<Thenable<ResultStatus>> {
+	const params: AddSqlBindingParams = {
+		bindingType: bindingType,
+		filePath: filePath,
+		functionName: functionName,
+		objectName: objectName,
+		connectionStringSetting: connectionStringSetting
+	};
+
+	const vscodeMssqlApi = await utils.getVscodeMssqlApi();
+
+	return vscodeMssqlApi.sendRequest(azureFunctionsContracts.AddSqlBindingRequest.type, params);
+}
+
+
+/**
+ * Gets the names of the Azure functions in the file
+ * @param filePath Path of the file to get the Azure functions
+ * @returns array of names of Azure functions in the file
+ */
+export async function getAzureFunctions(filePath: string): Promise<GetAzureFunctionsResult> {
+	const params: GetAzureFunctionsParams = {
+		filePath: filePath
+	};
+	const vscodeMssqlApi = await utils.getVscodeMssqlApi();
+
+	return vscodeMssqlApi.sendRequest(azureFunctionsContracts.GetAzureFunctionsRequest.type, params);
 }

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -9,7 +9,7 @@ import * as utils from '../common/utils';
 import * as azureFunctionUtils from '../common/azureFunctionsUtils';
 import * as constants from '../common/constants';
 import * as azureFunctionsContracts from '../contracts/azureFunctions/azureFunctionsContracts';
-import { AddSqlBindingParams, BindingType, GetAzureFunctionsParams, GetAzureFunctionsResult, ResultStatus } from 'sqlbindings';
+import { AddSqlBindingParams, BindingType, GetAzureFunctionsParams, GetAzureFunctionsResult, ResultStatus } from 'sql-bindings';
 
 export const hostFileName: string = 'host.json';
 

--- a/extensions/sql-bindings/src/sql-bindings.d.ts
+++ b/extensions/sql-bindings/src/sql-bindings.d.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-declare module 'sqlbindings' {
+declare module 'sql-bindings' {
 
 	/**
 	 * sql bindings extension
@@ -21,9 +21,9 @@ declare module 'sqlbindings' {
 		addSqlBinding(bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Promise<ResultStatus>;
 
 		/**
-		 * Gets the names of the Azure functions in the file
-		 * @param filePath Path of the file to get the Azure functions
-		 * @returns array of names of Azure functions in the file
+		 * Gets the names of the Azure Functions in the file
+		 * @param filePath Path of the file to get the Azure Functions
+		 * @returns array of names of Azure Functions in the file
 		 */
 		 getAzureFunctions(filePath: string): Promise<GetAzureFunctionsResult>;
 	}
@@ -59,7 +59,7 @@ declare module 'sqlbindings' {
 	}
 
 	/**
-	 * Azure functions binding type
+	 * Azure Functions binding type
 	 */
 	export const enum BindingType {
 		input,
@@ -67,7 +67,7 @@ declare module 'sqlbindings' {
 	}
 
 	/**
-	 * ResultStatus from d.ts
+	 * Base result object from a request to the SQL Tools Service
 	 */
 	export interface ResultStatus {
 		success: boolean;
@@ -75,21 +75,21 @@ declare module 'sqlbindings' {
 	}
 
 	/**
-	 * Parameters for getting the names of the Azure functions in a file
+	 * Parameters for getting the names of the Azure Functions in a file
 	 */
 	 export interface GetAzureFunctionsParams {
 		/**
-		 * Absolute file path of file to get Azure functions
+		 * Absolute file path of file to get Azure Functions
 		 */
 		filePath: string;
 	}
 
 	/**
-	 * Result from a get Azure functions request
+	 * Result from a get Azure Functions request
 	 */
 	 export interface GetAzureFunctionsResult extends ResultStatus {
 		/**
-		 * Array of names of Azure functions in the file
+		 * Array of names of Azure Functions in the file
 		 */
 		azureFunctions: string[];
 	}

--- a/extensions/sql-bindings/src/sql-bindings.d.ts
+++ b/extensions/sql-bindings/src/sql-bindings.d.ts
@@ -6,6 +6,11 @@
 
 declare module 'sql-bindings' {
 
+	export const enum extension {
+		name = 'Microsoft.sql-bindings',
+		vsCodeName = 'ms-mssql.sql-bindings-vscode'
+	}
+
 	/**
 	 * sql bindings extension
 	 */

--- a/extensions/sql-bindings/src/sqlbindings.d.ts
+++ b/extensions/sql-bindings/src/sqlbindings.d.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+declare module 'sqlbindings' {
+
+	/**
+	 * sql bindings extension
+	 */
+	export interface IExtension {
+		/**
+		 * Adds a SQL Binding to a specified Azure function in a file
+		 * @param bindingType Type of SQL Binding
+		 * @param filePath Path of the file where the Azure Functions are
+		 * @param functionName Name of the function where the SQL Binding is to be added
+		 * @param objectName Name of Object for the SQL Query
+		 * @param connectionStringSetting Setting for the connection string
+		 */
+		addSqlBinding(bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Promise<ResultStatus>;
+
+		/**
+		 * Gets the names of the Azure functions in the file
+		 * @param filePath Path of the file to get the Azure functions
+		 * @returns array of names of Azure functions in the file
+		 */
+		 getAzureFunctions(filePath: string): Thenable<GetAzureFunctionsResult>;
+	}
+
+	/**
+	 * Parameters for adding a SQL binding to an Azure function
+	 */
+	export interface AddSqlBindingParams {
+		/**
+		 * Aboslute file path of file to add SQL binding
+		 */
+		filePath: string;
+
+		/**
+		 * Name of function to add SQL binding
+		 */
+		functionName: string;
+
+		/**
+		 * Name of object to use in SQL binding
+		 */
+		objectName: string;
+
+		/**
+		 * Type of Azure function binding
+		 */
+		bindingType: BindingType;
+
+		/**
+		 * Name of SQL connection string setting specified in local.settings.json
+		 */
+		connectionStringSetting: string;
+	}
+
+	/**
+	 * Azure functions binding type
+	 */
+	export const enum BindingType {
+		input,
+		output
+	}
+
+	/**
+	 * ResultStatus from d.ts
+	 */
+	export interface ResultStatus {
+		success: boolean;
+		errorMessage: string;
+	}
+
+	/**
+	 * Parameters for getting the names of the Azure functions in a file
+	 */
+	 export interface GetAzureFunctionsParams {
+		/**
+		 * Absolute file path of file to get Azure functions
+		 */
+		filePath: string;
+	}
+
+	/**
+	 * Result from a get Azure functions request
+	 */
+	 export interface GetAzureFunctionsResult extends ResultStatus {
+		/**
+		 * Array of names of Azure functions in the file
+		 */
+		azureFunctions: string[];
+	}
+
+}

--- a/extensions/sql-bindings/src/sqlbindings.d.ts
+++ b/extensions/sql-bindings/src/sqlbindings.d.ts
@@ -25,7 +25,7 @@ declare module 'sqlbindings' {
 		 * @param filePath Path of the file to get the Azure functions
 		 * @returns array of names of Azure functions in the file
 		 */
-		 getAzureFunctions(filePath: string): Thenable<GetAzureFunctionsResult>;
+		 getAzureFunctions(filePath: string): Promise<GetAzureFunctionsResult>;
 	}
 
 	/**
@@ -33,7 +33,7 @@ declare module 'sqlbindings' {
 	 */
 	export interface AddSqlBindingParams {
 		/**
-		 * Aboslute file path of file to add SQL binding
+		 * Absolute file path of file to add SQL binding
 		 */
 		filePath: string;
 

--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -9,6 +9,8 @@ import * as path from 'path';
 import * as TypeMoq from 'typemoq';
 import * as mssql from '../../../mssql/src/mssql';
 import * as vscodeMssql from 'vscode-mssql';
+import { RequestType } from 'vscode-languageclient';
+import { BindingType, GetAzureFunctionsResult } from 'sqlbindings';
 
 export interface TestUtils {
 	context: vscode.ExtensionContext;
@@ -136,8 +138,8 @@ export const mockGetAzureFunctionsResult = {
 };
 
 export class MockAzureFunctionService implements vscodeMssql.IAzureFunctionsService {
-	addSqlBinding(_: vscodeMssql.BindingType, __: string, ___: string, ____: string, _____: string): Thenable<vscodeMssql.ResultStatus> { return Promise.resolve(mockResultStatus); }
-	getAzureFunctions(_: string): Thenable<vscodeMssql.GetAzureFunctionsResult> { return Promise.resolve(mockGetAzureFunctionsResult); }
+	addSqlBinding(_: BindingType, __: string, ___: string, ____: string, _____: string): Thenable<vscodeMssql.ResultStatus> { return Promise.resolve(mockResultStatus); }
+	getAzureFunctions(_: string): Thenable<GetAzureFunctionsResult> { return Promise.resolve(mockGetAzureFunctionsResult); }
 }
 
 export const mockDacFxMssqlOptionResult: vscodeMssql.DacFxOptionsResult = {
@@ -253,6 +255,9 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 		this.dacFx = new MockDacFxMssqlService;
 		this.schemaCompare = new MockSchemaCompareService;
 		this.azureFunctions = new MockAzureFunctionService;
+	}
+	sendRequest<P, R, E, R0>(_: RequestType<P, R, E, R0>, __?: P): Thenable<R> {
+		throw new Error('Method not implemented.');
 	}
 	promptForConnection(_?: boolean): Promise<vscodeMssql.IConnectionInfo | undefined> {
 		throw new Error('Method not implemented.');

--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -256,7 +256,7 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 		this.schemaCompare = new MockSchemaCompareService;
 		this.azureFunctions = new MockAzureFunctionService;
 	}
-	sendRequest<P, R, E, R0>(_: RequestType<P, R, E, R0>, __?: P): Thenable<R> {
+	sendRequest<P, R, E, R0>(_: RequestType<P, R, E, R0>, __?: P): Promise<R> {
 		throw new Error('Method not implemented.');
 	}
 	promptForConnection(_?: boolean): Promise<vscodeMssql.IConnectionInfo | undefined> {

--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -10,7 +10,7 @@ import * as TypeMoq from 'typemoq';
 import * as mssql from '../../../mssql/src/mssql';
 import * as vscodeMssql from 'vscode-mssql';
 import { RequestType } from 'vscode-languageclient';
-import { BindingType, GetAzureFunctionsResult } from 'sqlbindings';
+import { BindingType, GetAzureFunctionsResult } from 'sql-bindings';
 
 export interface TestUtils {
 	context: vscode.ExtensionContext;

--- a/extensions/sql-bindings/src/typings/vscode-mssql.d.ts
+++ b/extensions/sql-bindings/src/typings/vscode-mssql.d.ts
@@ -7,7 +7,7 @@ declare module 'vscode-mssql' {
 
 	import * as vscode from 'vscode';
 	import { RequestType } from 'vscode-languageclient';
-	import { BindingType, GetAzureFunctionsResult } from 'sqlbindings';
+	import { BindingType, GetAzureFunctionsResult } from 'sql-bindings';
 
 	/**
 	 * Covers defining what the vscode-mssql extension exports to other extensions

--- a/extensions/sql-bindings/src/typings/vscode-mssql.d.ts
+++ b/extensions/sql-bindings/src/typings/vscode-mssql.d.ts
@@ -6,6 +6,8 @@
 declare module 'vscode-mssql' {
 
 	import * as vscode from 'vscode';
+	import { RequestType } from 'vscode-languageclient';
+	import { BindingType, GetAzureFunctionsResult } from 'sqlbindings';
 
 	/**
 	 * Covers defining what the vscode-mssql extension exports to other extensions
@@ -86,12 +88,20 @@ declare module 'vscode-mssql' {
 		getConnectionString(connectionUriOrDetails: string | ConnectionDetails, includePassword?: boolean, includeApplicationName?: boolean): Promise<string>;
 
 		/**
-	 	 * Set connection details for the provided connection info
-	 	 * Able to use this for getConnectionString requests to STS that require ConnectionDetails type
-	 	 * @param connectionInfo connection info of the connection
-	 	 * @returns connection details credentials for the connection
-	 	 */
+		 * Set connection details for the provided connection info
+		 * Able to use this for getConnectionString requests to STS that require ConnectionDetails type
+		 * @param connectionInfo connection info of the connection
+		 * @returns connection details credentials for the connection
+		 */
 		createConnectionDetails(connectionInfo: IConnectionInfo): ConnectionDetails;
+
+		/**
+		 * Send a request to the SQL Tools Server client
+		 * @param type The of the request to make
+		 * @param params The params to pass with the request
+		 * @returns A thenable object for when the request receives a response
+		 */
+		sendRequest<P, R, E, R0>(requestType: RequestType<P, R, E, R0>, params?: P): Thenable<R>;
 	}
 
 	/**
@@ -587,64 +597,6 @@ declare module 'vscode-mssql' {
 		parentName?: string;
 
 		parentTypeName?: string;
-	}
-
-	/**
-	 * Azure functions binding type
-	 */
-	export const enum BindingType {
-		input,
-		output
-	}
-
-	/**
-	 * Parameters for adding a SQL binding to an Azure function
-	 */
-	export interface AddSqlBindingParams {
-		/**
-		 * Aboslute file path of file to add SQL binding
-		 */
-		filePath: string;
-
-		/**
-		 * Name of function to add SQL binding
-		 */
-		functionName: string;
-
-		/**
-		 * Name of object to use in SQL binding
-		 */
-		objectName: string;
-
-		/**
-		 * Type of Azure function binding
-		 */
-		bindingType: BindingType;
-
-		/**
-		 * Name of SQL connection string setting specified in local.settings.json
-		 */
-		connectionStringSetting: string;
-	}
-
-	/**
-	 * Parameters for getting the names of the Azure functions in a file
-	 */
-	export interface GetAzureFunctionsParams {
-		/**
-		 * Absolute file path of file to get Azure functions
-		 */
-		filePath: string;
-	}
-
-	/**
-	 * Result from a get Azure functions request
-	 */
-	export interface GetAzureFunctionsResult extends ResultStatus {
-		/**
-		 * Array of names of Azure functions in the file
-		 */
-		azureFunctions: string[];
 	}
 
 	/**

--- a/extensions/sql-bindings/src/typings/vscode-mssql.d.ts
+++ b/extensions/sql-bindings/src/typings/vscode-mssql.d.ts
@@ -97,11 +97,11 @@ declare module 'vscode-mssql' {
 
 		/**
 		 * Send a request to the SQL Tools Server client
-		 * @param type The of the request to make
+		 * @param requestType The type of the request
 		 * @param params The params to pass with the request
-		 * @returns A thenable object for when the request receives a response
+		 * @returns A promise object for when the request receives a response
 		 */
-		sendRequest<P, R, E, R0>(requestType: RequestType<P, R, E, R0>, params?: P): Thenable<R>;
+		 sendRequest<P, R, E, R0>(requestType: RequestType<P, R, E, R0>, params?: P): Promise<R>;
 	}
 
 	/**

--- a/extensions/sql-bindings/yarn.lock
+++ b/extensions/sql-bindings/yarn.lock
@@ -1045,7 +1045,7 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-semver@^5.3.0, semver@^5.4.1, semver@^5.6.0:
+semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -1237,6 +1237,32 @@ vscode-extension-telemetry@^0.1.6:
   integrity sha512-pZuZTHO9OpsrwlerOKotWBRLRYJ53DobYb7aWiRAXjlqkuqE+YJJaP+2WEy8GrLIF1EnitXTDMaTAKsmLQ5ORQ==
   dependencies:
     applicationinsights "1.7.4"
+
+vscode-jsonrpc@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
+  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
+
+vscode-languageclient@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz#7cfc83a294c409f58cfa2b910a8cfeaad0397193"
+  integrity sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==
+  dependencies:
+    semver "^5.5.0"
+    vscode-languageserver-protocol "3.14.1"
+
+vscode-languageserver-protocol@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
+  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
+  dependencies:
+    vscode-jsonrpc "^4.0.0"
+    vscode-languageserver-types "3.14.0"
+
+vscode-languageserver-types@3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
+  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
 
 vscode-nls@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds remaining logic that was dependent on STS in vscode-mssql to SQL bindings extension. Now that there is a sendRequest API in mssql we can then bring over the logic for both addSQLBinding and getAzureFunctions. I also added these to our own API to be utilized as well. 

For the moment I had to delete the vscode-mssql typings in order to make sure the build passes. I will be updating the vscode-mssql typings as well with the corresponding updates. 
