### PR TITLE
Add smoke tests for text cell toolbar actions.

### DIFF
--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -150,12 +150,12 @@ export class Notebook {
 		await this.code.waitForElementGone(Notebook.doubleClickToEditSelector);
 	}
 
-	async waitForTextCellPreviewContent(text: string, fontType: 'p' | 'h1' | 'h2' | 'h3', textStyle?: 'strong' | 'i' | 'u' | 'mark' | 'code'): Promise<void> {
+	async waitForTextCellPreviewContent(text: string, fontType: 'p' | 'h1' | 'h2' | 'h3' | 'pre', textStyle?: 'strong' | 'i' | 'em' | 'u' | 'mark' | 'code'): Promise<void> {
 		let textSelector = `${Notebook.textCellPreviewSelector} ${fontType}`;
 		if (textStyle) {
 			textSelector = `${textSelector} ${textStyle}`;
 		}
-		await this.code.waitForElement(textSelector, result => result?.textContent === text);
+		await this.code.waitForElement(textSelector, result => !!result?.textContent?.includes(text));
 	}
 
 	// Cell Output Actions

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -155,7 +155,7 @@ export class Notebook {
 		if (textStyle) {
 			textSelector = `${textSelector} ${textStyle}`;
 		}
-		await this.code.waitForElement(textSelector, result => !!result?.textContent?.includes(text));
+		await this.code.waitForElement(textSelector, result => !!result?.textContent?.includes(text)); // Use includes to handle whitespace edge cases
 	}
 
 	// Cell Output Actions

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -150,12 +150,9 @@ export class Notebook {
 		await this.code.waitForElementGone(Notebook.doubleClickToEditSelector);
 	}
 
-	async waitForTextCellPreviewContent(text: string, fontType: 'p' | 'h1' | 'h2' | 'h3' | 'pre', textStyle?: 'strong' | 'i' | 'em' | 'u' | 'mark' | 'code'): Promise<void> {
-		let textSelector = `${Notebook.textCellPreviewSelector} ${fontType}`;
-		if (textStyle) {
-			textSelector = `${textSelector} ${textStyle}`;
-		}
-		await this.code.waitForElement(textSelector, result => !!result?.textContent?.includes(text)); // Use includes to handle whitespace edge cases
+	async waitForTextCellPreviewContent(text: string, selector: string): Promise<void> {
+		let textSelector = `${Notebook.textCellPreviewSelector} ${selector}`;
+		await this.code.waitForElement(textSelector, result => !!result?.textContent?.includes(text)); // Use includes to handle whitespace/quote edge cases
 	}
 
 	// Cell Output Actions

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -10,6 +10,7 @@ import { Editors } from '../editors';
 import { IElement } from '..';
 
 const winOrCtrl = process.platform === 'win32' ? 'win' : 'ctrl';
+const ctrlOrCmd = process.platform === 'win32' ? 'ctrl' : 'cmd';
 
 export class Notebook {
 
@@ -83,7 +84,7 @@ export class Notebook {
 	public async selectAllTextInEditor(): Promise<void> {
 		const editor = '.notebook-cell.active .monaco-editor';
 		await this.code.waitAndClick(editor);
-		await this.code.dispatchKeybinding('cmd+a');
+		await this.code.dispatchKeybinding(ctrlOrCmd + '+a');
 	}
 
 	private static readonly placeholderSelector = 'div.placeholder-cell-component';
@@ -149,7 +150,7 @@ export class Notebook {
 		await this.code.waitForElementGone(Notebook.doubleClickToEditSelector);
 	}
 
-	async waitForTextCellPreviewContent(text: string, fontType: 'p' | 'h1' | 'h2' | 'h3', textStyle?: 'strong' | 'i' | 'u' | 'mark'): Promise<void> {
+	async waitForTextCellPreviewContent(text: string, fontType: 'p' | 'h1' | 'h2' | 'h3', textStyle?: 'strong' | 'i' | 'u' | 'mark' | 'code'): Promise<void> {
 		let textSelector = `${Notebook.textCellPreviewSelector} ${fontType}`;
 		if (textStyle) {
 			textSelector = `${textSelector} ${textStyle}`;
@@ -207,7 +208,7 @@ export class Notebook {
 }
 
 export class TextCellToolbar {
-	private static readonly textCellToolbar = 'text-cell-component markdown-toolbar-component ul.actions-container';
+	private static readonly textCellToolbar = 'text-cell-component markdown-toolbar-component ul.actions-container li.action-item';
 
 	constructor(private code: Code) { }
 
@@ -220,7 +221,7 @@ export class TextCellToolbar {
 	}
 
 	public async italicizeSelectedText(): Promise<void> {
-		await this.clickToolbarButton('Italics');
+		await this.clickToolbarButton('Italic');
 	}
 
 	public async underlineSelectedText(): Promise<void> {
@@ -232,7 +233,7 @@ export class TextCellToolbar {
 	}
 
 	public async codifySelectedText(): Promise<void> {
-		await this.clickToolbarButton('Code');
+		await this.clickToolbarButton('Insert code');
 	}
 
 	public async insertLink(): Promise<void> {
@@ -240,11 +241,11 @@ export class TextCellToolbar {
 	}
 
 	public async insertList(): Promise<void> {
-		await this.clickToolbarButton('List');
+		await this.clickToolbarButton('Insert list');
 	}
 
 	public async insertOrderedList(): Promise<void> {
-		await this.clickToolbarButton('Ordered list');
+		await this.clickToolbarButton('Insert ordered list');
 	}
 
 	public async changeSelectedTextSize(): Promise<void> {

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -145,6 +145,57 @@ export function setup(opts: minimist.ParsedArgs) {
 			});
 		});
 
+		describe('Cell Toolbar Actions', function () {
+			const sampleText: string = 'Test Text';
+			async function createCellAndSelectAllText(app: Application): Promise<void> {
+				await app.workbench.sqlNotebook.newUntitledNotebook();
+				await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
+				await app.workbench.sqlNotebook.waitForPlaceholderGone();
+				await app.workbench.sqlNotebook.textCellToolbar.changeTextCellView('Split View');
+				await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
+				await app.workbench.sqlNotebook.selectAllTextInEditor();
+			}
+
+			it('can bold selected text', async function () {
+				const app = this.app as Application;
+				await createCellAndSelectAllText(app);
+				await app.workbench.sqlNotebook.textCellToolbar.boldSelectedText();
+				await app.code.dispatchKeybinding('escape');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'strong');
+			});
+
+			it('can italicize selected text', async function () {
+				const app = this.app as Application;
+				await createCellAndSelectAllText(app);
+				await app.workbench.sqlNotebook.textCellToolbar.italicizeSelectedText();
+				await app.code.dispatchKeybinding('escape');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'i');
+			});
+
+			it('can underline selected text', async function () {
+				const app = this.app as Application;
+				await createCellAndSelectAllText(app);
+				await app.workbench.sqlNotebook.textCellToolbar.underlineSelectedText();
+				await app.code.dispatchKeybinding('escape');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'u');
+			});
+
+			it('can highlight selected text', async function () {
+				const app = this.app as Application;
+				await createCellAndSelectAllText(app);
+				await app.workbench.sqlNotebook.textCellToolbar.highlightSelectedText();
+				await app.code.dispatchKeybinding('escape');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'mark');
+			});
+
+			it('can codify selected text', async function () {
+				const app = this.app as Application;
+				await app.workbench.sqlNotebook.textCellToolbar.codifySelectedText();
+				await app.code.dispatchKeybinding('escape');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'code');
+			});
+		});
+
 		describe('markdown', function () {
 			it('can create http link from markdown', async function () {
 				const app = this.app as Application;

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -169,7 +169,7 @@ export function setup(opts: minimist.ParsedArgs) {
 				await createCellAndSelectAllText(app);
 				await app.workbench.sqlNotebook.textCellToolbar.italicizeSelectedText();
 				await app.code.dispatchKeybinding('escape');
-				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'i');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'em');
 			});
 
 			it('can underline selected text', async function () {
@@ -190,9 +190,10 @@ export function setup(opts: minimist.ParsedArgs) {
 
 			it('can codify selected text', async function () {
 				const app = this.app as Application;
+				await createCellAndSelectAllText(app);
 				await app.workbench.sqlNotebook.textCellToolbar.codifySelectedText();
 				await app.code.dispatchKeybinding('escape');
-				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'code');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'pre', 'code');
 			});
 		});
 

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -31,7 +31,7 @@ export function setup(opts: minimist.ParsedArgs) {
 			await app.workbench.sqlNotebook.selectAllTextInEditor();
 			await app.workbench.sqlNotebook.textCellToolbar.boldSelectedText();
 			await app.code.dispatchKeybinding('escape');
-			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'strong');
+			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p strong');
 		});
 
 		it('can perform basic code cell functionality', async function () {
@@ -161,7 +161,7 @@ export function setup(opts: minimist.ParsedArgs) {
 				await createCellAndSelectAllText(app);
 				await app.workbench.sqlNotebook.textCellToolbar.boldSelectedText();
 				await app.code.dispatchKeybinding('escape');
-				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'strong');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p strong');
 			});
 
 			it('can italicize selected text', async function () {
@@ -169,7 +169,7 @@ export function setup(opts: minimist.ParsedArgs) {
 				await createCellAndSelectAllText(app);
 				await app.workbench.sqlNotebook.textCellToolbar.italicizeSelectedText();
 				await app.code.dispatchKeybinding('escape');
-				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'em');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p em');
 			});
 
 			it('can underline selected text', async function () {
@@ -177,7 +177,7 @@ export function setup(opts: minimist.ParsedArgs) {
 				await createCellAndSelectAllText(app);
 				await app.workbench.sqlNotebook.textCellToolbar.underlineSelectedText();
 				await app.code.dispatchKeybinding('escape');
-				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'u');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p u');
 			});
 
 			it('can highlight selected text', async function () {
@@ -185,7 +185,7 @@ export function setup(opts: minimist.ParsedArgs) {
 				await createCellAndSelectAllText(app);
 				await app.workbench.sqlNotebook.textCellToolbar.highlightSelectedText();
 				await app.code.dispatchKeybinding('escape');
-				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'mark');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p mark');
 			});
 
 			it('can codify selected text', async function () {
@@ -193,7 +193,23 @@ export function setup(opts: minimist.ParsedArgs) {
 				await createCellAndSelectAllText(app);
 				await app.workbench.sqlNotebook.textCellToolbar.codifySelectedText();
 				await app.code.dispatchKeybinding('escape');
-				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'pre', 'code');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'pre code');
+			});
+
+			it('can bullet selected text', async function () {
+				const app = this.app as Application;
+				await createCellAndSelectAllText(app);
+				await app.workbench.sqlNotebook.textCellToolbar.insertList();
+				await app.code.dispatchKeybinding('escape');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'ul li');
+			});
+
+			it('can number selected text', async function () {
+				const app = this.app as Application;
+				await createCellAndSelectAllText(app);
+				await app.workbench.sqlNotebook.textCellToolbar.insertOrderedList();
+				await app.code.dispatchKeybinding('escape');
+				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'ol li');
 			});
 		});
 


### PR DESCRIPTION
These new smoke tests cover all the text toolbar actions besides links and font size. Those last two have secondary windows that pop up, so I'm still figuring those out. I'll take care of them in next week's round of fundamentals.