### PR TITLE
Fix dotnet-interactive extension's publisher ID in recommended extensions list.

### DIFF
--- a/product.json
+++ b/product.json
@@ -61,7 +61,7 @@
 		"Microsoft.sql-database-projects",
 		"Microsoft.sql-migration",
 		"Microsoft.machine-learning",
-		"Microsoft.dotnet-interactive-vscode",
+		"ms-dotnettools.dotnet-interactive-vscode",
 		"Redgate.sql-prompt",
 		"Redgate.sql-search",
 		"SentryOne.plan-explorer"


### PR DESCRIPTION
The Interactive extension hadn't been uploaded to the stable gallery when I was testing the product.json changes last week, so I couldn't see the changes in the extensions list in my local dev build. I copied the existing format of Publisher Display Name and then extension name for the recommended extensions, but it should be publisher ID instead. I didn't realize installed extensions would still get starred if listed as recommended, in addition to their gallery entry, so I missed this one.