### PR TITLE
fix the issue that chart axis's min/max value can't be zero

### DIFF
--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -391,7 +391,7 @@ export class ChartView extends Disposable implements IPanelView {
 				numberInput.onDidChange(e => {
 					if (this._options[entry] !== e) {
 						// When user clears the input box, the value we get from the input box will be empty string.
-						(this._options[entry] as any) = e === '' ? undefined : Number(e);
+						(this._options[entry] as any) = (e === '' ? undefined : Number(e));
 						if (this.insight) {
 							this.insight.options = this._options;
 						}

--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -389,8 +389,9 @@ export class ChartView extends Disposable implements IPanelView {
 				numberInput.setAriaLabel(option.label);
 				numberInput.value = value || '';
 				numberInput.onDidChange(e => {
-					if (this._options[entry] !== Number(e)) {
-						(this._options[entry] as any) = Number(e);
+					if (this._options[entry] !== e) {
+						// When user clears the input box, the value we get from the input box will be empty string.
+						(this._options[entry] as any) = e === '' ? undefined : Number(e);
 						if (this.insight) {
 							this.insight.options = this._options;
 						}

--- a/src/sql/workbench/contrib/charts/browser/graphInsight.ts
+++ b/src/sql/workbench/contrib/charts/browser/graphInsight.ts
@@ -208,11 +208,11 @@ export class Graph implements IInsight {
 					}
 				}];
 
-				if (options.xAxisMax) {
+				if (options.xAxisMax !== undefined) {
 					retval.scales = mixin(retval.scales, { xAxes: [{ ticks: { max: options.xAxisMax } }] }, true, customMixin);
 				}
 
-				if (options.xAxisMin) {
+				if (options.xAxisMin !== undefined) {
 					retval.scales = mixin(retval.scales, { xAxes: [{ ticks: { min: options.xAxisMin } }] }, true, customMixin);
 				}
 
@@ -230,17 +230,17 @@ export class Graph implements IInsight {
 					}
 				}];
 
-				if (options.yAxisMax) {
+				if (options.yAxisMax !== undefined) {
 					retval.scales = mixin(retval.scales, { yAxes: [{ ticks: { max: options.yAxisMax } }] }, true, customMixin);
 				}
 
-				if (options.yAxisMin) {
+				if (options.yAxisMin !== undefined) {
 					retval.scales = mixin(retval.scales, { yAxes: [{ ticks: { min: options.yAxisMin } }] }, true, customMixin);
 				}
 
 				if (this.originalType === ChartType.TimeSeries) {
 					retval = mixin(retval, timeSeriesScales, true, customMixin);
-					if (options.xAxisMax) {
+					if (options.xAxisMax !== undefined) {
 						retval = mixin(retval, {
 							scales: {
 								xAxes: [{
@@ -252,7 +252,7 @@ export class Graph implements IInsight {
 						}, true, customMixin);
 					}
 
-					if (options.xAxisMin) {
+					if (options.xAxisMin !== undefined) {
 						retval = mixin(retval, {
 							scales: {
 								xAxes: [{


### PR DESCRIPTION
This PR fixes #3538 

noticed this today while testing the feature and found this old issue.

Root cause: we are not differentiating 0 and undefined when processing the options.
Fix: check for undefined explicitly.

With the fix: 
![chartoption](https://user-images.githubusercontent.com/13777222/158484659-5615c7ee-e7d7-4a81-9c3a-c5a9097b9e77.gif)
