### PR TITLE
Remove ADS/azdata refs from SQL Bindings

### DIFF
--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -6,8 +6,7 @@
   "publisher": "Microsoft",
   "preview": true,
   "engines": {
-    "vscode": "^1.30.1",
-    "azdata": ">=1.35.0"
+    "vscode": "^1.30.1"
   },
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "media/defaultExtensionIcon.png",
@@ -47,18 +46,17 @@
       "commandPalette": [
         {
           "command": "sqlBindings.addSqlBinding",
-          "when": "editorLangId == csharp && !azdataAvailable && resourceScheme != untitled"
+          "when": "editorLangId == csharp && resourceScheme != untitled"
         },
         {
           "command": "sqlBindings.createAzureFunction",
-          "when": "!azdataAvailable",
           "group": "zAzure_Function@1"
         }
       ],
       "view/item/context": [
         {
           "command": "sqlBindings.createAzureFunction",
-          "when": "view == objectExplorer && viewItem == Table && !azdataAvailable",
+          "when": "view == objectExplorer && viewItem == Table",
           "group": "zAzure_Function@1"
         }
       ]

--- a/extensions/sql-bindings/src/common/utils.ts
+++ b/extensions/sql-bindings/src/common/utils.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type * as azdataType from 'azdata';
 import * as vscode from 'vscode';
 import * as vscodeMssql from 'vscode-mssql';
 import * as fs from 'fs';
@@ -39,27 +38,6 @@ export function getErrorMessage(error: any): string {
 export async function getVscodeMssqlApi(): Promise<vscodeMssql.IExtension> {
 	const ext = vscode.extensions.getExtension(vscodeMssql.extension.name) as vscode.Extension<vscodeMssql.IExtension>;
 	return ext.activate();
-}
-
-// Try to load the azdata API - but gracefully handle the failure in case we're running
-// in a context where the API doesn't exist (such as VS Code)
-let azdataApi: typeof azdataType | undefined = undefined;
-try {
-	azdataApi = require('azdata');
-	if (!azdataApi?.version) {
-		// webpacking makes the require return an empty object instead of throwing an error so make sure we clear the var
-		azdataApi = undefined;
-	}
-} catch {
-	// no-op
-}
-
-/**
- * Gets the azdata API if it's available in the context this extension is running in.
- * @returns The azdata API if it's available
- */
-export function getAzdataApi(): typeof azdataType | undefined {
-	return azdataApi;
 }
 
 export async function executeCommand(command: string, cwd?: string): Promise<string> {

--- a/extensions/sql-bindings/src/extension.ts
+++ b/extensions/sql-bindings/src/extension.ts
@@ -5,13 +5,11 @@
 import * as vscode from 'vscode';
 import { ITreeNodeInfo } from 'vscode-mssql';
 import { IExtension, BindingType, GetAzureFunctionsResult, ResultStatus } from 'sql-bindings';
-import { getAzdataApi } from './common/utils';
 import { addSqlBinding, createAzureFunction, getAzureFunctions } from './services/azureFunctionsService';
 import { launchAddSqlBindingQuickpick } from './dialogs/addSqlBindingQuickpick';
 import { promptForBindingType, promptAndUpdateConnectionStringSetting, promptForObjectName } from './common/azureFunctionsUtils';
 
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
-	void vscode.commands.executeCommand('setContext', 'azdataAvailable', !!getAzdataApi());
 	// register the add sql binding command
 	context.subscriptions.push(vscode.commands.registerCommand('sqlBindings.addSqlBinding', async (uri: vscode.Uri | undefined) => { return launchAddSqlBindingQuickpick(uri); }));
 	// Generate Azure Function command

--- a/extensions/sql-bindings/src/typings/ref.d.ts
+++ b/extensions/sql-bindings/src/typings/ref.d.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 /// <reference path='../../../../src/vs/vscode.d.ts'/>
-/// <reference path='../../../../src/sql/azdata.d.ts'/>
-/// <reference path='../../../../src/sql/azdata.proposed.d.ts'/>
 /// <reference path='../../../mssql/src/mssql.d.ts'/>
 /// <reference path='../../../types/vscode-mssql.d.ts'/>
 /// <reference types='@types/node'/>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19103.

This removes all references of azdata and azuredatastudio apart from the license and vscode-development instructions. We can further discuss where this extension should live in the future.
