### PR TITLE
Enable autoflush for STS logs

### DIFF
--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -105,12 +105,14 @@ export function getCommonLaunchArgsAndCleanupOldLogFiles(logPath: string, fileNa
 	launchArgs.push(logFile);
 
 	console.log(`logFile for ${path.basename(executablePath)} is ${logFile}`);
-	console.log(`This process (ui Extenstion Host) is pid: ${process.pid}`);
+	console.log(`This process (ui Extension Host) is pid: ${process.pid}`);
 	// Delete old log files
 	let deletedLogFiles = removeOldLogFiles(logPath, fileName);
 	console.log(`Old log files deletion report: ${JSON.stringify(deletedLogFiles)}`);
 	launchArgs.push('--tracing-level');
 	launchArgs.push(getConfigTracingLevel());
+	// Always enable autoflush so that log entries are written immediately to disk, otherwise we can end up with partial logs
+	launchArgs.push('--autoflush-log');
 	return launchArgs;
 }
 


### PR DESCRIPTION
A problem I've noticed a bunch when looking at the MSSQL logs it that they'll often be incomplete - sometimes only containing part of a log message. 

The issue is that currently we write the log messages but don't flush it manually, which means that it only gets written to disk when the buffer fills up (don't know exactly what that value is, but found a couple references to 8KB on stack overflow).

Given that partial logs like this can easily leave out important information (such as the last few things to happen before a crash...) it seems better to me to enable autoflushing so that every message written is immediately written to disk. 

There is the issue of possible performance implications, but given the relatively low amount of logging we do I don't see that being a huge issue. 

There are a couple other options we could look into if there's concern about the performance though : 

1. Have this be a setting in ADS that users can enable (possibly auto-enabled if the log level is high enough)
2. If autoflush isn't enabled in STS have a timer that calls flush every so often (5-10sec or so)