### PR TITLE
Treat Jupyter's Python 3 Ipykernel alias as a Python 3 kernel.

### DIFF
--- a/src/sql/workbench/common/constants.ts
+++ b/src/sql/workbench/common/constants.ts
@@ -36,6 +36,7 @@ export const FILE_QUERY_EDITOR_TYPEID = 'workbench.editorInput.fileQueryInput';
 export const RESOURCE_VIEWER_TYPEID = 'workbench.editorInput.resourceViewerInput';
 
 export const JUPYTER_PROVIDER_ID = 'jupyter';
+export const IPYKERNEL_DISPLAY_NAME = 'Python 3 (ipykernel)';
 export const INTERACTIVE_PROVIDER_ID = 'dotnet-interactive';
 export const INTERACTIVE_LANGUAGE_MODE = 'dib';
 export const DEFAULT_NB_LANGUAGE_MODE = 'notebook';

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -39,6 +39,7 @@ import { AddCellEdit, CellOutputEdit, ConvertCellTypeEdit, DeleteCellEdit, MoveC
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { deepClone } from 'vs/base/common/objects';
 import { DotnetInteractiveLabel } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { IPYKERNEL_DISPLAY_NAME } from 'sql/workbench/common/constants';
 
 /*
 * Used to control whether a message in a dialog/wizard is displayed as an error,
@@ -1345,19 +1346,20 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private sanitizeSavedKernelInfo(): void {
 		if (this._savedKernelInfo) {
 			let displayName = this._savedKernelInfo.display_name;
-
-			if (this._savedKernelInfo.display_name !== displayName) {
-				this._savedKernelInfo.display_name = displayName;
-			}
 			let standardKernel = this._standardKernels.find(kernel => kernel.displayName === displayName || displayName.startsWith(kernel.displayName));
-			if (standardKernel && this._savedKernelInfo.name && this._savedKernelInfo.name !== standardKernel.name) {
-				// Special case .NET Interactive kernel name to handle inconsistencies between notebook providers and jupyter kernel specs
-				if (this._savedKernelInfo.display_name === DotnetInteractiveLabel) {
-					this._savedKernelInfo.oldName = this._savedKernelInfo.name;
-				}
+			if (standardKernel) {
+				if (this._savedKernelInfo.name && this._savedKernelInfo.name !== standardKernel.name) {
+					// Special case .NET Interactive kernel name to handle inconsistencies between notebook providers and jupyter kernel specs
+					if (this._savedKernelInfo.display_name === DotnetInteractiveLabel) {
+						this._savedKernelInfo.oldName = this._savedKernelInfo.name;
+					}
 
-				this._savedKernelInfo.name = standardKernel.name;
-				this._savedKernelInfo.display_name = standardKernel.displayName;
+					this._savedKernelInfo.name = standardKernel.name;
+					this._savedKernelInfo.display_name = standardKernel.displayName;
+				} else if (displayName === IPYKERNEL_DISPLAY_NAME && this._savedKernelInfo.name === standardKernel.name) {
+					// Handle Jupyter alias for Python 3 kernel
+					this._savedKernelInfo.display_name = standardKernel.displayName;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When retrieving kernels during notebook startup, we use the kernel's display name to retrieve the notebook provider we should use. For our notebook extension we define the python kernel with the display name "Python 3", but Jupyter notebooks can save notebooks with a kernel display name of "Python 3 (ipykernel)". Normally this hasn't been a problem because when we hit an unknown kernel name we fall back to the most recently registered provider, which has historically been our jupyter provider, but when using an additional provider like .NET Interactive this causes notebooks to get a little screwed up underneath. When using an ipykernel notebook with Interactive installed, the kernel display name shows up as Python 3, but the code cells are trying to execute through Interactive, which fails. And even trying to switch the kernel to Interactive at that point appears to fail, because we're already running Interactive underneath so the kernel stays as Python 3. The fix here is to convert the "Python 3 (ipykernel)" display name into "Python 3" during the sanitizeKernelName step, which is the display name we expect for python.

This PR fixes #18894
