### PR TITLE
Update extensionsGallery.json version bump for arc and azcli and remove Preview flag

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.0",
-							"lastUpdated": "3/31/2022",
+							"version": "1.1.0",
+							"lastUpdated": "4/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.0.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.1.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3358,8 +3358,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				},
 				{
 					"extensionId": "69",
@@ -4272,14 +4271,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.0",
-							"lastUpdated": "3/31/2022",
+							"version": "1.1.0",
+							"lastUpdated": "4/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.0.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.1.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4314,8 +4313,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				},
 				{
 					"extensionId": "85",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3358,7 +3358,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],					
+					"flags": ""
 				},
 				{
 					"extensionId": "69",
@@ -4313,7 +4314,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],
+					"flags": ""
 				},
 				{
 					"extensionId": "85",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.0",
-							"lastUpdated": "2/22/2022",
+							"version": "1.1.0",
+							"lastUpdated": "4/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.0.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.1.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3358,8 +3358,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				},
 				{
 					"extensionId": "69",
@@ -4264,14 +4263,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.0",
-							"lastUpdated": "2/22/2022",
+							"version": "1.1.0",
+							"lastUpdated": "4/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.0.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.1.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4306,8 +4305,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				},
 				{
 					"extensionId": "85",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3358,7 +3358,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],
+					"flags": ""
 				},
 				{
 					"extensionId": "69",
@@ -4305,7 +4306,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],
+					"flags": ""
 				},
 				{
 					"extensionId": "85",


### PR DESCRIPTION
(To be merged in tomorrow morning after the .vsix files have been generated in tonight's nightly build)
For arc and azcli extensions:

- Bumped version up to 1.1.0
- Updated .vsix file links
- Removed preview flags