### PR TITLE
Suppress create function prompt

### DIFF
--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -59,7 +59,9 @@ export async function createAzureFunction(connectionString: string, schema: stri
 				// because of an AF extension API issue, we have to get the newly created file by adding a watcher
 				// issue: https://github.com/microsoft/vscode-azurefunctions/issues/3052
 				newHostProjectFile = await azureFunctionsUtils.waitForNewHostFile();
-				await azureFunctionApi.createFunction({ language: 'C#', targetFramework: 'netcoreapp3.1' });
+				await azureFunctionApi.createFunction({
+					language: 'C#', targetFramework: 'netcoreapp3.1', suppressCreateProjectPrompt: true,
+				});
 				const timeoutForHostFile = utils.timeoutPromise(constants.timeoutProjectError);
 				hostFile = await Promise.race([newHostProjectFile.filePromise, timeoutForHostFile]);
 				if (hostFile) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #18932.

After user clicks on `Create Azure Function Project`
![Screen Shot 2022-04-06 at 11 18 12 PM](https://user-images.githubusercontent.com/23587151/162132898-2e25851a-03cc-4d82-b0e7-c465cefc86a4.png)

it directly opens the templates (instead of asking the user again to create the project):
![Screen Shot 2022-04-06 at 11 18 20 PM](https://user-images.githubusercontent.com/23587151/162132963-6a751488-52c9-4509-a3b8-c321a251ac3c.png)
