### PR TITLE
Add event to track node expansion errors

### DIFF
--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -49,7 +49,8 @@ export const enum TelemetryView {
 }
 
 export const enum TelemetryError {
-	DatabaseConnectionError = 'DatabaseConnectionError'
+	DatabaseConnectionError = 'DatabaseConnectionError',
+	ObjectExplorerExpandError = 'ObjectExplorerExpandError'
 }
 
 export const enum TelemetryAction {

--- a/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
@@ -325,9 +325,10 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('expand node should expand node correctly', async () => {
+		const tablesNode = new TreeNode(NodeType.Folder, 'Tables', false, 'testServerName/tables', '', '', null, null, undefined, undefined);
 		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
-		const expandInfo = await objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, 'testServerName/tables');
+		const expandInfo = await objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, tablesNode);
 		assert.strictEqual(expandInfo !== null || expandInfo !== undefined, true);
 		assert.strictEqual(expandInfo.sessionId, '1234');
 		assert.strictEqual(expandInfo.nodes.length, 2);
@@ -337,9 +338,10 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('refresh node should refresh node correctly', async () => {
+		const tablesNode = new TreeNode(NodeType.Folder, 'Tables', false, 'testServerName/tables', '', '', null, null, undefined, undefined);
 		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
-		const expandInfo = await objectExplorerService.refreshNode(mssqlProviderName, objectExplorerSession, 'testServerName/tables');
+		const expandInfo = await objectExplorerService.refreshNode(mssqlProviderName, objectExplorerSession, tablesNode);
 		assert.strictEqual(expandInfo !== null || expandInfo !== undefined, true);
 		assert.strictEqual(expandInfo.sessionId, '1234');
 		assert.strictEqual(expandInfo.nodes.length, 2);
@@ -651,8 +653,9 @@ suite('SQL Object Explorer Service tests', () => {
 		sqlOEProvider.setup(x => x.expandNode(TypeMoq.It.is(x => x.nodePath === nodePath))).callback(() => { }).returns(() => Promise.resolve(true));
 
 		// If I queue a second expand request (the first compconstes normally because of the original mock) and then close the session
-		await objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, objectExplorerSession.rootNode.nodePath);
-		const expandPromise = objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, objectExplorerSession.rootNode.nodePath);
+		const rootNode = new TreeNode(NodeType.Root, '', false, objectExplorerSession.rootNode.nodePath, '', '', null, null, undefined, undefined);
+		await objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, rootNode);
+		const expandPromise = objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, rootNode);
 		const closeSessionResult = await objectExplorerService.closeSession(mssqlProviderName, objectExplorerSession);
 
 		// Then the expand request has compconsted and the session is closed

--- a/src/sql/workbench/services/objectExplorer/test/browser/testObjectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/testObjectExplorerService.ts
@@ -71,9 +71,9 @@ export class TestObjectExplorerService implements IObjectExplorerService {
 
 	public async createNewSession(providerId: string, connection: ConnectionProfile): Promise<azdata.ObjectExplorerSessionResponse> { throw new Error('Method not implemented'); }
 
-	public async expandNode(providerId: string, session: azdata.ObjectExplorerSession, nodePath: string): Promise<azdata.ObjectExplorerExpandInfo> { throw new Error('Method not implemented'); }
+	public async expandNode(providerId: string, session: azdata.ObjectExplorerSession, node: TreeNode): Promise<azdata.ObjectExplorerExpandInfo> { throw new Error('Method not implemented'); }
 
-	public async refreshNode(providerId: string, session: azdata.ObjectExplorerSession, nodePath: string): Promise<azdata.ObjectExplorerExpandInfo> { throw new Error('Method not implemented'); }
+	public async refreshNode(providerId: string, session: azdata.ObjectExplorerSession, node: TreeNode): Promise<azdata.ObjectExplorerExpandInfo> { throw new Error('Method not implemented'); }
 
 	public async closeSession(providerId: string, session: azdata.ObjectExplorerSession): Promise<azdata.ObjectExplorerCloseSessionResponse> { throw new Error('Method not implemented'); }
 


### PR DESCRIPTION
This will help us diagnose how often these issues happen and help determine if changes impact node expansion.

To start with this is just tracking timeout since there isn't an easy way to tell the full set of errors that may occur. I plan on following up with looking at adding an optional `errorType` property to the expand response but want to think about that a bit more so getting this in now so we at least have something. 

Note that this is only for the MSSQL provider since we have full control over that. Later on we can add for all providers if needed, but we'll need to do some extra work to ensure we're not sending any personal information coming from a provider (the folder names)

Had to refactor the OE service a bit to get the node type down to the place where the expansion error is seen, no functional changes. 