### PR TITLE
add sdk-style option to exposed sql project apis

### DIFF
--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -74,9 +74,11 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 * @param name name of the project
 	 * @param location the parent directory
 	 * @param projectTypeId the ID of the project/template
+	 * @param targetPlatform the target platform of the project
+	 * @param sdkStyle whether project is sdk-style. Default is false
 	 * @returns Uri of the newly created project file
 	 */
-	async createProject(name: string, location: vscode.Uri, projectTypeId: string, targetPlatform?: sqldbproj.SqlTargetPlatform, sdkStyle: boolean = true): Promise<vscode.Uri> {
+	async createProject(name: string, location: vscode.Uri, projectTypeId: string, targetPlatform?: sqldbproj.SqlTargetPlatform, sdkStyle: boolean = false): Promise<vscode.Uri> {
 
 		if (!targetPlatform) {
 			const projectType = this.supportedProjectTypes.find(x => x.id === projectTypeId);

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -20,9 +20,10 @@ declare module 'sqldbproj' {
 		 * @param location the parent directory
 		 * @param projectTypeId the ID of the project/template
 		 * @param targetPlatform the target platform for the project. Default is SQL Server 2019
+		 * @param sdkStyle whether the project is sdk-style. Default is false
 		 * @returns Uri of the newly created project file
 		 */
-		createProject(name: string, location: vscode.Uri, projectTypeId: string, targetPlatform: SqlTargetPlatform): Promise<vscode.Uri>;
+		createProject(name: string, location: vscode.Uri, projectTypeId: string, targetPlatform: SqlTargetPlatform, sdkStyle?: boolean): Promise<vscode.Uri>;
 
 		/**
 		 * Opens and loads a .sqlproj file


### PR DESCRIPTION
Allows sdk-style option to be specified when creating a project using the exposed sql project apis. Changed the default from true to false so people using this api don't get surprised with an SDk-style project getting created without specifying it. As far as I know, only the data workspace new project dialog uses this and passes this parameter, so nothing should be affected by this default change. 
