### PR TITLE
Take SQL MI billing Business Critical out of preview

### DIFF
--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -105,7 +105,7 @@
 	"arc.sql.high.availability": "High availability",
 	"arc.sql.high.availability.description": "Enable additional replicas for high availabilty. The compute and storage configuration selected below will be applied to all replicas.",
 	"arc.sql.service.tier.general.purpose": "General Purpose (Up to 24 vCores and 128 Gi of RAM, standard high availability)",
-	"arc.sql.service.tier.business.critical": "[PREVIEW] Business Critical (Unlimited vCores and RAM, advanced high availability)",
+	"arc.sql.service.tier.business.critical": "Business Critical (Unlimited vCores and RAM, advanced high availability)",
 	"arc.sql.one.replica": "1 replica",
 	"arc.sql.two.replicas": "2 replicas",
 	"arc.sql.three.replicas": "3 replicas",

--- a/extensions/arc/src/common/pricingUtils.ts
+++ b/extensions/arc/src/common/pricingUtils.ts
@@ -12,24 +12,19 @@ export const SqlManagedInstanceGeneralPurpose = {
 	licenseIncludedPricePerCore: 153,
 	maxMemorySize: 128,
 	maxVCores: 24,
-
 	replicaOptions: [
 		{
 			text: loc.replicaOne,
 			value: 1,
 		}
 	],
-
 	defaultReplicaValue: 1
 };
 
 const SqlManagedInstanceBusinessCritical = {
 	tierName: loc.businessCriticalLabel,
-
-	// Set to real values when BC is ready
-	basePricePerCore: 0,
-	licenseIncludedPricePerCore: 0,
-
+	basePricePerCore: 160,
+	licenseIncludedPricePerCore: 434,
 	replicaOptions: [
 		{
 			text: loc.replicaTwo,
@@ -40,7 +35,6 @@ const SqlManagedInstanceBusinessCritical = {
 			value: 3,
 		}
 	],
-
 	defaultReplicaValue: 3
 };
 


### PR DESCRIPTION
Changes: 
- Set price per vcore for Business Critical SQL MI to $434 for LicenseIncluded and $160 for BasePrice.
- Removed [Preview] label from Business Critical option in SQL MI create wizard
