### PR TITLE
update schema compare version to 1.13.1

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1474,14 +1474,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.13.0",
+							"version": "1.13.1",
 							"lastUpdated": "4/14/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.13.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.13.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Schema compare 1.13.1 was already uploaded, but I put the wrong version in the previous PR https://github.com/microsoft/azuredatastudio/pull/19098 when updating this extension in the RC gallery.
