### PR TITLE
Add UUID dependency to sql-bindings

### DIFF
--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -67,6 +67,7 @@
     "@microsoft/vscode-azext-utils": "^0.1.1",
     "fast-glob": "^3.2.7",
     "promisify-child-process": "^3.1.1",
+    "uuid": "^8.3.2",
     "vscode-nls": "^4.1.2",
     "vscode-languageclient": "5.2.1"
   },

--- a/extensions/sql-bindings/yarn.lock
+++ b/extensions/sql-bindings/yarn.lock
@@ -1302,6 +1302,11 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 vscode-extension-telemetry@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.7.tgz#18389bc24127c89dade29cd2b71ba69a6ee6ad26"


### PR DESCRIPTION
Usage added in https://github.com/microsoft/azuredatastudio/pull/18912 but the package was never added as a dependency. Any direct dependencies like this need to be added to the dependency list or stuff may break.

In this case it happened to work because webpacking picked up the root uuid dependency, but that's generally unsafe to rely on and was making it so this was broken for me when using an un-webpacked version.