### PR TITLE
Fix issues with cell outputs not being shown when doing Run All Cells in an Interactive notebook.

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -1099,7 +1099,7 @@ export class CellModel extends Disposable implements ICellModel {
 	}
 
 	public processEdits(edits: ICellEdit[]): void {
-		// Wait for any in-progress operations to complete before doing any edits so that we don't hit any race conditions
+		// Wait for any in-progress operations to complete before doing any edits so that we don't hit any race conditions with updating cell outputs
 		if (this._future?.inProgress) {
 			this._future.done.then(() => this.processOutputEdits(edits), error => onUnexpectedError(error));
 		} else {

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -1101,7 +1101,7 @@ export class CellModel extends Disposable implements ICellModel {
 	public processEdits(edits: ICellEdit[]): void {
 		// Wait for any in-progress operations to complete before doing any edits so that we don't hit any race conditions
 		if (this._future?.inProgress) {
-			this._future.done.then(() => this.processOutputEdits(edits));
+			this._future.done.then(() => this.processOutputEdits(edits), error => onUnexpectedError(error));
 		} else {
 			this.processOutputEdits(edits);
 		}

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -771,7 +771,7 @@ export class CellModel extends Disposable implements ICellModel {
 		if (this._future) {
 			this._future.dispose();
 		}
-		// this.clearOutputs(true);
+		this.clearOutputs(true);
 		this._future = future;
 		future.setReplyHandler({ handle: (msg) => this.handleReply(msg) });
 		future.setIOPubHandler({ handle: (msg) => this.handleIOPub(msg) });


### PR DESCRIPTION
When using Interactive notebooks with lots of cells, I noticed that some cells would succeed but the outputs wouldn't be updated. Looks like this is because there's a race condition between the runCell promise completing, and the cell outputs being manually updated from the Interactive extension. We only use a runCell Future promise with vscode notebooks for compatibility reasons, so it always returns undefined. So if that future promise completes after the cell outputs are updated from the extension, it sets the cell output to an empty array. My solution here to wait for any pending future promises to complete before updating the cell outputs.