### PR TITLE
Add .NET Interactive extension info to product.json.

### DIFF
--- a/product.json
+++ b/product.json
@@ -61,6 +61,7 @@
 		"Microsoft.sql-database-projects",
 		"Microsoft.sql-migration",
 		"Microsoft.machine-learning",
+		"Microsoft.dotnet-interactive-vscode",
 		"Redgate.sql-prompt",
 		"Redgate.sql-search",
 		"SentryOne.plan-explorer"
@@ -76,7 +77,9 @@
 		"ms-vscode.remotehub",
 		"ms-vscode.remotehub-insiders",
 		"GitHub.remotehub",
-		"GitHub.remotehub-insiders"
+		"GitHub.remotehub-insiders",
+		"ms-dotnettools.dotnet-interactive-vscode",
+		"ms-toolsai.jupyter"
 	],
 	"extensionsGallery": {
 		"version": "0.0.76",


### PR DESCRIPTION
I left out Jupyter from the recommended extensions since it's mainly a dependency for Interactive, so not all of its features are supported yet.

This PR fixes #19066
