### PR TITLE
fix timeout warning when exiting create function

### DIFF
--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -73,7 +73,7 @@ export async function createAzureFunction(connectionString: string, schema: stri
 				if (errorType === 'TimeoutError') {
 					// this error can be cause by many different scenarios including timeout or error occurred during createFunction
 					exitReason = 'timeout';
-					console.log('Error creating azure function project');
+					console.log('Timed out waiting for Azure Function project to be created. This may not necessarily be an error, for example if the user canceled out of the create flow.');
 				} else {
 					// else an error would occur during the createFunction
 					exitReason = 'error';
@@ -165,7 +165,7 @@ export async function createAzureFunction(connectionString: string, schema: stri
 			if (errorType === 'TimeoutError') {
 				// this error can be cause by many different scenarios including timeout or error occurred during createFunction
 				exitReason = 'timeout';
-				console.log('Error creating azure function project');
+				console.log('Timed out waiting for Azure Function project to be created. This may not necessarily be an error, for example if the user canceled out of the create flow.');
 			} else {
 				// else an error would occur during the createFunction
 				exitReason = 'error';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #18925 and fixes #18927.

This will not show any error if a user exits out of a create an azure function with SQL binding quick pick or create azure function.
In order to know when a user cancels out of the prompt we would need to use the timeout error to understand that it was canceled since that would result in the promise.race rejecting with timeout error. As such we can log this using the errorType we get and still capture any other errors that may potentially happen and send telemetry for it.

