### PR TITLE
Ignore coverage folders during hygiene

### DIFF
--- a/build/filters.js
+++ b/build/filters.js
@@ -122,7 +122,8 @@ module.exports.indentationFilter = [
 	'!extensions/simple-browser/media/*.js',
 	'!resources/xlf/LocProject.json',
 	'!build/**/*',
-	'!test/coverage/**'
+	'!test/coverage/**',
+	'!extensions/**/coverage/**'
 ];
 
 module.exports.copyrightFilter = [


### PR DESCRIPTION
Only really matters for local runs, but the stuff in these shouldn't be ran through the check. 