### PR TITLE
Move promptAddItem to extension API

### DIFF
--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -17,7 +17,7 @@ import { IconPathHelper } from '../common/iconHelper';
 import { WorkspaceTreeItem } from 'dataworkspace';
 import * as constants from '../common/constants';
 import { SqlDatabaseProjectProvider } from '../projectProvider/projectProvider';
-import { GenerateProjectFromOpenApiSpecOptions } from 'sqldbproj';
+import { GenerateProjectFromOpenApiSpecOptions, ItemType } from 'sqldbproj';
 
 /**
  * The main controller class that initializes the extension
@@ -67,13 +67,13 @@ export default class MainController implements vscode.Disposable {
 		vscode.commands.registerCommand('sqlDatabaseProjects.createProjectFromDatabase', async (context: azdataType.IConnectionProfile | vscodeMssql.ITreeNodeInfo | undefined) => { return this.projectsController.createProjectFromDatabase(context); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.generateProjectFromOpenApiSpec', async (options?: GenerateProjectFromOpenApiSpecOptions) => { return this.projectsController.generateProjectFromOpenApiSpec(options); });
 
-		vscode.commands.registerCommand('sqlDatabaseProjects.newScript', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.script); });
-		vscode.commands.registerCommand('sqlDatabaseProjects.newPreDeploymentScript', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.preDeployScript); });
-		vscode.commands.registerCommand('sqlDatabaseProjects.newPostDeploymentScript', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.postDeployScript); });
-		vscode.commands.registerCommand('sqlDatabaseProjects.newTable', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.table); });
-		vscode.commands.registerCommand('sqlDatabaseProjects.newView', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.view); });
-		vscode.commands.registerCommand('sqlDatabaseProjects.newStoredProcedure', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.storedProcedure); });
-		vscode.commands.registerCommand('sqlDatabaseProjects.newExternalStreamingJob', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, templates.externalStreamingJob); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.newScript', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, ItemType.script); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.newPreDeploymentScript', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, ItemType.preDeployScript); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.newPostDeploymentScript', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, ItemType.postDeployScript); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.newTable', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, ItemType.table); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.newView', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, ItemType.view); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.newStoredProcedure', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, ItemType.storedProcedure); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.newExternalStreamingJob', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, ItemType.externalStreamingJob); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.newItem', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.addExistingItem', async (node: WorkspaceTreeItem) => { return this.projectsController.addExistingItemPrompt(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.newFolder', async (node: WorkspaceTreeItem) => { return this.projectsController.addFolderPrompt(node); });

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -40,7 +40,7 @@ import { DashboardData, PublishData, Status } from '../models/dashboardData/dash
 import { getPublishDatabaseSettings, launchPublishTargetOption } from '../dialogs/publishDatabaseQuickpick';
 import { launchCreateAzureServerQuickPick, launchPublishToDockerContainerQuickpick } from '../dialogs/deployDatabaseQuickpick';
 import { DeployService } from '../models/deploy/deployService';
-import { GenerateProjectFromOpenApiSpecOptions, SqlTargetPlatform } from 'sqldbproj';
+import { GenerateProjectFromOpenApiSpecOptions, ISqlProject, ItemType, SqlTargetPlatform } from 'sqldbproj';
 import { AutorestHelper } from '../tools/autorestHelper';
 import { createNewProjectFromDatabaseWithQuickpick } from '../dialogs/createProjectFromDatabaseQuickpick';
 import { addDatabaseReferenceQuickpick } from '../dialogs/addDatabaseReferenceQuickpick';
@@ -643,7 +643,7 @@ export class ProjectsController {
 		const project = this.getProjectFromContext(treeNode);
 		const relativePathToParent = this.getRelativePath(treeNode.element);
 		const absolutePathToParent = path.join(project.projectFolderPath, relativePathToParent);
-		const newFolderName = await this.promptForNewObjectName(new templates.ProjectScriptType(templates.folder, constants.folderFriendlyName, ''),
+		const newFolderName = await this.promptForNewObjectName(new templates.ProjectScriptType(ItemType.folder, constants.folderFriendlyName, ''),
 			project, absolutePathToParent);
 
 		if (!newFolderName) {
@@ -678,7 +678,7 @@ export class ProjectsController {
 		await this.addItemPrompt(this.getProjectFromContext(treeNode), this.getRelativePath(treeNode.element), itemTypeName, treeNode.treeDataProvider as SqlDatabaseProjectTreeViewProvider);
 	}
 
-	public async addItemPrompt(project: Project, relativePath: string, itemTypeName?: string, treeDataProvider?: SqlDatabaseProjectTreeViewProvider): Promise<void> {
+	public async addItemPrompt(project: ISqlProject, relativePath: string, itemTypeName?: string, treeDataProvider?: SqlDatabaseProjectTreeViewProvider): Promise<void> {
 		if (!itemTypeName) {
 			const items: vscode.QuickPickItem[] = [];
 
@@ -711,9 +711,9 @@ export class ProjectsController {
 		const telemetryProps: Record<string, string> = { itemType: itemType.type };
 		const telemetryMeasurements: Record<string, number> = {};
 
-		if (itemType.type === templates.preDeployScript) {
+		if (itemType.type === ItemType.preDeployScript) {
 			telemetryMeasurements.numPredeployScripts = project.preDeployScripts.length;
-		} else if (itemType.type === templates.postDeployScript) {
+		} else if (itemType.type === ItemType.postDeployScript) {
 			telemetryMeasurements.numPostdeployScripts = project.postDeployScripts.length;
 		}
 
@@ -1240,7 +1240,7 @@ export class ProjectsController {
 			const postDeploymentScript: vscode.Uri | undefined = this.findPostDeploymentScript(fileFolderList);
 
 			if (postDeploymentScript) {
-				await project.addScriptItem(path.relative(project.projectFolderPath, postDeploymentScript.fsPath), undefined, templates.postDeployScript);
+				await project.addScriptItem(path.relative(project.projectFolderPath, postDeploymentScript.fsPath), undefined, ItemType.postDeployScript);
 			}
 
 			if (options?.doNotOpenInWorkspace !== true) {
@@ -1309,13 +1309,13 @@ export class ProjectsController {
 		if (projectTypeId === constants.edgeSqlDatabaseProjectTypeId) {
 			const project = await Project.openProject(newProjFilePath);
 
-			await this.createFileFromTemplate(project, templates.get(templates.table), 'DataTable.sql', { 'OBJECT_NAME': 'DataTable' });
-			await this.createFileFromTemplate(project, templates.get(templates.dataSource), 'EdgeHubInputDataSource.sql', { 'OBJECT_NAME': 'EdgeHubInputDataSource', 'LOCATION': 'edgehub://' });
-			await this.createFileFromTemplate(project, templates.get(templates.dataSource), 'SqlOutputDataSource.sql', { 'OBJECT_NAME': 'SqlOutputDataSource', 'LOCATION': 'sqlserver://tcp:.,1433' });
-			await this.createFileFromTemplate(project, templates.get(templates.fileFormat), 'StreamFileFormat.sql', { 'OBJECT_NAME': 'StreamFileFormat' });
-			await this.createFileFromTemplate(project, templates.get(templates.externalStream), 'EdgeHubInputStream.sql', { 'OBJECT_NAME': 'EdgeHubInputStream', 'DATA_SOURCE_NAME': 'EdgeHubInputDataSource', 'LOCATION': 'input', 'OPTIONS': ',\n\tFILE_FORMAT = StreamFileFormat' });
-			await this.createFileFromTemplate(project, templates.get(templates.externalStream), 'SqlOutputStream.sql', { 'OBJECT_NAME': 'SqlOutputStream', 'DATA_SOURCE_NAME': 'SqlOutputDataSource', 'LOCATION': 'TSQLStreaming.dbo.DataTable', 'OPTIONS': '' });
-			await this.createFileFromTemplate(project, templates.get(templates.externalStreamingJob), 'EdgeStreamingJob.sql', { 'OBJECT_NAME': 'EdgeStreamingJob' });
+			await this.createFileFromTemplate(project, templates.get(ItemType.table), 'DataTable.sql', { 'OBJECT_NAME': 'DataTable' });
+			await this.createFileFromTemplate(project, templates.get(ItemType.dataSource), 'EdgeHubInputDataSource.sql', { 'OBJECT_NAME': 'EdgeHubInputDataSource', 'LOCATION': 'edgehub://' });
+			await this.createFileFromTemplate(project, templates.get(ItemType.dataSource), 'SqlOutputDataSource.sql', { 'OBJECT_NAME': 'SqlOutputDataSource', 'LOCATION': 'sqlserver://tcp:.,1433' });
+			await this.createFileFromTemplate(project, templates.get(ItemType.fileFormat), 'StreamFileFormat.sql', { 'OBJECT_NAME': 'StreamFileFormat' });
+			await this.createFileFromTemplate(project, templates.get(ItemType.externalStream), 'EdgeHubInputStream.sql', { 'OBJECT_NAME': 'EdgeHubInputStream', 'DATA_SOURCE_NAME': 'EdgeHubInputDataSource', 'LOCATION': 'input', 'OPTIONS': ',\n\tFILE_FORMAT = StreamFileFormat' });
+			await this.createFileFromTemplate(project, templates.get(ItemType.externalStream), 'SqlOutputStream.sql', { 'OBJECT_NAME': 'SqlOutputStream', 'DATA_SOURCE_NAME': 'SqlOutputDataSource', 'LOCATION': 'TSQLStreaming.dbo.DataTable', 'OPTIONS': '' });
+			await this.createFileFromTemplate(project, templates.get(ItemType.externalStreamingJob), 'EdgeStreamingJob.sql', { 'OBJECT_NAME': 'EdgeStreamingJob' });
 		}
 	}
 
@@ -1340,7 +1340,7 @@ export class ProjectsController {
 		}
 	}
 
-	private async promptForNewObjectName(itemType: templates.ProjectScriptType, _project: Project, folderPath: string, fileExtension?: string): Promise<string | undefined> {
+	private async promptForNewObjectName(itemType: templates.ProjectScriptType, _project: ISqlProject, folderPath: string, fileExtension?: string): Promise<string | undefined> {
 		const suggestedName = itemType.friendlyName.replace(/\s+/g, '');
 		let counter: number = 0;
 

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -9,11 +9,10 @@ import * as constants from '../common/constants';
 import * as utils from '../common/utils';
 import * as xmlFormat from 'xml-formatter';
 import * as os from 'os';
-import * as templates from '../templates/templates';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 
 import { Uri, window } from 'vscode';
-import { ISqlProject, SqlTargetPlatform } from 'sqldbproj';
+import { ISqlProject, ItemType, SqlTargetPlatform } from 'sqldbproj';
 import { promises as fs } from 'fs';
 import { DataSource } from './dataSources/dataSources';
 import { ISystemDatabaseReferenceSettings, IDacpacReferenceSettings, IProjectReferenceSettings } from './IDatabaseReferenceSettings';
@@ -807,11 +806,11 @@ export class Project implements ISqlProject {
 
 		let xmlTag;
 		switch (itemType) {
-			case templates.preDeployScript:
+			case ItemType.preDeployScript:
 				xmlTag = constants.PreDeploy;
 				this._preDeployScripts.length === 0 ? this._preDeployScripts.push(fileEntry) : this._noneDeployScripts.push(fileEntry);
 				break;
-			case templates.postDeployScript:
+			case ItemType.postDeployScript:
 				xmlTag = constants.PostDeploy;
 				this._postDeployScripts.length === 0 ? this._postDeployScripts.push(fileEntry) : this._noneDeployScripts.push(fileEntry);
 				break;
@@ -822,7 +821,7 @@ export class Project implements ISqlProject {
 
 		const attributes = new Map<string, string>();
 
-		if (itemType === templates.externalStreamingJob) {
+		if (itemType === ItemType.externalStreamingJob) {
 			fileEntry.sqlObjectType = constants.ExternalStreamingJob;
 			attributes.set(constants.Type, constants.ExternalStreamingJob);
 		}

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -104,6 +104,10 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 		return Project.openProject(projectFilePath);
 	}
 
+	public promptAddItem(project: sqldbproj.ISqlProject, relativeFilePath: string, itemType?: string): Promise<void> {
+		return this.projectController.addItemPrompt(project, relativeFilePath, itemType);
+	}
+
 	/**
 	 * Gets the project actions to be placed on the dashboard toolbar
 	 */

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -215,9 +215,20 @@ declare module 'sqldbproj' {
 		 */
 		readonly sqlCmdVariables: Record<string, string>;
 
+		/**
+		 * Pre-deployment scripts in this project
+		 */
 		readonly preDeployScripts: IFileProjectEntry[];
 
+		/**
+		 * Post-deployment scripts in this project
+		 */
 		readonly postDeployScripts: IFileProjectEntry[];
+
+		/**
+		 * "None" scripts in this project (scripts ignored by the build)
+		 */
+		readonly noneDeployScripts: IFileProjectEntry[];
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -54,6 +54,32 @@ declare module 'sqldbproj' {
 		 * @returns the generated sql project
 		 */
 		generateProjectFromOpenApiSpec(options?: GenerateProjectFromOpenApiSpecOptions): Promise<ISqlProject | undefined>;
+
+		/**
+		 * Prompts the user to add a new item to the specified project
+		 * @param project The project to add the item to
+		 * @param relativeFilePath The relative path in the project where the item should be added
+		 * @param itemType Optional - The type of item to add. If not specified the user will choose from a list of available types
+		 */
+		promptAddItem(project: ISqlProject, relativeFilePath: string, itemType?: string): Promise<void>;
+
+	}
+
+	/**
+	 * The type of an item in a SQL Project
+	 */
+	export const enum ItemType {
+		script = 'script',
+		table = 'table',
+		view = 'view',
+		storedProcedure = 'storedProcedure',
+		dataSource = 'dataSource',
+		fileFormat = 'fileFormat',
+		externalStream = 'externalStream',
+		externalStreamingJob = 'externalStreamingJob',
+		folder = 'folder',
+		preDeployScript = 'preDeployScript',
+		postDeployScript = 'postDeployScript'
 	}
 
 	/**
@@ -125,15 +151,15 @@ declare module 'sqldbproj' {
 		 *
 		 * @param databaseSource Source of the database to add
 		 */
-		 addDatabaseSource(databaseSource: string): Promise<void>;
+		addDatabaseSource(databaseSource: string): Promise<void>;
 
-		 /**
-		  * Removes database source from the DatabaseSource property element.
-		  * If no sources remain, then property element will be removed from the project file.
-		  *
-		  * @param databaseSource Source of the database to remove
-		  */
-		 removeDatabaseSource(databaseSource: string): Promise<void>;
+		/**
+		 * Removes database source from the DatabaseSource property element.
+		 * If no sources remain, then property element will be removed from the project file.
+		 *
+		 * @param databaseSource Source of the database to remove
+		 */
+		removeDatabaseSource(databaseSource: string): Promise<void>;
 
 		/**
 		 * Excludes entry from project by removing it from the project file
@@ -188,6 +214,10 @@ declare module 'sqldbproj' {
 		 * SqlCmd variables and their values
 		 */
 		readonly sqlCmdVariables: Record<string, string>;
+
+		readonly preDeployScripts: IFileProjectEntry[];
+
+		readonly postDeployScripts: IFileProjectEntry[];
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/templates/templates.ts
+++ b/extensions/sql-database-projects/src/templates/templates.ts
@@ -6,24 +6,10 @@
 import * as path from 'path';
 import * as constants from '../common/constants';
 import { promises as fs } from 'fs';
+import { ItemType } from 'sqldbproj';
 
 export let newSqlProjectTemplate: string;
 export let newSdkSqlProjectTemplate: string;
-
-// Object types
-
-export const script: string = 'script';
-export const table: string = 'table';
-export const view: string = 'view';
-export const storedProcedure: string = 'storedProcedure';
-export const dataSource: string = 'dataSource';
-export const fileFormat: string = 'fileFormat';
-export const externalStream: string = 'externalStream';
-export const externalStreamingJob: string = 'externalStreamingJob';
-
-export const folder: string = 'folder';
-export const preDeployScript: string = 'preDeployScript';
-export const postDeployScript: string = 'postDeployScript';
 
 // Object maps
 
@@ -53,16 +39,16 @@ export async function loadTemplates(templateFolderPath: string) {
 	await Promise.all([
 		Promise.resolve(newSqlProjectTemplate = await loadTemplate(templateFolderPath, 'newSqlProjectTemplate.xml')),
 		Promise.resolve(newSdkSqlProjectTemplate = await loadTemplate(templateFolderPath, 'newSdkSqlProjectTemplate.xml')),
-		loadObjectTypeInfo(script, constants.scriptFriendlyName, templateFolderPath, 'newTsqlScriptTemplate.sql'),
-		loadObjectTypeInfo(table, constants.tableFriendlyName, templateFolderPath, 'newTsqlTableTemplate.sql'),
-		loadObjectTypeInfo(view, constants.viewFriendlyName, templateFolderPath, 'newTsqlViewTemplate.sql'),
-		loadObjectTypeInfo(storedProcedure, constants.storedProcedureFriendlyName, templateFolderPath, 'newTsqlStoredProcedureTemplate.sql'),
-		loadObjectTypeInfo(preDeployScript, constants.preDeployScriptFriendlyName, templateFolderPath, 'newTsqlPreDeployScriptTemplate.sql'),
-		loadObjectTypeInfo(postDeployScript, constants.postDeployScriptFriendlyName, templateFolderPath, 'newTsqlPostDeployScriptTemplate.sql'),
-		loadObjectTypeInfo(dataSource, constants.dataSourceFriendlyName, templateFolderPath, 'newTsqlDataSourceTemplate.sql'),
-		loadObjectTypeInfo(fileFormat, constants.fileFormatFriendlyName, templateFolderPath, 'newTsqlFileFormatTemplate.sql'),
-		loadObjectTypeInfo(externalStream, constants.externalStreamFriendlyName, templateFolderPath, 'newTsqlExternalStreamTemplate.sql'),
-		loadObjectTypeInfo(externalStreamingJob, constants.externalStreamingJobFriendlyName, templateFolderPath, 'newTsqlExternalStreamingJobTemplate.sql')
+		loadObjectTypeInfo(ItemType.script, constants.scriptFriendlyName, templateFolderPath, 'newTsqlScriptTemplate.sql'),
+		loadObjectTypeInfo(ItemType.table, constants.tableFriendlyName, templateFolderPath, 'newTsqlTableTemplate.sql'),
+		loadObjectTypeInfo(ItemType.view, constants.viewFriendlyName, templateFolderPath, 'newTsqlViewTemplate.sql'),
+		loadObjectTypeInfo(ItemType.storedProcedure, constants.storedProcedureFriendlyName, templateFolderPath, 'newTsqlStoredProcedureTemplate.sql'),
+		loadObjectTypeInfo(ItemType.preDeployScript, constants.preDeployScriptFriendlyName, templateFolderPath, 'newTsqlPreDeployScriptTemplate.sql'),
+		loadObjectTypeInfo(ItemType.postDeployScript, constants.postDeployScriptFriendlyName, templateFolderPath, 'newTsqlPostDeployScriptTemplate.sql'),
+		loadObjectTypeInfo(ItemType.dataSource, constants.dataSourceFriendlyName, templateFolderPath, 'newTsqlDataSourceTemplate.sql'),
+		loadObjectTypeInfo(ItemType.fileFormat, constants.fileFormatFriendlyName, templateFolderPath, 'newTsqlFileFormatTemplate.sql'),
+		loadObjectTypeInfo(ItemType.externalStream, constants.externalStreamFriendlyName, templateFolderPath, 'newTsqlExternalStreamTemplate.sql'),
+		loadObjectTypeInfo(ItemType.externalStreamingJob, constants.externalStreamingJobFriendlyName, templateFolderPath, 'newTsqlExternalStreamingJobTemplate.sql')
 	]);
 
 	for (const scriptType of scriptTypes) {

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -8,7 +8,6 @@ import * as path from 'path';
 import * as os from 'os';
 import * as sinon from 'sinon';
 import * as baselines from './baselines/baselines';
-import * as templates from '../templates/templates';
 import * as testUtils from './testUtils';
 import * as constants from '../common/constants';
 
@@ -17,7 +16,7 @@ import { Project } from '../models/project';
 import { exists, convertSlashesForSqlProj, getWellKnownDatabaseSources } from '../common/utils';
 import { Uri, window } from 'vscode';
 import { IDacpacReferenceSettings, IProjectReferenceSettings, ISystemDatabaseReferenceSettings } from '../models/IDatabaseReferenceSettings';
-import { SqlTargetPlatform } from 'sqldbproj';
+import { ItemType, SqlTargetPlatform } from 'sqldbproj';
 import { EntryType, SystemDatabaseReferenceProjectEntry, SqlProjectReferenceProjectEntry, SystemDatabase } from '../models/projectEntry';
 
 let projFilePath: string;
@@ -110,7 +109,7 @@ describe('Project: sqlproj content operations', function (): void {
 
 		await project.addFolderItem(folderPath);
 		await project.addScriptItem(scriptPath, scriptContents);
-		await project.addScriptItem(scriptPathTagged, scriptContentsTagged, templates.externalStreamingJob);
+		await project.addScriptItem(scriptPathTagged, scriptContentsTagged, ItemType.externalStreamingJob);
 
 		const newProject = await Project.openProject(projFilePath);
 
@@ -542,8 +541,8 @@ describe('Project: sqlproj content operations', function (): void {
 		const fileContents = ' ';
 
 		await project.addFolderItem(folderPath);
-		await project.addScriptItem(preDeploymentScriptFilePath, fileContents, templates.preDeployScript);
-		await project.addScriptItem(postDeploymentScriptFilePath, fileContents, templates.postDeployScript);
+		await project.addScriptItem(preDeploymentScriptFilePath, fileContents, ItemType.preDeployScript);
+		await project.addScriptItem(postDeploymentScriptFilePath, fileContents, ItemType.postDeployScript);
 
 		const newProject = await Project.openProject(projFilePath);
 
@@ -565,13 +564,13 @@ describe('Project: sqlproj content operations', function (): void {
 		const fileContents = ' ';
 
 		await project.addFolderItem(folderPath);
-		await project.addScriptItem(preDeploymentScriptFilePath, fileContents, templates.preDeployScript);
-		await project.addScriptItem(postDeploymentScriptFilePath, fileContents, templates.postDeployScript);
+		await project.addScriptItem(preDeploymentScriptFilePath, fileContents, ItemType.preDeployScript);
+		await project.addScriptItem(postDeploymentScriptFilePath, fileContents, ItemType.postDeployScript);
 
-		await project.addScriptItem(preDeploymentScriptFilePath2, fileContents, templates.preDeployScript);
+		await project.addScriptItem(preDeploymentScriptFilePath2, fileContents, ItemType.preDeployScript);
 		should(stub.calledWith(constants.deployScriptExists(constants.PreDeploy))).be.true(`showInformationMessage not called with expected message '${constants.deployScriptExists(constants.PreDeploy)}' Actual '${stub.getCall(0).args[0]}'`);
 
-		await project.addScriptItem(postDeploymentScriptFilePath2, fileContents, templates.postDeployScript);
+		await project.addScriptItem(postDeploymentScriptFilePath2, fileContents, ItemType.postDeployScript);
 		should(stub.calledWith(constants.deployScriptExists(constants.PostDeploy))).be.true(`showInformationMessage not called with expected message '${constants.deployScriptExists(constants.PostDeploy)}' Actual '${stub.getCall(0).args[0]}'`);
 
 		const newProject = await Project.openProject(projFilePath);
@@ -1026,9 +1025,9 @@ describe('Project: sdk style project content operations', function (): void {
 		projFilePath = await testUtils.createTestSqlProjFile(baselines.newSdkStyleProjectSdkNodeBaseline, folderPath);
 
 		const project: Project = await Project.openProject(projFilePath);
-		await project.addScriptItem('Script.PreDeployment1.sql', 'fake contents', templates.preDeployScript);
-		await project.addScriptItem('Script.PreDeployment2.sql', 'fake contents', templates.preDeployScript);
-		await project.addScriptItem('Script.PostDeployment1.sql', 'fake contents', templates.postDeployScript);
+		await project.addScriptItem('Script.PreDeployment1.sql', 'fake contents', ItemType.preDeployScript);
+		await project.addScriptItem('Script.PreDeployment2.sql', 'fake contents', ItemType.preDeployScript);
+		await project.addScriptItem('Script.PostDeployment1.sql', 'fake contents', ItemType.postDeployScript);
 
 		// verify they were added to the sqlproj
 		let projFileText = (await fs.readFile(projFilePath)).toString();
@@ -1119,7 +1118,7 @@ describe('Project: sdk style project content operations', function (): void {
 		const otherFolderPath = 'OtherFolder\\';
 
 		await project.addScriptItem(scriptPath, scriptContents);
-		await project.addScriptItem(scriptPathTagged, scriptContentsTagged, templates.externalStreamingJob);
+		await project.addScriptItem(scriptPathTagged, scriptContentsTagged, ItemType.externalStreamingJob);
 		await project.addScriptItem(outsideFolderScriptPath, outsideFolderScriptContents);
 		await project.addFolderItem(otherFolderPath);
 

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -30,7 +30,7 @@ import { AddDatabaseReferenceDialog } from '../dialogs/addDatabaseReferenceDialo
 import { IDacpacReferenceSettings } from '../models/IDatabaseReferenceSettings';
 import { CreateProjectFromDatabaseDialog } from '../dialogs/createProjectFromDatabaseDialog';
 import { ImportDataModel } from '../models/api/import';
-import { SqlTargetPlatform } from 'sqldbproj';
+import { ItemType, SqlTargetPlatform } from 'sqldbproj';
 import { SystemDatabaseReferenceProjectEntry, SystemDatabase, EntryType, FileProjectEntry } from '../models/projectEntry';
 
 let testContext: TestContext;
@@ -96,7 +96,7 @@ describe('ProjectsController', function (): void {
 					const project = new Project('FakePath');
 
 					should(project.files.length).equal(0);
-					await projController.addItemPrompt(new Project('FakePath'), '', templates.script);
+					await projController.addItemPrompt(new Project('FakePath'), '', ItemType.script);
 					should(project.files.length).equal(0, 'Expected to return without throwing an exception or adding a file when an empty/undefined name is provided.');
 					should(showErrorMessageSpy.notCalled).be.true('showErrorMessage should not have been called');
 					showInputBoxStub.restore();
@@ -112,9 +112,9 @@ describe('ProjectsController', function (): void {
 				const project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
 
 				should(project.files.length).equal(0, 'There should be no files');
-				await projController.addItemPrompt(project, '', templates.script);
+				await projController.addItemPrompt(project, '', ItemType.script);
 				should(project.files.length).equal(1, 'File should be successfully added');
-				await projController.addItemPrompt(project, '', templates.script);
+				await projController.addItemPrompt(project, '', ItemType.script);
 				const msg = constants.fileAlreadyExists(tableName);
 				should(spy.calledOnce).be.true('showErrorMessage should have been called exactly once');
 				should(spy.calledWith(msg)).be.true(`showErrorMessage not called with expected message '${msg}' Actual '${spy.getCall(0).args[0]}'`);
@@ -327,13 +327,13 @@ describe('ProjectsController', function (): void {
 
 				sinon.stub(vscode.window, 'showInputBox').resolves(preDeployScriptName);
 				should(project.preDeployScripts.length).equal(0, 'There should be no pre deploy scripts');
-				await projController.addItemPrompt(project, '', templates.preDeployScript);
+				await projController.addItemPrompt(project, '', ItemType.preDeployScript);
 				should(project.preDeployScripts.length).equal(1, `Pre deploy script should be successfully added. ${project.preDeployScripts.length}, ${project.files.length}`);
 
 				sinon.restore();
 				sinon.stub(vscode.window, 'showInputBox').resolves(postDeployScriptName);
 				should(project.postDeployScripts.length).equal(0, 'There should be no post deploy scripts');
-				await projController.addItemPrompt(project, '', templates.postDeployScript);
+				await projController.addItemPrompt(project, '', ItemType.postDeployScript);
 				should(project.postDeployScripts.length).equal(1, 'Post deploy script should be successfully added');
 			});
 
@@ -739,9 +739,9 @@ async function setupDeleteExcludeTest(proj: Project): Promise<[FileProjectEntry,
 	const scriptEntry = await proj.addScriptItem('UpperFolder/LowerFolder/someScript.sql', 'not a real script');
 	await proj.addScriptItem('UpperFolder/LowerFolder/someOtherScript.sql', 'Also not a real script');
 	await proj.addScriptItem('../anotherScript.sql', 'Also not a real script');
-	const preDeployEntry = await proj.addScriptItem('Script.PreDeployment1.sql', 'pre-deployment stuff', templates.preDeployScript);
-	const noneEntry = await proj.addScriptItem('Script.PreDeployment2.sql', 'more pre-deployment stuff', templates.preDeployScript);
-	const postDeployEntry = await proj.addScriptItem('Script.PostDeployment1.sql', 'post-deployment stuff', templates.postDeployScript);
+	const preDeployEntry = await proj.addScriptItem('Script.PreDeployment1.sql', 'pre-deployment stuff', ItemType.preDeployScript);
+	const noneEntry = await proj.addScriptItem('Script.PreDeployment2.sql', 'more pre-deployment stuff', ItemType.preDeployScript);
+	const postDeployEntry = await proj.addScriptItem('Script.PostDeployment1.sql', 'post-deployment stuff', ItemType.postDeployScript);
 
 	const projTreeRoot = new ProjectRootTreeItem(proj);
 	sinon.stub(vscode.window, 'showWarningMessage').returns(<any>Promise.resolve(constants.yesString));


### PR DESCRIPTION
Need access to this for some work I'm doing. 

In doing this I needed to slightly change the function signatures to take in an ISqlProject, which then also required added the deployment script properties to the public interface. Didn't seem like a bad change so getting that in as well.

And finally converting the list of item types to an enum for ease of use. They're still passed around as strings in the codebase so no functional change.

I really would have preferred this to live on the ISqlProject itself (so you'd call project.addItem(...) instead) but unfortunately addItem requires access to the project controller which the project itself doesn't know about and refactoring all that was out of scope of what I wanted to be doing here. So leaving it as is for now and I may look into doing that later on if it ends up being useful for other scenarios. 