### PR TITLE
hide account when using connection string

### DIFF
--- a/src/sql/workbench/services/connection/browser/media/connectionDialog.css
+++ b/src/sql/workbench/services/connection/browser/media/connectionDialog.css
@@ -154,6 +154,7 @@
 .connection-dialog .use-connection-string .auth-type-row,
 .connection-dialog .use-connection-string .database-row,
 .connection-dialog .use-connection-string .advanced-button,
+.connection-dialog .use-connection-string .azure-account-row,
 .connection-dialog .connection-string-row {
 	display: none;
 }


### PR DESCRIPTION
the account field is still showing when switched to connection string option.

Before
![conn-before](https://user-images.githubusercontent.com/13777222/170102805-12b47f89-b889-4fc6-a57c-8d1c39d74432.gif)


After
![conn-after](https://user-images.githubusercontent.com/13777222/170102773-dce672cc-0991-4268-866d-c9de267026a0.gif)
