### PR TITLE
Fix publisher ID for Jupyter extension in .NET Interactive's dependencies list.

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4610,7 +4610,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": "Microsoft.jupyter"
+									"value": "ms-toolsai.jupyter"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",


### PR DESCRIPTION
Noticed that the Jupyter extension was using the wrong publisher ID here. I didn't notice before because Jupyter was automatically getting installed alongside .NET Interactive just fine, but if you check Interactive's dependencies tab in the gallery page, then nothing shows up. Interestingly, it _does_ show up fine in the dependencies tab after you've installed Interactive.