### PR TITLE
Add a few more properties for dacpac telemetry

### DIFF
--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -308,7 +308,9 @@ export class DataTierApplicationWizard {
 	private cancelDataTierApplicationWizard(): void {
 		TelemetryReporter.createActionEvent(TelemetryViews.DataTierApplicationWizard, 'WizardCanceled')
 			.withAdditionalProperties({
-				isPotentialDataLoss: this.model.potentialDataLoss?.toString()
+				isPotentialDataLoss: this.model.potentialDataLoss?.toString(),
+				page: this.wizard.currentPage.toString(),
+				operation: this.selectedOperation.toString()
 			}).send();
 	}
 

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -334,7 +334,6 @@ export class DataTierApplicationWizard {
 	}
 
 	private async extract(): Promise<mssql.DacFxResult> {
-		let additionalProps: TelemetryEventProperties = {};
 		let additionalMeasurements: TelemetryEventMeasures = {};
 
 		const service = await this.getService();
@@ -345,9 +344,8 @@ export class DataTierApplicationWizard {
 
 		additionalMeasurements.totalDurationMs = (new Date().getTime() - extractStartTime);
 		additionalMeasurements.extractedDacpacFileSizeBytes = await utils.tryGetFileSize(this.model.filePath);
-		additionalProps.version = this.model.version;
 
-		this.sendDacFxOperationTelemetryEvent(result, TelemetryAction.ExtractDacpac, additionalProps, additionalMeasurements);
+		this.sendDacFxOperationTelemetryEvent(result, TelemetryAction.ExtractDacpac, { version: this.model.version }, additionalMeasurements);
 
 		return result;
 	}

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -334,6 +334,7 @@ export class DataTierApplicationWizard {
 	}
 
 	private async extract(): Promise<mssql.DacFxResult> {
+		let additionalProps: TelemetryEventProperties = {};
 		let additionalMeasurements: TelemetryEventMeasures = {};
 
 		const service = await this.getService();
@@ -344,8 +345,9 @@ export class DataTierApplicationWizard {
 
 		additionalMeasurements.totalDurationMs = (new Date().getTime() - extractStartTime);
 		additionalMeasurements.extractedDacpacFileSizeBytes = await utils.tryGetFileSize(this.model.filePath);
+		additionalProps.version = this.model.version;
 
-		this.sendDacFxOperationTelemetryEvent(result, TelemetryAction.ExtractDacpac, undefined, additionalMeasurements);
+		this.sendDacFxOperationTelemetryEvent(result, TelemetryAction.ExtractDacpac, additionalProps, additionalMeasurements);
 
 		return result;
 	}

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -310,7 +310,7 @@ export class DataTierApplicationWizard {
 			.withAdditionalProperties({
 				isPotentialDataLoss: this.model.potentialDataLoss?.toString(),
 				page: this.wizard.currentPage.toString(),
-				operation: this.selectedOperation.toString()
+				selectedOperation: this.selectedOperation.toString()
 			}).send();
 	}
 


### PR DESCRIPTION
Adding a few more properties to send from the dacpac wizard:
- page and selected operation when cancelling to see at which point people are cancelling out of the wizard since it's the second most used action.
- send version for extract. I suspect no one is changing this from the default version (1.0.0.0), so I'd like to get rid of the option if it isn't getting used.
