### PR TITLE
vbump and fix ads version dependency

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
@@ -10,7 +10,7 @@
   "aiKey": "AIF-37eefaf0-8022-4671-a3fb-64752724682e",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.37.0"
+    "azdata": ">=1.36.0"
   },
   "activationEvents": [
     "onDashboardOpen",


### PR DESCRIPTION
lowering the required ads version to 1.36 as 1.37 is not released.