### PR TITLE
add telemetry on how many projects are open

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -2,7 +2,7 @@
   "name": "data-workspace",
   "displayName": "Data Workspace",
   "description": "Additional common functionality for database projects",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/data-workspace/src/common/telemetry.ts
+++ b/extensions/data-workspace/src/common/telemetry.ts
@@ -26,8 +26,8 @@ export enum TelemetryActions {
 	ProjectRemovedFromWorkspace = 'ProjectRemovedFromWorkspace',
 	OpeningProject = 'OpeningProject',
 	NewProjectDialogLaunched = 'NewProjectDialogLaunched',
-	OpeningWorkspace = 'OpeningWorkspace',
 	OpenExistingDialogLaunched = 'OpenExistingDialogLaunched',
 	NewProjectDialogCompleted = 'NewProjectDialogCompleted',
-	GitClone = 'GitClone'
+	GitClone = 'GitClone',
+	ProjectsLoaded = 'ProjectsLoaded'
 }


### PR DESCRIPTION
Adding this since someone asked today how many projects people typically have open, but we didn't have an answer for him since we don't currently collect this info. It would also be interesting to see how many excluded projects users typically have.

We do currently send the number of handled and unhandled projects [here](https://github.com/microsoft/azuredatastudio/blob/d774548951aa28dd05f8d209dbd77feac3775508/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts#L84-L89), but it gets fired every time the project tree is refreshed, which can skew the numbers since the project tree gets refreshed for every change on the tree. Sending the number of projects when the extension is activated will give a more accurate picture of how many projects people work with.