### PR TITLE
fix language change issue

### DIFF
--- a/src/sql/base/query/browser/untitledQueryEditorInput.ts
+++ b/src/sql/base/query/browser/untitledQueryEditorInput.ts
@@ -34,6 +34,10 @@ export class UntitledQueryEditorInput extends QueryEditorInput implements IUntit
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super(description, text, results, connectionManagementService, queryModelService, configurationService, instantiationService);
+		// Set the mode explicitely to stop the auto language detection service from changing the mode unexpectedly.
+		// the auto language detection service won't do the language change only if the mode is explicitely set.
+		// if the mode (e.g. kusto, sql) do not exist for whatever reason, we will default it to sql.
+		text.setMode(text.getMode() ?? 'sql');
 	}
 
 	public override resolve(): Promise<IUntitledTextEditorModel & IResolvedTextEditorModel> {

--- a/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
@@ -59,10 +59,6 @@ export class QueryEditorService implements IQueryEditorService {
 		// Create a sql document pane with accoutrements
 		const mode = this._connectionManagementService.getProviderLanguageMode(connectionProviderName);
 		const fileInput = this._editorService.createEditorInput({ forceUntitled: true, resource: docUri, mode: mode }) as UntitledTextEditorInput;
-		// Set the mode explicitely to stop the language detection service from changing the mode unexpectedly.
-		// The mode parameter used when creating the editorInput is used as preferred mode,
-		// the language detection service won't do the language change only if the mode is explicitely set.
-		fileInput.setMode(mode);
 		let untitledEditorModel = await fileInput.resolve();
 		if (options.initalContent) {
 			untitledEditorModel.textEditorModel.setValue(options.initalContent);


### PR DESCRIPTION
This PR fixes #18800


in this PR: https://github.com/microsoft/azuredatastudio/pull/18402, I fixed the scenario that the auto language is changing the language mode for newly opened query editors. but missed some other places that the UntitledQueryEditorInput is created, for example, the untitled query editors restored from previous ADS sessions. and as a result, auto language detection will still kick in for it.

fix:
instead of adding the mode setting all over the places, I am moving it to the untitledQueryEditorInput constructor to make sure the mode is set regardless of entry points. FileQueryEditorInput do not have this problem because it is backed by a .sql file and no language detection is needed.