### PR TITLE
Inline source maps in dev build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,11 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
         run: yarn --frozen-lockfile --network-timeout 180000
 
+      # Don't inline source maps so that we generate code coverage for ts files
       - name: Compile and Download
         run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+        env:
+          SQL_NO_INLINE_SOURCEMAP: 1
 
       - name: Run Unit Tests (Electron)
         id: electron-unit-tests

--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -37,10 +37,9 @@ function createCompile(src, build, emitError) {
     const sourcemaps = require('gulp-sourcemaps');
     const projectPath = path.join(__dirname, '../../', src, 'tsconfig.json');
     const overrideOptions = Object.assign(Object.assign({}, getTypeScriptCompilerOptions(src)), { inlineSources: Boolean(build) });
-    // {{SQL CARBON EDIT}} Never inline source maps so that generating local coverage works
-    // if (!build) {
-    // 	// overrideOptions.inlineSourceMap = true;
-    // }
+    if (!build) {
+        overrideOptions.inlineSourceMap = true;
+    }
     const compilation = tsb.create(projectPath, overrideOptions, false, err => reporter(err));
     function pipeline(token) {
         const bom = require('gulp-bom');

--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -37,7 +37,7 @@ function createCompile(src, build, emitError) {
     const sourcemaps = require('gulp-sourcemaps');
     const projectPath = path.join(__dirname, '../../', src, 'tsconfig.json');
     const overrideOptions = Object.assign(Object.assign({}, getTypeScriptCompilerOptions(src)), { inlineSources: Boolean(build) });
-    if (!build) {
+    if (!build && !process.env['SQL_NO_INLINE_SOURCEMAP']) {
         overrideOptions.inlineSourceMap = true;
     }
     const compilation = tsb.create(projectPath, overrideOptions, false, err => reporter(err));

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -44,10 +44,9 @@ function createCompile(src: string, build: boolean, emitError?: boolean) {
 
 	const projectPath = path.join(__dirname, '../../', src, 'tsconfig.json');
 	const overrideOptions = { ...getTypeScriptCompilerOptions(src), inlineSources: Boolean(build) };
-	// {{SQL CARBON EDIT}} Never inline source maps so that generating local coverage works
-	// if (!build) {
-	// 	// overrideOptions.inlineSourceMap = true;
-	// }
+	if (!build) {
+		overrideOptions.inlineSourceMap = true;
+	}
 
 	const compilation = tsb.create(projectPath, overrideOptions, false, err => reporter(err));
 

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -44,7 +44,7 @@ function createCompile(src: string, build: boolean, emitError?: boolean) {
 
 	const projectPath = path.join(__dirname, '../../', src, 'tsconfig.json');
 	const overrideOptions = { ...getTypeScriptCompilerOptions(src), inlineSources: Boolean(build) };
-	if (!build) {
+	if (!build && !process.env['SQL_NO_INLINE_SOURCEMAP']) {
 		overrideOptions.inlineSourceMap = true;
 	}
 
@@ -87,7 +87,6 @@ function createCompile(src: string, build: boolean, emitError?: boolean) {
 export function compileTask(src: string, out: string, build: boolean): () => NodeJS.ReadWriteStream {
 
 	return function () {
-
 		if (os.totalmem() < 4_000_000_000) {
 			throw new Error('compilation requires 4GB of RAM');
 		}

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -38,4 +38,8 @@ The following command will create a `coverage` folder at the root of the workspa
 
 **Windows**
 
-	scripts\test --coverage
+	.\scripts\test.bat --coverage
+
+NOTE: When running locally the coverage will be generated for the .js files because the sourcemaps
+are inlined. You can run `yarn compile` to generate the source maps and then re-run the test script
+to see the coverage for the .ts files (but will have to re-run every time you make a change).

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -30,7 +30,7 @@ Unit tests from layers `common` and `browser` are run inside `chromium`, `webkit
 
 ## Coverage
 
-The following command will create a `coverage` folder at the root of the workspace:
+The following command will create a `coverage` folder in the `.build` folder at the root of the workspace:
 
 **OS X and Linux**
 

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -41,5 +41,5 @@ The following command will create a `coverage` folder at the root of the workspa
 	.\scripts\test.bat --coverage
 
 NOTE: When running locally the coverage will be generated for the .js files because the sourcemaps
-are inlined. You can run `yarn compile` to generate the source maps and then re-run the test script
+are inlined. You can run `yarn compile-build` to generate the source maps and then re-run the test script
 to see the coverage for the .ts files (but will have to re-run every time you make a change).

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -40,6 +40,6 @@ The following command will create a `coverage` folder at the root of the workspa
 
 	.\scripts\test.bat --coverage
 
-NOTE: When running locally the coverage will be generated for the .js files because the sourcemaps
-are inlined. You can run `yarn compile-build` to generate the source maps and then re-run the test script
-to see the coverage for the .ts files (but will have to re-run every time you make a change).
+NOTE: When running locally the coverage will be generated for the .js files because by default the sourcemaps
+are inlined. To fix this set the environment variable `SQL_NO_INLINE_SOURCEMAP` to `1`, re-run the
+compile/watch task and then re-run the test script with coverage enabled.


### PR DESCRIPTION
This was changed in https://github.com/microsoft/azuredatastudio/pull/18781/files

Unfortunately, not inlining the source maps breaks debugging. For some reason the JS debugger isn't able to properly load the map.js files, which results in breakpoints not being able to be bound. 

So to unblock that I'm reverting this change by default and will follow up with trying to understand why that isn't working and whether there's a better fix we can make. The `SQL_NO_INLINE_SOURCEMAP` environment variable controls the inlining so we can disable it during CI runs to enable reporting to coveralls to still generate the correct coverage. 