### PR TITLE
handle special values in the table filter

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -258,6 +258,16 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			}
 		}
 
+		// Sort the list to make it easier to find a string
+		filterItems.sort();
+
+		// Promote undefined (NULL) to be always at the top of the list
+		const nullValueIndex = filterItems.indexOf(undefined);
+		if (nullValueIndex !== -1) {
+			filterItems.splice(nullValueIndex, 1);
+			filterItems.unshift(undefined);
+		}
+
 		this.listData = [];
 		for (let i = 0; i < filterItems.length; i++) {
 			const filtered = workingFilters.some(x => x === filterItems[i]);
@@ -547,11 +557,9 @@ class TableFilterListElement {
 
 		// Handle the values that are visually hard to differentiate.
 		if (val === undefined) {
-			this.displayText = localize('tableFilter.nullDisplayText', "NULL");
+			this.displayText = localize('tableFilter.nullDisplayText', "(NULL)");
 		} else if (val === '') {
-			this.displayText = localize('tableFilter.emptyStringDisplayText', "Empty String");
-		} else if (val.trim() === '') {
-			this.displayText = localize('tableFilter.whiteSpacesDisplayText', "Whitespace ({0})", val.length);
+			this.displayText = localize('tableFilter.blankStringDisplayText', "(Blanks)");
 		} else {
 			this.displayText = val;
 		}

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -262,8 +262,9 @@ export class HeaderFilter<T extends Slick.SlickData> {
 		for (let i = 0; i < filterItems.length; i++) {
 			const filtered = workingFilters.some(x => x === filterItems[i]);
 			// work item to remove the 'Error:' string check: https://github.com/microsoft/azuredatastudio/issues/15206
-			if (filterItems[i] && filterItems[i].indexOf('Error:') < 0) {
-				this.listData.push(new TableFilterListElement(filterItems[i], filtered));
+			const filterItem = filterItems[i];
+			if (!filterItem || filterItem.indexOf('Error:') < 0) {
+				this.listData.push(new TableFilterListElement(filterItem, filtered));
 			}
 		}
 
@@ -543,8 +544,20 @@ class TableFilterListElement {
 	constructor(val: string, checked: boolean) {
 		this.value = val;
 		this._checked = checked;
+
+		// Handle the values that are visually hard to differentiate.
+		if (val === undefined) {
+			this.displayText = localize('tableFilter.nullDisplayText', "NULL");
+		} else if (val === '') {
+			this.displayText = localize('tableFilter.emptyStringDisplayText', "Empty String");
+		} else if (val.trim() === '') {
+			this.displayText = localize('tableFilter.whiteSpacesDisplayText', "Whitespace ({0})", val.length);
+		} else {
+			this.displayText = val;
+		}
 	}
 
+	public displayText: string;
 	public value: string;
 
 	public onCheckStateChanged = this._onCheckStateChanged.event;
@@ -605,9 +618,11 @@ class TableFilterListRenderer implements IListRenderer<TableFilterListElement, T
 			templateData.checkbox.checked = e;
 		}));
 		templateData.checkbox.checked = element.checked;
-		templateData.checkbox.setAttribute('aria-label', element.value);
-		templateData.text.innerText = element.value;
-		templateData.label.title = element.value;
+		templateData.checkbox.setAttribute('aria-label', element.displayText);
+		templateData.text.innerText = element.displayText;
+		templateData.label.title = element.displayText;
+		// Use italic to match the style that NULL value is displayed in the grid.
+		templateData.label.style.fontStyle = element.displayText === element.value ? 'normal' : 'italic';
 	}
 
 	disposeElement?(element: TableFilterListElement, index: number, templateData: TableFilterListItemTemplate, height: number): void {

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -491,7 +491,14 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 			(offset, count) => { return this.loadData(offset, count); },
 			undefined,
 			undefined,
-			(data: ICellValue) => { return data.isNull ? undefined : data?.displayValue; },
+			(data: ICellValue) => {
+				if (!data || data.isNull) {
+					return undefined;
+				}
+				// If the string only contains whitespaces, it will be treated as empty string to make the filtering easier.
+				// Note: this is the display string and does not impact the export/copy features.
+				return data.displayValue.trim() === '' ? '' : data.displayValue;
+			},
 			{
 				inMemoryDataProcessing: this.options.inMemoryDataProcessing,
 				inMemoryDataCountThreshold: this.options.inMemoryDataCountThreshold


### PR DESCRIPTION
This PR fixes #18707

previously 'undefined' and empty string are not added to the filter list. I am adding them to the list as requested by user. also added handled the whitespace(s) while implementing the feature.

![image](https://user-images.githubusercontent.com/13777222/160963532-6e3e9435-2e26-43de-9f1c-70c9bfd25343.png)
![image](https://user-images.githubusercontent.com/13777222/160963586-03e1c6ac-c6c7-4faa-9764-095d03eef5f2.png)

filter by NULL
![image](https://user-images.githubusercontent.com/13777222/160963656-0f143398-9ede-4900-9ae2-404d0627200d.png)

filter by Blanks
![image](https://user-images.githubusercontent.com/13777222/160963713-9d8f3e5a-75bd-4938-96b7-3f65fc150bd2.png)

filter by string
![image](https://user-images.githubusercontent.com/13777222/160963783-28ed8404-9277-4a00-ae91-57e5bcd5a785.png)



exported results:
```
[
  {
    "col1": " ",
    "col2": "1 space"
  },
  {
    "col1": null,
    "col2": "NULL"
  },
  {
    "col1": "abc",
    "col2": "abc"
  },
  {
    "col1": null,
    "col2": "NULL"
  },
  {
    "col1": "",
    "col2": "Empty"
  },
  {
    "col1": "bcd",
    "col2": "bcd"
  },
  {
    "col1": "   ",
    "col2": "3 spaces"
  }
]
```