### PR TITLE
Fix SQL Binding when creating new project

### DIFF
--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -35,6 +35,7 @@ export const azureFunctionsProjectMustBeOpened = localize('azureFunctionsProject
 export const needConnection = localize('needConnection', 'A connection is required to use Azure Function with SQL Binding');
 export const selectDatabase = localize('selectDatabase', 'Select Database');
 export const browseEllipsisWithIcon = `$(folder) ${localize('browseEllipsis', "Browse...")}`;
+export const selectButton = localize('selectButton', 'Select');
 
 // Insert SQL binding
 export const hostFileName = 'host.json';

--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -34,6 +34,7 @@ export const azureFunctionsExtensionNotInstalled = localize('azureFunctionsExten
 export const azureFunctionsProjectMustBeOpened = localize('azureFunctionsProjectMustBeOpened', 'A C# Azure Functions project must be present in order to create a new Azure Function for this table.');
 export const needConnection = localize('needConnection', 'A connection is required to use Azure Function with SQL Binding');
 export const selectDatabase = localize('selectDatabase', 'Select Database');
+export const browseEllipsisWithIcon = `$(folder) ${localize('browseEllipsis', "Browse...")}`;
 
 // Insert SQL binding
 export const hostFileName = 'host.json';

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -160,7 +160,8 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 				const projectFolders = (await vscode.window.showOpenDialog({
 					canSelectFiles: false,
 					canSelectFolders: true,
-					canSelectMany: false
+					canSelectMany: false,
+					openLabel: constants.selectButton
 				}));
 				if (!projectFolders) {
 					// User cancelled

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -166,15 +166,20 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 					// User cancelled
 					return;
 				}
+				const templateId: string = selectedBindingType === BindingType.input ? constants.inputTemplateID : constants.outputTemplateID;
 				// because of an AF extension API issue, we have to get the newly created file by adding a watcher
 				// issue: https://github.com/microsoft/vscode-azurefunctions/issues/3052
 				newHostProjectFile = azureFunctionsUtils.waitForNewHostFile();
 				await azureFunctionApi.createFunction({
 					language: 'C#',
 					targetFramework: 'netcoreapp3.1',
-					templateId: 'HttpTrigger',
+					templateId: templateId,
 					suppressCreateProjectPrompt: true,
-					folderPath: projectFolders[0].fsPath
+					folderPath: projectFolders[0].fsPath,
+					functionSettings: {
+						...(selectedBindingType === BindingType.input && { object: objectName }),
+						...(selectedBindingType === BindingType.output && { table: objectName })
+					},
 				});
 				const timeoutForHostFile = utils.timeoutPromise(constants.timeoutProjectError);
 				hostFile = await Promise.race([newHostProjectFile.filePromise, timeoutForHostFile]);


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/19116

Because of https://github.com/microsoft/vscode-azurefunctions/issues/3115 we have to get the folder ourselves before calling createFunction in order to keep the options

I also added the logic to use the sql binding templates so we actually generate a valid function with the binding added already. This should address https://github.com/microsoft/azuredatastudio/issues/18929, although we still want to revisit this flow to make sure there's nothing else that we need to do. 

Now this is what the user sees : 

Prompted to create project (unchanged)

![image](https://user-images.githubusercontent.com/28519865/163603581-2bd3a62d-d006-46c4-98af-dd735670a55f.png)

Prompted to browse project file location 
![image](https://user-images.githubusercontent.com/28519865/163603600-6ca0ac23-8146-4559-8cdd-cb06f17c5661.png)

Select folder
![image](https://user-images.githubusercontent.com/28519865/163603642-94f289b1-5cbc-47ff-aab5-72911da84259.png)

Prompted for binding info (no longer prompted for language/framework)
![image](https://user-images.githubusercontent.com/28519865/163604681-06019b99-eb58-45b2-b055-ac5271ed143b.png)
![image](https://user-images.githubusercontent.com/28519865/163604719-db34a7a3-33d2-46ad-87b0-1b819a7b97f0.png)
![image](https://user-images.githubusercontent.com/28519865/163604744-1e71067f-47c9-47c5-9554-72df7e148ea5.png)
![image](https://user-images.githubusercontent.com/28519865/163604771-45222445-c78e-43a3-9313-366942af52aa.png)

Project is created 