### PR TITLE
move system dbs to bottom of the list in update project from db dialog

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -234,6 +234,10 @@ export class UpdateProjectFromDatabaseDialog {
 		let values = [];
 		try {
 			values = await this.getDatabaseValues(connectionProfile.connectionId);
+
+			// move system dbs to the bottom of the list so it's easier to find user dbs
+			const systemDbs = values.filter(db => constants.systemDbs.includes(db));
+			values = values.filter(db => !constants.systemDbs.includes(db)).concat(systemDbs);
 		} catch (e) {
 			// if the user doesn't have access to master, just set the database of the connection profile
 			values = [connectionProfile.databaseName];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #18074. This sorts the databases dropdown to have the system dbs at the bottom of the list so it's easier to find user dbs. 
![image](https://user-images.githubusercontent.com/31145923/159373940-46ccf4cb-0b46-433d-8e56-900a8062f171.png)


