### PR TITLE
Fixes manually enter table name due to await

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -681,7 +681,7 @@ export async function promptSelectTable(connectionURI: string, bindingType: Bind
 		});
 
 		if (selectedObject === manuallyEnterObjectName) {
-			let selectedObject = promptToManuallyEnterObjectName(bindingType);
+			selectedObject = await promptToManuallyEnterObjectName(bindingType);
 			if (!selectedObject) {
 				// user cancelled so we will show the tables prompt again
 				continue;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19436.
We were not awaiting the inputBox result and as a result, we went straight to the function name prompt.
