### PR TITLE
Update sql-migration to v1.0.0

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4089,14 +4089,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.1.13",
-							"lastUpdated": "03/16/2022",
+							"version": "1.0.0",
+							"lastUpdated": "04/13/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-0.1.13.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4132,7 +4132,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": ""
 				},
 				{
 					"extensionId": "82",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the public extension gallery to bump the sql-migration extension to v1.0.0, and removes the preview flag.

VSIX has already been uploaded to the storage account as part of the previous PR to update the insiders extension gallery:
https://github.com/microsoft/azuredatastudio/pull/19022

The intention is to merge this on 4/13 at 8 AM, on time for our service's GA announcement.