### PR TITLE
show proper message when extension is not installed for a connection provider

### DIFF
--- a/src/sql/platform/capabilities/common/capabilitiesService.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesService.ts
@@ -21,6 +21,16 @@ export const clientCapabilities = {
 };
 
 /**
+ * The map containing the connection provider names and the owning extensions.
+ * This is to workaround the issue that we don't have the ability to store and query the information from extension gallery.
+ */
+export const ConnectionProviderAndExtensionMap = new Map<string, string>([
+	['PGSQL', 'microsoft.azuredatastudio-postgresql'],
+	['KUSTO', 'microsoft.kusto'],
+	['LOGANALYTICS', 'microsoft.azuremonitor']
+]);
+
+/**
  * The connection string options for connection provider.
  */
 export interface ConnectionStringOptions {

--- a/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
@@ -43,10 +43,11 @@ import { AsyncServerTree } from 'sql/workbench/services/objectExplorer/browser/a
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ConnectionBrowseTab } from 'sql/workbench/services/connection/browser/connectionBrowseTab';
 import { ElementSizeObserver } from 'vs/editor/browser/config/elementSizeObserver';
-import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
+import { ConnectionProviderAndExtensionMap, ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { VIEWLET_ID as ExtensionsViewletID } from 'vs/workbench/contrib/extensions/common/extensions';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 export interface OnShowUIResponse {
 	selectedProviderDisplayName: string;
@@ -129,7 +130,8 @@ export class ConnectionDialogWidget extends Modal {
 		@IConfigurationService private _configurationService: IConfigurationService,
 		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService,
 		@INotificationService private _notificationService: INotificationService,
-		@IViewletService private _viewletService: IViewletService
+		@IViewletService private _viewletService: IViewletService,
+		@ICommandService private _commandService: ICommandService
 	) {
 		super(
 			localize('connection', "Connection"),
@@ -406,15 +408,28 @@ export class ConnectionDialogWidget extends Modal {
 			}
 		}
 		else {
-			this._notificationService.prompt(Severity.Error,
-				localize('connectionDialog.connectionProviderNotInstalled', "The extension that supports provider type: '{0}' is not currently installed. Please install it and try again.", element.providerName),
-				[{
-					label: localize('connectionDialog.viewExtensions', "View Extensions"),
-					run: async () => {
-						this.close();
-						await this._viewletService.openViewlet(ExtensionsViewletID, true);
-					}
-				}]);
+			const extensionId = ConnectionProviderAndExtensionMap.get(element.providerName);
+			if (extensionId) {
+				this._notificationService.prompt(Severity.Error,
+					localize('connectionDialog.extensionNotInstalled', "The extension '{0}' is required in order to connect to this resource. Please install it and try again.", extensionId),
+					[{
+						label: localize('connectionDialog.viewExtension', "View Extension"),
+						run: async () => {
+							this.close();
+							await this._commandService.executeCommand('extension.open', extensionId);
+						}
+					}]);
+			} else {
+				this._notificationService.prompt(Severity.Error,
+					localize('connectionDialog.connectionProviderNotSupported', "The extension that supports provider type '{0}' is not currently installed. Please install it and try again.", element.providerName),
+					[{
+						label: localize('connectionDialog.viewExtensions', "View Extensions"),
+						run: async () => {
+							this.close();
+							await this._viewletService.openViewlet(ExtensionsViewletID, true);
+						}
+					}]);
+			}
 		}
 	}
 

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -115,7 +115,7 @@ suite('ConnectionDialogService tests', () => {
 		mockConnectionManagementService.setup(x => x.getConnectionGroups(TypeMoq.It.isAny())).returns(() => {
 			return [new ConnectionProfileGroup('test_group', undefined, 'test_group')];
 		});
-		testConnectionDialog = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, testInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService), new TestConfigurationService(), new TestCapabilitiesService());
+		testConnectionDialog = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, testInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService), new TestConfigurationService(), new TestCapabilitiesService(), undefined, undefined);
 		testConnectionDialog.render();
 		testConnectionDialog['renderBody'](DOM.createStyleSheet());
 		(connectionDialogService as any)._connectionDialog = testConnectionDialog;

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -123,7 +123,7 @@ suite('ConnectionDialogService tests', () => {
 				}
 			};
 		});
