### PR TITLE
fix loop for cancelling out databases

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -323,35 +323,31 @@ export async function promptForObjectName(bindingType: BindingType, connectionIn
 	let connectionURI: string | undefined;
 	let selectedDatabase: string | undefined;
 
-	while (true) {
-		if (!connectionInfo) {
-			// prompt is shown when user selects an existing connection string setting
-			// or manually enters a connection string
-			return promptToManuallyEnterObjectName(bindingType);
-		}
-
-		// TODO create path to solve for selectView (first need to support views as well)
-		// Prompt user to select a table based on connection profile and selected database}
-		// get connectionURI and selectedDatabase to be used for listing tables query request
-		connectionURI = await getConnectionURI(connectionInfo);
-		if (!connectionURI) {
-			// mssql connection error
-			// we will then prompt user to choose a connection profile again
-			return undefined;
-		}
-		selectedDatabase = await promptSelectDatabase(connectionURI);
-		if (!selectedDatabase) {
-			// User cancelled
-			// we will then prompt user to choose a connection profile again
-			return undefined;
-		}
-
-		connectionInfo.database = selectedDatabase;
-
-		let selectedObjectName = await promptSelectTable(connectionURI, bindingType, selectedDatabase);
-
-		return selectedObjectName;
+	if (!connectionInfo) {
+		// prompt is shown when user selects an existing connection string setting
+		// or manually enters a connection string
+		return promptToManuallyEnterObjectName(bindingType);
 	}
+
+	// TODO create path to solve for selectView (first need to support views as well)
+	// Prompt user to select a table based on connection profile and selected database}
+	// get connectionURI and selectedDatabase to be used for listing tables query request
+	connectionURI = await getConnectionURI(connectionInfo);
+	if (!connectionURI) {
+		// mssql connection error
+		return undefined;
+	}
+	selectedDatabase = await promptSelectDatabase(connectionURI);
+	if (!selectedDatabase) {
+		// User cancelled
+		return undefined;
+	}
+
+	connectionInfo.database = selectedDatabase;
+
+	let selectedObjectName = await promptSelectTable(connectionURI, bindingType, selectedDatabase);
+
+	return selectedObjectName;
 }
 
 /**

--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -335,15 +335,15 @@ export async function promptForObjectName(bindingType: BindingType, connectionIn
 		// get connectionURI and selectedDatabase to be used for listing tables query request
 		connectionURI = await getConnectionURI(connectionInfo);
 		if (!connectionURI) {
-			// User cancelled or mssql connection error
+			// mssql connection error
 			// we will then prompt user to choose a connection profile again
-			continue;
+			return undefined;
 		}
 		selectedDatabase = await promptSelectDatabase(connectionURI);
 		if (!selectedDatabase) {
 			// User cancelled
 			// we will then prompt user to choose a connection profile again
-			continue;
+			return undefined;
 		}
 
 		connectionInfo.database = selectedDatabase;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19451.
We should return undefined so that the azureFunctionService would then continue back to prompt the user to choose the connection profile. 
