### PR TITLE
fix json cell handling issue

### DIFF
--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -65,6 +65,11 @@ const ACTIONBAR_HEIGHT = 120;
 // this handles min size if rows is greater than the min grid visible rows
 const MIN_GRID_HEIGHT = (MIN_GRID_HEIGHT_ROWS * ROW_HEIGHT) + HEADER_HEIGHT + ESTIMATED_SCROLL_BAR_HEIGHT;
 
+// The regex to check whether a string is a valid JSON string. It is used to determine:
+// 1. whether the cell should be rendered as a hyperlink.
+// 2. when user clicks a cell, whether the cell content should be displayed in a new text editor as json.
+// Based on the requirements, the solution doesn't need to be very accurate, a simple regex is enough since it is more
+// performant than trying to parse the string to object.
 const IsJsonRegex = /({.*?})/g;
 
 export class GridPanel extends Disposable {
@@ -397,15 +402,13 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		this.container.style.height = '100%';
 
 		this.columns = this.resultSet.columnInfo.map((c, i) => {
-			let isLinked = c.isXml;
-
 			return <Slick.Column<T>>{
 				id: i.toString(),
 				name: c.columnName === 'Microsoft SQL Server 2005 XML Showplan'
 					? localize('xmlShowplan', "XML Showplan")
 					: escape(c.columnName),
 				field: i.toString(),
-				formatter: isLinked ? hyperLinkFormatter : queryResultTextFormatter,
+				formatter: c.isXml ? hyperLinkFormatter : queryResultTextFormatter,
 				width: this.state.columnSizes && this.state.columnSizes[i] ? this.state.columnSizes[i] : undefined
 			};
 		});


### PR DESCRIPTION
This PR fixes #17634

instead of relying on STS to do the JSON check only on the first row: https://github.com/microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs#L740, I am moving the logic to ADS, when a cell is clicked, we check whether it is a json cell and then open a new editor for it.

similarly render the cell as hyperlink if it is a json cell.

before:
![json-before](https://user-images.githubusercontent.com/13777222/167488604-1849a767-9e26-46b6-a3ce-be2a1ade07d3.gif)

after:
![json-after](https://user-images.githubusercontent.com/13777222/167488614-3752b6b0-bc53-4210-b8dd-bdebbff0f0cf.gif)
