### PR TITLE
Fix High Contrast theme name

### DIFF
--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -18,7 +18,7 @@ import { isMacintosh, isWeb, isWindows } from 'vs/base/common/platform';
 
 const DEFAULT_THEME_DARK_SETTING_VALUE = 'Default Dark Azure Data Studio'; // {{SQL CARBON EDIT}} replace default theme
 const DEFAULT_THEME_LIGHT_SETTING_VALUE = 'Default Light Azure Data Studio'; // {{SQL CARBON EDIT}} replace default theme
-const DEFAULT_THEME_HC_SETTING_VALUE = 'Default High Contrast Azure Data Studio'; // {{SQL CARBON EDIT}} replace default theme
+const DEFAULT_THEME_HC_SETTING_VALUE = 'High Contrast'; // {{SQL CARBON EDIT}} replace default theme
 
 const DEFAULT_FILE_ICON_THEME_SETTING_VALUE = 'vs-seti';
 


### PR DESCRIPTION
the name of high contrast theme is wrong and as a result, ADS is not responding the OS theme change.

This PR fixes #18555
