### PR TITLE
[Port] Fix SQL Binding when creating new project (#19118)

### DIFF
--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -34,6 +34,8 @@ export const azureFunctionsExtensionNotInstalled = localize('azureFunctionsExten
 export const azureFunctionsProjectMustBeOpened = localize('azureFunctionsProjectMustBeOpened', 'A C# Azure Functions project must be present in order to create a new Azure Function for this table.');
 export const needConnection = localize('needConnection', 'A connection is required to use Azure Function with SQL Binding');
 export const selectDatabase = localize('selectDatabase', 'Select Database');
+export const browseEllipsisWithIcon = `$(folder) ${localize('browseEllipsis', "Browse...")}`;
+export const selectButton = localize('selectButton', 'Select');
 
 // Insert SQL binding
 export const hostFileName = 'host.json';

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -149,11 +149,39 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 
 			// start the create azure function project flow
 			try {
+				// First prompt user for project location. We need to do this ourselves due to an issue
+				// in the AF extension : https://github.com/microsoft/vscode-azurefunctions/issues/3115
+				const browseProjectLocation = await vscode.window.showQuickPick(
+					[constants.browseEllipsisWithIcon],
+					{ title: constants.selectAzureFunctionProjFolder, ignoreFocusOut: true });
+				if (!browseProjectLocation) {
+					// User cancelled
+					return undefined;
+				}
+				const projectFolders = (await vscode.window.showOpenDialog({
+					canSelectFiles: false,
+					canSelectFolders: true,
+					canSelectMany: false,
+					openLabel: constants.selectButton
+				}));
+				if (!projectFolders) {
+					// User cancelled
+					return;
+				}
+				const templateId: string = selectedBindingType === BindingType.input ? constants.inputTemplateID : constants.outputTemplateID;
 				// because of an AF extension API issue, we have to get the newly created file by adding a watcher
 				// issue: https://github.com/microsoft/vscode-azurefunctions/issues/3052
-				newHostProjectFile = await azureFunctionsUtils.waitForNewHostFile();
+				newHostProjectFile = azureFunctionsUtils.waitForNewHostFile();
 				await azureFunctionApi.createFunction({
-					language: 'C#', targetFramework: 'netcoreapp3.1', suppressCreateProjectPrompt: true,
+					language: 'C#',
+					targetFramework: 'netcoreapp3.1',
+					templateId: templateId,
+					suppressCreateProjectPrompt: true,
+					folderPath: projectFolders[0].fsPath,
+					functionSettings: {
+						...(selectedBindingType === BindingType.input && { object: objectName }),
+						...(selectedBindingType === BindingType.output && { table: objectName })
+					},
 				});
 				const timeoutForHostFile = utils.timeoutPromise(constants.timeoutProjectError);
 				hostFile = await Promise.race([newHostProjectFile.filePromise, timeoutForHostFile]);


### PR DESCRIPTION
* Fix SQL Binding when creating new project

* Use sql binding templates

* fix openDialog to use select

Co-authored-by: Vasu Bhog <vabhog@microsoft.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19116
PR in main: https://github.com/microsoft/azuredatastudio/commit/784f8ac963e008868f7d3f6fac006ff310515d55

