### PR TITLE
Fix connection profile prompt for Create Function with SQL Binding

### DIFF
--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -87,4 +87,4 @@ export const userPasswordLater = localize('userPasswordLater', 'In order to user
 export const openFile = localize('openFile', "Open File");
 export const closeButton = localize('closeButton', "Close");
 export function addSqlBinding(functionName: string): string { return localize('addSqlBinding', 'Adding SQL Binding to function "{0}"...'), functionName; }
-export const connectionProgressTitle = localize('connectionProgressTitle', "Connecting to SQL Server Connection...");
+export const connectionProgressTitle = localize('connectionProgressTitle', "Testing SQL Server connection...");

--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -86,3 +86,4 @@ export const userPasswordLater = localize('userPasswordLater', 'In order to user
 export const openFile = localize('openFile', "Open File");
 export const closeButton = localize('closeButton', "Close");
 export function addSqlBinding(functionName: string): string { return localize('addSqlBinding', 'Adding SQL Binding to function "{0}"...'), functionName; }
+export const connectionProgressTitle = localize('connectionProgressTitle', "Connecting to SQL Server Connection...");

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -90,7 +90,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 				objectName = await azureFunctionsUtils.promptForObjectName(selectedBinding);
 				if (!objectName) {
 					// user cancelled
-					return;
+					continue;
 				}
 				break;
 			}

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -26,8 +26,6 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 	let connectionInfo: IConnectionInfo | undefined;
 	let isCreateNewProject: boolean = false;
 	let newFunctionFileObject: azureFunctionsUtils.IFileFunctionObject | undefined;
-	let connectionURI: string = '';
-	let listDatabases: string[] | undefined;
 
 	try {
 		const azureFunctionApi = await azureFunctionsUtils.getAzureFunctionsExtensionApi();
@@ -123,6 +121,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 					return;
 				}
 				telemetryStep = 'getConnectionInfo';
+				let connectionURI: string = '';
 				try {
 					await vscode.window.withProgress(
 						{
@@ -135,11 +134,12 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 						}
 					);
 				} catch (e) {
-					// connection error occurred
+					// mssql connection error will be shown to the user
+					// we will then prompt user to choose a connection profile again
 					continue;
 				}
 				// list databases based on connection profile selected
-				listDatabases = await vscodeMssqlApi.listDatabases(connectionURI);
+				let listDatabases = await vscodeMssqlApi.listDatabases(connectionURI);
 				const selectedDatabase = (await vscode.window.showQuickPick(listDatabases, {
 					canPickMany: false,
 					title: constants.selectDatabase,
@@ -156,7 +156,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 				objectName = await azureFunctionsUtils.promptForObjectName(selectedBinding);
 				if (!objectName) {
 					// user cancelled
-					continue;
+					return;
 				}
 				break;
 			}

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -148,6 +148,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 
 				if (!selectedDatabase) {
 					// User cancelled
+					// we will then prompt user to choose a connection profile again
 					continue;
 				}
 				connectionInfo.database = selectedDatabase;

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -69,7 +69,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 						}
 					);
 				} catch (e) {
-					// User cancelled
+					// connection error occurred
 					continue;
 				}
 				// list databases based on connection profile selected


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19107 and fixes #19106.

After the user chooses a connection from the connection profile list we will show this progress notification:
![image](https://user-images.githubusercontent.com/23587151/165237180-626ee59f-094b-40eb-9a3b-2325b0be2a47.png)

If we are unable to connect then it will go back to the prompt for choosing a connection. We will also go back to the connection profile picker if the user exits from the database prompt or objectName. 

#19108 - this issue seems to be on vscode-mssql side for promptForConnection since I correctly pass in ignoreFocusOut parameter as true but it does not respect it. 
