### PR TITLE
Fix manage packages wizard being reinitialized twice

### DIFF
--- a/extensions/notebook/src/dialog/managePackages/addNewPackageTab.ts
+++ b/extensions/notebook/src/dialog/managePackages/addNewPackageTab.ts
@@ -94,8 +94,6 @@ export class AddNewPackageTab {
 				}]).component();
 
 			await view.initializeModel(formModel);
-
-			await this.resetPageFields();
 		});
 	}
 


### PR DESCRIPTION
Removing the resetPageFields() call since it also gets called here
https://github.com/microsoft/azuredatastudio/blob/8c3c18e8dcda702d09b9dfe766db91eec7e3a76d/extensions/notebook/src/dialog/managePackages/installedPackagesTab.ts#L60-L64 when the wizard is initialized. 

I was a bit confused before I saw this change (https://github.com/microsoft/azuredatastudio/pull/13691) since I was expecting DropDownComponent.onValueChanged() to not be called when the dropdown value is initialized.

This should fix the smoke test failing because the content typed in the inputbox would get cleared by the second resetPageFields call.