### PR TITLE
[SQL Migration] Show correct recommendation when viewing issues in assessment results

### DIFF
--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -863,9 +863,9 @@ export class SqlDatabaseTree {
 		this._assessmentTitle.value = selectedIssue?.checkId || '';
 		this._descriptionText.value = selectedIssue?.description || '';
 		this._moreInfo.url = selectedIssue?.helpLink || '';
-		this._moreInfo.label = selectedIssue?.message || '';
+		this._moreInfo.label = selectedIssue?.displayName || '';
 		this._impactedObjects = selectedIssue?.impactedObjects || [];
-		this._recommendationText.value = selectedIssue?.message || ''; //TODO: Expose correct property for recommendation.
+		this._recommendationText.value = selectedIssue?.message || constants.NA;
 
 		await this._impactedObjectsTable.setDataValues(this._impactedObjects.map(
 			(object) => [{ value: object.objectType }, { value: object.name }]));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

See corresponding backend sqltoolsservice PR: https://github.com/microsoft/sqltoolsservice/pull/1441

---

In this PR, we fix the SQL migration extension's 'assessment results' dialog to show the correct recommendations provided by the assessment NuGet when viewing detected issues. Previously, the recommendation provided to the user was actually just the preview text for the 'more info' link duplicated. 

Before:
![image](https://user-images.githubusercontent.com/11844501/159795499-64cbe548-4006-4adc-803d-eeb1cdaa8316.png)

After:
![image](https://user-images.githubusercontent.com/11844501/159598083-7ad061f1-0dc5-4617-af02-0173249076d5.png)

The results now match the results provided by DMA exactly:
![image](https://user-images.githubusercontent.com/11844501/159799977-4f66731d-52db-4b1e-bb3d-5ed3eceba9e0.png)

Also, we now show 'N/A' when a recommendation is not available. Since it's possible for the assessment NuGet to not provide a recommendation, it was possible for both the recommendation text and the preview text for the 'more info' link to be completely blank since both were mapped to the same thing.

Before:
![image](https://user-images.githubusercontent.com/11844501/159597851-4fb14895-d197-4bae-8d2c-bd03d505d762.png)

After:
![image](https://user-images.githubusercontent.com/11844501/159597976-79745292-0695-4033-99b8-9b1b6d7b7aa8.png)

