### PR TITLE
Bump version to 1.36.1 for April hotfix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azuredatastudio",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "distro": "8f4d839fbcb98eaa7aa3fd8bf9f84ab9bae899d9",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Bump version directly in the release branch for April hotfix.