### PR TITLE
Skip manage packages test

### DIFF
--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -81,7 +81,8 @@ export function setup(opts: minimist.ParsedArgs) {
 			await app.workbench.sqlNotebook.waitForActiveCellResults();
 		});
 
-		it('can add a new package from the Manage Packages wizard', async function () {
+		// Skip this test for now since it is not stable - the way that the wizard is initialized needs to be refactored
+		it.skip('can add a new package from the Manage Packages wizard', async function () {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.newUntitledNotebook();
 			await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('SQL');


### PR DESCRIPTION
Skipping the manage packages test for now. 

The test is unstable because of the way that the wizard is initialized. While debugging I realized the wizard contents get reset twice. This isn't an issue for users since it happens really quickly (before the user can type anything). But it makes the smoke test unstable since sometimes, 'pyarrow' gets typed and then cleared by the reset. I need to do some refactoring for how the wizard initialization.