### PR TITLE
Fix Jupyter publisher ID in stable gallery files.

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4610,7 +4610,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": "Microsoft.jupyter"
+									"value": "ms-toolsai.jupyter"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4610,7 +4610,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": "ms-toolsai.jupyter"
+									"value": "Microsoft.jupyter"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4602,7 +4602,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": "Microsoft.jupyter"
+									"value": "ms-toolsai.jupyter"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",


### PR DESCRIPTION
A repeat of this other PR, but for the RC1 branch. https://github.com/microsoft/azuredatastudio/pull/19144

I noticed that the Jupyter publisher ID was wrong in the .NET Interactive dependencies list. This doesn't affect install at all, which is why I didn't notice it before, but it does mean there won't be any extension dependencies listed for Interactive on its gallery page.
