### PR TITLE
Also check for docs pane label in code cell completions test.

### DIFF
--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -46,7 +46,12 @@ export function setup(opts: minimist.ParsedArgs) {
 
 			// check for completion suggestions
 			await app.workbench.sqlNotebook.waitForSuggestionWidget();
-			await app.workbench.sqlNotebook.waitForSuggestionResult('SELECT');
+
+			// Docs pane might be visible in the completions list, so also check for a docs aria-label
+			await Promise.race([
+				app.workbench.sqlNotebook.waitForSuggestionResult('SELECT'),
+				app.workbench.sqlNotebook.waitForSuggestionResult('SELECT, docs: SELECT keyword')
+			]);
 			await app.code.dispatchKeybinding('tab');
 
 			const text2: string = ' * FROM employees';


### PR DESCRIPTION
I took a look through the recent failures for the basic code cell functionality smoke test, and every time it failed there was a docs pane open next to the completions list, as seen below. When this pane is open the aria-label for that SELECT list item can change, so the test is likely failing because we were looking for an aria-label of "SELECT", rather than the "SELECT, docs: SELECT keyword" label that shows up with the docs pane. I added an extra assert in the test to account for that additional case.

![SelectDocsPane](https://user-images.githubusercontent.com/12820011/170387437-90ba94ef-c4e9-4b84-8782-04360af59a29.PNG)