### PR TITLE
Add 'input parameters' used for recommending SKUs to telemetry

### DIFF
--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -444,6 +444,9 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 				{
 					'sessionId': this._sessionId,
 					'performanceDataSource': this._skuRecommendationPerformanceDataSource,
+					'scalingFactor': this._skuScalingFactor?.toString(),
+					'skuTargetPercentile': this._skuTargetPercentile?.toString(),
+					'skuEnablePreview': this._skuEnablePreview?.toString(),
 					'databaseLevelRequirements': JSON.stringify(this._skuRecommendationResults?.recommendations?.instanceRequirements?.databaseLevelRequirements?.map(i => {
 						return {
 							cpuRequirementInCores: i.cpuRequirementInCores,

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -445,8 +445,8 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 					'sessionId': this._sessionId,
 					'performanceDataSource': this._skuRecommendationPerformanceDataSource,
 					'scalingFactor': this._skuScalingFactor?.toString(),
-					'skuTargetPercentile': this._skuTargetPercentile?.toString(),
-					'skuEnablePreview': this._skuEnablePreview?.toString(),
+					'targetPercentile': this._skuTargetPercentile?.toString(),
+					'enablePreviewSkus': this._skuEnablePreview?.toString(),
 					'databaseLevelRequirements': JSON.stringify(this._skuRecommendationResults?.recommendations?.instanceRequirements?.databaseLevelRequirements?.map(i => {
 						return {
 							cpuRequirementInCores: i.cpuRequirementInCores,


### PR DESCRIPTION
Logging three input parameters (scaling factor, target percentile and enable preview features) which might affect the result of SKU recommendation.

![image](https://user-images.githubusercontent.com/16827327/164546935-6285fe2a-9d66-42a3-b005-3284708ac36c.png)
