### PR TITLE
Convert .NET Interactive notebooks' kernel spec to a VS Code compatible kernel when saving.

### DIFF
--- a/src/sql/workbench/api/common/notebooks/notebookUtils.ts
+++ b/src/sql/workbench/api/common/notebooks/notebookUtils.ts
@@ -201,7 +201,7 @@ export function addExternalInteractiveKernelMetadata(kernelSpec: azdata.nb.IKern
  * Converts a .NET Interactive notebook's metadata to an internal representation needed for VS Code notebook compatibility. This metadata is then restored when saving the notebook.
  * @param metadata The notebook metadata to be modified.
  */
-export function addInternalInteractiveKernelMetadata(metadata: azdata.nb.INotebookMetadata | undefined): void {
+export function convertToInternalInteractiveKernelMetadata(metadata: azdata.nb.INotebookMetadata | undefined): void {
 	if (metadata?.kernelspec?.name?.startsWith(DotnetInteractiveJupyterKernelPrefix)) {
 		metadata.kernelspec.oldDisplayName = metadata.kernelspec.display_name;
 		metadata.kernelspec.display_name = DotnetInteractiveDisplayName;

--- a/src/sql/workbench/api/common/notebooks/notebookUtils.ts
+++ b/src/sql/workbench/api/common/notebooks/notebookUtils.ts
@@ -12,10 +12,9 @@ import { CellTypes, MimeTypes, OutputTypes } from 'sql/workbench/services/notebo
 import { NBFORMAT, NBFORMAT_MINOR } from 'sql/workbench/common/constants';
 import { NotebookCellKind } from 'vs/workbench/api/common/extHostTypes';
 
-export const DotnetInteractiveJupyterLanguagePrefix = '.net-';
+export const DotnetInteractiveJupyterKernelPrefix = '.net-';
 export const DotnetInteractiveLanguagePrefix = 'dotnet-interactive.';
-export const DotnetInteractiveJupyterLabelPrefix = '.NET (';
-export const DotnetInteractiveLabel = '.NET Interactive';
+export const DotnetInteractiveDisplayName = '.NET Interactive';
 
 export function convertToVSCodeNotebookCell(cellKind: azdata.nb.CellType, cellIndex: number, cellUri: URI, docUri: URI, cellLanguage: string, cellSource?: string | string[]): vscode.NotebookCell {
 	return <vscode.NotebookCell>{

--- a/src/sql/workbench/api/common/notebooks/notebookUtils.ts
+++ b/src/sql/workbench/api/common/notebooks/notebookUtils.ts
@@ -169,8 +169,8 @@ kernelSpec: {
  * @param kernelSpec The notebook kernel metadata to be modified.
  */
 export function addExternalInteractiveKernelMetadata(kernelSpec: azdata.nb.IKernelSpec): void {
-	if (kernelSpec.name === 'jupyter-notebook' && kernelSpec.display_name === DotnetInteractiveDisplayName) {
-		let language = kernelSpec.language?.replace(DotnetInteractiveLanguagePrefix, '');
+	if (kernelSpec.name === 'jupyter-notebook' && kernelSpec.display_name === DotnetInteractiveDisplayName && kernelSpec.language) {
+		let language = kernelSpec.language.replace(DotnetInteractiveLanguagePrefix, '');
 		let displayLanguage: string;
 		switch (language) {
 			case 'csharp':

--- a/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
+++ b/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
@@ -86,7 +86,7 @@ class VSCodeKernel implements azdata.nb.IKernel {
 			this._kernelSpec.supportedLanguages = this._controller.supportedLanguages;
 		}
 
-		// Store external kernel names for .NET Interactive kernels for when notebook gets saved, so that notebook
+		// Store external kernel names for .NET Interactive kernels for when notebook gets saved, so that notebook is usable outside of ADS
 		if (this._kernelSpec.name === 'jupyter-notebook' && this._kernelSpec.display_name === DotnetInteractiveLabel) {
 			let language = this._kernelSpec.language?.replace(DotnetInteractiveLanguagePrefix, '');
 			let displayLanguage: string;

--- a/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
+++ b/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
@@ -7,7 +7,7 @@ import type * as vscode from 'vscode';
 import type * as azdata from 'azdata';
 import { ADSNotebookController } from 'sql/workbench/api/common/notebooks/adsNotebookController';
 import * as nls from 'vs/nls';
-import { convertToVSCodeNotebookCell, DotnetInteractiveDisplayName, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { convertToVSCodeNotebookCell, DotnetInteractiveDisplayName, DotnetInteractiveJupyterKernelPrefix, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/notebooks/vscodeNotebookDocument';
 import { URI } from 'vs/base/common/uri';
@@ -104,7 +104,7 @@ class VSCodeKernel implements azdata.nb.IKernel {
 					displayLanguage = language;
 			}
 			if (!this._kernelSpec.oldName) {
-				this._kernelSpec.oldName = `.net-${language}`;
+				this._kernelSpec.oldName = `${DotnetInteractiveJupyterKernelPrefix}${language}`;
 			}
 			if (!this._kernelSpec.oldDisplayName) {
 				this._kernelSpec.oldDisplayName = `.NET (${displayLanguage})`;

--- a/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
+++ b/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
@@ -7,7 +7,7 @@ import type * as vscode from 'vscode';
 import type * as azdata from 'azdata';
 import { ADSNotebookController } from 'sql/workbench/api/common/notebooks/adsNotebookController';
 import * as nls from 'vs/nls';
-import { convertToVSCodeNotebookCell, DotnetInteractiveDisplayName, DotnetInteractiveJupyterKernelPrefix, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { addExternalInteractiveKernelMetadata, convertToVSCodeNotebookCell } from 'sql/workbench/api/common/notebooks/notebookUtils';
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/notebooks/vscodeNotebookDocument';
 import { URI } from 'vs/base/common/uri';
@@ -87,32 +87,7 @@ class VSCodeKernel implements azdata.nb.IKernel {
 		}
 
 		// Store external kernel names for .NET Interactive kernels for when notebook gets saved, so that notebook is usable outside of ADS
-		if (this._kernelSpec.name === 'jupyter-notebook' && this._kernelSpec.display_name === DotnetInteractiveDisplayName) {
-			let language = this._kernelSpec.language?.replace(DotnetInteractiveLanguagePrefix, '');
-			let displayLanguage: string;
-			switch (language) {
-				case 'csharp':
-					displayLanguage = 'C#';
-					break;
-				case 'fsharp':
-					displayLanguage = 'F#';
-					break;
-				case 'pwsh':
-					displayLanguage = 'PowerShell';
-					break;
-				default:
-					displayLanguage = language;
-			}
-			if (!this._kernelSpec.oldName) {
-				this._kernelSpec.oldName = `${DotnetInteractiveJupyterKernelPrefix}${language}`;
-			}
-			if (!this._kernelSpec.oldDisplayName) {
-				this._kernelSpec.oldDisplayName = `.NET (${displayLanguage})`;
-			}
-			if (!this._kernelSpec.oldLanguage) {
-				this._kernelSpec.oldLanguage = displayLanguage;
-			}
-		}
+		addExternalInteractiveKernelMetadata(this._kernelSpec);
 
 		this._name = this._kernelSpec.name;
 		this._info = {

--- a/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
+++ b/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
@@ -7,7 +7,7 @@ import type * as vscode from 'vscode';
 import type * as azdata from 'azdata';
 import { ADSNotebookController } from 'sql/workbench/api/common/notebooks/adsNotebookController';
 import * as nls from 'vs/nls';
-import { convertToVSCodeNotebookCell, DotnetInteractiveLabel, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { convertToVSCodeNotebookCell, DotnetInteractiveDisplayName, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/notebooks/vscodeNotebookDocument';
 import { URI } from 'vs/base/common/uri';
@@ -87,7 +87,7 @@ class VSCodeKernel implements azdata.nb.IKernel {
 		}
 
 		// Store external kernel names for .NET Interactive kernels for when notebook gets saved, so that notebook is usable outside of ADS
-		if (this._kernelSpec.name === 'jupyter-notebook' && this._kernelSpec.display_name === DotnetInteractiveLabel) {
+		if (this._kernelSpec.name === 'jupyter-notebook' && this._kernelSpec.display_name === DotnetInteractiveDisplayName) {
 			let language = this._kernelSpec.language?.replace(DotnetInteractiveLanguagePrefix, '');
 			let displayLanguage: string;
 			switch (language) {

--- a/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
+++ b/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
@@ -7,7 +7,7 @@ import type * as vscode from 'vscode';
 import type * as azdata from 'azdata';
 import { ADSNotebookController } from 'sql/workbench/api/common/notebooks/adsNotebookController';
 import * as nls from 'vs/nls';
-import { convertToVSCodeNotebookCell } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { convertToVSCodeNotebookCell, DotnetInteractiveLabel, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/notebooks/vscodeNotebookDocument';
 import { URI } from 'vs/base/common/uri';
@@ -84,6 +84,34 @@ class VSCodeKernel implements azdata.nb.IKernel {
 		if (!this._kernelSpec.language) {
 			this._kernelSpec.language = this._controller.supportedLanguages[0];
 			this._kernelSpec.supportedLanguages = this._controller.supportedLanguages;
+		}
+
+		// Store external kernel names for .NET Interactive kernels for when notebook gets saved, so that notebook
+		if (this._kernelSpec.name === 'jupyter-notebook' && this._kernelSpec.display_name === DotnetInteractiveLabel) {
+			let language = this._kernelSpec.language?.replace(DotnetInteractiveLanguagePrefix, '');
+			let displayLanguage: string;
+			switch (language) {
+				case 'csharp':
+					displayLanguage = 'C#';
+					break;
+				case 'fsharp':
+					displayLanguage = 'F#';
+					break;
+				case 'pwsh':
+					displayLanguage = 'PowerShell';
+					break;
+				default:
+					displayLanguage = language;
+			}
+			if (!this._kernelSpec.oldName) {
+				this._kernelSpec.oldName = `.net-${language}`;
+			}
+			if (!this._kernelSpec.oldDisplayName) {
+				this._kernelSpec.oldDisplayName = `.NET (${displayLanguage})`;
+			}
+			if (!this._kernelSpec.oldLanguage) {
+				this._kernelSpec.oldLanguage = displayLanguage;
+			}
 		}
 
 		this._name = this._kernelSpec.name;

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -40,7 +40,7 @@ import { LocalContentManager } from 'sql/workbench/services/notebook/common/loca
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as LanguageAssociationExtensions, ILanguageAssociationRegistry } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
 import { NotebookLanguage } from 'sql/workbench/common/constants';
-import { DotnetInteractiveLabel, DotnetInteractiveJupyterLabelPrefix, DotnetInteractiveJupyterLanguagePrefix, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { DotnetInteractiveDisplayName, DotnetInteractiveJupyterKernelPrefix, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
 const languageAssociationRegistry = Registry.as<ILanguageAssociationRegistry>(LanguageAssociationExtensions.LanguageAssociations);
@@ -561,12 +561,12 @@ export class NotebookEditorContentLoader implements IContentLoader {
 		}
 
 		// Special case .NET Interactive kernel spec to handle inconsistencies between notebook providers and jupyter kernel specs
-		if (notebookContents.metadata?.kernelspec?.display_name?.startsWith(DotnetInteractiveJupyterLabelPrefix)) {
+		if (notebookContents.metadata?.kernelspec?.name?.startsWith(DotnetInteractiveJupyterKernelPrefix)) {
 			notebookContents.metadata.kernelspec.oldDisplayName = notebookContents.metadata.kernelspec.display_name;
-			notebookContents.metadata.kernelspec.display_name = DotnetInteractiveLabel;
+			notebookContents.metadata.kernelspec.display_name = DotnetInteractiveDisplayName;
 
 			let kernelName = notebookContents.metadata.kernelspec.name;
-			let baseLanguageName = kernelName.replace(DotnetInteractiveJupyterLanguagePrefix, '');
+			let baseLanguageName = kernelName.replace(DotnetInteractiveJupyterKernelPrefix, '');
 			if (baseLanguageName === 'powershell') {
 				baseLanguageName = 'pwsh';
 			}

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -40,7 +40,7 @@ import { LocalContentManager } from 'sql/workbench/services/notebook/common/loca
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as LanguageAssociationExtensions, ILanguageAssociationRegistry } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
 import { NotebookLanguage } from 'sql/workbench/common/constants';
-import { addInternalInteractiveKernelMetadata } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { convertToInternalInteractiveKernelMetadata } from 'sql/workbench/api/common/notebooks/notebookUtils';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
 const languageAssociationRegistry = Registry.as<ILanguageAssociationRegistry>(LanguageAssociationExtensions.LanguageAssociations);
@@ -561,7 +561,7 @@ export class NotebookEditorContentLoader implements IContentLoader {
 		}
 
 		// Special case .NET Interactive kernel spec to handle inconsistencies between notebook providers and jupyter kernel specs
-		addInternalInteractiveKernelMetadata(notebookContents.metadata);
+		convertToInternalInteractiveKernelMetadata(notebookContents.metadata);
 
 		return notebookContents;
 	}

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -40,7 +40,7 @@ import { LocalContentManager } from 'sql/workbench/services/notebook/common/loca
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as LanguageAssociationExtensions, ILanguageAssociationRegistry } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
 import { NotebookLanguage } from 'sql/workbench/common/constants';
-import { DotnetInteractiveDisplayName, DotnetInteractiveJupyterKernelPrefix, DotnetInteractiveLanguagePrefix } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { addInternalInteractiveKernelMetadata } from 'sql/workbench/api/common/notebooks/notebookUtils';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
 const languageAssociationRegistry = Registry.as<ILanguageAssociationRegistry>(LanguageAssociationExtensions.LanguageAssociations);
@@ -561,23 +561,8 @@ export class NotebookEditorContentLoader implements IContentLoader {
 		}
 
 		// Special case .NET Interactive kernel spec to handle inconsistencies between notebook providers and jupyter kernel specs
-		if (notebookContents.metadata?.kernelspec?.name?.startsWith(DotnetInteractiveJupyterKernelPrefix)) {
-			notebookContents.metadata.kernelspec.oldDisplayName = notebookContents.metadata.kernelspec.display_name;
-			notebookContents.metadata.kernelspec.display_name = DotnetInteractiveDisplayName;
+		addInternalInteractiveKernelMetadata(notebookContents.metadata);
 
-			let kernelName = notebookContents.metadata.kernelspec.name;
-			let baseLanguageName = kernelName.replace(DotnetInteractiveJupyterKernelPrefix, '');
-			if (baseLanguageName === 'powershell') {
-				baseLanguageName = 'pwsh';
-			}
-			let languageName = `${DotnetInteractiveLanguagePrefix}${baseLanguageName}`;
-
-			notebookContents.metadata.kernelspec.oldLanguage = notebookContents.metadata.kernelspec.language;
-			notebookContents.metadata.kernelspec.language = languageName;
-
-			notebookContents.metadata.language_info.oldName = notebookContents.metadata.language_info.name;
-			notebookContents.metadata.language_info.name = languageName;
-		}
 		return notebookContents;
 	}
 }

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -38,7 +38,7 @@ import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { AddCellEdit, CellOutputEdit, ConvertCellTypeEdit, DeleteCellEdit, MoveCellEdit, CellOutputDataEdit, SplitCellEdit } from 'sql/workbench/services/notebook/browser/models/cellEdit';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { deepClone } from 'vs/base/common/objects';
-import { DotnetInteractiveLabel } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { DotnetInteractiveDisplayName } from 'sql/workbench/api/common/notebooks/notebookUtils';
 import { IPYKERNEL_DISPLAY_NAME } from 'sql/workbench/common/constants';
 
 /*
@@ -1352,7 +1352,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			if (standardKernel) {
 				if (this._savedKernelInfo.name && this._savedKernelInfo.name !== standardKernel.name) {
 					// Special case .NET Interactive kernel name to handle inconsistencies between notebook providers and jupyter kernel specs
-					if (this._savedKernelInfo.display_name === DotnetInteractiveLabel) {
+					if (this._savedKernelInfo.display_name === DotnetInteractiveDisplayName) {
 						this._savedKernelInfo.oldName = this._savedKernelInfo.name;
 					}
 

--- a/src/sql/workbench/test/electron-browser/api/vscodeNotebookApi.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/vscodeNotebookApi.test.ts
@@ -514,6 +514,32 @@ suite('.NET Interactive Kernel Metadata Conversion', async () => {
 		assert.deepStrictEqual(originalMetadata, expectedCovertedMetadata);
 	});
 
+	test('Do not convert to internal metadata for non-Interactive kernels', async () => {
+		let originalMetadata: azdata.nb.INotebookMetadata = {
+			kernelspec: {
+				name: 'not-interactive',
+				display_name: '.NET (C#)',
+				language: 'C#'
+			},
+			language_info: {
+				name: 'C#'
+			}
+		};
+		let expectedCovertedMetadata: azdata.nb.INotebookMetadata = {
+			kernelspec: {
+				name: 'not-interactive',
+				display_name: '.NET (C#)',
+				language: 'C#'
+			},
+			language_info: {
+				name: 'C#'
+			}
+		};
+
+		convertToInternalInteractiveKernelMetadata(originalMetadata);
+		assert.deepStrictEqual(originalMetadata, expectedCovertedMetadata);
+	});
+
 	test('Add external kernel metadata', async () => {
 		let originalKernelSpec: azdata.nb.IKernelSpec = {
 			name: 'jupyter-notebook',
@@ -527,6 +553,48 @@ suite('.NET Interactive Kernel Metadata Conversion', async () => {
 			oldName: '.net-csharp',
 			oldDisplayName: '.NET (C#)',
 			oldLanguage: 'C#'
+		};
+		addExternalInteractiveKernelMetadata(originalKernelSpec);
+		assert.deepStrictEqual(originalKernelSpec, expectedCovertedKernel);
+	});
+
+	test('Do not add external metadata to non-Interactive kernels', async () => {
+		// Different kernel name
+		let originalKernelSpec: azdata.nb.IKernelSpec = {
+			name: 'not-interactive',
+			display_name: '.NET Interactive',
+			language: 'dotnet-interactive.csharp'
+		};
+		let expectedCovertedKernel: azdata.nb.IKernelSpec = {
+			name: 'not-interactive',
+			display_name: '.NET Interactive',
+			language: 'dotnet-interactive.csharp'
+		};
+		addExternalInteractiveKernelMetadata(originalKernelSpec);
+		assert.deepStrictEqual(originalKernelSpec, expectedCovertedKernel);
+
+		// Different display name
+		originalKernelSpec = {
+			name: 'jupyter-notebook',
+			display_name: 'Not An Interactive Kernel',
+			language: 'dotnet-interactive.csharp'
+		};
+		expectedCovertedKernel = {
+			name: 'jupyter-notebook',
+			display_name: 'Not An Interactive Kernel',
+			language: 'dotnet-interactive.csharp'
+		};
+		addExternalInteractiveKernelMetadata(originalKernelSpec);
+		assert.deepStrictEqual(originalKernelSpec, expectedCovertedKernel);
+
+		// No language provided
+		originalKernelSpec = {
+			name: 'jupyter-notebook',
+			display_name: '.NET Interactive'
+		};
+		expectedCovertedKernel = {
+			name: 'jupyter-notebook',
+			display_name: '.NET Interactive'
 		};
 		addExternalInteractiveKernelMetadata(originalKernelSpec);
 		assert.deepStrictEqual(originalKernelSpec, expectedCovertedKernel);

--- a/src/sql/workbench/test/electron-browser/api/vscodeNotebookApi.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/vscodeNotebookApi.test.ts
@@ -12,7 +12,7 @@ import { VSBuffer } from 'vs/base/common/buffer';
 import * as assert from 'assert';
 import { OutputTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { NBFORMAT, NBFORMAT_MINOR } from 'sql/workbench/common/constants';
-import { convertToVSCodeNotebookCell, convertToVSCodeCellOutput, convertToADSCellOutput } from 'sql/workbench/api/common/notebooks/notebookUtils';
+import { convertToVSCodeNotebookCell, convertToVSCodeCellOutput, convertToADSCellOutput, convertToInternalInteractiveKernelMetadata, addExternalInteractiveKernelMetadata } from 'sql/workbench/api/common/notebooks/notebookUtils';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/notebooks/vscodeNotebookDocument';
 import { URI } from 'vs/base/common/uri';
 import { VSCodeNotebookEditor } from 'sql/workbench/api/common/notebooks/vscodeNotebookEditor';
@@ -484,5 +484,51 @@ suite('Notebook Serializer', () => {
 	});
 });
 
-suite('Notebook Controller', () => {
+suite('.NET Interactive Kernel Metadata Conversion', async () => {
+	test('Convert to internal kernel metadata', async () => {
+		let originalMetadata: azdata.nb.INotebookMetadata = {
+			kernelspec: {
+				name: '.net-csharp',
+				display_name: '.NET (C#)',
+				language: 'C#'
+			},
+			language_info: {
+				name: 'C#'
+			}
+		};
+		let expectedCovertedMetadata: azdata.nb.INotebookMetadata = {
+			kernelspec: {
+				name: '.net-csharp',
+				display_name: '.NET Interactive',
+				language: 'dotnet-interactive.csharp',
+				oldDisplayName: '.NET (C#)',
+				oldLanguage: 'C#'
+			},
+			language_info: {
+				name: 'dotnet-interactive.csharp',
+				oldName: 'C#'
+			}
+		};
+
+		convertToInternalInteractiveKernelMetadata(originalMetadata);
+		assert.deepStrictEqual(originalMetadata, expectedCovertedMetadata);
+	});
+
+	test('Add external kernel metadata', async () => {
+		let originalKernelSpec: azdata.nb.IKernelSpec = {
+			name: 'jupyter-notebook',
+			display_name: '.NET Interactive',
+			language: 'dotnet-interactive.csharp'
+		};
+		let expectedCovertedKernel: azdata.nb.IKernelSpec = {
+			name: 'jupyter-notebook',
+			display_name: '.NET Interactive',
+			language: 'dotnet-interactive.csharp',
+			oldName: '.net-csharp',
+			oldDisplayName: '.NET (C#)',
+			oldLanguage: 'C#'
+		};
+		addExternalInteractiveKernelMetadata(originalKernelSpec);
+		assert.deepStrictEqual(originalKernelSpec, expectedCovertedKernel);
+	});
 });


### PR DESCRIPTION
We have to do some conversion for .NET Interactive notebooks so that their kernel spec matches our internal representation. This is because our Jupyter notebook kernels line up with the contributed kernels from our notebook extension, but .NET Interactive ipynb notebooks have kernels that don't match the kernel contributed from the Interactive extension. Our code is built on top of Jupyter kernels originally, so a kernelspec is often our source of truth for a lot of notebook details. Thus we need to change up the Interactive notebook's kernelspec in order to get VS Code API compatibility to work. We were already doing this conversion when opening an existing Interactive notebook, but not when changing to the .NET Interactive kernel on the fly in an opened notebook. This change adds that converted metadata.

An example of what this is doing:
1. This is an internal kernel representation we use to get compatibility working:
```
{
  name: 'jupyter-notebook', // Matches the notebook provider name
  language: 'dotnet-interactive.csharp', // Matches the contributed languages from Interactive extension
  display_name: '.NET Interactive' // The kernel name we need to show in our dropdown to match VS Code's notebooks
}
```
2. This is the kernel spec that notebook would need to be saved with to work in VS Code:
```
{
  name: '.net-csharp',
  language: 'C#',
  display_name: '.NET (C#)'
}
```

I also cleaned up some constants that get used in this conversion step in vscodeExecuteProvider.ts and notebookInput.ts.

This PR fixes #19162
