### PR TITLE
Add explicit return type linting to some extensions

### DIFF
--- a/extensions/.eslintrc.json
+++ b/extensions/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"no-cond-assign": 2,
-		"jsdoc/check-param-names": "error"
+		"jsdoc/check-param-names": "error",
+		"@typescript-eslint/explicit-function-return-type": ["error"]
 	}
 }

--- a/extensions/agent/.eslintrc.json
+++ b/extensions/agent/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/arc/.eslintrc.json
+++ b/extensions/arc/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/azcli/.eslintrc.json
+++ b/extensions/azcli/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/azurecore/.eslintrc.json
+++ b/extensions/azurecore/.eslintrc.json
@@ -8,6 +8,8 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		// Disabled until the issues can be fixed
+		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/azurehybridtoolkit/.eslintrc.json
+++ b/extensions/azurehybridtoolkit/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/azuremonitor/.eslintrc.json
+++ b/extensions/azuremonitor/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/big-data-cluster/.eslintrc.json
+++ b/extensions/big-data-cluster/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/cms/.eslintrc.json
+++ b/extensions/cms/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/configuration-editing/.eslintrc.json
+++ b/extensions/configuration-editing/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/dacpac/.eslintrc.json
+++ b/extensions/dacpac/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/data-workspace/.eslintrc.json
+++ b/extensions/data-workspace/.eslintrc.json
@@ -8,6 +8,8 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		// Disabled until the issues can be fixed
+		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/github-authentication/.eslintrc.json
+++ b/extensions/github-authentication/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/github/.eslintrc.json
+++ b/extensions/github/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/image-preview/.eslintrc.json
+++ b/extensions/image-preview/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/import/.eslintrc.json
+++ b/extensions/import/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/integration-tests/.eslintrc.json
+++ b/extensions/integration-tests/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/json-language-features/.eslintrc.json
+++ b/extensions/json-language-features/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/kusto/.eslintrc.json
+++ b/extensions/kusto/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/liveshare/.eslintrc.json
+++ b/extensions/liveshare/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/machine-learning/src/.eslintrc.json
+++ b/extensions/machine-learning/src/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/markdown-language-features/.eslintrc.json
+++ b/extensions/markdown-language-features/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/markdown-math/.eslintrc.json
+++ b/extensions/markdown-math/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/merge-conflict/.eslintrc.json
+++ b/extensions/merge-conflict/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/microsoft-authentication/.eslintrc.json
+++ b/extensions/microsoft-authentication/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/mssql/.eslintrc.json
+++ b/extensions/mssql/.eslintrc.json
@@ -8,6 +8,8 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		// Disabled until the issues can be fixed
+		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/notebook/.eslintrc.json
+++ b/extensions/notebook/.eslintrc.json
@@ -8,6 +8,8 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		// Disabled until the issues can be fixed
+		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/profiler/.eslintrc.json
+++ b/extensions/profiler/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/resource-deployment/.eslintrc.json
+++ b/extensions/resource-deployment/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/schema-compare/.eslintrc.json
+++ b/extensions/schema-compare/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/search-result/.eslintrc.json
+++ b/extensions/search-result/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/simple-browser/.eslintrc.json
+++ b/extensions/simple-browser/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/sql-assessment/.eslintrc.json
+++ b/extensions/sql-assessment/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -68,9 +68,9 @@ export const enterConnectionStringSettingName = localize('enterConnectionStringS
 export const enterConnectionString = localize('enterConnectionString', "Enter connection string");
 export const saveChangesInFile = localize('saveChangesInFile', "There are unsaved changes in the current file. Save now?");
 export const save = localize('save', "Save");
-export function settingAlreadyExists(settingName: string) { return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName); }
-export function failedToParse(errorMessage: string) { return localize('failedToParse', 'Failed to parse "{0}": {1}.', azureFunctionLocalSettingsFileName, errorMessage); }
-export function jsonParseError(error: string, line: number, column: number) { return localize('jsonParseError', '{0} near line "{1}", column "{2}"', error, line, column); }
+export function settingAlreadyExists(settingName: string): string { return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName); }
+export function failedToParse(errorMessage: string): string { return localize('failedToParse', 'Failed to parse "{0}": {1}.', azureFunctionLocalSettingsFileName, errorMessage); }
+export function jsonParseError(error: string, line: number, column: number): string { return localize('jsonParseError', '{0} near line "{1}", column "{2}"', error, line, column); }
 export const moreInformation = localize('moreInformation', "More Information");
 export const addPackageReferenceMessage = localize('addPackageReferenceMessage', 'To use SQL bindings, ensure your Azure Functions project has a reference to {0}', sqlExtensionPackageName);
 export const addSqlBindingPackageError = localize('addSqlBindingPackageError', 'Error adding Sql Binding extension package to project');
