### PR TITLE
Bump STS to .250

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.249",
+	"version": "3.0.0-release.250",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
Fixes failing test. 

Also bringing in a fix for backup devicetype. 

![image](https://user-images.githubusercontent.com/28519865/168178938-5d64cafb-4a6a-4e78-ab8d-aca20b0a2802.png)
