### PR TITLE
add initial SDK-style project migration

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -101,7 +101,7 @@ export function deleteConfirmationContents(toDelete: string) { return localize('
 export function deleteReferenceConfirmation(toDelete: string) { return localize('deleteReferenceConfirmation', "Are you sure you want to delete the reference to {0}?", toDelete); }
 export function selectTargetPlatform(currentTargetPlatform: string) { return localize('selectTargetPlatform', "Current target platform: {0}. Select new target platform", currentTargetPlatform); }
 export function currentTargetPlatform(projectName: string, currentTargetPlatform: string) { return localize('currentTargetPlatform', "Target platform of the project {0} is now {1}", projectName, currentTargetPlatform); }
-export function projectUpdatedToSdkStyle(projectName: string) { return localize('projectUpdatedToSdkStyle', "The project {0} has been updated to be an SDK-style project. Click 'Learn More' for details on the Microsoft.Build.Sql SDK and simplying the project file.", projectName); }
+export function projectUpdatedToSdkStyle(projectName: string) { return localize('projectUpdatedToSdkStyle', "The project {0} has been updated to be an SDK-style project. Click 'Learn More' for details on the Microsoft.Build.Sql SDK and ways to simplify the project file.", projectName); }
 
 // Publish dialog strings
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -22,6 +22,7 @@ export const msdbDacpac = 'msdb.dacpac';
 export const MicrosoftDatatoolsSchemaSqlSql = 'Microsoft.Data.Tools.Schema.Sql.Sql';
 export const databaseSchemaProvider = 'DatabaseSchemaProvider';
 export const sqlProjectSdk = 'Microsoft.Build.Sql';
+export const sqlProjectSdkVersion = '0.1.3-preview';
 
 // Project Provider
 export const emptySqlDatabaseProjectTypeId = 'EmptySqlDbProj';
@@ -100,6 +101,7 @@ export function deleteConfirmationContents(toDelete: string) { return localize('
 export function deleteReferenceConfirmation(toDelete: string) { return localize('deleteReferenceConfirmation', "Are you sure you want to delete the reference to {0}?", toDelete); }
 export function selectTargetPlatform(currentTargetPlatform: string) { return localize('selectTargetPlatform', "Current target platform: {0}. Select new target platform", currentTargetPlatform); }
 export function currentTargetPlatform(projectName: string, currentTargetPlatform: string) { return localize('currentTargetPlatform', "Target platform of the project {0} is now {1}", projectName, currentTargetPlatform); }
+export function projectUpdatedToSdkStyle(projectName: string) { return localize('projectUpdatedToSdkStyle', "The project {0} has been updated to be an SDK-style project. Click 'Learn More' for details on the Microsoft.Build.Sql SDK and simplying the project file.", projectName); }
 
 // Publish dialog strings
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -863,6 +863,24 @@ export class ProjectsController {
 	}
 
 	/**
+	 * Converts a legacy style project to an SDK-style project
+	 * @param context a treeItem in a project's hierarchy, to be used to obtain a Project
+	 */
+	public async convertToSdkStyleProject(context: dataworkspace.WorkspaceTreeItem): Promise<void> {
+		const project = this.getProjectFromContext(context);
+
+		await project.convertProjectToSdkStyle();
+		void this.reloadProject(context);
+
+		// show message that project file can be simplified
+		const result = await vscode.window.showInformationMessage(constants.projectUpdatedToSdkStyle(project.projectFileName), constants.learnMore);
+
+		if (result === constants.learnMore) {
+			void vscode.env.openExternal(vscode.Uri.parse(constants.sdkLearnMoreUrl!));
+		}
+	}
+
+	/**
 	 * Adds a database reference to the project
 	 * @param context a treeItem in a project's hierarchy, to be used to obtain a Project
 	 */

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -626,17 +626,13 @@ export class Project implements ISqlProject {
 		// make backup copy of project
 		await fs.copyFile(this._projectFilePath, this._projectFilePath + '_backup');
 
-		// remove SSDT and ADS SqlTargets imports
+		// remove SSDT and ADS SqlTasks imports
 		const importsToRemove = [];
 		for (let i = 0; i < this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.Import).length; i++) {
 			const importTarget = this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.Import)[i];
-
-			const condition = importTarget.getAttribute(constants.Condition);
 			const projectAttributeVal = importTarget.getAttribute(constants.Project);
 
-			if (condition === constants.NetCoreCondition && projectAttributeVal === constants.NetCoreTargets
-				|| condition === constants.RoundTripSqlDbPresentCondition && projectAttributeVal === constants.SqlDbTargets
-				|| condition === constants.RoundTripSqlDbNotPresentCondition && projectAttributeVal === constants.MsBuildtargets) {
+			if (projectAttributeVal === constants.NetCoreTargets || projectAttributeVal === constants.SqlDbTargets || projectAttributeVal === constants.MsBuildtargets) {
 				importsToRemove.push(importTarget);
 			}
 		}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -617,6 +617,49 @@ export class Project implements ISqlProject {
 		await this.createCleanFileNode(beforeBuildNode);
 	}
 
+	public async convertProjectToSdkStyle(): Promise<void> {
+		// don't do anything if the project is already SDK style or it's an SSDT project that hasn't been updated to build in ADS
+		if (this.isSdkStyleProject || !this._importedTargets.includes(constants.NetCoreTargets)) {
+			return;
+		}
+
+		// make backup copy of project
+		await fs.copyFile(this._projectFilePath, this._projectFilePath + '_backup');
+
+		// remove SSDT and ADS SqlTargets imports
+		const importsToRemove = [];
+		for (let i = 0; i < this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.Import).length; i++) {
+			const importTarget = this.projFileXmlDoc!.documentElement.getElementsByTagName(constants.Import)[i];
+
+			const condition = importTarget.getAttribute(constants.Condition);
+			const projectAttributeVal = importTarget.getAttribute(constants.Project);
+
+			if (condition === constants.NetCoreCondition && projectAttributeVal === constants.NetCoreTargets
+				|| condition === constants.RoundTripSqlDbPresentCondition && projectAttributeVal === constants.SqlDbTargets
+				|| condition === constants.RoundTripSqlDbNotPresentCondition && projectAttributeVal === constants.MsBuildtargets) {
+				importsToRemove.push(importTarget);
+			}
+		}
+
+		const parent = importsToRemove[0]?.parentNode;
+		importsToRemove.forEach(i => { parent?.removeChild(i); });
+
+		// add SDK node
+		const sdkNode = this.projFileXmlDoc!.createElement(constants.Sdk);
+		sdkNode.setAttribute(constants.Name, constants.sqlProjectSdk);
+		sdkNode.setAttribute(constants.Version, constants.sqlProjectSdkVersion);
+
+		const projectNode = this.projFileXmlDoc!.documentElement;
+		projectNode.insertBefore(sdkNode, projectNode.firstChild);
+
+		// TODO: also update system dacpac path, but might as well wait for them to get included in the SDK since the path will probably change again
+
+		// TODO: remove Build includes and folder includes. Make sure the same files and folders are being included and there aren't extra files included by the default **/*.sql glob
+
+		await this.serializeToProjFile(this.projFileXmlDoc!);
+		await this.readProjFile();
+	}
+
 	private async createCleanFileNode(parentNode: Element): Promise<void> {
 		const deleteFileNode = this.projFileXmlDoc!.createElement(constants.Delete);
 		deleteFileNode.setAttribute(constants.Files, constants.ProjJsonToClean);


### PR DESCRIPTION
This adds basic migration from legacy style to SDK-style sqlproj. It removes the ADS and SSDT SqlTargets imports and adds the SDK node. A backup copy of the sqlproj gets created before a legacy project gets converted.

I'll send out a separate PR to expose this in the project tree and for the option to further simplify the sqlproj (remove Build includes, default properties) later, to help keep these PRs easier to review :)
