### PR TITLE
Cleanup references to ADS in SQL Bindings Readme

### DIFF
--- a/extensions/sql-bindings/README.md
+++ b/extensions/sql-bindings/README.md
@@ -1,18 +1,12 @@
-# Microsoft SQL Bindings for Azure Data Studio and VS Code
+# Microsoft SQL Bindings for VS Code
 
 ## Overview
 
-Microsoft SQL Bindings for Azure Data Studio and VS Code enables users to develop Azure Functions with Azure SQL bindings
+Microsoft SQL Bindings for VS Code enables users to develop Azure Functions with Azure SQL bindings
 
 ### VS Code
 
 This extension is bundled into the `SQL Server (MSSQL)` extension for VS Code and will be installed automatically when that extension is updated or installed.
-
-### Azure Data Studio
-
-This extension is provided as a separate extension in the marketplace.
-
-Please report issues and feature requests [here.](https://github.com/microsoft/azuredatastudio/issues)
 
 ## Code of Conduct
 


### PR DESCRIPTION
Just noticed this when installing the extension in VS Code. Removing references to ADS, since we're not shipping the extension there.