### PR TITLE
update the lastUpdated year to 2022 for schema compare and sql database projects

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1475,7 +1475,7 @@
 					"versions": [
 						{
 							"version": "1.13.0",
-							"lastUpdated": "2/22/2021",
+							"lastUpdated": "2/22/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -3435,7 +3435,7 @@
 					"versions": [
 						{
 							"version": "0.15.0",
-							"lastUpdated": "2/22/2021",
+							"lastUpdated": "2/22/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [


### PR DESCRIPTION
Just noticed I didn't update the year to 2022 when I updated these two extensions in insiders last month.