@@ -78,11 +78,11 @@ export const failedToGetConnectionString = localize('failedToGetConnectionString
 export const connectionProfile = localize('connectionProfile', 'Select a connection profile');
 export const userConnectionString = localize('userConnectionString', 'Enter connection string');
 export const selectConnectionString = localize('selectConnectionString', 'Select SQL connection string method');
-export const selectConnectionError = (err?: any) => err ? localize('selectConnectionError', "Failed to set connection string app setting: {0}", utils.getErrorMessage(err)) : localize('unableToSetConnectionString', "Failed to set connection string app setting");
+export const selectConnectionError = (err?: any): string => err ? localize('selectConnectionError', "Failed to set connection string app setting: {0}", utils.getErrorMessage(err)) : localize('unableToSetConnectionString', "Failed to set connection string app setting");
 export const includePassword = localize('includePassword', 'Do you want to include the password from this connection in your local.settings.json file?');
 export const enterPasswordPrompt = localize('enterPasswordPrompt', 'Enter the password to be used for the connection string');
 export const enterPasswordManually = localize('enterPasswordManually', 'Enter password or press escape to cancel');
 export const userPasswordLater = localize('userPasswordLater', 'In order to user the SQL connection string later you will need to manually enter the password in your local.settings.json file.');
 export const openFile = localize('openFile', "Open File");
 export const closeButton = localize('closeButton', "Close");
-export function addSqlBinding(functionName: string) { return localize('addSqlBinding', 'Adding SQL Binding to function "{0}"...'), functionName; }
+export function addSqlBinding(functionName: string): string { return localize('addSqlBinding', 'Adding SQL Binding to function "{0}"...'), functionName; }

--- a/extensions/sql-bindings/src/extension.ts
+++ b/extensions/sql-bindings/src/extension.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
 import { ITreeNodeInfo } from 'vscode-mssql';
-import { IExtension, BindingType } from 'sql-bindings';
+import { IExtension, BindingType, GetAzureFunctionsResult, ResultStatus } from 'sql-bindings';
 import { getAzdataApi } from './common/utils';
 import { addSqlBinding, createAzureFunction, getAzureFunctions } from './services/azureFunctionsService';
 import { launchAddSqlBindingQuickpick } from './dialogs/addSqlBindingQuickpick';
@@ -19,19 +19,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		return await createAzureFunction(node);
 	}));
 	return {
-		addSqlBinding: async (bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string) => {
+		addSqlBinding: async (bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Promise<ResultStatus> => {
 			return addSqlBinding(bindingType, filePath, functionName, objectName, connectionStringSetting);
 		},
-		promptForBindingType: async () => {
+		promptForBindingType: async (): Promise<(vscode.QuickPickItem & { type: BindingType }) | undefined> => {
 			return promptForBindingType();
 		},
-		promptForObjectName: async (bindingType: BindingType) => {
+		promptForObjectName: async (bindingType: BindingType): Promise<string | undefined> => {
 			return promptForObjectName(bindingType);
 		},
-		promptAndUpdateConnectionStringSetting: async (projectUri: vscode.Uri | undefined) => {
+		promptAndUpdateConnectionStringSetting: async (projectUri: vscode.Uri | undefined): Promise<string | undefined> => {
 			return promptAndUpdateConnectionStringSetting(projectUri);
 		},
-		getAzureFunctions: async (filePath: string) => {
+		getAzureFunctions: async (filePath: string): Promise<GetAzureFunctionsResult> => {
 			return getAzureFunctions(filePath);
 		}
 	};

--- a/extensions/sql-database-projects/.eslintrc.json
+++ b/extensions/sql-database-projects/.eslintrc.json
@@ -8,6 +8,8 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		// Disabled until the issues can be fixed
+		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/sql-migration/.eslintrc.json
+++ b/extensions/sql-migration/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
+		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/vscode-test-resolver/.eslintrc.json
+++ b/extensions/vscode-test-resolver/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }

--- a/extensions/xml-language-features/.eslintrc.json
+++ b/extensions/xml-language-features/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"]
 	}
 }


### PR DESCRIPTION
https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/explicit-function-return-type.md

It's good to be explicit with return types - while this doesn't really prevent any errors it helps makes the code more readable and helps ensure that the correct return type is being used. 

This is disabled initially for most extensions since there's a lot of cases where this isn't being done currently - but this will get us started with enforcing it for some existing extensions and new ones going forward. 