### PR TITLE
change the trigger of inputbox commit event

### DIFF
--- a/src/sql/base/browser/ui/table/tableCellEditorFactory.ts
+++ b/src/sql/base/browser/ui/table/tableCellEditorFactory.ts
@@ -10,7 +10,6 @@ import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview
 import { KeyCode } from 'vs/base/common/keyCodes';
 import * as DOM from 'vs/base/browser/dom';
 import { Dropdown } from 'sql/base/browser/ui/editableDropdown/browser/dropdown';
-import { debounce } from 'vs/base/common/decorators';
 import { Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 
@@ -69,7 +68,7 @@ export class TableCellEditorFactory {
 				self._options.editorStyler(this._input);
 				this._input.element.style.height = '100%';
 				this._input.focus();
-				this._input.onDidChange(async () => {
+				this._input.onLoseFocus(async () => {
 					await this.commitEdit();
 				});
 				this._register(this._input);
@@ -78,7 +77,6 @@ export class TableCellEditorFactory {
 				}));
 			}
 
-			@debounce(200)
 			private async commitEdit(): Promise<void> {
 				if (this.isValueChanged()) {
 					const item = this._args.grid.getDataItem(this._args.grid.getActiveCell().row);

--- a/src/sql/workbench/browser/designer/designer.ts
+++ b/src/sql/workbench/browser/designer/designer.ts
@@ -45,7 +45,6 @@ import { alert } from 'vs/base/browser/ui/aria/aria';
 import { layoutDesignerTable, TableHeaderRowHeight, TableRowHeight } from 'sql/workbench/browser/designer/designerTableUtil';
 import { Dropdown, IDropdownStyles } from 'sql/base/browser/ui/editableDropdown/browser/dropdown';
 import { IListStyles } from 'vs/base/browser/ui/list/listWidget';
-import { debounce } from 'vs/base/common/decorators';
 
 export interface IDesignerStyle {
 	tabbedPanelStyles?: ITabbedPanelStyles;
@@ -723,11 +722,9 @@ export class Designer extends Disposable implements IThemable {
 					ariaLabel: inputProperties.title,
 					type: inputProperties.inputType,
 				});
-				input.onDidChange(() => {
-					// The supress edit processing check is done in the handleEdit method, but since we have debounce operation on input box we
-					// have to do it here to avoid treating system originated value setting operation as user edits.
-					if (!this._supressEditProcessing) {
-						this.handleInputBoxEdit({ type: DesignerEditType.Update, path: propertyPath, value: input.value, source: view });
+				input.onLoseFocus((args) => {
+					if (args.hasChanged) {
+						this.handleEdit({ type: DesignerEditType.Update, path: propertyPath, value: args.value, source: view });
 					}
 				});
 				input.onInputFocus(() => {
@@ -942,11 +939,6 @@ export class Designer extends Disposable implements IThemable {
 
 		this.styleComponent(component);
 		return component;
-	}
-
-	@debounce(200)
-	private handleInputBoxEdit(edit: DesignerEdit) {
-		this.handleEdit(edit);
 	}
 
 	private startLoading(message: string, timeout: number): void {


### PR DESCRIPTION
a few days ago I changed the commit trigger condition for input box https://github.com/microsoft/azuredatastudio/pull/18701, the changes will committed as the user is typing (200ms delay), as we are adding validation, this turns out to be a very annoying thing, so I am reverting to is previous behavior (SSDT's behavior). 

One of the goal for my previous PR was to solve the problem that user has to navigate to a different cell in order to commit the change. this PR won't regress this feature.

also, I tested and confirmed that the commit event won't be triggered twice.
1. when navigating to a different cell, the navigation is controlled by slickgrid, the change will be committed and the inputbox will be disposed, so the losefocus event will never fire.
2. when move focus away from the grid, the losefocus event will trigger and the slickgrid won't commit the change automatically.

![input-commit](https://user-images.githubusercontent.com/13777222/159063390-bab817ef-d9dd-4914-968a-c7d473f922ab.gif)
