### PR TITLE
Update azdataGraph version from 0.0.26 to 0.0.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
     "applicationinsights": "1.0.8",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.26",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.27",
     "chart.js": "^2.9.4",
     "chokidar": "3.5.2",
     "graceful-fs": "4.2.6",

--- a/remote/package.json
+++ b/remote/package.json
@@ -16,7 +16,7 @@
     "applicationinsights": "1.0.8",
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.26",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.27",
     "chart.js": "^2.9.4",
     "chokidar": "3.5.2",
     "cookie": "^0.4.0",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -15,7 +15,7 @@
 		"@vscode/vscode-languagedetection": "1.0.18",
 		"angular2-grid": "2.0.6",
 		"ansi_up": "^5.1.0",
-		"azdataGraph": "github:Microsoft/azdataGraph#0.0.26",
+		"azdataGraph": "github:Microsoft/azdataGraph#0.0.27",
 		"chart.js": "^2.9.4",
 		"gridstack": "^3.1.3",
 		"kburtram-query-plan": "2.6.1",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -150,9 +150,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.26":
-  version "0.0.26"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/a5f94e53cb655bc44f1a2727653bb403942e1cf9"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.27":
+  version "0.0.27"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/972e1f3a26cd2e5a9ce75594e83c041fce9cedcb"
 
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -198,9 +198,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.26":
-  version "0.0.26"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/a5f94e53cb655bc44f1a2727653bb403942e1cf9"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.27":
+  version "0.0.27"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/972e1f3a26cd2e5a9ce75594e83c041fce9cedcb"
 
 binary-extensions@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1831,9 +1831,9 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.26":
-  version "0.0.26"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/a5f94e53cb655bc44f1a2727653bb403942e1cf9"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.27":
+  version "0.0.27"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/972e1f3a26cd2e5a9ce75594e83c041fce9cedcb"
 
 azure-storage@^2.10.2:
   version "2.10.2"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR bumps azdataGraph version from 0.0.26 to 0.0.27, which fixes a bug that was present in the azdataGraph library that was impacting how polygons were being drawn.

Before:
![image](https://user-images.githubusercontent.com/87730006/169936771-fe33bdad-5336-4123-b3d4-827066ef9be2.png)

After:
![image](https://user-images.githubusercontent.com/87730006/169936805-9c26851d-364f-473d-8934-915dcd5561ca.png)

