### PR TITLE
Make data controller refresh handle direct mode

### DIFF
--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboard.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboard.ts
@@ -19,7 +19,7 @@ export class ControllerDashboard extends Dashboard {
 	public override async showDashboard(): Promise<void> {
 		await super.showDashboard();
 		// Kick off the model refresh but don't wait on it since that's all handled with callbacks anyways
-		this._controllerModel.refresh(false, this._controllerModel.info.namespace).catch(err => console.log(`Error refreshing Controller dashboard ${err}`));
+		this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace).catch(err => console.log(`Error refreshing Controller dashboard ${err}`));
 	}
 
 	protected async registerTabs(modelView: azdata.ModelView): Promise<(azdata.DashboardTab | azdata.DashboardTabGroup)[]> {

--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -57,7 +57,7 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 	}
 
 	protected async refresh(): Promise<void> {
-		await this._controllerModel.refresh(false, this._controllerModel.info.namespace);
+		await this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace);
 	}
 
 	public get container(): azdata.Component {

--- a/extensions/arc/src/ui/dashboards/controller/controllerUpgrades.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerUpgrades.ts
@@ -35,7 +35,7 @@ export class ControllerUpgradesPage extends DashboardPage {
 		return IconPathHelper.upgrade;
 	}
 	protected async refresh(): Promise<void> {
-		await Promise.resolve(this._controllerModel.refresh(false, this._controllerModel.info.namespace));
+		await Promise.resolve(this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace));
 		this.handleTableUpdated();
 	}
 
@@ -252,7 +252,7 @@ export class ControllerUpgradesPage extends DashboardPage {
 								}
 
 								try {
-									await this._controllerModel.refresh(false, this._controllerModel.info.namespace);
+									await this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace);
 								} catch (error) {
 									vscode.window.showErrorMessage(loc.refreshFailed(error));
 								}

--- a/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
@@ -56,7 +56,7 @@ export class MiaaBackupsPage extends DashboardPage {
 		return IconPathHelper.pitr;
 	}
 	protected async refresh(): Promise<void> {
-		await Promise.all([this._controllerModel.refresh(false, this._controllerModel.info.namespace), this._miaaModel.refresh()]);
+		await Promise.all([this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace), this._miaaModel.refresh()]);
 	}
 
 	public get container(): azdata.Component {

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboard.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboard.ts
@@ -23,7 +23,7 @@ export class MiaaDashboard extends Dashboard {
 	public override async showDashboard(): Promise<void> {
 		await super.showDashboard();
 		// Kick off the model refreshes but don't wait on it since that's all handled with callbacks anyways
-		this._controllerModel.refresh(false, this._controllerModel.info.namespace).catch(err => console.log(`Error refreshing controller model for MIAA dashboard ${err}`));
+		this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace).catch(err => console.log(`Error refreshing controller model for MIAA dashboard ${err}`));
 		this._miaaModel.refresh().catch(err => console.log(`Error refreshing MIAA model for MIAA dashboard ${err}`));
 	}
 

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -74,7 +74,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 	}
 
 	protected async refresh(): Promise<void> {
-		await Promise.all([this._controllerModel.refresh(false, this._controllerModel.info.namespace), this._miaaModel.refresh()]);
+		await Promise.all([this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace), this._miaaModel.refresh()]);
 	}
 
 	public get container(): azdata.Component {

--- a/extensions/arc/src/ui/dashboards/miaa/miaaUpgradeManagementPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaUpgradeManagementPage.ts
@@ -36,7 +36,7 @@ export class MiaaUpgradeManagementPage extends DashboardPage {
 		return IconPathHelper.upgrade;
 	}
 	protected async refresh(): Promise<void> {
-		await Promise.resolve(this._controllerModel.refresh(false, this._controllerModel.info.namespace));
+		await Promise.resolve(this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace));
 		this.handleTableUpdated();
 	}
 
