### PR TITLE
don't show error notification if no error message in dacpac extension

### DIFF
--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -279,8 +279,8 @@ export class DataTierApplicationWizard {
 			}
 		}
 
-		if (!result || !result.success) {
-			vscode.window.showErrorMessage(this.getOperationErrorMessage(this.selectedOperation, result?.errorMessage));
+		if (!result?.success && result.errorMessage) {
+			vscode.window.showErrorMessage(this.getOperationErrorMessage(this.selectedOperation, result.errorMessage));
 		}
 
 		return result;


### PR DESCRIPTION
This PR fixes #18870. It was a little confusing showing an error notification with "unknown" failure, but the error is actually shown in the tasks pane.
