### PR TITLE
Fix and enable core unit test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Run Unit Tests (Electron)
         id: electron-unit-tests
-        run: DISPLAY=:10 ./scripts/test.sh --runGlob "**/sql/**/*.test.js" # {{SQL CARBON EDIT}} Run only our tests with coverage. Disable for now since it's currently broken --coverage
+        run: DISPLAY=:10 ./scripts/test.sh --runGlob "**/sql/**/*.test.js" --coverage
 
       - name: Run Extension Unit Tests (Electron)
         id: electron-extension-unit-tests

--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -106,7 +106,7 @@ steps:
 
   - script: |
       set -e
-      ./scripts/test.sh --build --tfs "Unit Tests" # Disable code coverage since it's currently broken --coverage
+      ./scripts/test.sh --build --tfs "Unit Tests" --coverage
     displayName: Run unit tests
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -119,7 +119,7 @@ steps:
 
   - script: |
       set -e
-      DISPLAY=:10 ./scripts/test.sh --build --tfs "Unit Tests" # Disable code coverage since it's currently broken --coverage
+      DISPLAY=:10 ./scripts/test.sh --build --tfs "Unit Tests" --coverage
     displayName: Run unit tests (Electron)
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 

--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -37,9 +37,10 @@ function createCompile(src, build, emitError) {
     const sourcemaps = require('gulp-sourcemaps');
     const projectPath = path.join(__dirname, '../../', src, 'tsconfig.json');
     const overrideOptions = Object.assign(Object.assign({}, getTypeScriptCompilerOptions(src)), { inlineSources: Boolean(build) });
-    if (!build) {
-        overrideOptions.inlineSourceMap = true;
-    }
+    // {{SQL CARBON EDIT}} Never inline source maps so that generating local coverage works
+    // if (!build) {
+    // 	// overrideOptions.inlineSourceMap = true;
+    // }
     const compilation = tsb.create(projectPath, overrideOptions, false, err => reporter(err));
     function pipeline(token) {
         const bom = require('gulp-bom');

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -44,9 +44,10 @@ function createCompile(src: string, build: boolean, emitError?: boolean) {
 
 	const projectPath = path.join(__dirname, '../../', src, 'tsconfig.json');
 	const overrideOptions = { ...getTypeScriptCompilerOptions(src), inlineSources: Boolean(build) };
-	if (!build) {
-		overrideOptions.inlineSourceMap = true;
-	}
+	// {{SQL CARBON EDIT}} Never inline source maps so that generating local coverage works
+	// if (!build) {
+	// 	// overrideOptions.inlineSourceMap = true;
+	// }
 
 	const compilation = tsb.create(projectPath, overrideOptions, false, err => reporter(err));
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -964,7 +964,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		// Determine options
 		const openEditorOptions: IEditorOpenOptions = {
 			index: options ? options.index : undefined,
-			pinned: options?.sticky || !this.accessor.partOptions.enablePreview || editor.isDirty() || (options?.pinned ?? typeof options?.index === 'number' /* unless specified, prefer to pin when opening with index */) || (typeof options?.index === 'number' && this.model.isSticky(options.index)),
+			// {{SQL CARBON EDIT}} Refactor statement to not use ?? since that breaks code coverage on unit tests
+			pinned: options?.sticky || !this.accessor.partOptions.enablePreview || editor.isDirty() || (options?.pinned === null ? typeof options?.index === 'number' : options?.pinned /* unless specified, prefer to pin when opening with index */) || (typeof options?.index === 'number' && this.model.isSticky(options.index)),
 			sticky: options?.sticky || (typeof options?.index === 'number' && this.model.isSticky(options.index)),
 			active: this.count === 0 || !options || !options.inactive
 		};

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -965,7 +965,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		const openEditorOptions: IEditorOpenOptions = {
 			index: options ? options.index : undefined,
 			// {{SQL CARBON EDIT}} Refactor statement to not use ?? since that breaks code coverage on unit tests
-			pinned: options?.sticky || !this.accessor.partOptions.enablePreview || editor.isDirty() || (options?.pinned === null ? typeof options?.index === 'number' : options?.pinned /* unless specified, prefer to pin when opening with index */) || (typeof options?.index === 'number' && this.model.isSticky(options.index)),
+			pinned: options?.sticky || !this.accessor.partOptions.enablePreview || editor.isDirty() || (options?.pinned !== null ? options?.pinned : typeof options?.index === 'number' /* unless specified, prefer to pin when opening with index */) || (typeof options?.index === 'number' && this.model.isSticky(options.index)),
 			sticky: options?.sticky || (typeof options?.index === 'number' && this.model.isSticky(options.index)),
 			active: this.count === 0 || !options || !options.inactive
 		};

--- a/test/unit/coverage.js
+++ b/test/unit/coverage.js
@@ -41,7 +41,7 @@ exports.createReport = function (isSingle) {
 		Object.keys(transformed.data).forEach((file) => {
 			const entry = transformed.data[file];
 			const fixedPath = fixPath(entry.path);
-			if (fixedPath.includes('\\vs\\') || fixedPath.includes('/vs/')) { return; } // {{SQL CARBON EDIT}} skip vscode files
+			if (fixedPath.includes(`${path.delimiter}vs${path.delimiter}`) || path.basename(fixedPath) === 'marked.js') { return; } // {{SQL CARBON EDIT}} skip vscode files and imported marked.js
 			entry.data.path = fixedPath;
 			newData[fixedPath] = entry;
 		});

--- a/test/unit/coverage.js
+++ b/test/unit/coverage.js
@@ -41,7 +41,7 @@ exports.createReport = function (isSingle) {
 		Object.keys(transformed.data).forEach((file) => {
 			const entry = transformed.data[file];
 			const fixedPath = fixPath(entry.path);
-			if (fixedPath.includes(`${path.delimiter}vs${path.delimiter}`) || path.basename(fixedPath) === 'marked.js') { return; } // {{SQL CARBON EDIT}} skip vscode files and imported marked.js
+			if (fixedPath.includes(`/vs/`)  || fixedPath.includes('\\vs\\') || path.basename(fixedPath) === 'marked.js') { return; } // {{SQL CARBON EDIT}} skip vscode files and imported marked.js
 			entry.data.path = fixedPath;
 			newData[fixedPath] = entry;
 		});


### PR DESCRIPTION
I was able to track down what was causing the coverage to hang, but in the end I don't have a fully clear idea of why it's failing for us and presumably not for VS Code.

The line in question that led me to the fix was this : 

`[4225:0318/190144.273645:INFO:CONSOLE(109)] "Uncaught SyntaxError: Unexpected token '??'", source: vm.js (109)`

After digging around in loader.js for a bit I was able to get it to spit out what file it came from and from there was just a matter of seeing which one of the ??'s was causing the issue.

There are numerous other reports of similar invalid code generation being done by instanbul, but since this fixes the issue and is relatively scoped I chose to end my investigation here since there isn't much value to be gained currently from digging into it more.

https://coveralls.io/builds/47556601

![image](https://user-images.githubusercontent.com/28519865/159372219-ea98d7a4-0bba-437f-96c5-faf26acc40be.png)
