### PR TITLE
Added clickable more info links to designer validation issues

### DIFF
--- a/src/sql/workbench/browser/designer/designer.ts
+++ b/src/sql/workbench/browser/designer/designer.ts
@@ -983,7 +983,6 @@ export class Designer extends Disposable implements IThemable {
 				table.onBlur((e) => {
 					currentTableActions.forEach(a => a.updateState());
 					table.grid.setSelectedRows([]);
-					table.grid.resetActiveCell();
 				});
 				component = table;
 				break;

--- a/src/sql/workbench/browser/designer/designerIssuesTabPanelView.ts
+++ b/src/sql/workbench/browser/designer/designerIssuesTabPanelView.ts
@@ -132,6 +132,8 @@ class TableFilterListRenderer implements IListRenderer<DesignerIssue, DesignerIs
 				href: element.moreInfoLink
 			}, undefined);
 			templateData.issueMoreInfoLink.appendChild(linkElement.el);
+		} else {
+			templateData.issueMoreInfoLink = undefined;
 		}
 	}
 

--- a/src/sql/workbench/browser/designer/designerIssuesTabPanelView.ts
+++ b/src/sql/workbench/browser/designer/designerIssuesTabPanelView.ts
@@ -133,7 +133,7 @@ class TableFilterListRenderer implements IListRenderer<DesignerIssue, DesignerIs
 			}, undefined);
 			templateData.issueMoreInfoLink.appendChild(linkElement.el);
 		} else {
-			templateData.issueMoreInfoLink = undefined;
+			DOM.clearNode(templateData.issueMoreInfoLink);
 		}
 	}
 

--- a/src/sql/workbench/browser/designer/designerIssuesTabPanelView.ts
+++ b/src/sql/workbench/browser/designer/designerIssuesTabPanelView.ts
@@ -128,7 +128,7 @@ class TableFilterListRenderer implements IListRenderer<DesignerIssue, DesignerIs
 		templateData.issueIcon.className = `issue-icon ${iconClass}`;
 		if (element.moreInfoLink) {
 			const linkElement = this._instantiationService.createInstance(Link, {
-				label: localize('designer.moreInfoLink', 'More information'),
+				label: localize('designer.moreInfoLink', "More information"),
 				href: element.moreInfoLink
 			}, undefined);
 			templateData.issueMoreInfoLink.appendChild(linkElement.el);

--- a/src/sql/workbench/browser/designer/designerIssuesTabPanelView.ts
+++ b/src/sql/workbench/browser/designer/designerIssuesTabPanelView.ts
@@ -13,7 +13,7 @@ import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/lis
 import { localize } from 'vs/nls';
 import { IColorTheme, ICssStyleCollector, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { attachListStyler } from 'vs/platform/theme/common/styler';
-import { problemsErrorIconForeground, problemsInfoIconForeground, problemsWarningIconForeground, textLinkForeground } from 'vs/platform/theme/common/colorRegistry';
+import { problemsErrorIconForeground, problemsInfoIconForeground, problemsWarningIconForeground } from 'vs/platform/theme/common/colorRegistry';
 import { Codicon } from 'vs/base/common/codicons';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { Link } from 'vs/platform/opener/browser/link';

--- a/src/sql/workbench/browser/designer/interfaces.ts
+++ b/src/sql/workbench/browser/designer/interfaces.ts
@@ -239,7 +239,12 @@ export type DesignerPropertyPath = (string | number)[];
 export const DesignerRootObjectPath: DesignerPropertyPath = [];
 
 export type DesignerIssueSeverity = 'error' | 'warning' | 'information';
-export type DesignerIssue = { description: string, propertyPath?: DesignerPropertyPath, severity: DesignerIssueSeverity };
+export type DesignerIssue = {
+	description: string,
+	propertyPath?: DesignerPropertyPath,
+	severity: DesignerIssueSeverity,
+	moreInfoLink?: string;
+};
 
 export interface DesignerEditResult {
 	isValid: boolean;

--- a/src/sql/workbench/browser/designer/media/designer.css
+++ b/src/sql/workbench/browser/designer/media/designer.css
@@ -46,10 +46,13 @@
 }
 
 .designer-component .issues-container .issue-item .issue-text {
-	flex: 1 1 auto;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	user-select: text;
+}
+
+.designer-component .issues-container .issue-item .issue-more-info {
+	padding-left: 10px;
 }
 
 .designer-component .tabbed-panel-container {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/19078

STS PR: https://github.com/microsoft/sqltoolsservice/pull/1494

Also adds the functionality to add clickable links to designer errors in the Issues tab: 

![Screen Shot 2022-05-12 at 4 44 09 PM](https://user-images.githubusercontent.com/6411451/168184749-67e89f42-79c5-489b-8e22-3792d3cf38b1.png)

