### PR TITLE
Throw more detailed error when compilation fails

### DIFF
--- a/src/vs/loader.js
+++ b/src/vs/loader.js
@@ -789,6 +789,7 @@ var AMDLoader;
                 catch (_e) {
                     recorder.record(61 /* CachedDataMissed */, cachedDataPath);
                 }
+                // {{SQL CARBON EDIT}} Add more details to compile error
                 var script;
                 try {
                     script = new that._vm.Script(scriptSource, options);
@@ -857,6 +858,7 @@ var AMDLoader;
         NodeScriptLoader.prototype._createAndEvalScript = function (moduleManager, contents, options, callback, errorback) {
             var recorder = moduleManager.getRecorder();
             recorder.record(31 /* NodeBeginEvaluatingScript */, options.filename);
+            // {{SQL CARBON EDIT}} Add more details to compile error
             var script;
             try {
                 script = new this._vm.Script(contents, options);

--- a/src/vs/loader.js
+++ b/src/vs/loader.js
@@ -789,7 +789,12 @@ var AMDLoader;
                 catch (_e) {
                     recorder.record(61 /* CachedDataMissed */, cachedDataPath);
                 }
-                var script = new that._vm.Script(scriptSource, options);
+                var script;
+                try {
+                    script = new that._vm.Script(scriptSource, options);
+                } catch (err) {
+                    throw new Error(`Error compiling ${filename}. ${err}`);
+                }
                 var compileWrapper = script.runInThisContext(options);
                 // run script
                 var dirname = that._path.dirname(filename);
@@ -852,7 +857,12 @@ var AMDLoader;
         NodeScriptLoader.prototype._createAndEvalScript = function (moduleManager, contents, options, callback, errorback) {
             var recorder = moduleManager.getRecorder();
             recorder.record(31 /* NodeBeginEvaluatingScript */, options.filename);
-            var script = new this._vm.Script(contents, options);
+            var script;
+            try {
+                script = new this._vm.Script(contents, options);
+            } catch (err) {
+                throw new Error(`Error compiling ${options.filename}. ${err}`);
+            }
             var ret = script.runInThisContext(options);
             var globalDefineFunc = moduleManager.getGlobalAMDDefineFunc();
             var receivedDefineCall = false;


### PR DESCRIPTION
Related to https://github.com/microsoft/azuredatastudio/pull/18781 - it took me a long time to track down where this failure was coming from because the error being thrown wasn't very useful : 

`Uncaught SyntaxError: Unexpected token '??'`

this will make it now display something like this 

`Uncaught Error: Error compiling file:///.../vs/workbench/browser/parts/editor/editorGroupView.js. SyntaxError: Unexpected token '??'`

PR for VS Code : https://github.com/microsoft/vscode-loader/pull/37