### PR TITLE
Update .NET Interactive extension version in insiders gallery.

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4524,14 +4524,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.3175020",
-							"lastUpdated": "3/30/2022",
+							"version": "1.0.3255010",
+							"lastUpdated": "5/10/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dotnet-interactive-vscode/dotnet-interactive-vscode-1.0.3175020.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dotnet-interactive-vscode/dotnet-interactive-vscode-1.0.3255010.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
The built vsix for this new version can be found here: https://dev.azure.com/dnceng/_apis/resources/Containers/10386963/vscode?itemPath=vscode%2Fads-stable%2Fdotnet-interactive-vscode-1.0.3255010.vsix