### PR TITLE
fix activitybar icon focus style

### DIFF
--- a/src/sql/workbench/contrib/dataExplorer/browser/media/dataExplorer.contribution.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/dataExplorer.contribution.css
@@ -18,3 +18,7 @@
 .monaco-workbench .activitybar .monaco-action-bar .action-label.dataExplorer:hover {
 	background-color: rgb(255, 255, 255);
 }
+
+.monaco-workbench .activitybar .monaco-action-bar .action-item.focused .action-label.dataExplorer {
+	background-color: rgba(255, 255, 255);
+}

--- a/src/sql/workbench/contrib/dataExplorer/browser/media/dataExplorer.contribution.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/dataExplorer.contribution.css
@@ -19,6 +19,6 @@
 	background-color: rgb(255, 255, 255);
 }
 
-.monaco-workbench .activitybar .monaco-action-bar .action-item.focused .action-label.dataExplorer {
+.monaco-workbench .activitybar .monaco-action-bar .action-item:focus .action-label.dataExplorer {
 	background-color: rgba(255, 255, 255);
 }

--- a/src/sql/workbench/contrib/notebook/browser/media/notebook.contribution.css
+++ b/src/sql/workbench/contrib/notebook/browser/media/notebook.contribution.css
@@ -18,7 +18,7 @@
 	background-color: rgba(255, 255, 255);
 }
 
-.monaco-workbench .activitybar .monaco-action-bar .action-item.focused .action-label.book {
+.monaco-workbench .activitybar .monaco-action-bar .action-item:focus .action-label.book {
 	background-color: rgba(255, 255, 255);
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/media/notebook.contribution.css
+++ b/src/sql/workbench/contrib/notebook/browser/media/notebook.contribution.css
@@ -18,6 +18,10 @@
 	background-color: rgba(255, 255, 255);
 }
 
+.monaco-workbench .activitybar .monaco-action-bar .action-item.focused .action-label.book {
+	background-color: rgba(255, 255, 255);
+}
+
 .notebookExplorer-viewlet > .header {
 	box-sizing: border-box;
 	padding: 5px 12px 6px 16px;


### PR DESCRIPTION
This PR fixes #18587

Notebook and Connections view container are contributed with sql theme icon which are not actually codicons, as a result the focus highlighting does work for them.

just like the other css styles in these 2 files, I am adding a special selector for them to handle it.

before:
![activitybar-before](https://user-images.githubusercontent.com/13777222/164103928-94cca506-a91e-419d-b470-886ad0a0897a.gif)

after:
![activitybar-after](https://user-images.githubusercontent.com/13777222/164103936-25e3f267-7664-4ad9-a057-6772a48f0176.gif)
