### PR TITLE
Add test for last edit mode

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -1376,16 +1376,16 @@ suite('Cell Model', function (): void {
 		assert(cellModel.showPreview, 'showPreview should default to true when not in editMode');
 		assert(!cellModel.showMarkdown, 'showMarkdown should be false when not in editMode');
 
-		let currentCellEditModePromise = () => {
+		let getCurrentCellEditModePromise = () => {
 			return new Promise((resolve, reject) => {
-				setTimeout((error) => reject(error), 2000);
+				setTimeout((error) => reject(error));
 				cellModel.onCurrentEditModeChanged(cellEditMode => {
 					resolve(cellEditMode);
 				});
 			});
 		};
 
-		let cellModePromise = currentCellEditModePromise();
+		let cellModePromise = getCurrentCellEditModePromise();
 		// Initially mode is defaulted be WYSIWYG -> showPreview is true and showMarkdown is false
 		assert.strictEqual(cellModel.currentMode, CellEditModes.WYSIWYG, 'Current mode should be WYSIWYG when not in edit mode');
 		assert.strictEqual(cellModel.isEditMode, false, 'cell should not default to edit mode');
@@ -1394,7 +1394,7 @@ suite('Cell Model', function (): void {
 		let lastEditMode = await cellModePromise;
 		assert.strictEqual(lastEditMode, CellEditModes.WYSIWYG, 'Default edit mode should be WYSIWYG');
 		// update mode to SPLITVIEW -> showMarkdown and showPreview both are true
-		cellModePromise = currentCellEditModePromise();
+		cellModePromise = getCurrentCellEditModePromise();
 		cellModel.showMarkdown = true;
 		lastEditMode = await cellModePromise;
 		assert.strictEqual(lastEditMode, CellEditModes.SPLIT, 'LastEditMode should be set to split view');
@@ -1406,7 +1406,7 @@ suite('Cell Model', function (): void {
 		assert.strictEqual(cellModel.currentMode, CellEditModes.SPLIT, 'Should persist lastEditMode and be in Split View');
 
 		// update mode to markdown mode only -> showPreview is false and showMarkdown is true
-		cellModePromise = currentCellEditModePromise();
+		cellModePromise = getCurrentCellEditModePromise();
 		cellModel.showPreview = false;
 		lastEditMode = await cellModePromise;
 		assert.strictEqual(lastEditMode, CellEditModes.MARKDOWN, 'LastEditMode should be set to markdown');

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -1378,7 +1378,6 @@ suite('Cell Model', function (): void {
 
 		let getCurrentCellEditModePromise = () => {
 			return new Promise((resolve, reject) => {
-				setTimeout((error) => reject(error));
 				cellModel.onCurrentEditModeChanged(cellEditMode => {
 					resolve(cellEditMode);
 				});

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -9,6 +9,7 @@ import * as assert from 'assert';
 
 import * as objects from 'vs/base/common/objects';
 
+
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { ModelFactory } from 'sql/workbench/services/notebook/browser/models/modelFactory';
 import { NotebookModelStub, ClientSessionStub, KernelStub, FutureStub } from 'sql/workbench/contrib/notebook/test/stubs';
@@ -1358,4 +1359,65 @@ suite('Cell Model', function (): void {
 		assert(editMode);
 		assert.strictEqual(editMode, CellEditModes.WYSIWYG, 'Default edit mode should be WYSIWYG.');
 	});
+
+	test('cell should have lastEditMode set to whatever the user edited out of last', async function () {
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Markdown,
+			source: '',
+			metadata: {}
+		};
+		let cellModel = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+
+		// Non-Editing Preview mode -> showPreview should be true and showMarkdown should be false.
+		assert(cellModel.showPreview, 'showPreview should default to true when not in editMode');
+		assert(!cellModel.showMarkdown, 'showMarkdown should be false when not in editMode');
+
+		let currentCellEditModePromise = () => {
+			return new Promise((resolve, reject) => {
+				setTimeout((error) => reject(error), 2000);
+				cellModel.onCurrentEditModeChanged(cellEditMode => {
+					resolve(cellEditMode);
+				});
+			});
+		};
+
+		let cellModePromise = currentCellEditModePromise();
+		// Initially mode is defaulted be WYSIWYG -> showPreview is true and showMarkdown is false
+		assert.strictEqual(cellModel.currentMode, CellEditModes.WYSIWYG, 'Current mode should be WYSIWYG when not in edit mode');
+		assert.strictEqual(cellModel.isEditMode, false, 'cell should not default to edit mode');
+
+		cellModel.isEditMode = true;
+		let lastEditMode = await cellModePromise;
+		assert.strictEqual(lastEditMode, CellEditModes.WYSIWYG, 'Default edit mode should be WYSIWYG');
+		// update mode to SPLITVIEW -> showMarkdown and showPreview both are true
+		cellModePromise = currentCellEditModePromise();
+		cellModel.showMarkdown = true;
+		lastEditMode = await cellModePromise;
+		assert.strictEqual(lastEditMode, CellEditModes.SPLIT, 'LastEditMode should be set to split view');
+
+		// come out of edit mode and enter edit mode again to check edit mode.
+		cellModel.isEditMode = false;
+		assert.strictEqual(cellModel.currentMode, CellEditModes.WYSIWYG, 'Should default to WYSIWYG when not editing');
+		cellModel.isEditMode = true;
+		assert.strictEqual(cellModel.currentMode, CellEditModes.SPLIT, 'Should persist lastEditMode and be in Split View');
+
+		// update mode to markdown mode only -> showPreview is false and showMarkdown is true
+		cellModePromise = currentCellEditModePromise();
+		cellModel.showPreview = false;
+		lastEditMode = await cellModePromise;
+		assert.strictEqual(lastEditMode, CellEditModes.MARKDOWN, 'LastEditMode should be set to markdown');
+
+		// come out of edit mode and enter edit mode again to check edit mode.
+		cellModel.isEditMode = false;
+		assert.strictEqual(cellModel.currentMode, CellEditModes.WYSIWYG, 'Should default to WYSIWYG when not editing');
+		cellModel.isEditMode = true;
+		assert.strictEqual(cellModel.currentMode, CellEditModes.MARKDOWN, 'Should persist lastEditMode and be in markdown only');
+
+	});
+
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -9,7 +9,6 @@ import * as assert from 'assert';
 
 import * as objects from 'vs/base/common/objects';
 
-
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { ModelFactory } from 'sql/workbench/services/notebook/browser/models/modelFactory';
 import { NotebookModelStub, ClientSessionStub, KernelStub, FutureStub } from 'sql/workbench/contrib/notebook/test/stubs';

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -242,9 +242,10 @@ export class CellModel extends Disposable implements ICellModel {
 			this.showPreview = newEditMode !== TextCellEditModes.Markdown;
 			this.showMarkdown = newEditMode !== TextCellEditModes.RichText;
 		} else {
-			// when not in edit mode, default the values to false.
+			// when not in edit mode, default the values since they are only valid when editing.
+			// And to return the correct currentMode value.
 			this._showMarkdown = false;
-			this._showPreview = false;
+			this._showPreview = true;
 		}
 		this._onCellModeChanged.fire(this._isEditMode);
 		// Note: this does not require a notebook update as it does not change overall state

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -241,6 +241,10 @@ export class CellModel extends Disposable implements ICellModel {
 			const newEditMode = this._lastEditMode ?? this._defaultTextEditMode;
 			this.showPreview = newEditMode !== TextCellEditModes.Markdown;
 			this.showMarkdown = newEditMode !== TextCellEditModes.RichText;
+		} else {
+			// when not in edit mode, default the values to false.
+			this._showMarkdown = false;
+			this._showPreview = false;
 		}
 		this._onCellModeChanged.fire(this._isEditMode);
 		// Note: this does not require a notebook update as it does not change overall state
@@ -1036,12 +1040,10 @@ export class CellModel extends Disposable implements ICellModel {
 		if (this._cellType === CellTypes.Code) {
 			return CellEditModes.CODE;
 		}
-		if (this.isEditMode) {
-			if (this._showMarkdown && this._showPreview) {
-				return CellEditModes.SPLIT;
-			} else if (this._showMarkdown && !this._showPreview) {
-				return CellEditModes.MARKDOWN;
-			}
+		if (this._showMarkdown && this._showPreview) {
+			return CellEditModes.SPLIT;
+		} else if (this._showMarkdown && !this._showPreview) {
+			return CellEditModes.MARKDOWN;
 		}
 		// defaulting to WYSIWYG
 		return CellEditModes.WYSIWYG;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -1036,10 +1036,12 @@ export class CellModel extends Disposable implements ICellModel {
 		if (this._cellType === CellTypes.Code) {
 			return CellEditModes.CODE;
 		}
-		if (this._showMarkdown && this._showPreview) {
-			return CellEditModes.SPLIT;
-		} else if (this._showMarkdown && !this._showPreview) {
-			return CellEditModes.MARKDOWN;
+		if (this.isEditMode) {
+			if (this._showMarkdown && this._showPreview) {
+				return CellEditModes.SPLIT;
+			} else if (this._showMarkdown && !this._showPreview) {
+				return CellEditModes.MARKDOWN;
+			}
 		}
 		// defaulting to WYSIWYG
 		return CellEditModes.WYSIWYG;


### PR DESCRIPTION
Unit test for last edit mode changes.

Updated the showMarkdown and showPreview values to their defaults when not in edit mode. This is because the currentMode value is not reflecting the correct value since these values are not updated on edit mode change (i.e. whenever user comes out of edit mode, they still retain their values while on edit mode)
Tested the basic scenarios after the update and didn't find any behavioral changes.