### PR TITLE
remove password for connection string non sql auth types

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -579,6 +579,7 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 			connectionString = await vscodeMssqlApi.getConnectionString(connectionDetails, false, false);
 
 			if (connectionInfo.authenticationType !== 'SqlLogin') {
+				// temporarily fix until STS is fix to not include the placeholder: https://github.com/microsoft/sqltoolsservice/issues/1508
 				// if authentication type is not SQL login, remove password in connection string
 				connectionString = connectionString.replace(`Password=${constants.passwordPlaceholder};`, '');
 			}

--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -578,6 +578,11 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 			// or user chooses to not include password (or if user cancels out of include password prompt), or authentication type is not SQL login
 			connectionString = await vscodeMssqlApi.getConnectionString(connectionDetails, false, false);
 
+			if (connectionInfo.authenticationType !== 'SqlLogin') {
+				// if authentication type is not SQL login, remove password in connection string
+				connectionString = connectionString.replace(`Password=${constants.passwordPlaceholder};`, '');
+			}
+
 			if (!connectionInfo.password && connectionInfo.authenticationType === 'SqlLogin') {
 				// if a connection exists but does not have password saved we ask user if they would like to enter it and save it in local.settings.json
 				userPassword = await vscode.window.showInputBox({

--- a/extensions/sql-bindings/src/test/common/azureFunctionsUtils.test.ts
+++ b/extensions/sql-bindings/src/test/common/azureFunctionsUtils.test.ts
@@ -177,7 +177,7 @@ describe('Tests to verify Azure Functions Utils functions', function (): void {
 		should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
 		should(warningSpy.notCalled).be.true('showWarningMessage should not have been called');
 		// returned connection string should NOT include password
-		should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`);
+		should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};`);
 	});
 
 	it('Should ask user to enter password and set password to connection string when connection info does not contain password and auth type is SQL', async () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19452.
Short-term fix for non-SQL auth types only.
Removes `Password=******;` from connection string.
