### PR TITLE
Resolves cannot read property 'accessToken' of undefined error while connecting to a cloud DB

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -199,8 +199,10 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 			if (remainingTime < maxTolerance) {
 				const result = await this.refreshToken(tenant, resource, cachedTokens.refreshToken);
-				accessToken = result?.accessToken;
-				expiresOn = Number(result?.expiresOn);
+				if (result) {
+					accessToken = result.accessToken;
+					expiresOn = Number(result.expiresOn);
+				}
 			}
 			// Let's just return here.
 			if (accessToken) {
@@ -242,6 +244,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 	 * @param tenant
 	 * @param resource
 	 * @param refreshToken
+	 * @returns The oauth token response or undefined. Undefined is returned when the user wants to ignore a tenant or chooses not to start the
+	 * re-authentication process for their tenant.
 	 */
 	public async refreshToken(tenant: Tenant, resource: Resource, refreshToken: RefreshToken | undefined): Promise<OAuthTokenResponse> | undefined {
 		Logger.pii('Refreshing token', [{ name: 'token', objOrArray: refreshToken }], []);

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -223,7 +223,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 		}
 		// Let's try to convert the access token type, worst case we'll have to prompt the user to do an interactive authentication.
 		const result = await this.refreshToken(tenant, resource, baseTokens.refreshToken);
-		if (result.accessToken) {
+		if (result?.accessToken) {
 			return {
 				...result.accessToken,
 				expiresOn: Number(result.expiresOn),

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -199,8 +199,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 			if (remainingTime < maxTolerance) {
 				const result = await this.refreshToken(tenant, resource, cachedTokens.refreshToken);
-				accessToken = result.accessToken;
-				expiresOn = Number(result.expiresOn);
+				accessToken = result?.accessToken;
+				expiresOn = Number(result?.expiresOn);
 			}
 			// Let's just return here.
 			if (accessToken) {
@@ -243,7 +243,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 	 * @param resource
 	 * @param refreshToken
 	 */
-	public async refreshToken(tenant: Tenant, resource: Resource, refreshToken: RefreshToken | undefined): Promise<OAuthTokenResponse> {
+	public async refreshToken(tenant: Tenant, resource: Resource, refreshToken: RefreshToken | undefined): Promise<OAuthTokenResponse> | undefined {
 		Logger.pii('Refreshing token', [{ name: 'token', objOrArray: refreshToken }], []);
 		if (refreshToken) {
 			const postData: RefreshTokenPostData = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13936

Solution context:
The "Cannot read property 'accessToken' of undefined" error was occurring because the `refreshToken` method can return undefined when the `handleInteractionRequired` method determines that there isn't a need for additional user interactions to authenticate a login.


In the event that a firewall rule is missing or the database is in a paused state, the following error message will be seen and the database will need to be checked in the Azure portal.
![image](https://user-images.githubusercontent.com/87730006/164817048-9a0d9a57-68bd-43fe-929d-a428c4f51728.png)


