### PR TITLE
Make sure markdown.showSource correctly awaits opening the document

### DIFF
--- a/extensions/markdown-language-features/src/commands/showSource.ts
+++ b/extensions/markdown-language-features/src/commands/showSource.ts
@@ -18,7 +18,7 @@ export class ShowSourceCommand implements Command {
 		const { activePreviewResource, activePreviewResourceColumn } = this.previewManager;
 		if (activePreviewResource && activePreviewResourceColumn) {
 			return vscode.workspace.openTextDocument(activePreviewResource).then(document => {
-				vscode.window.showTextDocument(document, activePreviewResourceColumn);
+				return vscode.window.showTextDocument(document, activePreviewResourceColumn);
 			});
 		}
 		return undefined;


### PR DESCRIPTION
Cherry-pick https://github.com/microsoft/vscode/commit/d3585388be90a5763d9f491b6e5b674f0af398fd

Fixes #19288
