### PR TITLE
Fix issues with unknown notebook file types not opening as a default notebook.

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/notebookUtils.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookUtils.ts
@@ -29,11 +29,11 @@ export function getProvidersForFileName(fileName: string, notebookService: INote
 		providers = notebookService.getProvidersForFileType(fileExt);
 	}
 	// Fallback to provider for default file type (assume this is a global handler)
-	if (!providers) {
+	if (!providers || providers.length === 0) {
 		providers = notebookService.getProvidersForFileType(DEFAULT_NOTEBOOK_FILETYPE);
 	}
 	// Finally if all else fails, use the built-in handler
-	if (!providers) {
+	if (!providers || providers.length === 0) {
 		providers = [DEFAULT_NOTEBOOK_PROVIDER];
 	}
 	return providers;

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -510,7 +510,7 @@ export class NotebookService extends Disposable implements INotebookService {
 	getProvidersForFileType(fileType: string): string[] | undefined {
 		let provDescriptions = this._fileToProviderDescriptions.get(fileType.toLowerCase());
 		let providers = provDescriptions?.map(provider => provider.provider);
-		return [...new Set(providers)]; // Remove duplicates
+		return providers ? [...new Set(providers)] : undefined; // Remove duplicates
 	}
 
 	public async getStandardKernelsForProvider(provider: string): Promise<nb.IStandardKernel[] | undefined> {

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -510,7 +510,7 @@ export class NotebookService extends Disposable implements INotebookService {
 	getProvidersForFileType(fileType: string): string[] | undefined {
 		let provDescriptions = this._fileToProviderDescriptions.get(fileType.toLowerCase());
 		let providers = provDescriptions?.map(provider => provider.provider);
-		return providers ? [...new Set(providers)] : undefined; // Remove duplicates
+		return providers ? [...new Set(providers)] : undefined; // Use a set to remove duplicates
 	}
 
 	public async getStandardKernelsForProvider(provider: string): Promise<nb.IStandardKernel[] | undefined> {


### PR DESCRIPTION
In my recent .dib file PR, I added a small optimization to the NotebookService.getProvidersForFileType() method that removed duplicate providers from the output. However, if the retrieved providers array was undefined (like for an unknown file type), then the method would now return an empty array instead of undefined. As a result, when trying to open an unknown notebook file type, we wouldn't fall back to the default notebook file behavior (i.e. ipynb), because we were specifically checking for undefined providers in that edge case. This change now correctly returns undefined from getProvidersForFileType(), and also checks the providers array length in getProvidersForFileName() (in addition to undefined) to protect against future issues like this.

This PR fixes #18777
