### PR TITLE
Fix publisher IDs for .NET extensions

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4576,7 +4576,7 @@
 					"shortDescription": ".NET Interactive Notebooks for Azure Data Studio.",
 					"publisher": {
 						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
+						"publisherId": "ms-dotnettools",
 						"publisherName": "Microsoft"
 					},
 					"versions": [
@@ -4637,7 +4637,7 @@
 					"shortDescription": "Jupyter notebook support, interactive programming and computing that supports Intellisense, debugging and more.",
 					"publisher": {
 						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
+						"publisherId": "ms-toolsai",
 						"publisherName": "Microsoft"
 					},
 					"versions": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4577,7 +4577,7 @@
 					"publisher": {
 						"displayName": "Microsoft",
 						"publisherId": "ms-dotnettools",
-						"publisherName": "Microsoft"
+						"publisherName": "ms-dotnettools"
 					},
 					"versions": [
 						{
@@ -4638,7 +4638,7 @@
 					"publisher": {
 						"displayName": "Microsoft",
 						"publisherId": "ms-toolsai",
-						"publisherName": "Microsoft"
+						"publisherName": "ms-toolsai"
 					},
 					"versions": [
 						{


### PR DESCRIPTION
These need to match the publisher ID in the package.json, otherwise we get issues like not installing the dependent extensions automatically from the gallery. 