### PR TITLE
table designer - handle validation error differently

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1089,6 +1089,10 @@ declare module 'azdata' {
 			 * Issues of current state.
 			 */
 			issues?: { severity: DesignerIssueSeverity, description: string, propertyPath?: DesignerEditPath }[];
+			/**
+			 * The input validation error.
+			 */
+			inputValidationError?: string;
 		}
 
 		/**
@@ -1118,6 +1122,10 @@ declare module 'azdata' {
 			 * Format (mimeType) of the report
 			 */
 			mimeType: string;
+			/**
+			 * The table schema validation error.
+			 */
+			schemaValidationError?: string;
 		}
 	}
 

--- a/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
+++ b/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
@@ -89,6 +89,9 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 		this.updateState(this.valid, this.dirty, 'processEdit');
 		this._provider.processTableEdit(this.tableInfo, edit).then(
 			result => {
+				if (result.inputValidationError) {
+					this._errorMessageService.showDialog(Severity.Error, ErrorDialogTitle, localize('tableDesigner.inputValidationError', "The input validation failed with error: {0}", result.inputValidationError));
+				}
 				this._viewModel = result.viewModel;
 				if (result.view) {
 					this.setDesignerView(result.view);
@@ -187,6 +190,10 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 		} catch (error) {
 			this._errorMessageService.showDialog(Severity.Error, ErrorDialogTitle, localize('tableDesigner.generatePreviewReportError', "An error occured while generating preview report: {0}", error?.message ?? error));
 			this.updateState(this.valid, this.dirty);
+			return;
+		}
+		if (previewReportResult.schemaValidationError) {
+			this._errorMessageService.showDialog(Severity.Error, ErrorDialogTitle, localize('tableDesigner.TableSchemaValidationError', "Table schema validation failed with error: {0}", previewReportResult.schemaValidationError));
 			return;
 		}
 		const dialog = this._instantiationService.createInstance(TableDesignerPublishDialog);


### PR DESCRIPTION
Currently validation errors (user input validation and schema validation) are treated no differently compared to unexpected errors, when looking at the telemetry report, we want to know how many application errors users ran into, with current implementation, we won't have a clear answer.

with this change, the table designer provider will explicitly include the validation error in the response.

I personally don't think we need to collect data for the validation errors, but we are going to have a telemetry review discussion next week sometime, we can always add telemetry for it if we decide to.