### PR TITLE
Pre-fill prompts with language and .Net runtime 

### DIFF
--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -59,7 +59,7 @@ export async function createAzureFunction(connectionString: string, schema: stri
 				// because of an AF extension API issue, we have to get the newly created file by adding a watcher
 				// issue: https://github.com/microsoft/vscode-azurefunctions/issues/3052
 				newHostProjectFile = await azureFunctionsUtils.waitForNewHostFile();
-				await azureFunctionApi.createFunction({});
+				await azureFunctionApi.createFunction({ language: 'C#', targetFramework: 'netcoreapp3.1' });
 				const timeoutForHostFile = utils.timeoutPromise(constants.timeoutProjectError);
 				hostFile = await Promise.race([newHostProjectFile.filePromise, timeoutForHostFile]);
 				if (hostFile) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #18928.
![image](https://user-images.githubusercontent.com/23587151/161898886-18a64efb-5c81-4392-9fe7-9c7cee083432.png)

Once the user clicks `Create Azure Function Project` on this then we would pre-populate the language to be C# and use .NET 3.1 runtime for the createFunction settings. 

Future outlook:
- Merge this logic and if a user already has an azure function project to just set up one createAzurefunction with SQL binding template instead. (This would require a good bit of refactoring which I will look at once all other bugs are covered).


