### PR TITLE
Bump version numbers of arc and azcli extensions

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,7 +2,7 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -2,7 +2,7 @@
   "name": "azcli",
   "displayName": "%azcli.arc.displayName%",
   "description": "%azcli.arc.description%",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",


### PR DESCRIPTION
Bumping version numbers of arc and azcli extensions to 1.1.0 for both.