@@ -289,7 +289,7 @@ export class MiaaUpgradeManagementPage extends DashboardPage {
 								}
 
 								try {
-									await this._controllerModel.refresh(false, this._controllerModel.info.namespace);
+									await this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace);
 								} catch (error) {
 									vscode.window.showErrorMessage(loc.refreshFailed(error));
 								}

--- a/extensions/arc/src/ui/dashboards/postgres/postgresDashboard.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresDashboard.ts
@@ -29,7 +29,7 @@ export class PostgresDashboard extends Dashboard {
 		await super.showDashboard();
 
 		// Kick off the model refresh but don't wait on it since that's all handled with callbacks anyways
-		this._controllerModel.refresh(false, this._controllerModel.info.namespace).catch(err => console.log(`Error refreshing controller model for Postgres dashboard ${err}`));
+		this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace).catch(err => console.log(`Error refreshing controller model for Postgres dashboard ${err}`));
 		this._postgresModel.refresh().catch(err => console.log(`Error refreshing Postgres model for Postgres dashboard ${err}`));
 	}
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -295,7 +295,7 @@ export class PostgresOverviewPage extends DashboardPage {
 
 					await Promise.all([
 						this._postgresModel.refresh(),
-						this._controllerModel.refresh(false, this._controllerModel.info.namespace)
+						this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace)
 					]);
 				} catch (error) {
 					vscode.window.showErrorMessage(loc.refreshFailed(error));

--- a/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
@@ -77,7 +77,7 @@ export class PostgresPropertiesPage extends DashboardPage {
 					this.loading!.loading = true;
 					await Promise.all([
 						this._postgresModel.refresh(),
-						this._controllerModel.refresh(false, this._controllerModel.info.namespace)
+						this._controllerModel.refresh(false, this._controllerModel.info.resourceGroup, this._controllerModel.info.namespace)
 					]);
 				} catch (error) {
 					vscode.window.showErrorMessage(loc.refreshFailed(error));

--- a/extensions/arc/src/ui/dialogs/connectControllerDialog.ts
+++ b/extensions/arc/src/ui/dialogs/connectControllerDialog.ts
@@ -196,7 +196,7 @@ export class ConnectToControllerDialog extends ControllerDialogBase {
 		const controllerModel = new ControllerModel(this.treeDataProvider, controllerInfo);
 		try {
 			// Validate that we can connect to the controller, this also populates the controllerRegistration from the connection response.
-			await controllerModel.refresh(false, this.namespaceInputBox.value);
+			await controllerModel.refresh(false, this.resourceGroup, this.namespaceInputBox.value);
 			// default info.name to the name of the controller instance if the user did not specify their own and to a pre-canned default if for some weird reason controller endpoint returned instanceName is also not a valid value
 			controllerModel.info.name = controllerModel.info.name || controllerModel.controllerConfig?.metadata.name || loc.defaultControllerName;
 			controllerModel.info.resourceGroup = <string>controllerModel.controllerConfig?.spec.settings.azure.resourceGroup;

--- a/extensions/arc/src/ui/tree/controllerTreeNode.ts
+++ b/extensions/arc/src/ui/tree/controllerTreeNode.ts
@@ -39,12 +39,12 @@ export class ControllerTreeNode extends TreeNode {
 
 	public override async getChildren(): Promise<TreeNode[]> {
 		try {
-			await this.model.refresh(false, this.model.info.namespace);
+			await this.model.refresh(false, this.model.info.resourceGroup, this.model.info.namespace);
 			this.updateChildren(this.model.registrations);
 		} catch (err) {
 			vscode.window.showErrorMessage(loc.errorConnectingToController(err));
 			try {
-				await this.model.refresh(false, this.model.info.namespace);
+				await this.model.refresh(false, this.model.info.resourceGroup, this.model.info.namespace);
 				this.updateChildren(this.model.registrations);
 			} catch (err) {
 				if (!(err instanceof UserCancelledError)) {

--- a/extensions/azcli/src/api.ts
+++ b/extensions/azcli/src/api.ts
@@ -123,10 +123,18 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 					validateAz(azToolService.localAz);
 					return azToolService.localAz!.sql.miarc.delete(name, namespace, additionalEnvVars);
 				},
-				list: async (namespace: string, additionalEnvVars?: azExt.AdditionalEnvVars) => {
+				list: async (
+					args: {
+						// Direct mode arguments
+						resourceGroup?: string;
+						// Indirect mode arguments
+						namespace?: string;
+					},
+					additionalEnvVars?: azExt.AdditionalEnvVars
+				) => {
 					await localAzDiscovered;
 					validateAz(azToolService.localAz);
-					return azToolService.localAz!.sql.miarc.list(namespace, additionalEnvVars);
+					return azToolService.localAz!.sql.miarc.list(args, additionalEnvVars);
 				},
 				show: async (
 					name: string,

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -178,8 +178,25 @@ export class AzTool implements azExt.IAzApi {
 			delete: (name: string, namespace: string, additionalEnvVars?: azExt.AdditionalEnvVars): Promise<azExt.AzOutput<void>> => {
 				return this.executeCommand<void>(['sql', 'mi-arc', 'delete', '-n', name, '--k8s-namespace', namespace, '--use-k8s'], additionalEnvVars);
 			},
-			list: (namespace: string, additionalEnvVars?: azExt.AdditionalEnvVars): Promise<azExt.AzOutput<azExt.SqlMiListResult[]>> => {
-				return this.executeCommand<azExt.SqlMiListResult[]>(['sql', 'mi-arc', 'list', '--k8s-namespace', namespace, '--use-k8s'], additionalEnvVars);
+			list: (
+				args: {
+					// Direct mode arguments
+					resourceGroup?: string,
+					// Indirect mode arguments
+					namespace?: string
+					// Additional arguments
+				},
+				additionalEnvVars?: azExt.AdditionalEnvVars
+			): Promise<azExt.AzOutput<azExt.SqlMiListResult[]>> => {
+				const argsArray = ['sql', 'mi-arc', 'list'];
+				if (args.resourceGroup) {
+					argsArray.push('--resource-group', args.resourceGroup);
+				}
+				if (args.namespace) {
+					argsArray.push('--k8s-namespace', args.namespace);
+					argsArray.push('--use-k8s');
+				}
+				return this.executeCommand<azExt.SqlMiListResult[]>(argsArray, additionalEnvVars);
 			},
 			show: (
 				name: string,

--- a/extensions/azcli/src/test/az.test.ts
+++ b/extensions/azcli/src/test/az.test.ts
@@ -116,7 +116,7 @@ describe('az', function () {
 				});
 				it('list', async function (): Promise<void> {
 					// Assume indirect mode
-					await azTool.sql.miarc.list(namespace);
+					await azTool.sql.miarc.list({resourceGroup: undefined, namespace: namespace});
 					verifyExecuteCommandCalledWithArgs(['sql', 'mi-arc', 'list', '--k8s-namespace', namespace, '--use-k8s']);
 				});
 				it('show', async function (): Promise<void> {

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -567,7 +567,16 @@ declare module 'az-ext' {
 		sql: {
 			miarc: {
 				delete(name: string, namespace?: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzOutput<void>>,
-				list(namespace?: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzOutput<SqlMiListResult[]>>,
+				list(
+					args: {
+					// Direct mode arguments
+					resourceGroup?: string,
+					// Indirect mode arguments
+					namespace?: string
+					},
+					// Additional arguments
+					additionalEnvVars?: AdditionalEnvVars
+				): Promise<AzOutput<SqlMiListResult[]>>,
 				show(
 					name: string,
 					args: {


### PR DESCRIPTION
Changes:
- Changed az arcdata dc config show to take resourceGroup as a param for direct mode
- Handled direct mode and indirect mode az arcdata dc config show differences
- Made refresh() call either refreshDirectMode() or refreshIndirectMode() depending on connectionMode
- Added resourceGroup as a param for all calls to refresh()

This is an example of the refresh button that will call refresh():
![image](https://user-images.githubusercontent.com/22386690/168931759-aefa7894-1270-494e-915c-d9c817c022aa.png)