-		testConnectionDialog = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, testInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService), new TestConfigurationService(), new TestCapabilitiesService(), undefined, undefined);
+		testConnectionDialog = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, testInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService), new TestConfigurationService(), new TestCapabilitiesService(), undefined, undefined, undefined);
 		testConnectionDialog.render();
 		testConnectionDialog['renderBody'](DOM.createStyleSheet());
 		(connectionDialogService as any)._connectionDialog = testConnectionDialog;

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
@@ -65,7 +65,7 @@ suite('ConnectionDialogWidget tests', () => {
 			new TestCapabilitiesService());
 		let providerDisplayNames = ['Mock SQL Server'];
 		let providerNameToDisplayMap = { 'MSSQL': 'Mock SQL Server' };
-		connectionDialogWidget = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, cmInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService()), new TestConfigurationService(), new TestCapabilitiesService());
+		connectionDialogWidget = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, cmInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService()), new TestConfigurationService(), new TestCapabilitiesService(), undefined, undefined);
 		element = DOM.createStyleSheet();
 		connectionDialogWidget.render();
 		connectionDialogWidget['renderBody'](element);

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
@@ -65,7 +65,7 @@ suite('ConnectionDialogWidget tests', () => {
 			new TestCapabilitiesService());
 		let providerDisplayNames = ['Mock SQL Server'];
 		let providerNameToDisplayMap = { 'MSSQL': 'Mock SQL Server' };
-		connectionDialogWidget = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, cmInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService()), new TestConfigurationService(), new TestCapabilitiesService(), undefined, undefined);
+		connectionDialogWidget = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, cmInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService()), new TestConfigurationService(), new TestCapabilitiesService(), undefined, undefined, undefined);
 		element = DOM.createStyleSheet();
 		connectionDialogWidget.render();
 		connectionDialogWidget['renderBody'](element);

--- a/src/sql/workbench/services/connection/test/browser/testConnectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/test/browser/testConnectionDialogWidget.ts
@@ -19,6 +19,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 export class TestConnectionDialogWidget extends ConnectionDialogWidget {
 	constructor(
@@ -40,8 +41,9 @@ export class TestConnectionDialogWidget extends ConnectionDialogWidget {
 		@IConfigurationService configurationService: IConfigurationService,
 		@ICapabilitiesService capabilitiesService: ICapabilitiesService,
 		@INotificationService notificationService: INotificationService,
-		@IViewletService viewletService: IViewletService
+		@IViewletService viewletService: IViewletService,
+		@ICommandService commandService: ICommandService
 	) {
-		super(providerDisplayNameOptions, selectedProviderType, providerNameToDisplayNameMap, _instantiationService, _connectionManagementService, _contextMenuService, _contextViewService, themeService, layoutService, telemetryService, contextKeyService, clipboardService, logService, textResourcePropertiesService, configurationService, capabilitiesService, notificationService, viewletService);
+		super(providerDisplayNameOptions, selectedProviderType, providerNameToDisplayNameMap, _instantiationService, _connectionManagementService, _contextMenuService, _contextViewService, themeService, layoutService, telemetryService, contextKeyService, clipboardService, logService, textResourcePropertiesService, configurationService, capabilitiesService, notificationService, viewletService, commandService);
 	}
 }

--- a/src/sql/workbench/services/connection/test/browser/testConnectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/test/browser/testConnectionDialogWidget.ts
@@ -17,6 +17,8 @@ import { ITextResourcePropertiesService } from 'vs/editor/common/services/textRe
 import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 
 export class TestConnectionDialogWidget extends ConnectionDialogWidget {
 	constructor(
@@ -36,8 +38,10 @@ export class TestConnectionDialogWidget extends ConnectionDialogWidget {
 		@ILogService logService: ILogService,
 		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@ICapabilitiesService capabilitiesService: ICapabilitiesService
+		@ICapabilitiesService capabilitiesService: ICapabilitiesService,
+		@INotificationService notificationService: INotificationService,
+		@IViewletService viewletService: IViewletService
 	) {
-		super(providerDisplayNameOptions, selectedProviderType, providerNameToDisplayNameMap, _instantiationService, _connectionManagementService, _contextMenuService, _contextViewService, themeService, layoutService, telemetryService, contextKeyService, clipboardService, logService, textResourcePropertiesService, configurationService, capabilitiesService);
+		super(providerDisplayNameOptions, selectedProviderType, providerNameToDisplayNameMap, _instantiationService, _connectionManagementService, _contextMenuService, _contextViewService, themeService, layoutService, telemetryService, contextKeyService, clipboardService, logService, textResourcePropertiesService, configurationService, capabilitiesService, notificationService, viewletService);
 	}
 }


### PR DESCRIPTION
This PR fixes #19299

When the selected resource's provider type isn't supported, instead of doing nothing I am showing a prompt with the problem statement and an action to go to the extensions view.

Ideally, the extension metadata in the extension gallery should include the supported providers and in ADS we can query and directly show the extension, but that is not a trivial change, and the priority doesn't seem high enough to justify the cost since user can easily find the extension in the extensions view.

**Before**:
Nothing helps when you click on a resource that is not supported.

![before-no-extension](https://user-images.githubusercontent.com/13777222/168396926-28e5ef33-f795-4d5d-b10a-b8b2b20ca42d.gif)

**After**:
Provider not added to the mapping list:
![after-no-extension](https://user-images.githubusercontent.com/13777222/168396934-ed1a6697-8eb5-4b44-8949-035523cb21c7.gif)

provider with known extension:
![known-extension](https://user-images.githubusercontent.com/13777222/168406814-0e9752a2-8a96-45ac-8c2c-efdcb7d79710.gif)

