### PR TITLE
Fix Python smoke test failures.

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -24,12 +24,12 @@ export class ConfigurePythonDialog extends Dialog {
 
 	async waitForPageOneLoaded(): Promise<void> {
 		// Wait up to 1 minute for the python install location to be loaded.
-		const pythonInstallLocationDropdownValue = `${ConfigurePythonDialog.dialogPageInView} option[value*="/azuredatastudio-python (Default)"]`;
+		const pythonInstallLocationDropdownValue = `${ConfigurePythonDialog.dialogPageInView} option[value*="azuredatastudio-python (Default)"]`;
 		try {
 			await this.code.waitForElement(pythonInstallLocationDropdownValue, undefined, 600);
 		} finally {
 			// log the select box to help debug when the default python install location fails to load
-			await this.code.waitForElement('select[class="monaco-select-box"][aria-label="Python Install Location"]');
+			await this.code.waitForElement('select.monaco-select-box[aria-label="Python Install Location"]');
 		}
 
 		const loadingSpinner = `${ConfigurePythonDialog.dialogPageInView} .modelview-loadingComponent-content-loading`;


### PR DESCRIPTION
Fixes these issues blocking the python smoke tests:
1. The select box option selector was using a unix path separator, which would fail on Windows.
2. The select box wait in the finally statement was looking for exactly the monaco-select-box class, but there were several classes present.