### PR TITLE
Cleanup sql bindings test utils

### DIFF
--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as azdata from 'azdata';
-import * as path from 'path';
 import * as TypeMoq from 'typemoq';
 import * as mssql from '../../../mssql/src/mssql';
 import * as vscodeMssql from 'vscode-mssql';
@@ -20,218 +18,6 @@ export interface TestUtils {
 	schemaCompareService: TypeMoq.IMock<vscodeMssql.ISchemaCompareService>;
 }
 
-export const mockDacFxResult = {
-	operationId: '',
-	success: true,
-	errorMessage: '',
-	report: ''
-};
-
-export const mockDacFxOptionsResult: mssql.DacFxOptionsResult = {
-	success: true,
-	errorMessage: '',
-	deploymentOptions: {
-		ignoreTableOptions: false,
-		ignoreSemicolonBetweenStatements: false,
-		ignoreRouteLifetime: false,
-		ignoreRoleMembership: false,
-		ignoreQuotedIdentifiers: false,
-		ignorePermissions: false,
-		ignorePartitionSchemes: false,
-		ignoreObjectPlacementOnPartitionScheme: false,
-		ignoreNotForReplication: false,
-		ignoreLoginSids: false,
-		ignoreLockHintsOnIndexes: false,
-		ignoreKeywordCasing: false,
-		ignoreIndexPadding: false,
-		ignoreIndexOptions: false,
-		ignoreIncrement: false,
-		ignoreIdentitySeed: false,
-		ignoreUserSettingsObjects: false,
-		ignoreFullTextCatalogFilePath: false,
-		ignoreWhitespace: false,
-		ignoreWithNocheckOnForeignKeys: false,
-		verifyCollationCompatibility: false,
-		unmodifiableObjectWarnings: false,
-		treatVerificationErrorsAsWarnings: false,
-		scriptRefreshModule: false,
-		scriptNewConstraintValidation: false,
-		scriptFileSize: false,
-		scriptDeployStateChecks: false,
-		scriptDatabaseOptions: false,
-		scriptDatabaseCompatibility: false,
-		scriptDatabaseCollation: false,
-		runDeploymentPlanExecutors: false,
-		registerDataTierApplication: false,
-		populateFilesOnFileGroups: false,
-		noAlterStatementsToChangeClrTypes: false,
-		includeTransactionalScripts: false,
-		includeCompositeObjects: false,
-		allowUnsafeRowLevelSecurityDataMovement: false,
-		ignoreWithNocheckOnCheckConstraints: false,
-		ignoreFillFactor: false,
-		ignoreFileSize: false,
-		ignoreFilegroupPlacement: false,
-		doNotAlterReplicatedObjects: false,
-		doNotAlterChangeDataCaptureObjects: false,
-		disableAndReenableDdlTriggers: false,
-		deployDatabaseInSingleUserMode: false,
-		createNewDatabase: false,
-		compareUsingTargetCollation: false,
-		commentOutSetVarDeclarations: false,
-		blockWhenDriftDetected: false,
-		blockOnPossibleDataLoss: false,
-		backupDatabaseBeforeChanges: false,
-		allowIncompatiblePlatform: false,
-		allowDropBlockingAssemblies: false,
-		dropConstraintsNotInSource: false,
-		dropDmlTriggersNotInSource: false,
-		dropExtendedPropertiesNotInSource: false,
-		dropIndexesNotInSource: false,
-		ignoreFileAndLogFilePath: false,
-		ignoreExtendedProperties: false,
-		ignoreDmlTriggerState: false,
-		ignoreDmlTriggerOrder: false,
-		ignoreDefaultSchema: false,
-		ignoreDdlTriggerState: false,
-		ignoreDdlTriggerOrder: false,
-		ignoreCryptographicProviderFilePath: false,
-		verifyDeployment: false,
-		ignoreComments: false,
-		ignoreColumnCollation: false,
-		ignoreAuthorizer: false,
-		ignoreAnsiNulls: false,
-		generateSmartDefaults: false,
-		dropStatisticsNotInSource: false,
-		dropRoleMembersNotInSource: false,
-		dropPermissionsNotInSource: false,
-		dropObjectsNotInSource: false,
-		ignoreColumnOrder: false,
-		doNotDropObjectTypes: [],
-		excludeObjectTypes: []
-	}
-};
-
-export class MockDacFxService implements mssql.IDacFxService {
-	public exportBacpac(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public importBacpac(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public extractDacpac(_: string, __: string, ___: string, ____: string, _____: string, ______: azdata.TaskExecutionMode): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public createProjectFromDatabase(_: string, __: string, ___: string, ____: string, _____: string, ______: mssql.ExtractTarget, _______: azdata.TaskExecutionMode): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public deployDacpac(_: string, __: string, ___: boolean, ____: string, _____: azdata.TaskExecutionMode, ______?: Record<string, string>): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public generateDeployScript(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode, ______?: Record<string, string>): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public generateDeployPlan(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<mssql.GenerateDeployPlanResult> { return Promise.resolve(mockDacFxResult); }
-	public getOptionsFromProfile(_: string): Thenable<mssql.DacFxOptionsResult> { return Promise.resolve(mockDacFxOptionsResult); }
-	public validateStreamingJob(_: string, __: string): Thenable<mssql.ValidateStreamingJobResult> { return Promise.resolve(mockDacFxResult); }
-}
-
-export const mockResultStatus = {
-	success: true,
-	errorMessage: ''
-};
-
-export const mockDacFxMssqlOptionResult: vscodeMssql.DacFxOptionsResult = {
-	success: true,
-	errorMessage: '',
-	deploymentOptions: {
-		ignoreTableOptions: false,
-		ignoreSemicolonBetweenStatements: false,
-		ignoreRouteLifetime: false,
-		ignoreRoleMembership: false,
-		ignoreQuotedIdentifiers: false,
-		ignorePermissions: false,
-		ignorePartitionSchemes: false,
-		ignoreObjectPlacementOnPartitionScheme: false,
-		ignoreNotForReplication: false,
-		ignoreLoginSids: false,
-		ignoreLockHintsOnIndexes: false,
-		ignoreKeywordCasing: false,
-		ignoreIndexPadding: false,
-		ignoreIndexOptions: false,
-		ignoreIncrement: false,
-		ignoreIdentitySeed: false,
-		ignoreUserSettingsObjects: false,
-		ignoreFullTextCatalogFilePath: false,
-		ignoreWhitespace: false,
-		ignoreWithNocheckOnForeignKeys: false,
-		verifyCollationCompatibility: false,
-		unmodifiableObjectWarnings: false,
-		treatVerificationErrorsAsWarnings: false,
-		scriptRefreshModule: false,
-		scriptNewConstraintValidation: false,
-		scriptFileSize: false,
-		scriptDeployStateChecks: false,
-		scriptDatabaseOptions: false,
-		scriptDatabaseCompatibility: false,
-		scriptDatabaseCollation: false,
-		runDeploymentPlanExecutors: false,
-		registerDataTierApplication: false,
-		populateFilesOnFileGroups: false,
-		noAlterStatementsToChangeClrTypes: false,
-		includeTransactionalScripts: false,
-		includeCompositeObjects: false,
-		allowUnsafeRowLevelSecurityDataMovement: false,
-		ignoreWithNocheckOnCheckConstraints: false,
-		ignoreFillFactor: false,
-		ignoreFileSize: false,
-		ignoreFilegroupPlacement: false,
-		doNotAlterReplicatedObjects: false,
-		doNotAlterChangeDataCaptureObjects: false,
-		disableAndReenableDdlTriggers: false,
-		deployDatabaseInSingleUserMode: false,
-		createNewDatabase: false,
-		compareUsingTargetCollation: false,
-		commentOutSetVarDeclarations: false,
-		blockWhenDriftDetected: false,
-		blockOnPossibleDataLoss: false,
-		backupDatabaseBeforeChanges: false,
-		allowIncompatiblePlatform: false,
-		allowDropBlockingAssemblies: false,
-		dropConstraintsNotInSource: false,
-		dropDmlTriggersNotInSource: false,
-		dropExtendedPropertiesNotInSource: false,
-		dropIndexesNotInSource: false,
-		ignoreFileAndLogFilePath: false,
-		ignoreExtendedProperties: false,
-		ignoreDmlTriggerState: false,
-		ignoreDmlTriggerOrder: false,
-		ignoreDefaultSchema: false,
-		ignoreDdlTriggerState: false,
-		ignoreDdlTriggerOrder: false,
-		ignoreCryptographicProviderFilePath: false,
-		verifyDeployment: false,
-		ignoreComments: false,
-		ignoreColumnCollation: false,
-		ignoreAuthorizer: false,
-		ignoreAnsiNulls: false,
-		generateSmartDefaults: false,
-		dropStatisticsNotInSource: false,
-		dropRoleMembersNotInSource: false,
-		dropPermissionsNotInSource: false,
-		dropObjectsNotInSource: false,
-		ignoreColumnOrder: false,
-		doNotDropObjectTypes: [],
-		excludeObjectTypes: []
-	}
-};
-
-export class MockDacFxMssqlService implements vscodeMssql.IDacFxService {
-	public exportBacpac(_: string, __: string, ___: string, ____: vscodeMssql.TaskExecutionMode): Thenable<vscodeMssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public importBacpac(_: string, __: string, ___: string, ____: vscodeMssql.TaskExecutionMode): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public extractDacpac(_: string, __: string, ___: string, ____: string, _____: string, ______: vscodeMssql.TaskExecutionMode): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public createProjectFromDatabase(_: string, __: string, ___: string, ____: string, _____: string, ______: vscodeMssql.ExtractTarget, _______: vscodeMssql.TaskExecutionMode): Thenable<vscodeMssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public deployDacpac(_: string, __: string, ___: boolean, ____: string, _____: vscodeMssql.TaskExecutionMode, ______?: Record<string, string>): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public generateDeployScript(_: string, __: string, ___: string, ____: vscodeMssql.TaskExecutionMode, ______?: Record<string, string>): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
-	public generateDeployPlan(_: string, __: string, ___: string, ____: vscodeMssql.TaskExecutionMode): Thenable<vscodeMssql.GenerateDeployPlanResult> { return Promise.resolve(mockDacFxResult); }
-	public getOptionsFromProfile(_: string): Thenable<vscodeMssql.DacFxOptionsResult> { return Promise.resolve(mockDacFxMssqlOptionResult); }
-	public validateStreamingJob(_: string, __: string): Thenable<mssql.ValidateStreamingJobResult> { return Promise.resolve(mockDacFxResult); }
-}
-
-export class MockSchemaCompareService implements vscodeMssql.ISchemaCompareService {
-	schemaCompareGetDefaultOptions(): Thenable<vscodeMssql.SchemaCompareOptionsResult> {
-		throw new Error('Method not implemented.');
-	}
-}
-
 export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 	sqlToolsServicePath: string = '';
 	dacFx: vscodeMssql.IDacFxService;
@@ -239,8 +25,8 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 	azureAccountService: vscodeMssql.IAzureAccountService;
 
 	constructor() {
-		this.dacFx = new MockDacFxMssqlService;
-		this.schemaCompare = new MockSchemaCompareService;
+		this.dacFx = TypeMoq.Mock.ofType<vscodeMssql.IDacFxService>().object;
+		this.schemaCompare = TypeMoq.Mock.ofType<vscodeMssql.ISchemaCompareService>().object;
 		this.azureAccountService = TypeMoq.Mock.ofType<vscodeMssql.IAzureAccountService>().object;
 	}
 
@@ -271,75 +57,15 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 }
 
 export function createTestUtils(): TestUtils {
-	let extensionPath = path.join(__dirname, '..', '..');
-
 	return {
-		context: {
-			subscriptions: [],
-			workspaceState: {
-				get: () => { return undefined; },
-				update: () => { return Promise.resolve(); },
-				keys: () => []
-			},
-			globalState: {
-				setKeysForSync: (): void => { },
-				get: (): any | undefined => { return Promise.resolve(); },
-				update: (): Thenable<void> => { return Promise.resolve(); },
-				keys: () => []
-			},
-			extensionPath: extensionPath,
-			asAbsolutePath: () => { return ''; },
-			storagePath: '',
-			globalStoragePath: '',
-			logPath: '',
-			extensionUri: vscode.Uri.parse(''),
-			environmentVariableCollection: undefined as any,
-			extensionMode: undefined as any,
-			globalStorageUri: vscode.Uri.parse('test://'),
-			logUri: vscode.Uri.parse('test://'),
-			storageUri: vscode.Uri.parse('test://'),
-			secrets: undefined as any,
-			extension: undefined as any
-		},
-		dacFxService: TypeMoq.Mock.ofType(MockDacFxService),
+		context: TypeMoq.Mock.ofType<vscode.ExtensionContext>().object,
+		dacFxService: TypeMoq.Mock.ofType<mssql.IDacFxService>(),
 		vscodeMssqlIExtension: TypeMoq.Mock.ofType(MockVscodeMssqlIExtension),
-		dacFxMssqlService: TypeMoq.Mock.ofType(MockDacFxMssqlService),
-		schemaCompareService: TypeMoq.Mock.ofType(MockSchemaCompareService),
-		outputChannel: {
-			name: '',
-			append: () => { },
-			appendLine: () => { },
-			clear: () => { },
-			show: () => { },
-			hide: () => { },
-			dispose: () => { }
-		}
+		dacFxMssqlService: TypeMoq.Mock.ofType<vscodeMssql.IDacFxService>(),
+		schemaCompareService: TypeMoq.Mock.ofType<vscodeMssql.ISchemaCompareService>(),
+		outputChannel: TypeMoq.Mock.ofType<vscode.OutputChannel>().object
 	};
 }
-
-// Mock test data
-export const mockConnectionProfile: azdata.IConnectionProfile = {
-	connectionName: 'My Connection',
-	serverName: 'My Server',
-	databaseName: 'My Database',
-	userName: 'My User',
-	password: 'My Pwd',
-	authenticationType: 'SqlLogin',
-	savePassword: false,
-	groupFullName: 'My groupName',
-	groupId: 'My GroupId',
-	providerName: 'My Server',
-	saveProfile: true,
-	id: 'My Id',
-	options: {
-		server: 'My Server',
-		database: 'My Database',
-		user: 'My User',
-		password: 'My Pwd',
-		authenticationType: 'SqlLogin',
-		connectionName: 'My Connection Name'
-	}
-};
 
 export function createTestCredentials(): vscodeMssql.IConnectionInfo {
 	const creds: vscodeMssql.IConnectionInfo = {


### PR DESCRIPTION
Cleaning this up to just use basic mocks instead of hard definitions so that we don't have to keep updating these every time the underlying type changes. 