### PR TITLE
Updating the execution plan cache entry whenever the entry is reinitialized 

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanFileView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanFileView.ts
@@ -41,7 +41,7 @@ export class ExecutionPlanFileView {
 	}
 
 	public onHide(parentContainer: HTMLElement): void {
-		if (parentContainer === this._parent) {
+		if (parentContainer === this._parent && parentContainer.contains(this._container)) {
 			this._parent.removeChild(this._container);
 		}
 	}

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanTab.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanTab.ts
@@ -84,6 +84,7 @@ export class ExecutionPlanTabView implements IPanelView {
 			currentView.onHide(this._container);
 			this._input.graphs = [];
 			currentView = this._instantiationService.createInstance(ExecutionPlanFileView);
+			this._viewCache.executionPlanFileViewMap.set(this._input.executionPlanFileViewUUID, currentView);
 			currentView.render(this._container);
 		}
 	}


### PR DESCRIPTION
This PR fixes the issue where the actual cache entry was not updated whenever I reinitialized the cache entry. I have also added a check to removeChild node only when the child is contained within the parent container. 

issue: #19046 