### PR TITLE
Resolves undefined tenant error while adding an account.

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -695,9 +695,10 @@ export class ConnectionWidget extends lifecycle.Disposable {
 					let account = this._azureAccountList.find(account => account.key.accountId === this._azureAccountDropdown.value);
 					if (account && account.properties.tenants.length > 1) {
 						let tenant = account.properties.tenants.find(tenant => tenant.id === tenantId);
-						if (tenant) {
-							this._azureTenantDropdown.selectWithOptionName(tenant.displayName);
+						if (!tenant) {
+							tenant = account.properties.tenants.find(tenant => tenant.displayName === this._azureTenantDropdown.values[0]);
 						}
+						this._azureTenantDropdown.selectWithOptionName(tenant.displayName);
 						this.onAzureTenantSelected(this._azureTenantDropdown.values.indexOf(this._azureTenantDropdown.value));
 					}
 				}).catch(err => this._logService.error(`Unexpected error populating initial Azure Account options : ${err}`));

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -686,8 +686,8 @@ export class ConnectionWidget extends lifecycle.Disposable {
 			}
 
 			if (this.authType === AuthenticationType.AzureMFA || this.authType === AuthenticationType.AzureMFAAndUser) {
-				let tenantId = connectionInfo.azureTenantId;
 				this.fillInAzureAccountOptions().then(async () => {
+					let tenantId = connectionInfo.azureTenantId;
 					let accountName = (this.authType === AuthenticationType.AzureMFA)
 						? connectionInfo.azureAccount : connectionInfo.userName;
 					this._azureAccountDropdown.selectWithOptionName(this.getModelValue(accountName));
@@ -695,10 +695,9 @@ export class ConnectionWidget extends lifecycle.Disposable {
 					let account = this._azureAccountList.find(account => account.key.accountId === this._azureAccountDropdown.value);
 					if (account && account.properties.tenants.length > 1) {
 						let tenant = account.properties.tenants.find(tenant => tenant.id === tenantId);
-						if (!tenant) {
-							tenant = account.properties.tenants.find(tenant => tenant.displayName === this._azureTenantDropdown.values[0]);
+						if (tenant) {
+							this._azureTenantDropdown.selectWithOptionName(tenant.displayName);
 						}
-						this._azureTenantDropdown.selectWithOptionName(tenant.displayName);
 						this.onAzureTenantSelected(this._azureTenantDropdown.values.indexOf(this._azureTenantDropdown.value));
 					}
 				}).catch(err => this._logService.error(`Unexpected error populating initial Azure Account options : ${err}`));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #17894

Resolves unknown tenant issue when adding a connection for an Azure account with multiple tenants.

### Solution context:
The error was occurring because `accountInfo.azureTenantId` is set to `undefined` outside the async callback, but contains a valid tenant ID once the callback is executing. Since `tenantId` was being initialized outside the callback and referenced in the callback body instead of `accountInfo.azureTenantId`, an undefined tenant error would appear when a user would try to connect to Azure Data Explorer (Kusto).

By moving the `tenantId` initialization to inside the callback, the error no longer appears.