### PR TITLE
Fix SQL Bindings tests on windows

### DIFF
--- a/extensions/sql-bindings/src/test/common/azureFunctionsUtils.test.ts
+++ b/extensions/sql-bindings/src/test/common/azureFunctionsUtils.test.ts
@@ -9,11 +9,10 @@ import * as should from 'should';
 import * as sinon from 'sinon';
 import * as constants from '../../common/constants';
 import * as azureFunctionsUtils from '../../common/azureFunctionsUtils';
-import { EOL } from 'os';
 
-let rootFolderPath = 'test';
-let localSettingsPath: string = `${rootFolderPath}/local.settings.json`;
-let projectFilePath: string = `${rootFolderPath}//projectFilePath.csproj`;
+const rootFolderPath = 'test';
+const localSettingsPath: string = path.join(rootFolderPath, 'local.settings.json');
+const projectFilePath: string = path.join(rootFolderPath, 'projectFilePath.csproj');
 
 describe('Tests to verify Azure Functions Utils functions', function (): void {
 
@@ -37,7 +36,7 @@ describe('Tests to verify Azure Functions Utils functions', function (): void {
 
 		let writeFileStub = sinon.stub(fs.promises, 'writeFile');
 		await azureFunctionsUtils.setLocalAppSetting(path.dirname(localSettingsPath), 'test4', 'test4');
-		should(writeFileStub.calledWithExactly(localSettingsPath, `{${EOL}  "IsEncrypted": false,${EOL}  "Values": {${EOL}    "test1": "test1",${EOL}    "test2": "test2",${EOL}    "test3": "test3",${EOL}    "test4": "test4"${EOL}  }${EOL}}`)).equals(true);
+		should(writeFileStub.calledWithExactly(localSettingsPath, `{\n  "IsEncrypted": false,\n  "Values": {\n    "test1": "test1",\n    "test2": "test2",\n    "test3": "test3",\n    "test4": "test4"\n  }\n}`)).equals(true);
 	});
 
 	it('Should not overwrite setting if value already exists in local.settings.json', async () => {
@@ -70,7 +69,7 @@ describe('Tests to verify Azure Functions Utils functions', function (): void {
 
 		let writeFileStub = sinon.stub(fs.promises, 'writeFile');
 		await azureFunctionsUtils.addConnectionStringToConfig(connectionString, projectFilePath);
-		should(writeFileStub.calledWithExactly(localSettingsPath, `{${EOL}  "IsEncrypted": false,${EOL}  "Values": {${EOL}    "test1": "test1",${EOL}    "test2": "test2",${EOL}    "test3": "test3",${EOL}    "SqlConnectionString": "testConnectionString"${EOL}  }${EOL}}`)).equals(true);
+		should(writeFileStub.calledWithExactly(localSettingsPath, `{\n  "IsEncrypted": false,\n  "Values": {\n    "test1": "test1",\n    "test2": "test2",\n    "test3": "test3",\n    "SqlConnectionString": "testConnectionString"\n  }\n}`)).equals(true);
 	});
 
 	afterEach(async function (): Promise<void> {


### PR DESCRIPTION
1. Use path.join to ensure that correct path separators are used
2. Remove EOL uses, apparently JSON.stringify will always insert `\n` regardless of the OS