### PR TITLE
Add 'az sql mi-arc upgrade' command to azcli api

### DIFF
--- a/extensions/azcli/src/api.ts
+++ b/extensions/azcli/src/api.ts
@@ -153,6 +153,21 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 					await localAzDiscovered;
 					validateAz(azToolService.localAz);
 					return azToolService.localAz!.sql.miarc.update(name, args, resourceGroup, namespace, usek8s, additionalEnvVars);
+				},
+				upgrade: async (
+					desiredVersion: string,
+					name: string,
+					// Direct mode arguments
+					resourceGroup?: string,
+					// Indirect mode arguments
+					namespace?: string,
+					usek8s?: boolean,
+					// Additional arguments
+					additionalEnvVars?: azExt.AdditionalEnvVars
+				) => {
+					await localAzDiscovered;
+					validateAz(azToolService.localAz);
+					return azToolService.localAz!.sql.miarc.upgrade(desiredVersion, name, resourceGroup, namespace, usek8s, additionalEnvVars);
 				}
 			},
 			midbarc: {

--- a/extensions/azcli/src/api.ts
+++ b/extensions/azcli/src/api.ts
@@ -157,17 +157,19 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 				upgrade: async (
 					desiredVersion: string,
 					name: string,
-					// Direct mode arguments
-					resourceGroup?: string,
-					// Indirect mode arguments
-					namespace?: string,
-					usek8s?: boolean,
+					args: {
+						// Direct mode arguments
+						resourceGroup?: string;
+						// Indirect mode arguments
+						namespace?: string;
+						usek8s?: boolean;
+					},
 					// Additional arguments
 					additionalEnvVars?: azExt.AdditionalEnvVars
 				) => {
 					await localAzDiscovered;
 					validateAz(azToolService.localAz);
-					return azToolService.localAz!.sql.miarc.upgrade(desiredVersion, name, resourceGroup, namespace, usek8s, additionalEnvVars);
+					return azToolService.localAz!.sql.miarc.upgrade(desiredVersion, name, args, additionalEnvVars);
 				}
 			},
 			midbarc: {

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -222,7 +222,7 @@ export class AzTool implements azExt.IAzApi {
 					resourceGroup?: string,
 					// Indirect mode arguments
 					namespace?: string,
-					usek8s?: boolean,
+					usek8s?: boolean
 					// Additional arguments
 				},
 				additionalEnvVars?: azExt.AdditionalEnvVars

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -213,6 +213,23 @@ export class AzTool implements azExt.IAzApi {
 				if (namespace) { argsArray.push('--k8s-namespace', namespace); }
 				if (usek8s) { argsArray.push('--use-k8s'); }
 				return this.executeCommand<void>(argsArray, additionalEnvVars);
+			},
+			upgrade: (
+				desiredVersion: string,
+				name: string,
+				// Direct mode arguments
+				resourceGroup?: string,
+				// Indirect mode arguments
+				namespace?: string,
+				usek8s?: boolean,
+				// Additional arguments
+				additionalEnvVars?: azExt.AdditionalEnvVars
+			): Promise<azExt.AzOutput<void>> => {
+				const argsArray = ['sql', 'mi-arc', 'upgrade', '--desired-version', desiredVersion, '--name', name];
+				if (resourceGroup) { argsArray.push('--resource-group', resourceGroup); }
+				if (namespace) { argsArray.push('--k8s-namespace', namespace); }
+				if (usek8s) { argsArray.push('--use-k8s'); }
+				return this.executeCommand<void>(argsArray, additionalEnvVars);
 			}
 		},
 		midbarc: {

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -217,18 +217,20 @@ export class AzTool implements azExt.IAzApi {
 			upgrade: (
 				desiredVersion: string,
 				name: string,
-				// Direct mode arguments
-				resourceGroup?: string,
-				// Indirect mode arguments
-				namespace?: string,
-				usek8s?: boolean,
-				// Additional arguments
+				args: {
+					// Direct mode arguments
+					resourceGroup?: string,
+					// Indirect mode arguments
+					namespace?: string,
+					usek8s?: boolean,
+					// Additional arguments
+				},
 				additionalEnvVars?: azExt.AdditionalEnvVars
 			): Promise<azExt.AzOutput<void>> => {
 				const argsArray = ['sql', 'mi-arc', 'upgrade', '--desired-version', desiredVersion, '--name', name];
-				if (resourceGroup) { argsArray.push('--resource-group', resourceGroup); }
-				if (namespace) { argsArray.push('--k8s-namespace', namespace); }
-				if (usek8s) { argsArray.push('--use-k8s'); }
+				if (args.resourceGroup) { argsArray.push('--resource-group', args.resourceGroup); }
+				if (args.namespace) { argsArray.push('--k8s-namespace', args.namespace); }
+				if (args.usek8s) { argsArray.push('--use-k8s'); }
 				return this.executeCommand<void>(argsArray, additionalEnvVars);
 			}
 		},

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -392,6 +392,17 @@ declare module 'az-ext' {
 					usek8s?: boolean,
 					// Additional arguments
 					additionalEnvVars?: AdditionalEnvVars
+				): Promise<AzOutput<void>>,
+				upgrade(
+					desiredVersion: string,
+					name: string,
+					// Direct mode arguments
+					resourceGroup?: string,
+					// Indirect mode arguments
+					namespace?: string,
+					usek8s?: boolean,
+					// Additional arguments
+					additionalEnvVars?: AdditionalEnvVars
 				): Promise<AzOutput<void>>
 			},
 			midbarc: {

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -396,11 +396,13 @@ declare module 'az-ext' {
 				upgrade(
 					desiredVersion: string,
 					name: string,
-					// Direct mode arguments
-					resourceGroup?: string,
-					// Indirect mode arguments
-					namespace?: string,
-					usek8s?: boolean,
+					args: {
+						// Direct mode arguments
+						resourceGroup?: string,
+						// Indirect mode arguments
+						namespace?: string,
+						usek8s?: boolean
+					},
 					// Additional arguments
 					additionalEnvVars?: AdditionalEnvVars
 				): Promise<AzOutput<void>>


### PR DESCRIPTION
Adding SQL MIAA upgrade command to the Azure CLI extension API.

Output of 'az sql mi-arc upgrade --help' for reference:
![image](https://user-images.githubusercontent.com/22386690/165385589-8072eb27-6bce-4696-8d65-5b549a8d9a65.png)
