### PR TITLE
Return BindingType directly from promptForBindingType

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -284,7 +284,7 @@ export async function isFunctionProject(folderPath: string): Promise<boolean> {
 /**
  * Prompts the user to select type of binding and returns result
  */
-export async function promptForBindingType(): Promise<(vscode.QuickPickItem & { type: BindingType }) | undefined> {
+export async function promptForBindingType(): Promise<BindingType | undefined> {
 	const inputOutputItems: (vscode.QuickPickItem & { type: BindingType })[] = [
 		{
 			label: constants.input,
@@ -302,7 +302,7 @@ export async function promptForBindingType(): Promise<(vscode.QuickPickItem & { 
 		ignoreFocusOut: true
 	}));
 
-	return selectedBinding;
+	return selectedBinding?.type;
 }
 
 /**

--- a/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
@@ -73,13 +73,13 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined):
 		if (!selectedBinding) {
 			return;
 		}
-		propertyBag.bindingType = selectedBinding.type;
+		propertyBag.bindingType = selectedBinding;
 		TelemetryReporter.createActionEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.getBindingType)
 			.withAdditionalProperties(propertyBag).send();
 
 		// 3. ask for object name for the binding
 		quickPickStep = 'getObjectName';
-		const objectName = await azureFunctionsUtils.promptForObjectName(selectedBinding.type);
+		const objectName = await azureFunctionsUtils.promptForObjectName(selectedBinding);
 
 		if (!objectName) {
 			return;
@@ -106,7 +106,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined):
 		// 5. insert binding
 		try {
 			quickPickStep = 'insertBinding';
-			const result = await addSqlBinding(selectedBinding.type, uri.fsPath, azureFunctionName, objectName, connectionStringSettingName);
+			const result = await addSqlBinding(selectedBinding, uri.fsPath, azureFunctionName, objectName, connectionStringSettingName);
 
 			if (!result.success) {
 				void vscode.window.showErrorMessage(result.errorMessage);

--- a/extensions/sql-bindings/src/extension.ts
+++ b/extensions/sql-bindings/src/extension.ts
@@ -22,7 +22,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		addSqlBinding: async (bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Promise<ResultStatus> => {
 			return addSqlBinding(bindingType, filePath, functionName, objectName, connectionStringSetting);
 		},
-		promptForBindingType: async (): Promise<(vscode.QuickPickItem & { type: BindingType }) | undefined> => {
+		promptForBindingType: async (): Promise<BindingType | undefined> => {
 			return promptForBindingType();
 		},
 		promptForObjectName: async (bindingType: BindingType): Promise<string | undefined> => {

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -40,7 +40,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			if (!selectedBinding) {
 				return;
 			}
-			selectedBindingType = selectedBinding.type;
+			selectedBindingType = selectedBinding;
 			propertyBag.bindingType = selectedBindingType;
 			TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.startCreateAzureFunctionWithSqlBinding)
 				.withAdditionalProperties(propertyBag).send();
@@ -71,7 +71,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			connectionInfo.database = selectedDatabase;
 
 			// prompt user for object name to create function from
-			objectName = await azureFunctionsUtils.promptForObjectName(selectedBinding.type);
+			objectName = await azureFunctionsUtils.promptForObjectName(selectedBinding);
 			if (!objectName) {
 				// user cancelled
 				return;
@@ -106,8 +106,8 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			// User cancelled
 			return;
 		}
-		selectedBindingType = selectedBinding.type;
-		propertyBag.bindingType = selectedBinding.type;
+		selectedBindingType = selectedBinding;
+		propertyBag.bindingType = selectedBinding;
 		TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.startCreateAzureFunctionWithSqlBinding)
 			.withAdditionalProperties(propertyBag).withConnectionInfo(connectionInfo).send();
 

--- a/extensions/sql-bindings/src/sql-bindings.d.ts
+++ b/extensions/sql-bindings/src/sql-bindings.d.ts
@@ -42,7 +42,7 @@ declare module 'sql-bindings' {
 		 * Prompts the user to enter connection setting and updates it from AF project
 		 * @param projectUri Azure Function project uri
 		 */
-		 promptAndUpdateConnectionStringSetting(projectUri: vscode.Uri | undefined): Promise<string | undefined>;
+		promptAndUpdateConnectionStringSetting(projectUri: vscode.Uri | undefined): Promise<string | undefined>;
 
 		/**
 		 * Gets the names of the Azure Functions in the file

--- a/extensions/sql-bindings/src/sql-bindings.d.ts
+++ b/extensions/sql-bindings/src/sql-bindings.d.ts
@@ -28,9 +28,9 @@ declare module 'sql-bindings' {
 		addSqlBinding(bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Promise<ResultStatus>;
 
 		/**
-		 * Prompts the user to select type of binding and returns result
+		 * Prompts the user to select type of binding and returns result or undefined if the user cancelled out of the prompt
 		 */
-		promptForBindingType(): Promise<(vscode.QuickPickItem & { type: BindingType })  | undefined>;
+		promptForBindingType(): Promise<BindingType | undefined>;
 
 		/**
 		 * Prompts the user to enter object name for the SQL query

--- a/extensions/sql-bindings/src/test/dialog/addSqlBindingQuickpick.test.ts
+++ b/extensions/sql-bindings/src/test/dialog/addSqlBindingQuickpick.test.ts
@@ -14,6 +14,7 @@ import * as azureFunctionService from '../../services/azureFunctionsService';
 
 import { createTestUtils, TestUtils, createTestCredentials } from '../testUtils';
 import { launchAddSqlBindingQuickpick } from '../../dialogs/addSqlBindingQuickpick';
+import { BindingType } from 'sql-bindings';
 
 let testUtils: TestUtils;
 const fileUri = vscode.Uri.file('testUri');
@@ -66,7 +67,7 @@ describe('Add SQL Binding quick pick', () => {
 		// select Azure function
 		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').onFirstCall().resolves({ label: 'af1' });
 		// select input or output binding
-		quickpickStub.onSecondCall().resolves({ label: constants.input });
+		quickpickStub.onSecondCall().resolves(<any>{ label: constants.input, type: BindingType.input });
 		// give object name
 		let inputBoxStub = sinon.stub(vscode.window, 'showInputBox').onFirstCall().resolves('dbo.table1');
 		// give connection string setting name
@@ -100,7 +101,7 @@ describe('Add SQL Binding quick pick', () => {
 		// select Azure function
 		quickpickStub.onFirstCall().resolves({ label: 'af1' });
 		// select input or output binding
-		quickpickStub.onSecondCall().resolves({ label: constants.input });
+		quickpickStub.onSecondCall().resolves(<any>{ label: constants.input, type: BindingType.input });
 
 		// give object name
 		let inputBoxStub = sinon.stub(vscode.window, 'showInputBox').onFirstCall().resolves('dbo.table1');


### PR DESCRIPTION
There's no reason to return the entire quickpick object - that's more of an implementation detail and shouldn't ever be something callers need to use.