### PR TITLE
ADS Enhancement - Support Sending Query Results to a File

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -942,6 +942,11 @@ declare module 'azdata' {
 		numberOfRows: number;
 	}
 
+	/**
+	 * Result message object with timestamp and actual message that comes from STS.
+	 * A result message is any message that appears in the messages panel when a query
+	 * is executed.
+	 */
 	export interface IResultMessage {
 		batchId?: number | undefined;
 		isError: boolean;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -8,6 +8,22 @@
 import * as vscode from 'vscode';
 
 declare module 'azdata' {
+	/**
+	 * Result message object with timestamp and actual message that comes from STS.
+	 * A result message is any message that appears in the messages panel when a query
+	 * is executed.
+	 */
+	export interface IResultMessage {
+		/**
+		 * Flag to indicate if the incoming result message marks the completion of a query statement.
+		 *
+		 * This flag will be set to true if a message like, "2 row(s) affected" is received and is intended to
+		 * alleviate the need for string comparisons to detect the row count message at the end of a query statement,
+		 * so that query results can be interpolated with query messages.
+		 */
+		hasRowCount?: boolean;
+	}
+
 	export namespace nb {
 		export interface NotebookDocument {
 			/**

--- a/src/sql/platform/query/common/query.ts
+++ b/src/sql/platform/query/common/query.ts
@@ -33,4 +33,5 @@ export interface IQueryEditorConfiguration {
 	readonly tabColorMode: 'off' | 'border' | 'fill',
 	readonly showConnectionInfoInTitle: boolean;
 	readonly promptToSaveGeneratedFiles: boolean;
+	readonly writeQueryResultsToFile: boolean;
 }

--- a/src/sql/workbench/contrib/query/browser/fileQueryResultsWriter.ts
+++ b/src/sql/workbench/contrib/query/browser/fileQueryResultsWriter.ts
@@ -46,9 +46,9 @@ export class FileQueryResultsWriter extends Disposable implements IQueryResultsW
 		super();
 	}
 
-	public enable(): void {
+	public subscribeToQueryRunner(): void {
 		this.queryRunnerDisposables.add(this.runner.onQueryStart(() => {
-			this.reset();
+			this.clear();
 		}));
 
 		this.queryRunnerDisposables.add(this.runner.onMessage(async (message) => {
@@ -64,11 +64,11 @@ export class FileQueryResultsWriter extends Disposable implements IQueryResultsW
 		}));
 	}
 
-	public disable(): void {
+	public unsubscribeFromQueryRunner(): void {
 		this.queryRunnerDisposables.clear();
 	}
 
-	public reset() {
+	public clear() {
 		this.messages = [];
 		this.formattedQueryResults = [];
 		this.tables = [];

--- a/src/sql/workbench/contrib/query/browser/fileQueryResultsWriter.ts
+++ b/src/sql/workbench/contrib/query/browser/fileQueryResultsWriter.ts
@@ -1,0 +1,431 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { hyperLinkFormatter, textFormatter } from 'sql/base/browser/ui/table/formatters';
+import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
+import { GetLocalizedXMLShowPlanColumnName } from 'sql/workbench/contrib/query/browser/gridPanel';
+import { IGridDataProvider } from 'sql/workbench/services/query/common/gridDataProvider';
+import { IQueryMessage, ResultSetSummary, MessageType, IQueryResultsWriter } from 'sql/workbench/services/query/common/query';
+import QueryRunner, { QueryGridDataProvider } from 'sql/workbench/services/query/common/queryRunner';
+import { asArray } from 'vs/base/common/arrays';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { isArray } from 'vs/base/common/types';
+import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
+import { formatDocumentWithSelectedProvider, FormattingMode } from 'vs/editor/contrib/format/format';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { ILogService } from 'vs/platform/log/common/log';
+import { Progress } from 'vs/platform/progress/common/progress';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
+
+export class FileQueryResultsWriter extends Disposable implements IQueryResultsWriter {
+	protected queryRunnerDisposables = this._register(new DisposableStore());
+	private runner: QueryRunner;
+	private messages: Array<IQueryMessage> = [];
+	private formattedQueryResults: Array<string> = [];
+	private tables: Array<Table> = [];
+	private numQueriesToFormat: number = 0;
+	private queryContainsError: boolean = false;
+	private closingMessageIncluded: boolean = false;
+	private hasCreatedResultsFile: boolean = false;
+
+	private readonly newLineEscapeSequence: string = this.textResourcePropertiesService.getEOL(undefined);
+
+	constructor(
+		@IInstantiationService private instantiationService: IInstantiationService,
+		@IUntitledTextEditorService private readonly untitledEditorService: IUntitledTextEditorService,
+		@IEditorService private readonly editorService: IEditorService,
+		@ILogService private readonly logService: ILogService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@ITextResourcePropertiesService private readonly textResourcePropertiesService: ITextResourcePropertiesService
+	) {
+		super();
+	}
+
+	public enable(): void {
+		this.queryRunnerDisposables.add(this.runner.onQueryStart(() => {
+			this.reset();
+		}));
+
+		this.queryRunnerDisposables.add(this.runner.onMessage((message) => {
+			this.onMessage(message);
+		}));
+
+		this.queryRunnerDisposables.add(this.runner.onResultSet((resultSet) => {
+			this.onResultSet(resultSet);
+		}));
+
+		this.queryRunnerDisposables.add(this.runner.onResultSetUpdate((resultSet) => {
+			this.updateResultSet(resultSet);
+		}));
+	}
+
+	public disable(): void {
+		this.queryRunnerDisposables.clear();
+	}
+
+	public reset() {
+		this.messages = [];
+		this.formattedQueryResults = [];
+		this.tables = [];
+		this.numQueriesToFormat = 0;
+		this.queryContainsError = false;
+		this.closingMessageIncluded = false;
+		this.hasCreatedResultsFile = false;
+	}
+
+	public set queryRunner(runner: QueryRunner) {
+		this.runner = runner;
+	}
+
+	private onResultSet(resultSet: ResultSetSummary | ResultSetSummary[]) {
+		this.numQueriesToFormat++;
+		let resultsToAdd = asArray(resultSet);
+
+		if (this.configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.streaming) {
+			this.addResultSet(resultsToAdd);
+		} else {
+			resultsToAdd = resultsToAdd.filter(e => e.complete);
+			if (resultsToAdd.length > 0) {
+				this.addResultSet(resultsToAdd);
+			}
+		}
+	}
+
+	private async updateResultSet(resultSet: ResultSetSummary | ResultSetSummary[]) {
+		let resultSetSummaries = asArray(resultSet);
+
+		if (this.configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.streaming) {
+			for (let resultSetSummary of resultSetSummaries) {
+				let table = this.tables.find(t => t.resultSet.batchId === resultSetSummary.batchId && t.resultSet.id === resultSetSummary.id);
+				if (table) {
+					await table.updateResult(resultSetSummary);
+				} else {
+					this.logService.warn('Got result set update request for non-existant table');
+				}
+			}
+		} else {
+			resultSetSummaries = resultSetSummaries.filter(e => e.complete);
+			if (resultSetSummaries.length > 0) {
+				this.addResultSet(resultSetSummaries);
+			}
+		}
+	}
+
+	private async onMessage(incomingMessage: IQueryMessage | IQueryMessage[]) {
+		if (isArray(incomingMessage)) {
+			incomingMessage.forEach(m => {
+				if (m.isError) {
+					this.queryContainsError = true;
+				}
+
+				if (m?.messageType === MessageType.queryEnd) {
+					this.closingMessageIncluded = true;
+				}
+
+				this.messages.push(m);
+			});
+		}
+		else {
+			this.messages.push(incomingMessage);
+		}
+
+		if (!this.hasCreatedResultsFile && this.closingMessageIncluded && this.queryContainsError && this.numQueriesToFormat === 0) {
+			await this.createResultsFile();
+		}
+	}
+
+	private addResultSet(resultSetSummaries: ResultSetSummary[]) {
+		for (const resultSetSummary of resultSetSummaries) {
+			// ensure we aren't adding a resultSet that has already been added
+			if (this.tables.find(t => t.resultSet.batchId === resultSetSummary.batchId && t.resultSet.id === resultSetSummary.id)) {
+				continue;
+			}
+
+			const table = this.instantiationService.createInstance(Table, this.runner, resultSetSummary, this.textResourcePropertiesService, this);
+			this.tables.push(table);
+		}
+	}
+
+	public async aggregateQueryResults(results: string) {
+		this.numQueriesToFormat--;
+		this.formattedQueryResults.push(results);
+
+		if (this.numQueriesToFormat === 0 && !this.hasCreatedResultsFile) {
+			await this.createResultsFile();
+		}
+	}
+
+	private async createResultsFile() {
+		this.messages = this.messages.filter(m => m?.messageType !== MessageType.queryStart);
+		this.messages.forEach(m => {
+			if (m?.hasRowCount) {
+				m.message = this.newLineEscapeSequence + m.message + this.newLineEscapeSequence;
+			}
+			else if (m?.messageType === MessageType.queryEnd) {
+				m.message = this.newLineEscapeSequence + m.message;
+			}
+		});
+
+		let fileData = this.mergeQueryResultsWithMessages().join(this.newLineEscapeSequence);
+
+		const input = this.untitledEditorService.create({ initialValue: fileData });
+		await input.resolve();
+		input.setDirty(false);
+		await this.instantiationService.invokeFunction(formatDocumentWithSelectedProvider, input.textEditorModel, FormattingMode.Explicit, Progress.None, CancellationToken.None);
+		this.hasCreatedResultsFile = true;
+
+		return this.editorService.openEditor(input);
+	}
+
+	private mergeQueryResultsWithMessages(): string[] {
+		let content: Array<string> = [];
+
+		// Merges query result set before respective '# row(s) affected' message
+		while (this.messages.length > 0 && this.formattedQueryResults.length > 0) {
+			if (this.messages[0]?.hasRowCount) {
+				content.push(this.newLineEscapeSequence + this.formattedQueryResults.shift());
+			}
+
+			let queryMessage = this.messages.shift();
+			content.push(queryMessage.message);
+		}
+
+		let remainingMessages = this.messages.map(m => m.message);
+		// append any remaining query results and messages.
+		return [...content, ...this.formattedQueryResults, ...remainingMessages];
+	}
+}
+
+class Table extends Disposable {
+	private gridDataProvider: IGridDataProvider;
+	private columns: IColumn[];
+	private readonly maxColWidthForJsonOrXml = 257;
+
+	constructor(
+		private runner: QueryRunner,
+		public resultSet: ResultSetSummary,
+		private readonly textResourcePropertiesService: ITextResourcePropertiesService,
+		private fileQueryResultsWriter: FileQueryResultsWriter,
+		@IInstantiationService private readonly instantiationService: IInstantiationService
+	) {
+		super();
+
+		this.columns = this.resultSet.columnInfo.map((col, index) => {
+			let isLinked = col.isXml || col.isJson;
+
+			return <IColumn>{
+				id: index.toString(),
+				name: GetLocalizedXMLShowPlanColumnName(col),
+				field: index.toString(),
+				formatter: isLinked ? hyperLinkFormatter : textFormatter,
+				width: col.columnSize,
+				dataTypeName: col.dataTypeName
+			};
+		});
+
+		this.gridDataProvider = this.instantiationService.createInstance(QueryGridDataProvider, this.runner, resultSet.batchId, resultSet.id);
+	}
+
+	public async updateResult(resultSet: ResultSetSummary) {
+		this.resultSet = resultSet;
+
+		if (this.resultSet.complete) {
+			let offset = 0;
+			await this.getData(offset, resultSet.rowCount);
+		}
+	}
+
+	private async getData(offset: number, count: number): Promise<void> {
+		let response = await this.gridDataProvider.getRowData(offset, count);
+		if (!response) {
+			return;
+		}
+
+		let unformattedData = response.rows.map(row => {
+			let dataWithSchema = {};
+
+			let numColumns = this.resultSet.columnInfo.length;
+			for (let curCol = 0; curCol < numColumns; curCol++) {
+				dataWithSchema[this.columns[curCol].field] = {
+					displayValue: row[curCol].displayValue,
+					ariaLabel: escape(row[curCol].displayValue),
+					isNull: row[curCol].isNull,
+					invariantCultureDisplayValue: row[curCol].invariantCultureDisplayValue
+				};
+			}
+			return dataWithSchema;
+		});
+
+		let formattedResults = this.formatQueryResults(unformattedData);
+		await this.fileQueryResultsWriter.aggregateQueryResults(formattedResults);
+	}
+
+	private formatQueryResults(unformattedData: any[]): string {
+		let columnWidths = this.calculateColumnWidths();
+		let formattedTable = this.formatTableHeader(columnWidths);
+		formattedTable = formattedTable.concat(this.formatData(unformattedData, columnWidths));
+
+		return formattedTable.join(this.textResourcePropertiesService.getEOL(undefined));
+	}
+
+	private calculateColumnWidths(): number[] {
+		let columnWidths: number[] = [];
+
+		for (const column of this.columns) {
+			let colWidth = this.calculateColumnWidth(column);
+
+			if (column?.formatter?.name === 'hyperLinkFormatter') {
+				colWidth = this.maxColWidthForJsonOrXml;
+			}
+
+			columnWidths.push(colWidth);
+		}
+
+		return columnWidths;
+	}
+
+	private calculateColumnWidth(column: IColumn): number {
+		let columnWidth = 0;
+		let nameLength = column?.name ? column.name.length : 0;
+
+		switch (column.dataTypeName.toUpperCase()) {
+			case 'BIT':
+				columnWidth = Math.max(1, nameLength);
+				break;
+			case 'TINYINT':
+				columnWidth = Math.max(3, nameLength);
+				break;
+			case 'SMALLINT':
+				columnWidth = Math.max(6, nameLength);
+				break;
+			case 'INT':
+				columnWidth = Math.max(11, nameLength);
+				break;
+			case 'BIGINT':
+				columnWidth = Math.max(21, nameLength);
+				break;
+			case 'REAL':
+				columnWidth = Math.max(14, nameLength);
+				break;
+			case 'FLOAT':
+				columnWidth = Math.max(24, nameLength);
+				break;
+			case 'DECIMAL':
+				columnWidth = Math.max(26, nameLength, column.width);
+			case 'DATE':
+				columnWidth = Math.max(16, nameLength);
+				break;
+			case 'DATETIME':
+				columnWidth = Math.max(23, nameLength);
+				break;
+			case 'SMALLDATETIME':
+				columnWidth = Math.max(19, nameLength);
+				break;
+			case 'DATETIME2':
+				columnWidth = Math.max(38, nameLength);
+				break;
+			case 'DATETIMEOFFSET':
+				columnWidth = Math.max(45, nameLength);
+				break;
+			case 'UNIQUEIDENTIFIER':
+				columnWidth = Math.max(36, nameLength);
+				break;
+			case 'VARCHAR':
+			case 'NVARCHAR':
+				columnWidth = Math.max(column.width, nameLength);
+				break;
+			case 'VARBINARY':
+				columnWidth = Math.max(column.width, nameLength);
+				break;
+			case 'CHAR':
+			case 'NCHAR':
+			case 'VARIANT':
+				columnWidth = Math.max(column.width, nameLength);
+				break;
+			case 'XML':
+			case 'TEXT':
+			case 'NTEXT':
+			case 'IMAGE':
+			case 'BINARY':
+				columnWidth = Math.max(column.width, nameLength);
+				break;
+			default:
+				columnWidth = Math.max(column.width, nameLength);
+		}
+
+		return columnWidth;
+	}
+
+	private formatTableHeader(columnWidths: number[]): string[] {
+		let tableHeader: string[] = [];
+
+		let columnNames = '';
+		for (let curCol = 0; curCol < this.columns.length; curCol++) {
+			columnNames += (this.columns[curCol].name !== undefined) ? this.columns[curCol].name : '';
+
+			// Padding every column name before the last one to fill it's width and including extra space to separate each column.
+			if (curCol < this.columns.length - 1) {
+				columnNames += ' '.repeat((columnWidths[curCol] - this.columns[curCol].name.length) + 1);
+			}
+		}
+		tableHeader.push(columnNames);
+
+		let headingDivider = columnWidths.map((colWidth, index) => {
+			let columnUnderline = '-'.repeat(colWidth);
+
+			if (index < this.columns.length - 1) {
+				columnUnderline += ' ';
+			}
+
+			return columnUnderline;
+		}).join('');
+		tableHeader.push(headingDivider);
+
+		return tableHeader;
+	}
+
+	private formatData(unformattedRows: IRow[], columnSizes: number[]): string[] {
+		let formattedRows: string[] = [];
+
+		unformattedRows.forEach(r => {
+			let row = '';
+			for (let curCol = 0; curCol < this.columns.length; curCol++) {
+				if (this.columns[curCol]?.formatter?.name === 'hyperLinkFormatter') {
+					row += r[curCol].displayValue.substring(0, this.maxColWidthForJsonOrXml);
+				}
+				else {
+					row += r[curCol].displayValue;
+				}
+
+				if (curCol < this.columns.length - 1) {
+					row += ' '.repeat((columnSizes[curCol] - r[curCol].displayValue.length) + 1);
+				}
+			}
+
+			formattedRows.push(row);
+		});
+
+		return formattedRows;
+	}
+}
+
+interface IRow {
+	displayValue: string;
+	ariaLabel: string;
+	isNull: boolean;
+	invariantCultureDisplayValue: string;
+}
+
+interface IColumn {
+	id: string,
+	name: string,
+	field: string,
+	formatter: (row: number | undefined, cell: any | undefined, value: any, columnDef: any | undefined, dataContext: any | undefined) => string,
+	width: number,
+	dataTypeName: string
+}

--- a/src/sql/workbench/contrib/query/browser/fileQueryResultsWriter.ts
+++ b/src/sql/workbench/contrib/query/browser/fileQueryResultsWriter.ts
@@ -51,16 +51,16 @@ export class FileQueryResultsWriter extends Disposable implements IQueryResultsW
 			this.reset();
 		}));
 
-		this.queryRunnerDisposables.add(this.runner.onMessage((message) => {
-			this.onMessage(message);
+		this.queryRunnerDisposables.add(this.runner.onMessage(async (message) => {
+			await this.onMessage(message);
 		}));
 
 		this.queryRunnerDisposables.add(this.runner.onResultSet((resultSet) => {
 			this.onResultSet(resultSet);
 		}));
 
-		this.queryRunnerDisposables.add(this.runner.onResultSetUpdate((resultSet) => {
-			this.updateResultSet(resultSet);
+		this.queryRunnerDisposables.add(this.runner.onResultSetUpdate(async (resultSet) => {
+			await this.updateResultSet(resultSet);
 		}));
 	}
 

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -52,6 +52,7 @@ import { FilterButtonWidth, HeaderFilter } from 'sql/base/browser/ui/table/plugi
 import { HybridDataProvider } from 'sql/base/browser/ui/table/hybridDataProvider';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
+import { QueryResultsWriterMode } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
 
 const ROW_HEIGHT = 29;
 const HEADER_HEIGHT = 26;
@@ -104,7 +105,7 @@ export class GridPanel extends Disposable {
 
 		this._register(this.editorService.onDidActiveEditorOutputModeChange(() => {
 			let editor = this.editorService.activeEditorPane as QueryEditor;
-			this.isWritingResultsToGrid = editor.queryResultsWriterStatus.isWritingToGrid();
+			this.isWritingResultsToGrid = editor.queryResultsWriterStatus.mode === QueryResultsWriterMode.ToGrid;
 
 			this.queryRunnerDisposables.clear();
 			if (!this.isWritingResultsToGrid) {

--- a/src/sql/workbench/contrib/query/browser/messagePanel.ts
+++ b/src/sql/workbench/contrib/query/browser/messagePanel.ts
@@ -94,6 +94,7 @@ export class MessagePanel extends Disposable {
 
 	private _treeStates = new Map<string, IDataTreeViewState>();
 	private currentUri: string;
+	private notificationMessages = new Map<string, Array<IMessagePanelMessage>>();
 
 	private tree: WorkbenchDataTree<Model, IResultMessageIntern, FuzzyScore>;
 	private runner: QueryRunner;
@@ -138,7 +139,7 @@ export class MessagePanel extends Disposable {
 		this._register(attachListStyler(this.tree, this.themeService));
 		this._register(this.themeService.onDidColorThemeChange(this.applyStyles, this));
 		this.applyStyles(this.themeService.getColorTheme());
-		this.queryResultsWriterFactory = this.instantiationService.createInstance(QueryResultsWriterFactory, this.model, this.tree, this._treeStates);
+		this.queryResultsWriterFactory = this.instantiationService.createInstance(QueryResultsWriterFactory, this.model, this.tree, this._treeStates, this.notificationMessages);
 		this.queryResultsWriter = this.queryResultsWriterFactory.getQueryResultsWriter();
 
 		this._register(this.editorService.onDidActiveEditorOutputModeChange(() => {
@@ -201,14 +202,12 @@ export class MessagePanel extends Disposable {
 	}
 
 	public set queryRunner(runner: QueryRunner) {
-		this.queryResultsWriter?.dispose();
 		if (this.currentUri) {
 			this._treeStates.set(this.currentUri, this.tree.getViewState());
 		}
-
 		this.currentUri = runner.uri;
 		this.runner = runner;
-
+		this.queryResultsWriter.dispose();
 		this.queryResultsWriter = this.queryResultsWriterFactory.getQueryResultsWriter();
 		this.queryResultsWriter.queryRunner = runner;
 		this.queryResultsWriter.subscribeToQueryRunner();

--- a/src/sql/workbench/contrib/query/browser/messagePanel.ts
+++ b/src/sql/workbench/contrib/query/browser/messagePanel.ts
@@ -143,11 +143,11 @@ export class MessagePanel extends Disposable {
 		this.queryResultsWriter = new MessagesPanelQueryResultsWriter(this.model, this.tree, this._treeStates);
 
 		this._register(this.editorService.onDidActiveEditorOutputModeChange(() => {
-			this.queryResultsWriter.reset();
-			this.queryResultsWriter.disable();
+			this.queryResultsWriter.clear();
+			this.queryResultsWriter.unsubscribeFromQueryRunner();
 			this.queryResultsWriter = this.queryResultsWriterFactory.getQueryResultsWriter();
 			this.queryResultsWriter.queryRunner = this.runner;
-			this.queryResultsWriter.enable();
+			this.queryResultsWriter.subscribeToQueryRunner();
 		}));
 	}
 
@@ -202,7 +202,7 @@ export class MessagePanel extends Disposable {
 	}
 
 	public set queryRunner(runner: QueryRunner) {
-		this.queryResultsWriter.disable();
+		this.queryResultsWriter.unsubscribeFromQueryRunner();
 		if (this.currentUri) {
 			this._treeStates.set(this.currentUri, this.tree.getViewState());
 		}
@@ -213,7 +213,7 @@ export class MessagePanel extends Disposable {
 		this.reset();
 		this.queryResultsWriter = this.queryResultsWriterFactory.getQueryResultsWriter();
 		this.queryResultsWriter.queryRunner = runner;
-		this.queryResultsWriter.enable();
+		this.queryResultsWriter.subscribeToQueryRunner();
 	}
 
 	private applyStyles(theme: IColorTheme): void {
@@ -230,7 +230,7 @@ export class MessagePanel extends Disposable {
 	}
 
 	private reset() {
-		this.queryResultsWriter.reset();
+		this.queryResultsWriter.clear();
 	}
 
 	public clear() {

--- a/src/sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter.ts
+++ b/src/sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter.ts
@@ -38,19 +38,22 @@ export class MessagesPanelQueryResultsWriter extends Disposable implements IQuer
 		this.onMessage(this.runner.messages, true);
 	}
 
-	public unsubscribeFromQueryRunner(): void {
-		this.queryRunnerDisposables.clear();
+	public override dispose() {
+		this.clear();
+		this.queryRunnerDisposables.dispose();
+
+		super.dispose();
+	}
+
+	public set queryRunner(runner: QueryRunner) {
+		this.runner = runner;
+		this.currentUri = runner.uri;
 	}
 
 	public clear(): void {
 		this.model.messages = [];
 		this.model.totalExecuteMessage = undefined;
 		this.tree.updateChildren();
-	}
-
-	public set queryRunner(runner: QueryRunner) {
-		this.runner = runner;
-		this.currentUri = runner.uri;
 	}
 
 	private onMessage(resultMessage: IQueryMessage | IQueryMessage[], setInput: boolean = false): void {

--- a/src/sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter.ts
+++ b/src/sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IResultMessageIntern, Model } from 'sql/workbench/contrib/query/browser/messagePanel';
+import { IQueryMessage, IQueryResultsWriter } from 'sql/workbench/services/query/common/query';
+import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
+import { IDataTreeViewState } from 'vs/base/browser/ui/tree/dataTree';
+import { FuzzyScore } from 'vs/base/common/filters';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { isArray } from 'vs/base/common/types';
+import { WorkbenchDataTree } from 'vs/platform/list/browser/listService';
+
+export class MessagesPanelQueryResultsWriter extends Disposable implements IQueryResultsWriter {
+	private runner: QueryRunner;
+	private currentUri: string;
+
+	protected queryRunnerDisposables = this._register(new DisposableStore());
+
+	constructor(
+		private readonly model: Model,
+		private readonly tree: WorkbenchDataTree<Model, IResultMessageIntern, FuzzyScore>,
+		private readonly treeStates: Map<string, IDataTreeViewState>,
+	) {
+		super();
+	}
+
+	public enable(): void {
+		this.queryRunnerDisposables.add(this.runner.onQueryStart(() => {
+			this.reset();
+		}));
+
+		this.queryRunnerDisposables.add(this.runner.onMessage((resultMessage) => {
+			this.onMessage(resultMessage);
+		}));
+
+		this.onMessage(this.runner.messages, true);
+	}
+
+	public disable(): void {
+		this.queryRunnerDisposables.clear();
+	}
+
+	public reset(): void {
+		this.model.messages = [];
+		this.model.totalExecuteMessage = undefined;
+		this.tree.updateChildren();
+	}
+
+	set queryRunner(runner: QueryRunner) {
+		this.runner = runner;
+		this.currentUri = runner.uri;
+	}
+
+	private onMessage(resultMessage: IQueryMessage | IQueryMessage[], setInput: boolean = false): void {
+		if (isArray(resultMessage)) {
+			this.model.messages.push(...resultMessage);
+		} else {
+			this.model.messages.push(resultMessage);
+		}
+		if (setInput) {
+			this.tree.setInput(this.model, this.treeStates.get(this.currentUri));
+		} else {
+			this.tree.updateChildren();
+		}
+	}
+}

--- a/src/sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter.ts
+++ b/src/sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter.ts
@@ -26,9 +26,9 @@ export class MessagesPanelQueryResultsWriter extends Disposable implements IQuer
 		super();
 	}
 
-	public enable(): void {
+	public subscribeToQueryRunner(): void {
 		this.queryRunnerDisposables.add(this.runner.onQueryStart(() => {
-			this.reset();
+			this.clear();
 		}));
 
 		this.queryRunnerDisposables.add(this.runner.onMessage((resultMessage) => {
@@ -38,17 +38,17 @@ export class MessagesPanelQueryResultsWriter extends Disposable implements IQuer
 		this.onMessage(this.runner.messages, true);
 	}
 
-	public disable(): void {
+	public unsubscribeFromQueryRunner(): void {
 		this.queryRunnerDisposables.clear();
 	}
 
-	public reset(): void {
+	public clear(): void {
 		this.model.messages = [];
 		this.model.totalExecuteMessage = undefined;
 		this.tree.updateChildren();
 	}
 
-	set queryRunner(runner: QueryRunner) {
+	public set queryRunner(runner: QueryRunner) {
 		this.runner = runner;
 		this.currentUri = runner.uri;
 	}

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -458,6 +458,11 @@ const queryEditorConfiguration: IConfigurationNode = {
 			'type': 'boolean',
 			'default': false,
 			'description': localize('queryEditor.promptToSaveGeneratedFiles', "Prompt to save generated SQL files")
+		},
+		'queryEditor.writeQueryResultsToFile': {
+			'type': 'boolean',
+			'default': false,
+			'description': localize('queryEditor.writeQueryResultsToFile', 'Send query results to a file')
 		}
 	}
 };

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -47,7 +47,7 @@ import { FileEditorInput } from 'vs/workbench/contrib/files/browser/editors/file
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ILogService } from 'vs/platform/log/common/log';
-import { QueryResultsToFileAction, QueryResultsToGridAction } from 'sql/workbench/contrib/query/browser/queryResultsDisplayActions';
+import { ChangeQueryResultsOutputAction } from 'sql/workbench/contrib/query/browser/queryResultsDisplayActions';
 
 export const QueryEditorVisibleCondition = ContextKeyExpr.has(queryContext.queryEditorVisibleId);
 export const ResultsGridFocusCondition = ContextKeyExpr.and(ContextKeyExpr.has(queryContext.resultsVisibleId), ContextKeyExpr.has(queryContext.resultsGridFocussedId));
@@ -228,23 +228,13 @@ actionRegistry.registerWorkbenchAction(
 	'Change Language Flavor'
 );
 
-// Query Result writer actions
 actionRegistry.registerWorkbenchAction(
 	SyncActionDescriptor.create(
-		QueryResultsToGridAction,
-		QueryResultsToGridAction.ID,
-		QueryResultsToGridAction.LABEL
+		ChangeQueryResultsOutputAction,
+		ChangeQueryResultsOutputAction.ID,
+		ChangeQueryResultsOutputAction.LABEL
 	),
-	'Query Results to Grid'
-);
-
-actionRegistry.registerWorkbenchAction(
-	SyncActionDescriptor.create(
-		QueryResultsToFileAction,
-		QueryResultsToFileAction.ID,
-		QueryResultsToFileAction.LABEL
-	),
-	'Query Results to File'
+	'Change Results Output Mode'
 );
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -27,7 +27,7 @@ import { localize } from 'vs/nls';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
 
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
-import { TimeElapsedStatusBarContributions, RowCountStatusBarContributions, QueryStatusStatusBarContributions, QueryResultSelectionSummaryStatusBarContribution } from 'sql/workbench/contrib/query/browser/statusBarItems';
+import { TimeElapsedStatusBarContributions, RowCountStatusBarContributions, QueryStatusStatusBarContributions, QueryResultSelectionSummaryStatusBarContribution, QueryResultsEditorOutputModeStatusBarContribution } from 'sql/workbench/contrib/query/browser/statusBarItems';
 import { SqlFlavorStatusbarItem, ChangeFlavorAction } from 'sql/workbench/contrib/query/browser/flavorStatus';
 import { EditorExtensions, IEditorFactoryRegistry } from 'vs/workbench/common/editor';
 import { FileQueryEditorInput } from 'sql/workbench/contrib/query/browser/fileQueryEditorInput';
@@ -47,6 +47,7 @@ import { FileEditorInput } from 'vs/workbench/contrib/files/browser/editors/file
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ILogService } from 'vs/platform/log/common/log';
+import { QueryResultsToFileAction, QueryResultsToGridAction } from 'sql/workbench/contrib/query/browser/queryResultsDisplayActions';
 
 export const QueryEditorVisibleCondition = ContextKeyExpr.has(queryContext.queryEditorVisibleId);
 export const ResultsGridFocusCondition = ContextKeyExpr.and(ContextKeyExpr.has(queryContext.resultsVisibleId), ContextKeyExpr.has(queryContext.resultsGridFocussedId));
@@ -225,6 +226,25 @@ actionRegistry.registerWorkbenchAction(
 		ChangeFlavorAction.LABEL
 	),
 	'Change Language Flavor'
+);
+
+// Query Result writer actions
+actionRegistry.registerWorkbenchAction(
+	SyncActionDescriptor.create(
+		QueryResultsToGridAction,
+		QueryResultsToGridAction.ID,
+		QueryResultsToGridAction.LABEL
+	),
+	'Query Results to Grid'
+);
+
+actionRegistry.registerWorkbenchAction(
+	SyncActionDescriptor.create(
+		QueryResultsToFileAction,
+		QueryResultsToFileAction.ID,
+		QueryResultsToFileAction.LABEL
+	),
+	'Query Results to File'
 );
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
@@ -491,6 +511,7 @@ workbenchRegistry.registerWorkbenchContribution(RowCountStatusBarContributions, 
 workbenchRegistry.registerWorkbenchContribution(QueryStatusStatusBarContributions, LifecyclePhase.Restored);
 workbenchRegistry.registerWorkbenchContribution(SqlFlavorStatusbarItem, LifecyclePhase.Restored);
 workbenchRegistry.registerWorkbenchContribution(QueryResultSelectionSummaryStatusBarContribution, LifecyclePhase.Restored);
+workbenchRegistry.registerWorkbenchContribution(QueryResultsEditorOutputModeStatusBarContribution, LifecyclePhase.Restored);
 
 const languageAssociationRegistry = Registry.as<ILanguageAssociationRegistry>(LanguageAssociationExtensions.LanguageAssociations);
 

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -47,6 +47,7 @@ import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { gen3Version, sqlDataWarehouse } from 'sql/platform/connection/common/constants';
 import { Dropdown } from 'sql/base/browser/ui/editableDropdown/browser/dropdown';
 import { QueryResultsWriterMode } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
+import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
 
 /**
  * Action class that query-based Actions will extend. This base class automatically handles activating and
@@ -851,10 +852,13 @@ export class ResultsToFileAction extends QueryTaskbarAction {
 
 	constructor(
 		editor: QueryEditor,
-		@IConnectionManagementService connectionManagementService: IConnectionManagementService
+		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
+		@IConfigurationService configurationService: IConfigurationService
 	) {
 		super(connectionManagementService, editor, ResultsToFileAction.ID, ResultsToFileAction.IconClass);
-		this.label = 'Results to File';
+
+		let writeQueryResultsToFile = configurationService.getValue<IQueryEditorConfiguration>('queryEditor').writeQueryResultsToFile;
+		this.label = writeQueryResultsToFile ? 'Results to Grid' : 'Results to File';
 	}
 
 	public override async run(): Promise<void> {

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -862,7 +862,7 @@ export class ResultsToFileAction extends QueryTaskbarAction {
 	}
 
 	public override async run(): Promise<void> {
-		if (this.editor.queryResultsWriterStatus.isWritingToFile()) {
+		if (this.editor.queryResultsWriterStatus.mode === QueryResultsWriterMode.ToFile) {
 			this.editor.queryResultsWriterMode = QueryResultsWriterMode.ToGrid;
 			this.label = 'Results to File';
 		}

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -46,6 +46,7 @@ import { getErrorMessage, onUnexpectedError } from 'vs/base/common/errors';
 import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { gen3Version, sqlDataWarehouse } from 'sql/platform/connection/common/constants';
 import { Dropdown } from 'sql/base/browser/ui/editableDropdown/browser/dropdown';
+import { QueryResultsWriterMode } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
 
 /**
  * Action class that query-based Actions will extend. This base class automatically handles activating and
@@ -838,5 +839,32 @@ export class ExportAsNotebookAction extends QueryTaskbarAction {
 
 	public override async run(): Promise<void> {
 		this._commandService.executeCommand('mssql.exportSqlAsNotebook', this.editor.input.uri);
+	}
+}
+
+/**
+ * Action class that sends query results to a file.
+ */
+export class ResultsToFileAction extends QueryTaskbarAction {
+	public static IconClass = '';
+	public static ID = 'ResultsToFile';
+
+	constructor(
+		editor: QueryEditor,
+		@IConnectionManagementService connectionManagementService: IConnectionManagementService
+	) {
+		super(connectionManagementService, editor, ResultsToFileAction.ID, ResultsToFileAction.IconClass);
+		this.label = 'Results to File';
+	}
+
+	public override async run(): Promise<void> {
+		if (this.editor.queryResultsWriterStatus.isWritingToFile()) {
+			this.editor.queryResultsWriterMode = QueryResultsWriterMode.ToGrid;
+			this.label = 'Results to File';
+		}
+		else {
+			this.editor.queryResultsWriterMode = QueryResultsWriterMode.ToFile;
+			this.label = 'Results to Grid';
+		}
 	}
 }

--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -673,7 +673,7 @@ export class QueryEditor extends EditorPane {
 	public get queryResultsWriterStatus() {
 		let writerStatus = this.resultsWriterStatus[this.input.uri];
 		if (writerStatus === undefined) {
-			writerStatus = new QueryResultsWriterStatus();
+			writerStatus = this.instantiationService.createInstance(QueryResultsWriterStatus, undefined);
 			this.resultsWriterStatus[this.input.uri] = writerStatus;
 		}
 
@@ -683,7 +683,7 @@ export class QueryEditor extends EditorPane {
 	public set queryResultsWriterMode(mode: QueryResultsWriterMode) {
 		let writerStatus = this.resultsWriterStatus[this.input.uri];
 		if (writerStatus === undefined) {
-			writerStatus = new QueryResultsWriterStatus(mode);
+			writerStatus = this.instantiationService.createInstance(QueryResultsWriterStatus, mode);
 			this.resultsWriterStatus[this.input.uri] = writerStatus;
 		}
 		else {

--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -100,6 +100,7 @@ export class QueryEditor extends EditorPane {
 	private _listDatabasesActionItem: actions.ListDatabasesActionItem;
 	private _toggleSqlcmdMode: actions.ToggleSqlCmdModeAction;
 	private _exportAsNotebookAction: actions.ExportAsNotebookAction;
+	private _resultsToFileAction: actions.ResultsToFileAction;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -209,6 +210,7 @@ export class QueryEditor extends EditorPane {
 		this._actualQueryPlanAction = this.instantiationService.createInstance(actions.ActualQueryPlanAction, this);
 		this._toggleSqlcmdMode = this.instantiationService.createInstance(actions.ToggleSqlCmdModeAction, this, false);
 		this._exportAsNotebookAction = this.instantiationService.createInstance(actions.ExportAsNotebookAction, this);
+		this._resultsToFileAction = this.instantiationService.createInstance(actions.ResultsToFileAction, this);
 		this.setTaskbarContent();
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('workbench.enablePreviewFeatures')) {
@@ -326,7 +328,8 @@ export class QueryEditor extends EditorPane {
 				{ element: Taskbar.createTaskbarSeparator() },
 				{ action: this._estimatedQueryPlanAction },
 				{ action: this._toggleSqlcmdMode },
-				{ action: this._exportAsNotebookAction }
+				{ action: this._exportAsNotebookAction },
+				{ action: this._resultsToFileAction }
 			);
 		}
 

--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -45,6 +45,7 @@ import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ConnectionOptionSpecialType } from 'sql/platform/connection/common/interfaces';
+import { QueryResultsWriterMode, QueryResultsWriterStatus } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
 
 const QUERY_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'queryEditorViewState';
 
@@ -85,6 +86,8 @@ export class QueryEditor extends EditorPane {
 	private queryEditorVisible: IContextKey<boolean>;
 
 	private editorMemento: IEditorMemento<IQueryEditorViewState>;
+
+	private resultsWriterStatus: { [uri: string]: QueryResultsWriterStatus } = {};
 
 	//actions
 	private _runQueryAction: actions.RunQueryAction;
@@ -662,5 +665,28 @@ export class QueryEditor extends EditorPane {
 
 	public chart(dataId: { batchId: number, resultId: number }): void {
 		this.resultsEditor.chart(dataId);
+	}
+
+	public get queryResultsWriterStatus() {
+		let writerStatus = this.resultsWriterStatus[this.input.uri];
+		if (writerStatus === undefined) {
+			writerStatus = new QueryResultsWriterStatus();
+			this.resultsWriterStatus[this.input.uri] = writerStatus;
+		}
+
+		return writerStatus;
+	}
+
+	public set queryResultsWriterMode(mode: QueryResultsWriterMode) {
+		let writerStatus = this.resultsWriterStatus[this.input.uri];
+		if (writerStatus === undefined) {
+			writerStatus = new QueryResultsWriterStatus(mode);
+			this.resultsWriterStatus[this.input.uri] = writerStatus;
+		}
+		else {
+			this.resultsWriterStatus[this.input.uri].mode = mode;
+		}
+
+		this.editorService.activeEditorOutputModeChanged();
 	}
 }

--- a/src/sql/workbench/contrib/query/browser/queryResultsDisplayActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsDisplayActions.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
+import { QueryResultsWriterMode } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
+import { Action } from 'vs/base/common/actions';
+import * as nls from 'vs/nls';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+
+export class QueryResultsToFileAction extends Action {
+	public static ID = 'sql.action.query.queryResultsToFile';
+	public static LABEL = nls.localize('queryResults.resultsToFile', 'Query Results to File');
+
+	constructor(
+		actionId: string,
+		actionLabel: string,
+		@IEditorService private readonly editorService: IEditorService
+	) {
+		super(actionId, actionLabel);
+	}
+
+	public override run(): Promise<void> {
+		let editor = this.editorService.activeEditorPane as QueryEditor;
+		editor.queryResultsWriterMode = QueryResultsWriterMode.ToFile;
+
+		return Promise.resolve();
+	}
+}
+
+export class QueryResultsToGridAction extends Action {
+	public static ID = 'sql.action.query.queryResultsToGrid';
+	public static LABEL = nls.localize('queryResults.resultsToGrid', 'Query Results to Grid');
+
+	constructor(
+		actionId: string,
+		actionLabel: string,
+		@IEditorService private readonly editorService: IEditorService
+	) {
+		super(actionId, actionLabel);
+	}
+
+	public override run(): Promise<void> {
+		let editor = this.editorService.activeEditorPane as QueryEditor;
+		editor.queryResultsWriterMode = QueryResultsWriterMode.ToGrid;
+
+		return Promise.resolve();
+	}
+}

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -27,6 +27,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { ExecutionPlanTab } from 'sql/workbench/contrib/executionPlan/browser/executionPlan';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
+import { QueryResultsWriterMode } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
 
 class MessagesView extends Disposable implements IPanelView {
 	private messagePanel: MessagePanel;
@@ -212,7 +213,7 @@ export class QueryResultsView extends Disposable {
 	private setQueryRunner(runner: QueryRunner) {
 		const activeTab = this._input?.state.activeTab;
 		let editor = this.editorService.activeEditorPane as QueryEditor;
-		let writingResultsToGrid = editor.queryResultsWriterStatus.isWritingToGrid();
+		let writingResultsToGrid = editor.queryResultsWriterStatus.mode === QueryResultsWriterMode.ToGrid;
 		if (this.hasResults(runner) && writingResultsToGrid) {
 			this.showResults();
 		} else {

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -25,6 +25,8 @@ import { attachTabbedPanelStyler } from 'sql/workbench/common/styler';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ExecutionPlanTab } from 'sql/workbench/contrib/executionPlan/browser/executionPlan';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
 
 class MessagesView extends Disposable implements IPanelView {
 	private messagePanel: MessagePanel;
@@ -175,7 +177,8 @@ export class QueryResultsView extends Disposable {
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@IQueryModelService private queryModelService: IQueryModelService,
 		@INotificationService private notificationService: INotificationService,
-		@ILogService private logService: ILogService
+		@ILogService private logService: ILogService,
+		@IEditorService private readonly editorService: IEditorService
 	) {
 		super();
 		this.resultsTab = this._register(new ResultsTab(instantiationService));
@@ -208,7 +211,9 @@ export class QueryResultsView extends Disposable {
 
 	private setQueryRunner(runner: QueryRunner) {
 		const activeTab = this._input?.state.activeTab;
-		if (this.hasResults(runner)) {
+		let editor = this.editorService.activeEditorPane as QueryEditor;
+		let writingResultsToGrid = editor.queryResultsWriterStatus.isWritingToGrid();
+		if (this.hasResults(runner) && writingResultsToGrid) {
 			this.showResults();
 		} else {
 			if (runner.isExecuting) { // in case we don't have results yet, but we also have already started executing

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -112,6 +112,7 @@ class ResultsView extends Disposable implements IPanelView {
 		this.gridPanel.state = val;
 	}
 }
+
 class ResultsTab implements IPanelTab {
 	public readonly title = nls.localize('resultsTabTitle', "Results");
 	public readonly identifier = 'resultsTab';

--- a/src/sql/workbench/contrib/query/browser/queryResultsWriterFactory.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsWriterFactory.ts
@@ -7,6 +7,7 @@ import { FileQueryResultsWriter } from 'sql/workbench/contrib/query/browser/file
 import { Model, IResultMessageIntern } from 'sql/workbench/contrib/query/browser/messagePanel';
 import { MessagesPanelQueryResultsWriter } from 'sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter';
 import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
+import { QueryResultsWriterMode } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
 import { IQueryResultsWriter } from 'sql/workbench/services/query/common/query';
 import { IDataTreeViewState } from 'vs/base/browser/ui/tree/dataTree';
 import { FuzzyScore } from 'vs/base/common/filters';
@@ -26,7 +27,7 @@ export class QueryResultsWriterFactory {
 
 	getQueryResultsWriter(): IQueryResultsWriter {
 		let editor = this.editorService.activeEditorPane as QueryEditor;
-		if (editor.queryResultsWriterStatus.isWritingToGrid()) {
+		if (editor.queryResultsWriterStatus.mode === QueryResultsWriterMode.ToGrid) {
 			return this.instantiationService.createInstance(MessagesPanelQueryResultsWriter, this.model, this.tree, this.treeStates);
 		}
 		else {

--- a/src/sql/workbench/contrib/query/browser/queryResultsWriterFactory.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsWriterFactory.ts
@@ -5,7 +5,7 @@
 
 import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
 import { FileQueryResultsWriter } from 'sql/workbench/contrib/query/browser/fileQueryResultsWriter';
-import { Model, IResultMessageIntern } from 'sql/workbench/contrib/query/browser/messagePanel';
+import { Model, IResultMessageIntern, IMessagePanelMessage } from 'sql/workbench/contrib/query/browser/messagePanel';
 import { MessagesPanelQueryResultsWriter } from 'sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter';
 import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
 import { QueryResultsWriterMode } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
@@ -22,6 +22,7 @@ export class QueryResultsWriterFactory {
 		private readonly model: Model,
 		private readonly tree: WorkbenchDataTree<Model, IResultMessageIntern, FuzzyScore>,
 		private readonly treeStates: Map<string, IDataTreeViewState>,
+		private readonly notificationMessages: Map<string, Array<IMessagePanelMessage>>,
 		@IEditorService private readonly editorService: IEditorService,
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@IConfigurationService private configurationService: IConfigurationService
@@ -36,7 +37,7 @@ export class QueryResultsWriterFactory {
 		}
 
 		if (isWritingToFile) {
-			return this.instantiationService.createInstance(FileQueryResultsWriter);
+			return this.instantiationService.createInstance(FileQueryResultsWriter, this.model, this.tree, this.treeStates, this.notificationMessages);
 		}
 		else {
 			return this.instantiationService.createInstance(MessagesPanelQueryResultsWriter, this.model, this.tree, this.treeStates);

--- a/src/sql/workbench/contrib/query/browser/queryResultsWriterFactory.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsWriterFactory.ts
@@ -27,7 +27,7 @@ export class QueryResultsWriterFactory {
 	getQueryResultsWriter(): IQueryResultsWriter {
 		let editor = this.editorService.activeEditorPane as QueryEditor;
 		if (editor.queryResultsWriterStatus.isWritingToGrid()) {
-			return new MessagesPanelQueryResultsWriter(this.model, this.tree, this.treeStates);
+			return this.instantiationService.createInstance(MessagesPanelQueryResultsWriter, this.model, this.tree, this.treeStates);
 		}
 		else {
 			return this.instantiationService.createInstance(FileQueryResultsWriter);

--- a/src/sql/workbench/contrib/query/browser/queryResultsWriterFactory.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsWriterFactory.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { FileQueryResultsWriter } from 'sql/workbench/contrib/query/browser/fileQueryResultsWriter';
+import { Model, IResultMessageIntern } from 'sql/workbench/contrib/query/browser/messagePanel';
+import { MessagesPanelQueryResultsWriter } from 'sql/workbench/contrib/query/browser/messagesPanelQueryResultsWriter';
+import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
+import { IQueryResultsWriter } from 'sql/workbench/services/query/common/query';
+import { IDataTreeViewState } from 'vs/base/browser/ui/tree/dataTree';
+import { FuzzyScore } from 'vs/base/common/filters';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { WorkbenchDataTree } from 'vs/platform/list/browser/listService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+
+export class QueryResultsWriterFactory {
+	constructor(
+		private readonly model: Model,
+		private readonly tree: WorkbenchDataTree<Model, IResultMessageIntern, FuzzyScore>,
+		private readonly treeStates: Map<string, IDataTreeViewState>,
+		@IEditorService private readonly editorService: IEditorService,
+		@IInstantiationService private instantiationService: IInstantiationService,
+
+	) { }
+
+	getQueryResultsWriter(): IQueryResultsWriter {
+		let editor = this.editorService.activeEditorPane as QueryEditor;
+		if (editor.queryResultsWriterStatus.isWritingToGrid()) {
+			return new MessagesPanelQueryResultsWriter(this.model, this.tree, this.treeStates);
+		}
+		else {
+			return this.instantiationService.createInstance(FileQueryResultsWriter);
+		}
+	}
+}

--- a/src/sql/workbench/contrib/query/browser/statusBarItems.ts
+++ b/src/sql/workbench/contrib/query/browser/statusBarItems.ts
@@ -6,6 +6,7 @@
 import { parseNumAsTimeString } from 'sql/platform/connection/common/utils';
 import { QueryEditorInput } from 'sql/workbench/common/editor/query/queryEditorInput';
 import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
+import { QueryResultsWriterMode } from 'sql/workbench/contrib/query/common/queryResultsWriterStatus';
 import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
 import { ICellValue } from 'sql/workbench/services/query/common/query';
 import { IQueryModelService } from 'sql/workbench/services/query/common/queryModel';
@@ -347,7 +348,7 @@ export class QueryResultsEditorOutputModeStatusBarContribution extends Disposabl
 		this.hide();
 
 		let editor = this.editorService.activeEditorPane as QueryEditor;
-		if (editor?.queryResultsWriterStatus.isWritingToFile()) {
+		if (editor?.queryResultsWriterStatus.mode === QueryResultsWriterMode.ToFile) {
 			this.show();
 		}
 		else {

--- a/src/sql/workbench/contrib/query/browser/statusBarItems.ts
+++ b/src/sql/workbench/contrib/query/browser/statusBarItems.ts
@@ -347,7 +347,7 @@ export class QueryResultsEditorOutputModeStatusBarContribution extends Disposabl
 		this.hide();
 
 		let editor = this.editorService.activeEditorPane as QueryEditor;
-		if (editor?.queryResultsWriterStatus.isWritingToFIle()) {
+		if (editor?.queryResultsWriterStatus.isWritingToFile()) {
 			this.show();
 		}
 		else {

--- a/src/sql/workbench/contrib/query/browser/statusBarItems.ts
+++ b/src/sql/workbench/contrib/query/browser/statusBarItems.ts
@@ -347,7 +347,7 @@ export class QueryResultsEditorOutputModeStatusBarContribution extends Disposabl
 		this.hide();
 
 		let editor = this.editorService.activeEditorPane as QueryEditor;
-		if (editor.queryResultsWriterStatus.isWritingToFIle()) {
+		if (editor?.queryResultsWriterStatus.isWritingToFIle()) {
 			this.show();
 		}
 		else {

--- a/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
+++ b/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
@@ -3,7 +3,9 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export enum QueryResultsWriterMode {
 	ToGrid,
@@ -13,8 +15,16 @@ export enum QueryResultsWriterMode {
 export class QueryResultsWriterStatus extends Disposable {
 	private writerMode: QueryResultsWriterMode;
 
-	constructor(mode: QueryResultsWriterMode = QueryResultsWriterMode.ToGrid) {
+	constructor(mode: QueryResultsWriterMode | undefined,
+		@IConfigurationService configurationService: IConfigurationService
+	) {
 		super();
+
+		if (mode === undefined) {
+			let writeQueryResultsToFile = configurationService.getValue<IQueryEditorConfiguration>('queryEditor').writeQueryResultsToFile;
+			mode = writeQueryResultsToFile ? QueryResultsWriterMode.ToFile : QueryResultsWriterMode.ToGrid;
+		}
+
 		this.writerMode = mode;
 	}
 

--- a/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
+++ b/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
@@ -35,12 +35,4 @@ export class QueryResultsWriterStatus extends Disposable {
 	public get mode() {
 		return this.writerMode;
 	}
-
-	public isWritingToGrid(): boolean {
-		return this.writerMode === QueryResultsWriterMode.ToGrid;
-	}
-
-	public isWritingToFile(): boolean {
-		return this.writerMode === QueryResultsWriterMode.ToFile;
-	}
 }

--- a/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
+++ b/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
@@ -30,7 +30,7 @@ export class QueryResultsWriterStatus extends Disposable {
 		return this.writerMode === QueryResultsWriterMode.ToGrid;
 	}
 
-	public isWritingToFIle(): boolean {
+	public isWritingToFile(): boolean {
 		return this.writerMode === QueryResultsWriterMode.ToFile;
 	}
 }

--- a/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
+++ b/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
@@ -11,8 +11,6 @@ export enum QueryResultsWriterMode {
 }
 
 export class QueryResultsWriterStatus extends Disposable {
-	public static instance: QueryResultsWriterStatus = undefined;
-
 	private writerMode: QueryResultsWriterMode;
 
 	constructor(mode: QueryResultsWriterMode = QueryResultsWriterMode.ToGrid) {

--- a/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
+++ b/src/sql/workbench/contrib/query/common/queryResultsWriterStatus.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+
+export enum QueryResultsWriterMode {
+	ToGrid,
+	ToFile,
+}
+
+export class QueryResultsWriterStatus extends Disposable {
+	public static instance: QueryResultsWriterStatus = undefined;
+
+	private writerMode: QueryResultsWriterMode;
+
+	constructor(mode: QueryResultsWriterMode = QueryResultsWriterMode.ToGrid) {
+		super();
+		this.writerMode = mode;
+	}
+
+	public set mode(mode: QueryResultsWriterMode) {
+		this.writerMode = mode;
+	}
+
+	public get mode() {
+		return this.writerMode;
+	}
+
+	public isWritingToGrid(): boolean {
+		return this.writerMode === QueryResultsWriterMode.ToGrid;
+	}
+
+	public isWritingToFIle(): boolean {
+		return this.writerMode === QueryResultsWriterMode.ToFile;
+	}
+}

--- a/src/sql/workbench/services/query/common/query.ts
+++ b/src/sql/workbench/services/query/common/query.ts
@@ -94,9 +94,9 @@ export interface IQueryResultsWriter {
 	 */
 	subscribeToQueryRunner(): void;
 	/**
-	 * unsubscribes the writer from query runner callbacks like onMessage, onResultSet, etc.
+	 * Disposes the query results writer.
 	 */
-	unsubscribeFromQueryRunner(): void;
+	dispose(): void;
 	/**
 	 * Clears out any previous query results.
 	 */

--- a/src/sql/workbench/services/query/common/query.ts
+++ b/src/sql/workbench/services/query/common/query.ts
@@ -89,8 +89,20 @@ export interface ICellValue {
 }
 
 export interface IQueryResultsWriter {
-	enable(): void;
-	disable(): void;
-	reset(): void;
+	/**
+	 * subscribes the writer to query runner callbacks like onMessage, onResultSet, etc.
+	 */
+	subscribeToQueryRunner(): void;
+	/**
+	 * unsubscribes the writer from query runner callbacks like onMessage, onResultSet, etc.
+	 */
+	unsubscribeFromQueryRunner(): void;
+	/**
+	 * Clears out any previous query results.
+	 */
+	clear(): void;
+	/**
+	 * Setter for the query runner instance the writer will subscribe to.
+	 */
 	set queryRunner(runner: QueryRunner);
 }

--- a/src/sql/workbench/services/query/common/query.ts
+++ b/src/sql/workbench/services/query/common/query.ts
@@ -3,12 +3,15 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 import { IRange } from 'vs/editor/common/core/range';
 
 export interface IColumn {
 	columnName: string;
 	isXml?: boolean;
 	isJson?: boolean;
+	columnSize?: number;
+	dataTypeName?: string;
 }
 
 export type VisualizationType = 'bar' | 'count' | 'doughnut' | 'horizontalBar' | 'image' | 'line' | 'pie' | 'scatter' | 'table' | 'timeSeries';
@@ -48,6 +51,14 @@ export interface IQueryMessage {
 	time?: string;
 	message: string;
 	range?: IRange;
+	hasRowCount?: boolean;
+	messageType?: MessageType;
+}
+
+export enum MessageType {
+	normal,
+	queryStart,
+	queryEnd
 }
 
 export interface IResultMessage {
@@ -55,6 +66,7 @@ export interface IResultMessage {
 	isError: boolean;
 	time?: string;
 	message: string;
+	hasRowCount?: boolean;
 }
 
 export interface QueryExecuteSubsetParams {
@@ -74,4 +86,11 @@ export interface ICellValue {
 	displayValue: string;
 	isNull?: boolean;
 	invariantCultureDisplayValue?: string;
+}
+
+export interface IQueryResultsWriter {
+	enable(): void;
+	disable(): void;
+	reset(): void;
+	set queryRunner(runner: QueryRunner);
 }

--- a/src/sql/workbench/services/query/common/queryRunner.ts
+++ b/src/sql/workbench/services/query/common/queryRunner.ts
@@ -25,7 +25,7 @@ import { IGridDataProvider, getResultsString } from 'sql/workbench/services/quer
 import { getErrorMessage } from 'vs/base/common/errors';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IRange, Range } from 'vs/editor/common/core/range';
-import { BatchSummary, IQueryMessage, ResultSetSummary, QueryExecuteSubsetParams, CompleteBatchSummary, IResultMessage, ResultSetSubset, BatchStartSummary } from './query';
+import { BatchSummary, IQueryMessage, ResultSetSummary, QueryExecuteSubsetParams, CompleteBatchSummary, IResultMessage, ResultSetSubset, BatchStartSummary, MessageType } from './query';
 import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
 import { IDisposableDataProvider } from 'sql/base/common/dataProvider';
 
@@ -255,10 +255,11 @@ export default class QueryRunner extends Disposable {
 		let timeStamp = Utils.parseNumAsTimeString(this._totalElapsedMilliseconds);
 		// We're done with this query so shut down any waiting mechanisms
 
-		let message = {
+		let message: IQueryMessage = {
 			message: nls.localize('query.message.executionTime', "Total execution time: {0}", timeStamp),
 			isError: false,
-			time: undefined
+			time: undefined,
+			messageType: MessageType.queryEnd
 		};
 		this._messages.push(message);
 
@@ -285,7 +286,8 @@ export default class QueryRunner extends Disposable {
 			message: batch.range ? nls.localize('query.message.startQueryWithRange', "Started executing query at Line {0}", batch.range.startLineNumber) : nls.localize('query.message.startQuery', "Started executing batch {0}", batch.id),
 			time: batch.executionStart,
 			range: batch.range,
-			isError: false
+			isError: false,
+			messageType: MessageType.queryStart
 		};
 		this._messages.push(message);
 		this._onMessage.fire([message]);

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -63,6 +63,9 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 	private readonly _onDidMostRecentlyActiveEditorsChange = this._register(new Emitter<void>());
 	readonly onDidMostRecentlyActiveEditorsChange = this._onDidMostRecentlyActiveEditorsChange.event;
 
+	private readonly _onDidActiveEditorOutputModeChange = this._register(new Emitter<void>());
+	readonly onDidActiveEditorOutputModeChange = this._onDidActiveEditorOutputModeChange.event;
+
 	//#endregion
 
 	private readonly fileEditorFactory = Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).getFileEditorFactory();
@@ -1172,6 +1175,12 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		return uniqueEditors;
 	}
 
+	//#endregion
+
+	//#region activeEditorOutputModeChanged()
+	activeEditorOutputModeChanged(): void {
+		this._onDidActiveEditorOutputModeChange.fire();
+	}
 	//#endregion
 
 	override dispose(): void {

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -103,6 +103,11 @@ export interface IEditorService {
 	readonly onDidCloseEditor: Event<IEditorCloseEvent>;
 
 	/**
+	 * Emitted when query results output mode for an editor is changed.
+	 */
+	readonly onDidActiveEditorOutputModeChange: Event<void>;
+
+	/**
 	 * The currently active editor pane or `undefined` if none. The editor pane is
 	 * the workbench container for editors of any kind.
 	 *
@@ -278,4 +283,9 @@ export interface IEditorService {
 	 * @returns `true` if all editors reverted and `false` otherwise.
 	 */
 	revertAll(options?: IRevertAllEditorsOptions): Promise<boolean>;
+
+	/**
+	 * Fires an event when the active editor output mode has changed.
+	 */
+	activeEditorOutputModeChanged: () => void;
 }

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -800,6 +800,7 @@ export class TestEditorService implements EditorServiceImpl {
 	onDidCloseEditor: Event<IEditorCloseEvent> = Event.None;
 	onDidOpenEditorFail: Event<IEditorIdentifier> = Event.None;
 	onDidMostRecentlyActiveEditorsChange: Event<void> = Event.None;
+	onDidActiveEditorOutputModeChange: Event<void> = Event.None;
 
 	private _activeTextEditorControl: ICodeEditor | IDiffEditor | undefined;
 	public get activeTextEditorControl(): ICodeEditor | IDiffEditor | undefined { return this._activeTextEditorControl; }
@@ -820,6 +821,7 @@ export class TestEditorService implements EditorServiceImpl {
 	count = this.editors.length;
 
 	constructor(private editorGroupService?: IEditorGroupsService) { }
+	activeEditorOutputModeChanged() { }
 	getEditors() { return []; }
 	findEditors() { return [] as any; }
 	openEditor(editor: IEditorInput, options?: IEditorOptions, group?: PreferredGroup): Promise<IEditorPane | undefined>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #86

This PR is like an earlier PR (https://github.com/microsoft/azuredatastudio/pull/17958), and contains all requested review changes and UX improvements. The difference with this PR is essentially that it's rebased on the latest change set found in Main.

### Description
The change set in this PR is the first iteration to enhance ADS to support sending query results to a file. To enable sending query results to a file, open the command palette and enter "Query Results to File".
![image](https://user-images.githubusercontent.com/87730006/146491976-e7bc1732-a99a-4f3c-a77b-e331ffc9ff6e.png)

As can be seen in the screen shot above, the "Query Results to Grid" option allows the user to go back to sending query results to a grid, if they are wanting to no longer send results to a file.



When a query editor is set to write query results to a file, the status bar will appear with "Results to File" on the right side of it. This status will only appear for query editors that are set to write results to a file.
![image](https://user-images.githubusercontent.com/87730006/160026847-c3143edd-f001-40a5-8ef0-6554ec1d1f28.png)

When query results are being sent to appear in a grid "Results to File" will not appear on the status bar.
![image](https://user-images.githubusercontent.com/87730006/160026876-706654ae-f939-46b1-8815-9a422f8bedb7.png)




### Testing
_1. Query Results to File:_
- Launch ADS
- Open the command palette, and select "Query Results to File"
- Execute any query
- ADS will open an untitled editor that includes both the query results and messages and doesn't mark the editor as needing to be saved for quick closing.

When query results are sent to a file, results appear like this:
![image](https://user-images.githubusercontent.com/87730006/148109542-672c89c3-720b-47f6-9f34-5e50590d9cc6.png)




_2. Query Results to Grid_
- Launch ADS
- Open the command palette, and select "Query Results to Grid"
- Execute any query
- ADS will send the query results to the grid in the "Results" tab and messages will appear in the "Messages" tab like they have been appearing in ADS.

When query results are sent to a grid, results appear like this:
![image](https://user-images.githubusercontent.com/87730006/148109657-95653778-adc8-4086-b4f2-2d47d73e6b7e.png)




























