### PR TITLE
Only update hover execution state if cell is not active.

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -287,8 +287,8 @@ export class CellModel extends Disposable implements ICellModel {
 
 	public set hover(value: boolean) {
 		this._hover = value;
-		// Skip changing the execution state while running to prevent focus changes from breaking things like user input
-		if (!this.isRunning) {
+		// The Run button is always visible while the cell is active, so we only need to emit this event for inactive cells
+		if (!this.active) {
 			this.fireExecutionStateChanged();
 		}
 	}
@@ -592,12 +592,9 @@ export class CellModel extends Disposable implements ICellModel {
 		}
 	}
 
-	private get isRunning(): boolean {
-		return !!(this._future && this._future.inProgress);
-	}
-
 	public get executionState(): CellExecutionState {
-		if (this.isRunning) {
+		let isRunning = !!(this._future && this._future.inProgress);
+		if (isRunning) {
 			return CellExecutionState.Running;
 		} else if (this.active || this.hover) {
 			return CellExecutionState.Stopped;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -287,7 +287,10 @@ export class CellModel extends Disposable implements ICellModel {
 
 	public set hover(value: boolean) {
 		this._hover = value;
-		this.fireExecutionStateChanged();
+		// Skip changing the execution state while running to prevent focus changes from breaking things like user input
+		if (!this.isRunning) {
+			this.fireExecutionStateChanged();
+		}
 	}
 
 	public get executionCount(): number | undefined {
@@ -589,9 +592,12 @@ export class CellModel extends Disposable implements ICellModel {
 		}
 	}
 
+	private get isRunning(): boolean {
+		return !!(this._future && this._future.inProgress);
+	}
+
 	public get executionState(): CellExecutionState {
-		let isRunning = !!(this._future && this._future.inProgress);
-		if (isRunning) {
+		if (this.isRunning) {
 			return CellExecutionState.Running;
 		} else if (this.active || this.hover) {
 			return CellExecutionState.Stopped;


### PR DESCRIPTION
Currently, prompting for user input with .NET Interactive breaks when mousing over the cell because we always re-focus on the cell when changing the execution state on hover. So if you click run on a cell that prompts for input and mouse anywhere off of the run button, then the input box closes immediately. The hover state is only used to determine if the cell's Run button should be visible, so my fix here is to only fire the hover state change if the cell isn't active, since the Run button is always visible while active anyway.

This PR fixes #18980
