### PR TITLE
Bump STS to 4.0.0.5

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.0.0.4",
+	"version": "4.0.0.5",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/19117

There's only one commit after `4.0.0.4` https://github.com/microsoft/sqltoolsservice/compare/4.0.0.4...4.0.0.5

![image](https://user-images.githubusercontent.com/21186993/170100645-b21683c1-2e9f-4a03-b3e4-5851028ca21a.png)