### PR TITLE
Add require-param rule for sql-bindings

### DIFF
--- a/extensions/sql-bindings/.eslintrc.json
+++ b/extensions/sql-bindings/.eslintrc.json
@@ -8,6 +8,7 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		"jsdoc/require-param": "error"
 	}
 }

--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -41,7 +41,7 @@ export async function getLocalSettingsJson(localSettingsPath: string): Promise<I
 			return JSON.parse(data);
 		} catch (error) {
 			console.log(error);
-			throw new Error(utils.formatString(constants.failedToParse(error.message), constants.azureFunctionLocalSettingsFileName, error.message));
+			throw new Error(constants.failedToParse(constants.azureFunctionLocalSettingsFileName, error));
 		}
 	}
 	return {
@@ -243,6 +243,7 @@ export async function addNugetReferenceToProjectFile(selectedProjectFile: string
 /**
  * Adds the Sql Connection String to the local.settings.json
  * @param connectionString of the SQL Server connection that was chosen by the user
+ * @param projectFile The path to the project the setting should be added to
  */
 export async function addConnectionStringToConfig(connectionString: string, projectFile: string): Promise<void> {
 	const settingsFile = await getSettingsFile(projectFile);

--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -69,7 +69,7 @@ export const enterConnectionString = localize('enterConnectionString', "Enter co
 export const saveChangesInFile = localize('saveChangesInFile', "There are unsaved changes in the current file. Save now?");
 export const save = localize('save', "Save");
 export function settingAlreadyExists(settingName: string): string { return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName); }
-export function failedToParse(errorMessage: string): string { return localize('failedToParse', 'Failed to parse "{0}": {1}.', azureFunctionLocalSettingsFileName, errorMessage); }
+export function failedToParse(filename: string, error: any): string { return localize('failedToParse', 'Failed to parse "{0}": {1}.', filename, utils.getErrorMessage(error)); }
 export function jsonParseError(error: string, line: number, column: number): string { return localize('jsonParseError', '{0} near line "{1}", column "{2}"', error, line, column); }
 export const moreInformation = localize('moreInformation', "More Information");
 export const addPackageReferenceMessage = localize('addPackageReferenceMessage', 'To use SQL bindings, ensure your Azure Functions project has a reference to {0}', sqlExtensionPackageName);

--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -29,7 +29,7 @@ export const selectAzureFunctionProjFolder = localize('selectAzureFunctionProjFo
 export const timeoutExtensionError = localize('timeoutExtensionError', 'Timed out waiting for extension to install');
 export const timeoutAzureFunctionFileError = localize('timeoutAzureFunctionFileError', 'Timed out waiting for Azure Function file to be created');
 export const timeoutProjectError = localize('timeoutProjectError', 'Timed out waiting for project to be created');
-export const errorNewAzureFunction = localize('errorNewAzureFunction', 'Error creating new Azure Function: {0}');
+export function errorNewAzureFunction(error: any) { return localize('errorNewAzureFunction', 'Error creating new Azure Function: {0}', utils.getErrorMessage(error)); }
 export const azureFunctionsExtensionNotInstalled = localize('azureFunctionsExtensionNotInstalled', 'Azure Functions extension must be installed in order to use this feature.');
 export const azureFunctionsProjectMustBeOpened = localize('azureFunctionsProjectMustBeOpened', 'A C# Azure Functions project must be present in order to create a new Azure Function for this table.');
 export const needConnection = localize('needConnection', 'A connection is required to use Azure Function with SQL Binding');
@@ -69,7 +69,7 @@ export const enterConnectionString = localize('enterConnectionString', "Enter co
 export const saveChangesInFile = localize('saveChangesInFile', "There are unsaved changes in the current file. Save now?");
 export const save = localize('save', "Save");
 export function settingAlreadyExists(settingName: string) { return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName); }
-export function failedToParse(errorMessage: string) { return localize('failedToParse', 'Failed to parse "{0}": {1}.', azureFunctionLocalSettingsFileName, errorMessage); }
+export function failedToParse(filename: string, error: any) { return localize('failedToParse', 'Failed to parse "{0}": {1}.', filename, utils.getErrorMessage(error)); }
 export function jsonParseError(error: string, line: number, column: number) { return localize('jsonParseError', '{0} near line "{1}", column "{2}"', error, line, column); }
 export const moreInformation = localize('moreInformation', "More Information");
 export const addPackageReferenceMessage = localize('addPackageReferenceMessage', 'To use SQL bindings, ensure your Azure Functions project has a reference to {0}', sqlExtensionPackageName);

--- a/extensions/sql-bindings/src/common/utils.ts
+++ b/extensions/sql-bindings/src/common/utils.ts
@@ -28,6 +28,7 @@ export class TimeoutError extends Error { }
 
 /**
  * Consolidates on the error message string
+ * @param error The error object to get the message from
  */
 export function getErrorMessage(error: any): string {
 	return (error instanceof Error)
@@ -92,24 +93,6 @@ export async function getAllProjectsInFolder(folder: vscode.Uri, projectExtensio
 
 	// glob will return an array of file paths with forward slashes, so they need to be converted back if on windows
 	return (await glob(projFilter)).map(p => vscode.Uri.file(path.resolve(p)));
-}
-
-/**
- * Format a string. Behaves like C#'s string.Format() function.
- */
-export function formatString(str: string, ...args: any[]): string {
-	// This is based on code originally from https://github.com/Microsoft/vscode/blob/master/src/vs/nls.js
-	// License: https://github.com/Microsoft/vscode/blob/master/LICENSE.txt
-	let result: string;
-	if (args.length === 0) {
-		result = str;
-	} else {
-		result = str.replace(/\{(\d+)\}/g, (match, rest) => {
-			let index = rest[0];
-			return typeof args[index] !== 'undefined' ? args[index] : match;
-		});
-	}
-	return result;
 }
 
 /**

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -199,7 +199,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 				} else {
 					// else an error would occur during the createFunction
 					exitReason = 'error';
-					void vscode.window.showErrorMessage(utils.formatString(constants.errorNewAzureFunction, error.message ?? error));
+					void vscode.window.showErrorMessage(constants.errorNewAzureFunction(error));
 				}
 				TelemetryReporter.createErrorEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick, undefined, errorType)
 					.withAdditionalProperties(propertyBag).send();


### PR DESCRIPTION
Good practice to always have the parameters in the doc comments - this will ensure that we don't miss updating these in PRs

Also removed an unnecessary function - all localized strings should just use the arg format support in the localize function. 