### PR TITLE
Adds SQL Binding Create Azure Function with SQL Binding tests

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -458,7 +458,6 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 					continue;
 				}
 
-				const listOfConnectionStringMethods = [constants.connectionProfile, constants.userConnectionString];
 				let selectedConnectionStringMethod: string | undefined;
 				let connectionString: string | undefined = '';
 				while (true) {
@@ -467,6 +466,7 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 						const localSettingsPath: string = path.join(projectFolder, constants.azureFunctionLocalSettingsFileName);
 
 						if (!connectionInfo) {
+							const listOfConnectionStringMethods = [constants.connectionProfile, constants.userConnectionString];
 							// show the connection string methods (user input and connection profile options)
 							selectedConnectionStringMethod = await vscode.window.showQuickPick(listOfConnectionStringMethods, {
 								canPickMany: false,

--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -210,6 +210,7 @@ export function waitForNewFunctionFile(projectFolder: string): IFileFunctionObje
 			resolve(e.fsPath);
 		});
 	});
+	console.log('Promise resolved!');
 	return {
 		filePromise,
 		watcherDisposable: watcher
@@ -370,6 +371,7 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 			void vscode.window.showErrorMessage(utils.getErrorMessage(e));
 			return;
 		}
+		console.log(`getLocalSettingsJson`);
 
 		// Known Azure settings reference for Azure Functions
 		// https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings
@@ -444,6 +446,7 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 			}
 
 			if (selectedSetting.label === constants.createNewLocalAppSettingWithIcon) {
+				console.log(`createNewLocalAppSetting`);
 				const newConnectionStringSettingName = await vscode.window.showInputBox(
 					{
 						title: constants.enterConnectionStringSettingName,
@@ -466,6 +469,7 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 						const localSettingsPath: string = path.join(projectFolder, constants.azureFunctionLocalSettingsFileName);
 
 						if (!connectionInfo) {
+							console.log(`getConnectionInfo`);
 							const listOfConnectionStringMethods = [constants.connectionProfile, constants.userConnectionString];
 							// show the connection string methods (user input and connection profile options)
 							selectedConnectionStringMethod = await vscode.window.showQuickPick(listOfConnectionStringMethods, {
@@ -509,7 +513,7 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 							// user cancelled the prompts
 							return;
 						}
-
+						console.log(`setConnectionString: ${connectionString}`);
 						const success = await setLocalAppSetting(projectFolder, newConnectionStringSettingName, connectionString);
 						if (success) {
 							// exit both loops and insert binding
@@ -532,6 +536,7 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 			}
 		}
 		// Add sql extension package reference to project. If the reference is already there, it doesn't get added again
+		console.log(`addSqlExtensionPackageReference`);
 		await addNugetReferenceToProjectFile(projectUri.fsPath);
 	} else {
 		// if no AF project was found or there's more than one AF functions project in the workspace,
@@ -560,6 +565,7 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 	connectionDetails = { options: connectionInfo };
 
 	try {
+		console.log(`passwordPrompts`);
 		if (connectionInfo.authenticationType === 'SqlLogin' && connectionInfo.password) {
 			// Prompt to include password in connection string if authentication type is SqlLogin and connection has password saved
 			includePassword = await vscode.window.showQuickPick([constants.yesString, constants.noString], {
@@ -569,6 +575,7 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 			});
 			if (includePassword === constants.yesString) {
 				// get connection string to include password
+				console.log(`getConnectionString Request`);
 				connectionString = await vscodeMssqlApi.getConnectionString(connectionDetails, true, false);
 			}
 		}
@@ -576,6 +583,7 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 		if (includePassword !== constants.yesString || !connectionInfo.password || connectionInfo.authenticationType !== 'SqlLogin') {
 			// get connection string to not include the password if connection info does not include password,
 			// or user chooses to not include password (or if user cancels out of include password prompt), or authentication type is not SQL login
+			console.log(`getConnectionString Request with no password`);
 			connectionString = await vscodeMssqlApi.getConnectionString(connectionDetails, false, false);
 
 			if (connectionInfo.authenticationType !== 'SqlLogin') {
@@ -609,6 +617,7 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 				});
 			}
 		}
+		console.log(`return getConnectionString`);
 
 		return connectionString;
 	} catch (e) {

--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -210,7 +210,6 @@ export function waitForNewFunctionFile(projectFolder: string): IFileFunctionObje
 			resolve(e.fsPath);
 		});
 	});
-	console.log('Promise resolved!');
 	return {
 		filePromise,
 		watcherDisposable: watcher
@@ -371,7 +370,6 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 			void vscode.window.showErrorMessage(utils.getErrorMessage(e));
 			return;
 		}
-		console.log(`getLocalSettingsJson`);
 
 		// Known Azure settings reference for Azure Functions
 		// https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings
@@ -446,7 +444,6 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 			}
 
 			if (selectedSetting.label === constants.createNewLocalAppSettingWithIcon) {
-				console.log(`createNewLocalAppSetting`);
 				const newConnectionStringSettingName = await vscode.window.showInputBox(
 					{
 						title: constants.enterConnectionStringSettingName,
@@ -469,7 +466,6 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 						const localSettingsPath: string = path.join(projectFolder, constants.azureFunctionLocalSettingsFileName);
 
 						if (!connectionInfo) {
-							console.log(`getConnectionInfo`);
 							const listOfConnectionStringMethods = [constants.connectionProfile, constants.userConnectionString];
 							// show the connection string methods (user input and connection profile options)
 							selectedConnectionStringMethod = await vscode.window.showQuickPick(listOfConnectionStringMethods, {
@@ -513,7 +509,6 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 							// user cancelled the prompts
 							return;
 						}
-						console.log(`setConnectionString: ${connectionString}`);
 						const success = await setLocalAppSetting(projectFolder, newConnectionStringSettingName, connectionString);
 						if (success) {
 							// exit both loops and insert binding
@@ -536,7 +531,6 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 			}
 		}
 		// Add sql extension package reference to project. If the reference is already there, it doesn't get added again
-		console.log(`addSqlExtensionPackageReference`);
 		await addNugetReferenceToProjectFile(projectUri.fsPath);
 	} else {
 		// if no AF project was found or there's more than one AF functions project in the workspace,
@@ -565,7 +559,6 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 	connectionDetails = { options: connectionInfo };
 
 	try {
-		console.log(`passwordPrompts`);
 		if (connectionInfo.authenticationType === 'SqlLogin' && connectionInfo.password) {
 			// Prompt to include password in connection string if authentication type is SqlLogin and connection has password saved
 			includePassword = await vscode.window.showQuickPick([constants.yesString, constants.noString], {
@@ -575,7 +568,6 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 			});
 			if (includePassword === constants.yesString) {
 				// get connection string to include password
-				console.log(`getConnectionString Request`);
 				connectionString = await vscodeMssqlApi.getConnectionString(connectionDetails, true, false);
 			}
 		}
@@ -583,7 +575,6 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 		if (includePassword !== constants.yesString || !connectionInfo.password || connectionInfo.authenticationType !== 'SqlLogin') {
 			// get connection string to not include the password if connection info does not include password,
 			// or user chooses to not include password (or if user cancels out of include password prompt), or authentication type is not SQL login
-			console.log(`getConnectionString Request with no password`);
 			connectionString = await vscodeMssqlApi.getConnectionString(connectionDetails, false, false);
 
 			if (connectionInfo.authenticationType !== 'SqlLogin') {
@@ -617,7 +608,6 @@ export async function promptConnectionStringPasswordAndUpdateConnectionString(co
 				});
 			}
 		}
-		console.log(`return getConnectionString`);
 
 		return connectionString;
 	} catch (e) {

--- a/extensions/sql-bindings/src/createNewProject/addConnectionStringStep.ts
+++ b/extensions/sql-bindings/src/createNewProject/addConnectionStringStep.ts
@@ -17,7 +17,6 @@ import * as azureFunctionsUtils from '../common/azureFunctionsUtils';
  * @returns AzureWizardExecuteStep to be used in the createFunction API call
  */
 export function createAddConnectionStringStep(projectFolder: string, connectionInfo: IConnectionInfo, connectionStringSettingName?: string): AzureWizardExecuteStep<IActionContext> {
-	console.log(`azure wizard execute step`);
 	return new class AzureWizardExecuteStep {
 		// priority number is set to be lower than OpenFolderStep in vscode-azurefunctions
 		// https://github.com/microsoft/vscode-azurefunctions/blob/main/src/commands/createNewProject/OpenFolderStep.ts#L11

--- a/extensions/sql-bindings/src/createNewProject/addConnectionStringStep.ts
+++ b/extensions/sql-bindings/src/createNewProject/addConnectionStringStep.ts
@@ -9,7 +9,7 @@ import * as azureFunctionsUtils from '../common/azureFunctionsUtils';
 
 /**
  * This execute step is used to add a connection string to the local.settings.json file when creating a new Azure Functions project
- * and is needed due to vscode restarting the extension host after the user chooses to open project in new window or current window 
+ * and is needed due to vscode restarting the extension host after the user chooses to open project in new window or current window
  * through the createFunction API call for vscode-azurefunctions
  * @param projectFolder The folder containing the Azure Functions project
  * @param connectionInfo The connection info to use when creating the connection string
@@ -17,6 +17,7 @@ import * as azureFunctionsUtils from '../common/azureFunctionsUtils';
  * @returns AzureWizardExecuteStep to be used in the createFunction API call
  */
 export function createAddConnectionStringStep(projectFolder: string, connectionInfo: IConnectionInfo, connectionStringSettingName?: string): AzureWizardExecuteStep<IActionContext> {
+	console.log(`azure wizard execute step`);
 	return new class AzureWizardExecuteStep {
 		// priority number is set to be lower than OpenFolderStep in vscode-azurefunctions
 		// https://github.com/microsoft/vscode-azurefunctions/blob/main/src/commands/createNewProject/OpenFolderStep.ts#L11

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -63,7 +63,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 
 					isCreateNewProject = true;
 					telemetryStep = CreateAzureFunctionStep.getSelectedFolder;
-					// user either has not folder open or an empty workspace
+					// user either has no folder open or an empty workspace
 					// prompt user to choose a folder to create the project in
 					const browseProjectLocation = await vscode.window.showQuickPick(
 						[constants.browseEllipsisWithIcon],
@@ -190,6 +190,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		// prompt for Connection String Setting Name
 		let connectionStringInfo: IConnectionStringInfo | undefined = { connectionStringSettingName: constants.sqlConnectionStringSetting, connectionInfo: connectionInfo };
 		if (!isCreateNewProject && projectFile) {
+			// if it is not a new project, we can prompt user for connection string setting name and connection string password prompts
 			telemetryStep = CreateAzureFunctionStep.getConnectionStringSettingName;
 			connectionStringInfo = await azureFunctionsUtils.promptAndUpdateConnectionStringSetting(vscode.Uri.parse(projectFile), connectionInfo);
 			if (!connectionStringInfo) {

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -46,6 +46,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		let projectFile = await azureFunctionsUtils.getAzureFunctionProject();
 		let projectFolder: string;
 		telemetryStep = CreateAzureFunctionStep.getAzureFunctionProject;
+		console.log(`${telemetryStep}`);
 		if (!projectFile) {
 			while (true) {
 				// show warning message that user needs an azure function project to create a function
@@ -53,16 +54,19 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 					constants.createProject, constants.learnMore);
 				if (projectCreate === constants.learnMore) {
 					telemetryStep = CreateAzureFunctionStep.learnMore;
+					console.log(`${telemetryStep}`);
 					exitReason = ExitReason.exit;
 					void vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(constants.sqlBindingsDoc));
 					return;
 				} else if (projectCreate === constants.createProject) {
 					telemetryStep = CreateAzureFunctionStep.helpCreateAzureFunctionProject;
+					console.log(`${telemetryStep}`);
 					TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, telemetryStep)
 						.withAdditionalProperties(propertyBag).send();
 
 					isCreateNewProject = true;
 					telemetryStep = CreateAzureFunctionStep.getSelectedFolder;
+					console.log(`${telemetryStep}`);
 					// user either has no folder open or an empty workspace
 					// prompt user to choose a folder to create the project in
 					const browseProjectLocation = await vscode.window.showQuickPick(
@@ -98,9 +102,11 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		}
 		// create a system file watcher for the project folder
 		newFunctionFileObject = azureFunctionsUtils.waitForNewFunctionFile(projectFolder);
+		console.log(`newFunctionFileObject: ${newFunctionFileObject}`);
 
 		// Prompt user for binding type
 		telemetryStep = CreateAzureFunctionStep.getBindingType;
+		console.log(`${telemetryStep}`);
 		let selectedBindingType: BindingType | undefined;
 		let selectedBinding = await azureFunctionsUtils.promptForBindingType();
 		if (!selectedBinding) {
@@ -117,6 +123,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		if (!node) {
 			// if user selects command in command palette we prompt user for information
 			telemetryStep = CreateAzureFunctionStep.launchFromCommandPalette;
+			console.log(`${telemetryStep}`);
 			// prompt user for connection profile to get connection info
 			while (true) {
 				try {
@@ -133,6 +140,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 				TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, telemetryStep)
 					.withAdditionalProperties(propertyBag).withConnectionInfo(connectionInfo).send();
 				telemetryStep = CreateAzureFunctionStep.getObjectName;
+				console.log(`${telemetryStep}`);
 
 				// prompt user for object name to create function from
 				objectName = await azureFunctionsUtils.promptForObjectName(selectedBinding, connectionInfo);
@@ -145,6 +153,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		} else {
 			// if user selects table in tree view we use connection info from Object Explorer node
 			telemetryStep = CreateAzureFunctionStep.launchFromTable;
+			console.log(`${telemetryStep}`);
 			connectionInfo = node.connectionInfo;
 			TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, telemetryStep)
 				.withAdditionalProperties(propertyBag).withConnectionInfo(connectionInfo).send();
@@ -166,6 +175,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 
 		// get function name from user
 		telemetryStep = CreateAzureFunctionStep.getAzureFunctionName;
+		console.log(`${telemetryStep}`);
 		let functionName: string;
 		// remove special characters from function name
 		let uniqueObjectName = utils.santizeObjectName(objectName);
@@ -185,6 +195,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 
 		// set the templateId based on the selected binding type
 		telemetryStep = CreateAzureFunctionStep.getTemplateId;
+		console.log(`${telemetryStep}`);
 		let templateId: string = selectedBindingType === BindingType.input ? constants.inputTemplateID : constants.outputTemplateID;
 
 		// prompt for Connection String Setting Name
@@ -192,11 +203,13 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		if (!isCreateNewProject && projectFile) {
 			// if it is not a new project, we can prompt user for connection string setting name and connection string password prompts
 			telemetryStep = CreateAzureFunctionStep.getConnectionStringSettingName;
+			console.log(`${telemetryStep}`);
 			connectionStringInfo = await azureFunctionsUtils.promptAndUpdateConnectionStringSetting(vscode.Uri.parse(projectFile), connectionInfo);
 			if (!connectionStringInfo) {
 				// User cancelled connection string setting name prompt or connection string method prompt
 				return;
 			}
+			console.log(`connectionStringInfo: ${JSON.stringify(connectionStringInfo)}`);
 			TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, telemetryStep)
 				.withAdditionalProperties(propertyBag)
 				.withConnectionInfo(connectionInfo).send();
@@ -206,6 +219,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 
 		// create C# Azure Function with SQL Binding
 		telemetryStep = 'createFunctionAPI';
+		console.log(`${telemetryStep}`);
 		await azureFunctionApi.createFunction({
 			language: 'C#',
 			targetFramework: 'netcoreapp3.1',
@@ -227,10 +241,12 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 
 		// check for the new function file to be created and dispose of the file system watcher
 		const timeoutForFunctionFile = utils.timeoutPromise(constants.timeoutAzureFunctionFileError);
+		console.log(`timeoutForFunctionFile: ${timeoutForFunctionFile}`);
 		await Promise.race([newFunctionFileObject.filePromise, timeoutForFunctionFile]);
-
+		console.log('Promise.race fulfilled');
 		telemetryStep = 'finishCreateFunction';
 		propertyBag.telemetryStep = telemetryStep;
+		console.log(`${telemetryStep}`);
 		exitReason = ExitReason.finishCreate;
 		TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.finishCreateAzureFunctionWithSqlBinding)
 			.withAdditionalProperties(propertyBag)
@@ -256,6 +272,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick)
 			.withAdditionalProperties(propertyBag).send();
 		if (newFunctionFileObject) {
+			console.log(`${telemetryStep}`);
 			newFunctionFileObject.watcherDisposable.dispose();
 		}
 	}

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -271,10 +271,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		propertyBag.exitReason = exitReason;
 		TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick)
 			.withAdditionalProperties(propertyBag).send();
-		if (newFunctionFileObject) {
-			console.log(`${telemetryStep}`);
-			newFunctionFileObject.watcherDisposable.dispose();
-		}
+		newFunctionFileObject?.watcherDisposable.dispose();
 	}
 }
 

--- a/extensions/sql-bindings/src/test/common/azureFunctionsUtils.test.ts
+++ b/extensions/sql-bindings/src/test/common/azureFunctionsUtils.test.ts
@@ -17,220 +17,223 @@ const rootFolderPath = 'test';
 const localSettingsPath: string = path.join(rootFolderPath, 'local.settings.json');
 let testUtils: TestUtils;
 
-describe('Tests to verify Azure Functions Utils functions', function (): void {
+describe('AzureFunctionUtils', function (): void {
 	beforeEach(function (): void {
 		testUtils = createTestUtils();
 	});
 
-	it('Should correctly parse local.settings.json', async () => {
-		sinon.stub(fs, 'existsSync').withArgs(localSettingsPath).returns(true);
-		sinon.stub(fs, 'readFileSync').withArgs(localSettingsPath).returns(
-			`{"IsEncrypted": false,
+	describe('Local.Settings.Json', function (): void {
+		it('Should correctly parse local.settings.json', async () => {
+			sinon.stub(fs, 'existsSync').withArgs(localSettingsPath).returns(true);
+			sinon.stub(fs, 'readFileSync').withArgs(localSettingsPath).returns(
+				`{"IsEncrypted": false,
 			"Values": {"test1": "test1", "test2": "test2", "test3":"test3"}}`
-		);
-		let settings = await azureFunctionsUtils.getLocalSettingsJson(localSettingsPath);
-		should(settings.IsEncrypted).equals(false);
-		should(Object.keys(settings.Values!).length).equals(3);
-	});
+			);
+			let settings = await azureFunctionsUtils.getLocalSettingsJson(localSettingsPath);
+			should(settings.IsEncrypted).equals(false);
+			should(Object.keys(settings.Values!).length).equals(3);
+		});
 
-	it('setLocalAppSetting can update settings.json with new setting value', async () => {
-		sinon.stub(fs, 'existsSync').withArgs(localSettingsPath).returns(true);
-		sinon.stub(fs, 'readFileSync').withArgs(localSettingsPath).returns(
-			`{"IsEncrypted": false,
+		it('setLocalAppSetting can update settings.json with new setting value', async () => {
+			sinon.stub(fs, 'existsSync').withArgs(localSettingsPath).returns(true);
+			sinon.stub(fs, 'readFileSync').withArgs(localSettingsPath).returns(
+				`{"IsEncrypted": false,
 			"Values": {"test1": "test1", "test2": "test2", "test3":"test3"}}`
-		);
+			);
 
-		let writeFileStub = sinon.stub(fs.promises, 'writeFile');
-		await azureFunctionsUtils.setLocalAppSetting(path.dirname(localSettingsPath), 'test4', 'test4');
-		should(writeFileStub.calledWithExactly(localSettingsPath, `{\n  "IsEncrypted": false,\n  "Values": {\n    "test1": "test1",\n    "test2": "test2",\n    "test3": "test3",\n    "test4": "test4"\n  }\n}`)).equals(true);
-	});
+			let writeFileStub = sinon.stub(fs.promises, 'writeFile');
+			await azureFunctionsUtils.setLocalAppSetting(path.dirname(localSettingsPath), 'test4', 'test4');
+			should(writeFileStub.calledWithExactly(localSettingsPath, `{\n  "IsEncrypted": false,\n  "Values": {\n    "test1": "test1",\n    "test2": "test2",\n    "test3": "test3",\n    "test4": "test4"\n  }\n}`)).equals(true);
+		});
 
-	it('Should not overwrite setting if value already exists in local.settings.json', async () => {
-		sinon.stub(fs, 'existsSync').withArgs(localSettingsPath).returns(true);
-		sinon.stub(fs, 'readFileSync').withArgs(localSettingsPath).returns(
-			`{"IsEncrypted": false,
+		it('Should not overwrite setting if value already exists in local.settings.json', async () => {
+			sinon.stub(fs, 'existsSync').withArgs(localSettingsPath).returns(true);
+			sinon.stub(fs, 'readFileSync').withArgs(localSettingsPath).returns(
+				`{"IsEncrypted": false,
 			"Values": {"test1": "test1", "test2": "test2", "test3":"test3"}}`
-		);
+			);
 
-		let warningMsg = constants.settingAlreadyExists('test1');
-		const spy = sinon.stub(vscode.window, 'showWarningMessage').resolves({ title: constants.settingAlreadyExists('test1') });
+			let warningMsg = constants.settingAlreadyExists('test1');
+			const spy = sinon.stub(vscode.window, 'showWarningMessage').resolves({ title: constants.settingAlreadyExists('test1') });
 
-		await azureFunctionsUtils.setLocalAppSetting(path.dirname(localSettingsPath), 'test1', 'newValue');
-		should(spy.calledOnce).be.true('showWarningMessage should have been called exactly once');
-		should(spy.calledWith(warningMsg)).be.true(`showWarningMessage not called with expected message '${warningMsg}' Actual '${spy.getCall(0).args[0]}'`);
-	});
+			await azureFunctionsUtils.setLocalAppSetting(path.dirname(localSettingsPath), 'test1', 'newValue');
+			should(spy.calledOnce).be.true('showWarningMessage should have been called exactly once');
+			should(spy.calledWith(warningMsg)).be.true(`showWarningMessage not called with expected message '${warningMsg}' Actual '${spy.getCall(0).args[0]}'`);
+		});
 
-	it('Should get settings file given project file', async () => {
-		const settingsFile = await azureFunctionsUtils.getSettingsFile(rootFolderPath);
-		should(settingsFile).equals(localSettingsPath);
-	});
+		it('Should get settings file given project file', async () => {
+			const settingsFile = await azureFunctionsUtils.getSettingsFile(rootFolderPath);
+			should(settingsFile).equals(localSettingsPath);
+		});
 
-	it('Should add connection string to local.settings.json', async () => {
-		sinon.stub(fs, 'existsSync').withArgs(localSettingsPath).returns(true);
-		sinon.stub(fs, 'readFileSync').withArgs(localSettingsPath).returns(
-			`{"IsEncrypted": false,
+		it('Should add connection string to local.settings.json', async () => {
+			sinon.stub(fs, 'existsSync').withArgs(localSettingsPath).returns(true);
+			sinon.stub(fs, 'readFileSync').withArgs(localSettingsPath).returns(
+				`{"IsEncrypted": false,
 			"Values": {"test1": "test1", "test2": "test2", "test3":"test3"}}`
-		);
-		const connectionString = 'testConnectionString';
+			);
+			const connectionString = 'testConnectionString';
 
-		let writeFileStub = sinon.stub(fs.promises, 'writeFile');
-		await azureFunctionsUtils.addConnectionStringToConfig(connectionString, rootFolderPath);
-		should(writeFileStub.calledWithExactly(localSettingsPath, `{\n  "IsEncrypted": false,\n  "Values": {\n    "test1": "test1",\n    "test2": "test2",\n    "test3": "test3",\n    "SqlConnectionString": "testConnectionString"\n  }\n}`)).equals(true);
+			let writeFileStub = sinon.stub(fs.promises, 'writeFile');
+			await azureFunctionsUtils.addConnectionStringToConfig(connectionString, rootFolderPath);
+			should(writeFileStub.calledWithExactly(localSettingsPath, `{\n  "IsEncrypted": false,\n  "Values": {\n    "test1": "test1",\n    "test2": "test2",\n    "test3": "test3",\n    "SqlConnectionString": "testConnectionString"\n  }\n}`)).equals(true);
+		});
 	});
 
-	// Password Prompts
-	it('Should include password if user includes password and connection info contains the password and auth type is SQL', async () => {
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		let connectionDetails = { options: connectionInfo };
+	describe('Password Prompts', function (): void {
+		it('Should include password if user includes password and connection info contains the password and auth type is SQL', async () => {
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			let connectionDetails = { options: connectionInfo };
 
-		// getConnectionString should return a connection string with the password
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${connectionInfo.password};`));
+			// getConnectionString should return a connection string with the password
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${connectionInfo.password};`));
 
-		// Include Password Prompt - Yes to include password
-		let quickPickStub = sinon.stub(vscode.window, 'showQuickPick').onFirstCall().returns(Promise.resolve(constants.yesString) as any);
-		// Manually enter password
-		let quickInputSpy = sinon.spy(vscode.window, 'showInputBox');
-		// show warning window
-		const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
+			// Include Password Prompt - Yes to include password
+			let quickPickStub = sinon.stub(vscode.window, 'showQuickPick').onFirstCall().returns(Promise.resolve(constants.yesString) as any);
+			// Manually enter password
+			let quickInputSpy = sinon.spy(vscode.window, 'showInputBox');
+			// show warning window
+			const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
 
-		let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
+			let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
 
-		// manually entered password prompt and warning prompt should not be called
-		should(quickPickStub.calledOnce).be.true('showQuickPick should have been called');
-		should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
-		should(warningSpy.notCalled).be.true('showWarningMessage should not have been called');
-		// get connection string result
-		should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${connectionInfo.password};`);
-	});
+			// manually entered password prompt and warning prompt should not be called
+			should(quickPickStub.calledOnce).be.true('showQuickPick should have been called');
+			should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
+			should(warningSpy.notCalled).be.true('showWarningMessage should not have been called');
+			// get connection string result
+			should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${connectionInfo.password};`);
+		});
 
-	it('Should not include password and show warning if user does not want to include password prompt and connection info contains the password and auth type is SQL', async () => {
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		let connectionDetails = { options: connectionInfo };
+		it('Should not include password and show warning if user does not want to include password prompt and connection info contains the password and auth type is SQL', async () => {
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			let connectionDetails = { options: connectionInfo };
 
-		// getConnectionString should return a connection string with password placeholder
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
+			// getConnectionString should return a connection string with password placeholder
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
 
-		// Include Password Prompt - NO to include password
-		let quickPickStub = sinon.stub(vscode.window, 'showQuickPick').onFirstCall().returns(Promise.resolve(constants.noString) as any);
-		// Manually enter password
-		let quickInputSpy = sinon.spy(vscode.window, 'showInputBox');
-		// show warning window
-		const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
+			// Include Password Prompt - NO to include password
+			let quickPickStub = sinon.stub(vscode.window, 'showQuickPick').onFirstCall().returns(Promise.resolve(constants.noString) as any);
+			// Manually enter password
+			let quickInputSpy = sinon.spy(vscode.window, 'showInputBox');
+			// show warning window
+			const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
 
-		let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
+			let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
 
-		// warning prompt should be shown and manually entered password prompt should not be called (since user indicated they do not want to include password)
-		should(quickPickStub.calledOnce).be.true('showQuickPick should have been called');
-		should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
-		should(warningSpy.calledOnce).be.true('showWarningMessage should have been called');
-		// returned connection string should NOT include password
-		should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`);
-	});
+			// warning prompt should be shown and manually entered password prompt should not be called (since user indicated they do not want to include password)
+			should(quickPickStub.calledOnce).be.true('showQuickPick should have been called');
+			should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
+			should(warningSpy.calledOnce).be.true('showWarningMessage should have been called');
+			// returned connection string should NOT include password
+			should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`);
+		});
 
-	it('Should not include password and show warning if user cancels include password prompt and connection info contains the password and auth type is SQL', async () => {
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		let connectionDetails = { options: connectionInfo };
+		it('Should not include password and show warning if user cancels include password prompt and connection info contains the password and auth type is SQL', async () => {
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			let connectionDetails = { options: connectionInfo };
 
-		// getConnectionString should return a connection string with password placeholder
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
+			// getConnectionString should return a connection string with password placeholder
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
 
-		// Include Password Prompt - cancels out of include password prompt
-		let quickPickStub = sinon.stub(vscode.window, 'showQuickPick').onFirstCall().resolves(undefined);
-		// Manually enter password
-		let quickInputSpy = sinon.spy(vscode.window, 'showInputBox');
-		// show warning window
-		const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
+			// Include Password Prompt - cancels out of include password prompt
+			let quickPickStub = sinon.stub(vscode.window, 'showQuickPick').onFirstCall().resolves(undefined);
+			// Manually enter password
+			let quickInputSpy = sinon.spy(vscode.window, 'showInputBox');
+			// show warning window
+			const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
 
-		let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
+			let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
 
-		// warning prompt should be shown and manually entered password prompt should not be called (since user indicated they do not want to include password)
-		should(quickPickStub.calledOnce).be.true('showQuickPick should have been called');
-		should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
-		should(warningSpy.calledOnce).be.true('showWarningMessage should have been called');
-		// returned connection string should NOT include password
-		should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`);
-	});
+			// warning prompt should be shown and manually entered password prompt should not be called (since user indicated they do not want to include password)
+			should(quickPickStub.calledOnce).be.true('showQuickPick should have been called');
+			should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
+			should(warningSpy.calledOnce).be.true('showWarningMessage should have been called');
+			// returned connection string should NOT include password
+			should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`);
+		});
 
-	it('Should return connection string with no password saved when connection auth type is not SQL', async () => {
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		connectionInfo.authenticationType = 'TestAuth'; // auth type is not SQL
-		let connectionDetails = { options: connectionInfo };
+		it('Should return connection string with no password saved when connection auth type is not SQL', async () => {
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			connectionInfo.authenticationType = 'TestAuth'; // auth type is not SQL
+			let connectionDetails = { options: connectionInfo };
 
-		// getConnectionString should return a connection string with password placeholder
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
+			// getConnectionString should return a connection string with password placeholder
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
 
-		// Include password prompt
-		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick');
-		// Manually enter password
-		let quickInputSpy = sinon.spy(vscode.window, 'showInputBox');
-		// show warning window
-		const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
+			// Include password prompt
+			let quickpickStub = sinon.stub(vscode.window, 'showQuickPick');
+			// Manually enter password
+			let quickInputSpy = sinon.spy(vscode.window, 'showInputBox');
+			// show warning window
+			const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
 
-		let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
+			let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
 
-		// should not call any of the prompts (include password, manually enter password, or show warning) since connection auth type is not SQL
-		should(quickpickStub.notCalled).be.true('showQuickPick should not have been called');
-		should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
-		should(warningSpy.notCalled).be.true('showWarningMessage should not have been called');
-		// returned connection string should NOT include password
-		should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};`);
-	});
+			// should not call any of the prompts (include password, manually enter password, or show warning) since connection auth type is not SQL
+			should(quickpickStub.notCalled).be.true('showQuickPick should not have been called');
+			should(quickInputSpy.notCalled).be.true('showInputBox should not have been called');
+			should(warningSpy.notCalled).be.true('showWarningMessage should not have been called');
+			// returned connection string should NOT include password
+			should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};`);
+		});
 
-	it('Should ask user to enter password and set password to connection string when connection info does not contain password and auth type is SQL', async () => {
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		connectionInfo.password = ''; // password is not saved for the connection
-		let connectionDetails = { options: connectionInfo };
+		it('Should ask user to enter password and set password to connection string when connection info does not contain password and auth type is SQL', async () => {
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			connectionInfo.password = ''; // password is not saved for the connection
+			let connectionDetails = { options: connectionInfo };
 
-		// getConnectionString should return a connection string with password placeholder
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
+			// getConnectionString should return a connection string with password placeholder
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
 
-		// Include password prompt
-		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick');
-		// Manually enter password
-		let enteredPassword = 'testPassword';
-		let quickInputSpy = sinon.stub(vscode.window, 'showInputBox').onFirstCall().resolves(enteredPassword);
-		// show warning window
-		const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
+			// Include password prompt
+			let quickpickStub = sinon.stub(vscode.window, 'showQuickPick');
+			// Manually enter password
+			let enteredPassword = 'testPassword';
+			let quickInputSpy = sinon.stub(vscode.window, 'showInputBox').onFirstCall().resolves(enteredPassword);
+			// show warning window
+			const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
 
-		let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
+			let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
 
-		// manually entered password prompt should be called while warning prompt and include password prompt should not be called (since user connection info does not contain password)
-		should(quickpickStub.notCalled).be.true('showQuickPick should not have been called');
-		should(quickInputSpy.calledOnce).be.true('showInputBox should have been called');
-		should(warningSpy.notCalled).be.true('showWarningMessage should have been called');
-		// returned connection string should have the entered password
-		should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${enteredPassword};`);
-	});
+			// manually entered password prompt should be called while warning prompt and include password prompt should not be called (since user connection info does not contain password)
+			should(quickpickStub.notCalled).be.true('showQuickPick should not have been called');
+			should(quickInputSpy.calledOnce).be.true('showInputBox should have been called');
+			should(warningSpy.notCalled).be.true('showWarningMessage should have been called');
+			// returned connection string should have the entered password
+			should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${enteredPassword};`);
+		});
 
-	it('Should ask user to enter password and not include password to connection string since user cancelled prompt when connection info does not contain password and auth type is SQL', async () => {
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		connectionInfo.password = ''; // password is not saved for the connection
-		let connectionDetails = { options: connectionInfo };
+		it('Should ask user to enter password and not include password to connection string since user cancelled prompt when connection info does not contain password and auth type is SQL', async () => {
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			connectionInfo.password = ''; // password is not saved for the connection
+			let connectionDetails = { options: connectionInfo };
 
-		// getConnectionString should return a connection string with password placeholder
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
+			// getConnectionString should return a connection string with password placeholder
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, false, false)).returns(() => Promise.resolve(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`));
 
-		// Include password prompt
-		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick');
-		// Manually enter password
-		let quickInputSpy = sinon.stub(vscode.window, 'showInputBox').onFirstCall().resolves(undefined);
-		// show warning window
-		const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
+			// Include password prompt
+			let quickpickStub = sinon.stub(vscode.window, 'showQuickPick');
+			// Manually enter password
+			let quickInputSpy = sinon.stub(vscode.window, 'showInputBox').onFirstCall().resolves(undefined);
+			// show warning window
+			const warningSpy = sinon.spy(vscode.window, 'showWarningMessage');
 
-		let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
+			let getConnectionString = await azureFunctionsUtils.promptConnectionStringPasswordAndUpdateConnectionString(connectionInfo, localSettingsPath);
 
-		// manually entered password prompt and warning prompt should be shown and include password prompt should not be called (since user cancelled manually enter password prompt)
-		should(quickpickStub.notCalled).be.true('showQuickPick should not have been called');
-		should(quickInputSpy.calledOnce).be.true('showInputBox should have been called');
-		should(warningSpy.calledOnce).be.true('showWarningMessage should have been called ');
-		// returned connection string should have the entered password
-		should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`);
+			// manually entered password prompt and warning prompt should be shown and include password prompt should not be called (since user cancelled manually enter password prompt)
+			should(quickpickStub.notCalled).be.true('showQuickPick should not have been called');
+			should(quickInputSpy.calledOnce).be.true('showInputBox should have been called');
+			should(warningSpy.calledOnce).be.true('showWarningMessage should have been called ');
+			// returned connection string should have the entered password
+			should(getConnectionString).equals(`Server=${connectionInfo.server};Initial Catalog=${connectionInfo.database};User ID=${connectionInfo.user};Password=${constants.passwordPlaceholder};`);
+		});
 	});
 
 	afterEach(async function (): Promise<void> {

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -86,7 +86,7 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
 			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 			await azureFunctionService.createAzureFunction();
 
 			should(spy.notCalled).be.true('showErrorMessage should not have been called');
@@ -127,7 +127,7 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
 			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 			await azureFunctionService.createAzureFunction(tableTestNode);
 
@@ -191,7 +191,7 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
 			let testWatcher: vscode.FileSystemWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 			await azureFunctionService.createAzureFunction(tableTestNode);
 

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -85,10 +85,8 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
-			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
-			testWatcher.setup((x: any) => x.then).returns(() => Promise.resolve(undefined));
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			const testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 			await azureFunctionService.createAzureFunction();
 
 			should(spy.notCalled).be.true('showErrorMessage should not have been called');
@@ -128,10 +126,8 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
-			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
-			testWatcher.setup((x: any) => x.then).returns(() => Promise.resolve(undefined));
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			const testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 			await azureFunctionService.createAzureFunction(tableTestNode);
 
@@ -194,10 +190,8 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
-			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
-			testWatcher.setup((x: any) => x.then).returns(() => Promise.resolve(undefined));
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			const testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 			await azureFunctionService.createAzureFunction(tableTestNode);
 

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -87,8 +87,8 @@ describe('AzureFunctionsService', () => {
 
 			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
 			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
-			testWatcher.setup((x: any) => x.then).returns(() => undefined);
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			testWatcher.setup((x: any) => x.then).returns(() => Promise.resolve(undefined));
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 			await azureFunctionService.createAzureFunction();
 
 			should(spy.notCalled).be.true('showErrorMessage should not have been called');
@@ -130,8 +130,8 @@ describe('AzureFunctionsService', () => {
 
 			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
 			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
-			testWatcher.setup((x: any) => x.then).returns(() => undefined);
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			testWatcher.setup((x: any) => x.then).returns(() => Promise.resolve(undefined));
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 			await azureFunctionService.createAzureFunction(tableTestNode);
 
@@ -196,8 +196,8 @@ describe('AzureFunctionsService', () => {
 
 			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
 			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
-			testWatcher.setup((x: any) => x.then).returns(() => undefined);
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			testWatcher.setup((x: any) => x.then).returns(() => Promise.resolve(undefined));
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 			await azureFunctionService.createAzureFunction(tableTestNode);
 

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -145,7 +145,7 @@ describe('AzureFunctionsService', () => {
 			let connectionDetails = { options: connectionInfo };
 			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
 
-			const executeCommandSpy = sinon.spy(vscode.commands, 'executeCommand');
+			const executeCommandSpy = sinon.stub(vscode.commands, 'executeCommand').withArgs(sinon.match.any, sinon.match.any).returns(Promise.resolve());
 			const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').returns(Promise.resolve(constants.learnMore) as any);
 			await azureFunctionService.createAzureFunction();
 

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -1,0 +1,201 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as should from 'should';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as utils from '../../common/utils';
+import * as constants from '../../common/constants';
+import * as azureFunctionUtils from '../../common/azureFunctionsUtils';
+import * as azureFunctionsContracts from '../../contracts/azureFunctions/azureFunctionsContracts';
+import * as azureFunctionService from '../../services/azureFunctionsService';
+
+import { createTestUtils, TestUtils, createTestCredentials, createTestTableNode } from '../testUtils';
+import { IConnectionInfo } from 'vscode-mssql';
+import { BindingType } from 'sql-bindings';
+
+const rootFolderPath = 'test';
+const projectFilePath: string = path.join(rootFolderPath, 'test.csproj');
+let testUtils: TestUtils;
+describe('Tests to verify Create Azure Function with SQL Binding', () => {
+	beforeEach(function (): void {
+		testUtils = createTestUtils();
+	});
+
+	afterEach(function (): void {
+		sinon.restore();
+	});
+
+	it('Should show info message to install azure functions extension if not installed', async function (): Promise<void> {
+		const infoStub = sinon.stub(vscode.window, 'showInformationMessage').resolves(undefined);
+		await azureFunctionService.createAzureFunction();
+		should(infoStub.calledOnce).be.true('showInformationMessage should be called once');
+		should(infoStub.args).containEql([constants.azureFunctionsExtensionNotFound,
+		constants.install, constants.learnMore, constants.doNotInstall]);
+	});
+
+	it('Should create azure function project using command from command palette (no connection info)', async function (): Promise<void> {
+		// This test will have an azure function project already in the project and the azure functions extension installed (stubbed)
+		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
+		sinon.stub(azureFunctionUtils, 'getAzureFunctionProject').resolves(projectFilePath); //set azure function project to have one project
+		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+
+		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+		connectionInfo.database = 'testDb';
+
+		let connectionDetails = { options: connectionInfo };
+		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+
+		const spy = sinon.spy(vscode.window, 'showErrorMessage');
+
+		// select input or output binding
+		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(<any>{ label: constants.input, type: BindingType.input });
+
+		// no table used for connection info so prompt user to get connection info
+		testUtils.vscodeMssqlIExtension.setup(x => x.promptForConnection(true)).returns(() => Promise.resolve(connectionInfo));
+		testUtils.vscodeMssqlIExtension.setup(x => x.connect(connectionInfo)).returns(() => Promise.resolve('testConnectionURI'));
+		testUtils.vscodeMssqlIExtension.setup(x => x.listDatabases('testConnectionURI')).returns(() => Promise.resolve(['testDb']));
+		// select the testDB from list of databases based on connection info
+		quickpickStub.onSecondCall().returns(Promise.resolve('testDb') as any);
+		// get tables from selected database
+		const params = { ownerUri: 'testConnectionURI', queryString: azureFunctionUtils.tablesQuery('testDb') };
+		testUtils.vscodeMssqlIExtension.setup(x => x.sendRequest(azureFunctionsContracts.SimpleExecuteRequest.type, params))
+			.returns(() => Promise.resolve({ rowCount: 1, columnInfo: [], rows: [['[schema].[testTable]']] }));
+		// select the schema.testTable from list of tables based on connection info and database
+		quickpickStub.onThirdCall().returns(Promise.resolve('[schema].[testTable]') as any);
+
+		// set azure function name
+		let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
+
+		// promptAndUpdateConnectionStringSetting
+		quickpickStub.onCall(3).resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
+		inputStub.onSecondCall().resolves('SqlConnectionString');
+		// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
+		quickpickStub.onCall(4).returns(Promise.resolve(constants.yesString) as any);
+		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+		// setLocalAppSetting with connection string setting name and connection string
+		// fails if we dont set writeFile stub
+		sinon.stub(fs.promises, 'writeFile');
+		sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
+		sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
+
+		let testWatcher = vscode.workspace.createFileSystemWatcher((
+			new vscode.RelativePattern(rootFolderPath, '**/*.cs')), false, true, true);
+		sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+		await azureFunctionService.createAzureFunction();
+
+		should(spy.notCalled).be.true('showErrorMessage should not have been called');
+		// set the connection info to be the one the user selects from list of databases quickpick
+		should(connectionInfo.database).equal('testDb');
+	});
+
+	it('Should create azure function project using command via the sql server table OE', async function (): Promise<void> {
+		// This test will have an azure function project already in the project and the azure functions extension installed (stubbed)
+		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
+		sinon.stub(azureFunctionUtils, 'getAzureFunctionProject').resolves(projectFilePath); //set azure function project to have one project
+		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+
+		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+		let connectionDetails = { options: connectionInfo };
+		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+
+		const spy = sinon.spy(vscode.window, 'showErrorMessage');
+
+		// select input or output binding
+		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(<any>{ label: constants.input, type: BindingType.input });
+		// table node used when creating azure function project
+		let tableTestNode = createTestTableNode(connectionInfo);
+
+		// set azure function name
+		let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
+
+		// promptAndUpdateConnectionStringSetting
+		quickpickStub.onSecondCall().resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
+		inputStub.onSecondCall().resolves('SqlConnectionString');
+		// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
+		quickpickStub.onThirdCall().returns(Promise.resolve(constants.yesString) as any);
+		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+		// setLocalAppSetting with connection string setting name and connection string
+		// fails if we dont set writeFile stub
+		sinon.stub(fs.promises, 'writeFile');
+		sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
+		sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
+
+		let testWatcher = vscode.workspace.createFileSystemWatcher((
+			new vscode.RelativePattern(rootFolderPath, '**/*.cs')), false, true, true);
+		sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+
+		await azureFunctionService.createAzureFunction(tableTestNode);
+
+		should(spy.notCalled).be.true('showErrorMessage should not have been called');
+		// set the connection info to be the one used from the test table node from OE
+		should(connectionInfo.database).equal('testDb');
+	});
+
+	it('Should open link to learn more about SQL bindings when no azure function project found in folder or workspace', async function (): Promise<void> {
+		// This test will ask user that an azure function project must be opened to create an azure function with sql binding
+		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
+		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+
+		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+		let connectionDetails = { options: connectionInfo };
+		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+
+		const executeCommandSpy = sinon.spy(vscode.commands, 'executeCommand');
+		const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').returns(Promise.resolve(constants.learnMore) as any);
+		await azureFunctionService.createAzureFunction();
+
+		should(executeCommandSpy.calledOnce).be.true('showErrorMessage should have been called');
+		should(showErrorStub.calledOnce).be.true('showErrorMessage should have been called');
+	});
+
+	it('Should ask user to choose folder to use for azure project and create azure function with the selected folder', async function (): Promise<void> {
+		// This test will ask user that an azure function project must be opened to create an azure function with sql binding
+		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
+		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+
+		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+		let connectionDetails = { options: connectionInfo };
+		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+
+		// error since no project file found in workspace or folder
+		const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').returns(Promise.resolve(constants.createProject) as any);
+
+		// user chooses to browse for folder
+		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').returns(Promise.resolve(constants.browseEllipsisWithIcon) as any);
+
+		// stub out folder to be chosen (showOpenDialog)
+		sinon.stub(vscode.window, 'showOpenDialog').withArgs(sinon.match.any).resolves([vscode.Uri.file(projectFilePath)]);
+		// select input or output binding
+		quickpickStub.onSecondCall().resolves(<any>{ label: constants.input, type: BindingType.input });
+		// table node used when creating azure function project
+		let tableTestNode = createTestTableNode(connectionInfo);
+
+		// set azure function name
+		let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
+
+		// promptAndUpdateConnectionStringSetting
+		quickpickStub.onThirdCall().resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
+		inputStub.onSecondCall().resolves('SqlConnectionString');
+		// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
+		quickpickStub.onCall(3).returns(Promise.resolve(constants.yesString) as any);
+		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+		// setLocalAppSetting with connection string setting name and connection string
+		// fails if we dont set writeFile stub
+		sinon.stub(fs.promises, 'writeFile');
+		sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
+		sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
+
+		let testWatcher = vscode.workspace.createFileSystemWatcher((
+			new vscode.RelativePattern(rootFolderPath, '**/*.cs')), false, true, true);
+		sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+
+		await azureFunctionService.createAzureFunction(tableTestNode);
+
+		should(showErrorStub.calledOnce).be.true('showErrorMessage should have been called');
+	});
+});

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -85,7 +85,9 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
+			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
+			testWatcher.setup((x: any) => x.then).returns(() => undefined);
 			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 			await azureFunctionService.createAzureFunction();
 
@@ -126,7 +128,9 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
+			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
+			testWatcher.setup((x: any) => x.then).returns(() => undefined);
 			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 			await azureFunctionService.createAzureFunction(tableTestNode);
@@ -190,7 +194,9 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-			let testWatcher: vscode.FileSystemWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>();
+			// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
+			testWatcher.setup((x: any) => x.then).returns(() => undefined);
 			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).resolves({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 			await azureFunctionService.createAzureFunction(tableTestNode);

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -8,6 +8,7 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as TypeMoq from 'typemoq';
 import * as utils from '../../common/utils';
 import * as constants from '../../common/constants';
 import * as azureFunctionUtils from '../../common/azureFunctionsUtils';
@@ -21,181 +22,180 @@ import { BindingType } from 'sql-bindings';
 const rootFolderPath = 'test';
 const projectFilePath: string = path.join(rootFolderPath, 'test.csproj');
 let testUtils: TestUtils;
-describe('Tests to verify Create Azure Function with SQL Binding', () => {
-	beforeEach(function (): void {
-		testUtils = createTestUtils();
-	});
+describe('AzureFunctionsService', () => {
+	describe('Create Azure Function with SQL Binding', () => {
+		beforeEach(function (): void {
+			testUtils = createTestUtils();
+		});
 
-	afterEach(function (): void {
-		sinon.restore();
-	});
+		afterEach(function (): void {
+			sinon.restore();
+		});
 
-	it('Should show info message to install azure functions extension if not installed', async function (): Promise<void> {
-		const infoStub = sinon.stub(vscode.window, 'showInformationMessage').resolves(undefined);
-		await azureFunctionService.createAzureFunction();
-		should(infoStub.calledOnce).be.true('showInformationMessage should be called once');
-		should(infoStub.args).containEql([constants.azureFunctionsExtensionNotFound,
-		constants.install, constants.learnMore, constants.doNotInstall]);
-	});
+		it('Should show info message to install azure functions extension if not installed', async function (): Promise<void> {
+			const infoStub = sinon.stub(vscode.window, 'showInformationMessage').resolves(undefined);
+			await azureFunctionService.createAzureFunction();
+			should(infoStub.calledOnce).be.true('showInformationMessage should be called once');
+			should(infoStub.args).containEql([constants.azureFunctionsExtensionNotFound,
+			constants.install, constants.learnMore, constants.doNotInstall]);
+		});
 
-	it('Should create azure function project using the command from command palette (no connection info)', async function (): Promise<void> {
-		// This test will have an azure function project already in the project and the azure functions extension installed (stubbed)
-		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
-		sinon.stub(azureFunctionUtils, 'getAzureFunctionProject').resolves(projectFilePath); //set azure function project to have one project
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+		it('Should create azure function project using the command from command palette (no connection info)', async function (): Promise<void> {
+			// This test will have an azure function project already in the project and the azure functions extension installed (stubbed)
+			sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
+			sinon.stub(azureFunctionUtils, 'getAzureFunctionProject').resolves(projectFilePath); //set azure function project to have one project
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
 
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		connectionInfo.database = 'testDb';
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			connectionInfo.database = 'testDb';
 
-		let connectionDetails = { options: connectionInfo };
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+			let connectionDetails = { options: connectionInfo };
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
 
-		const spy = sinon.spy(vscode.window, 'showErrorMessage');
+			const spy = sinon.spy(vscode.window, 'showErrorMessage');
 
-		// select input or output binding
-		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(<any>{ label: constants.input, type: BindingType.input });
+			// select input or output binding
+			let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(<any>{ label: constants.input, type: BindingType.input });
 
-		// no table used for connection info so prompt user to get connection info
-		testUtils.vscodeMssqlIExtension.setup(x => x.promptForConnection(true)).returns(() => Promise.resolve(connectionInfo));
-		testUtils.vscodeMssqlIExtension.setup(x => x.connect(connectionInfo)).returns(() => Promise.resolve('testConnectionURI'));
-		testUtils.vscodeMssqlIExtension.setup(x => x.listDatabases('testConnectionURI')).returns(() => Promise.resolve(['testDb']));
-		// select the testDB from list of databases based on connection info
-		quickpickStub.onSecondCall().returns(Promise.resolve('testDb') as any);
-		// get tables from selected database
-		const params = { ownerUri: 'testConnectionURI', queryString: azureFunctionUtils.tablesQuery('testDb') };
-		testUtils.vscodeMssqlIExtension.setup(x => x.sendRequest(azureFunctionsContracts.SimpleExecuteRequest.type, params))
-			.returns(() => Promise.resolve({ rowCount: 1, columnInfo: [], rows: [['[schema].[testTable]']] }));
-		// select the schema.testTable from list of tables based on connection info and database
-		quickpickStub.onThirdCall().returns(Promise.resolve('[schema].[testTable]') as any);
+			// no table used for connection info so prompt user to get connection info
+			testUtils.vscodeMssqlIExtension.setup(x => x.promptForConnection(true)).returns(() => Promise.resolve(connectionInfo));
+			testUtils.vscodeMssqlIExtension.setup(x => x.connect(connectionInfo)).returns(() => Promise.resolve('testConnectionURI'));
+			testUtils.vscodeMssqlIExtension.setup(x => x.listDatabases('testConnectionURI')).returns(() => Promise.resolve(['testDb']));
+			// select the testDB from list of databases based on connection info
+			quickpickStub.onSecondCall().returns(Promise.resolve('testDb') as any);
+			// get tables from selected database
+			const params = { ownerUri: 'testConnectionURI', queryString: azureFunctionUtils.tablesQuery('testDb') };
+			testUtils.vscodeMssqlIExtension.setup(x => x.sendRequest(azureFunctionsContracts.SimpleExecuteRequest.type, params))
+				.returns(() => Promise.resolve({ rowCount: 1, columnInfo: [], rows: [['[schema].[testTable]']] }));
+			// select the schema.testTable from list of tables based on connection info and database
+			quickpickStub.onThirdCall().returns(Promise.resolve('[schema].[testTable]') as any);
 
-		// set azure function name
-		let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
+			// set azure function name
+			let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
 
-		// promptAndUpdateConnectionStringSetting
-		quickpickStub.onCall(3).resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
-		inputStub.onSecondCall().resolves('SqlConnectionString');
-		// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
-		quickpickStub.onCall(4).returns(Promise.resolve(constants.yesString) as any);
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
-		// setLocalAppSetting with connection string setting name and connection string
-		// fails if we dont set writeFile stub
-		sinon.stub(fs.promises, 'writeFile');
-		sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
-		sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
+			// promptAndUpdateConnectionStringSetting
+			quickpickStub.onCall(3).resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
+			inputStub.onSecondCall().resolves('SqlConnectionString');
+			// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
+			quickpickStub.onCall(4).returns(Promise.resolve(constants.yesString) as any);
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+			// setLocalAppSetting with connection string setting name and connection string
+			// fails if we dont set writeFile stub
+			sinon.stub(fs.promises, 'writeFile');
+			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
+			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-		let testWatcher = vscode.workspace.createFileSystemWatcher((
-			new vscode.RelativePattern(rootFolderPath, '**/*.cs')), false, true, true);
-		sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
-		await azureFunctionService.createAzureFunction();
+			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			await azureFunctionService.createAzureFunction();
 
-		should(spy.notCalled).be.true('showErrorMessage should not have been called');
-		// set the connection info to be the one the user selects from list of databases quickpick
-		should(connectionInfo.database).equal('testDb');
-	});
+			should(spy.notCalled).be.true('showErrorMessage should not have been called');
+			// set the connection info to be the one the user selects from list of databases quickpick
+			should(connectionInfo.database).equal('testDb');
+		});
 
-	it('Should create azure function project using command via the sql server table OE', async function (): Promise<void> {
-		// This test will have an azure function project already in the project and the azure functions extension installed (stubbed)
-		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
-		sinon.stub(azureFunctionUtils, 'getAzureFunctionProject').resolves(projectFilePath); //set azure function project to have one project
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+		it('Should create azure function project using command via the sql server table OE', async function (): Promise<void> {
+			// This test will have an azure function project already in the project and the azure functions extension installed (stubbed)
+			sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
+			sinon.stub(azureFunctionUtils, 'getAzureFunctionProject').resolves(projectFilePath); //set azure function project to have one project
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
 
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		let connectionDetails = { options: connectionInfo };
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			let connectionDetails = { options: connectionInfo };
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
 
-		const spy = sinon.spy(vscode.window, 'showErrorMessage');
+			const spy = sinon.spy(vscode.window, 'showErrorMessage');
 
-		// select input or output binding
-		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(<any>{ label: constants.input, type: BindingType.input });
-		// table node used when creating azure function project
-		let tableTestNode = createTestTableNode(connectionInfo);
+			// select input or output binding
+			let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(<any>{ label: constants.input, type: BindingType.input });
+			// table node used when creating azure function project
+			let tableTestNode = createTestTableNode(connectionInfo);
 
-		// set azure function name
-		let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
+			// set azure function name
+			let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
 
-		// promptAndUpdateConnectionStringSetting
-		quickpickStub.onSecondCall().resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
-		inputStub.onSecondCall().resolves('SqlConnectionString');
-		// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
-		quickpickStub.onThirdCall().returns(Promise.resolve(constants.yesString) as any);
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
-		// setLocalAppSetting with connection string setting name and connection string
-		// fails if we dont set writeFile stub
-		sinon.stub(fs.promises, 'writeFile');
-		sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
-		sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
+			// promptAndUpdateConnectionStringSetting
+			quickpickStub.onSecondCall().resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
+			inputStub.onSecondCall().resolves('SqlConnectionString');
+			// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
+			quickpickStub.onThirdCall().returns(Promise.resolve(constants.yesString) as any);
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+			// setLocalAppSetting with connection string setting name and connection string
+			// fails if we dont set writeFile stub
+			sinon.stub(fs.promises, 'writeFile');
+			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
+			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-		let testWatcher = vscode.workspace.createFileSystemWatcher((
-			new vscode.RelativePattern(rootFolderPath, '**/*.cs')), false, true, true);
-		sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			let testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
-		await azureFunctionService.createAzureFunction(tableTestNode);
+			await azureFunctionService.createAzureFunction(tableTestNode);
 
-		should(spy.notCalled).be.true('showErrorMessage should not have been called');
-		// set the connection info to be the one used from the test table node from OE
-		should(connectionInfo.database).equal('testDb');
-	});
+			should(spy.notCalled).be.true('showErrorMessage should not have been called');
+			// set the connection info to be the one used from the test table node from OE
+			should(connectionInfo.database).equal('testDb');
+		});
 
-	it('Should open link to learn more about SQL bindings when no azure function project found in folder or workspace', async function (): Promise<void> {
-		// This test will ask user that an azure function project must be opened to create an azure function with sql binding
-		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+		it('Should open link to learn more about SQL bindings when no azure function project found in folder or workspace', async function (): Promise<void> {
+			// This test will ask user that an azure function project must be opened to create an azure function with sql binding
+			sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
 
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		let connectionDetails = { options: connectionInfo };
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			let connectionDetails = { options: connectionInfo };
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
 
-		const executeCommandSpy = sinon.spy(vscode.commands, 'executeCommand');
-		const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').returns(Promise.resolve(constants.learnMore) as any);
-		await azureFunctionService.createAzureFunction();
+			const executeCommandSpy = sinon.spy(vscode.commands, 'executeCommand');
+			const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').returns(Promise.resolve(constants.learnMore) as any);
+			await azureFunctionService.createAzureFunction();
 
-		should(executeCommandSpy.calledOnce).be.true('showErrorMessage should have been called');
-		should(showErrorStub.calledOnce).be.true('showErrorMessage should have been called');
-	});
+			should(executeCommandSpy.calledOnce).be.true('showErrorMessage should have been called');
+			should(showErrorStub.calledOnce).be.true('showErrorMessage should have been called');
+		});
 
-	it('Should ask the user to choose a folder to use for the azure project and create an azure function with the selected folder', async function (): Promise<void> {
-		// This test will ask user that an azure function project must be opened to create an azure function with sql binding
-		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
-		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
+		it('Should ask the user to choose a folder to use for the azure project and create an azure function with the selected folder', async function (): Promise<void> {
+			// This test will ask user that an azure function project must be opened to create an azure function with sql binding
+			sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
+			sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);
 
-		let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
-		let connectionDetails = { options: connectionInfo };
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+			let connectionInfo: IConnectionInfo = createTestCredentials();// Mocks promptForConnection
+			let connectionDetails = { options: connectionInfo };
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
 
-		// error since no project file found in workspace or folder
-		const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').returns(Promise.resolve(constants.createProject) as any);
+			// error since no project file found in workspace or folder
+			const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').returns(Promise.resolve(constants.createProject) as any);
 
-		// user chooses to browse for folder
-		let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').returns(Promise.resolve(constants.browseEllipsisWithIcon) as any);
+			// user chooses to browse for folder
+			let quickpickStub = sinon.stub(vscode.window, 'showQuickPick').returns(Promise.resolve(constants.browseEllipsisWithIcon) as any);
 
-		// stub out folder to be chosen (showOpenDialog)
-		sinon.stub(vscode.window, 'showOpenDialog').withArgs(sinon.match.any).resolves([vscode.Uri.file(projectFilePath)]);
-		// select input or output binding
-		quickpickStub.onSecondCall().resolves(<any>{ label: constants.input, type: BindingType.input });
-		// table node used when creating azure function project
-		let tableTestNode = createTestTableNode(connectionInfo);
+			// stub out folder to be chosen (showOpenDialog)
+			sinon.stub(vscode.window, 'showOpenDialog').withArgs(sinon.match.any).resolves([vscode.Uri.file(projectFilePath)]);
+			// select input or output binding
+			quickpickStub.onSecondCall().resolves(<any>{ label: constants.input, type: BindingType.input });
+			// table node used when creating azure function project
+			let tableTestNode = createTestTableNode(connectionInfo);
 
-		// set azure function name
-		let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
+			// set azure function name
+			let inputStub = sinon.stub(vscode.window, 'showInputBox').resolves('testFunctionName');
 
-		// promptAndUpdateConnectionStringSetting
-		quickpickStub.onThirdCall().resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
-		inputStub.onSecondCall().resolves('SqlConnectionString');
-		// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
-		quickpickStub.onCall(3).returns(Promise.resolve(constants.yesString) as any);
-		testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
-		// setLocalAppSetting with connection string setting name and connection string
-		// fails if we dont set writeFile stub
-		sinon.stub(fs.promises, 'writeFile');
-		sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
-		sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
+			// promptAndUpdateConnectionStringSetting
+			quickpickStub.onThirdCall().resolves(<any>{ label: constants.createNewLocalAppSettingWithIcon });
+			inputStub.onSecondCall().resolves('SqlConnectionString');
+			// promptConnectionStringPasswordAndUpdateConnectionString - tested in AzureFunctionUtils.test.ts
+			quickpickStub.onCall(3).returns(Promise.resolve(constants.yesString) as any);
+			testUtils.vscodeMssqlIExtension.setup(x => x.getConnectionString(connectionDetails, true, false)).returns(() => Promise.resolve('testConnectionString'));
+			// setLocalAppSetting with connection string setting name and connection string
+			// fails if we dont set writeFile stub
+			sinon.stub(fs.promises, 'writeFile');
+			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').returns(Promise.resolve(true));
+			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-		let testWatcher = vscode.workspace.createFileSystemWatcher((
-			new vscode.RelativePattern(rootFolderPath, '**/*.cs')), false, true, true);
-		sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
+			let testWatcher: vscode.FileSystemWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
+			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
-		await azureFunctionService.createAzureFunction(tableTestNode);
+			await azureFunctionService.createAzureFunction(tableTestNode);
 
-		should(showErrorStub.calledOnce).be.true('showErrorMessage should have been called');
+			should(showErrorStub.calledOnce).be.true('showErrorMessage should have been called');
+		});
 	});
 });

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -38,7 +38,7 @@ describe('Tests to verify Create Azure Function with SQL Binding', () => {
 		constants.install, constants.learnMore, constants.doNotInstall]);
 	});
 
-	it('Should create azure function project using command from command palette (no connection info)', async function (): Promise<void> {
+	it('Should create azure function project using the command from command palette (no connection info)', async function (): Promise<void> {
 		// This test will have an azure function project already in the project and the azure functions extension installed (stubbed)
 		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
 		sinon.stub(azureFunctionUtils, 'getAzureFunctionProject').resolves(projectFilePath); //set azure function project to have one project
@@ -153,7 +153,7 @@ describe('Tests to verify Create Azure Function with SQL Binding', () => {
 		should(showErrorStub.calledOnce).be.true('showErrorMessage should have been called');
 	});
 
-	it('Should ask user to choose folder to use for azure project and create azure function with the selected folder', async function (): Promise<void> {
+	it('Should ask the user to choose a folder to use for the azure project and create an azure function with the selected folder', async function (): Promise<void> {
 		// This test will ask user that an azure function project must be opened to create an azure function with sql binding
 		sinon.stub(azureFunctionUtils, 'getAzureFunctionsExtensionApi').resolves(testUtils.azureFunctionsExtensionApi.object); // set azure functions extension api
 		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);

--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -8,6 +8,7 @@ import * as TypeMoq from 'typemoq';
 import * as mssql from 'mssql';
 import * as vscodeMssql from 'vscode-mssql';
 import { RequestType } from 'vscode-languageclient';
+import { AzureFunctionsExtensionApi, IAppSettingsClient, ICreateFunctionOptions } from '../../../types/vscode-azurefunctions.api';
 
 export interface TestUtils {
 	context: vscode.ExtensionContext;
@@ -16,6 +17,7 @@ export interface TestUtils {
 	vscodeMssqlIExtension: TypeMoq.IMock<vscodeMssql.IExtension>
 	dacFxMssqlService: TypeMoq.IMock<vscodeMssql.IDacFxService>;
 	schemaCompareService: TypeMoq.IMock<vscodeMssql.ISchemaCompareService>;
+	azureFunctionsExtensionApi: TypeMoq.IMock<AzureFunctionsExtensionApi>;
 }
 
 export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
@@ -58,6 +60,26 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 	}
 }
 
+export class MockAzureFunctionExtensionAPI implements AzureFunctionsExtensionApi {
+	public apiVersion: string = 'latest';
+
+	public revealTreeItem(_: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	public createFunction(_: ICreateFunctionOptions): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	public downloadAppSettings(_: IAppSettingsClient): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	public uploadAppSettings(_: IAppSettingsClient, __?: (RegExp | string)[]): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+}
+
 export function createTestUtils(): TestUtils {
 	return {
 		context: TypeMoq.Mock.ofType<vscode.ExtensionContext>().object,
@@ -65,7 +87,8 @@ export function createTestUtils(): TestUtils {
 		vscodeMssqlIExtension: TypeMoq.Mock.ofType(MockVscodeMssqlIExtension),
 		dacFxMssqlService: TypeMoq.Mock.ofType<vscodeMssql.IDacFxService>(),
 		schemaCompareService: TypeMoq.Mock.ofType<vscodeMssql.ISchemaCompareService>(),
-		outputChannel: TypeMoq.Mock.ofType<vscode.OutputChannel>().object
+		outputChannel: TypeMoq.Mock.ofType<vscode.OutputChannel>().object,
+		azureFunctionsExtensionApi: TypeMoq.Mock.ofType(MockAzureFunctionExtensionAPI)
 	};
 }
 
@@ -106,4 +129,40 @@ export function createTestCredentials(): vscodeMssql.IConnectionInfo {
 		connectionString: ''
 	};
 	return creds;
+}
+
+/**
+ * Create SQL server table node used for testing
+ * @param connectionInfo the connection info used for the test case
+ * @returns SQL Server table node
+ */
+export function createTestTableNode(connectionInfo: vscodeMssql.IConnectionInfo): vscodeMssql.ITreeNodeInfo {
+	return {
+		connectionInfo: connectionInfo,
+		nodeType: 'Table',
+		metadata: {
+			metadataType: 0,
+			metadataTypeName: 'Table',
+			urn: '',
+			name: 'testTable',
+			schema: 'testSchema',
+		},
+		parentNode: {
+			connectionInfo: connectionInfo,
+			nodeType: 'Folder',
+			metadata: null!,
+			parentNode: {
+				connectionInfo: connectionInfo,
+				nodeType: 'Database',
+				metadata: {
+					metadataType: 0,
+					metadataTypeName: 'Database',
+					urn: '',
+					name: 'testDb',
+					schema: null!,
+				},
+				parentNode: undefined! // set to undefined since we do not need further parent node
+			}
+		}
+	};
 }

--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -8,7 +8,7 @@ import * as TypeMoq from 'typemoq';
 import * as mssql from 'mssql';
 import * as vscodeMssql from 'vscode-mssql';
 import { RequestType } from 'vscode-languageclient';
-import { AzureFunctionsExtensionApi, IAppSettingsClient, ICreateFunctionOptions } from '../../../types/vscode-azurefunctions.api';
+import { AzureFunctionsExtensionApi } from '../../../types/vscode-azurefunctions.api';
 
 export interface TestUtils {
 	context: vscode.ExtensionContext;
@@ -60,26 +60,6 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 	}
 }
 
-export class MockAzureFunctionExtensionAPI implements AzureFunctionsExtensionApi {
-	public apiVersion: string = 'latest';
-
-	public revealTreeItem(_: string): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
-
-	public createFunction(_: ICreateFunctionOptions): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
-
-	public downloadAppSettings(_: IAppSettingsClient): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
-
-	public uploadAppSettings(_: IAppSettingsClient, __?: (RegExp | string)[]): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
-}
-
 export function createTestUtils(): TestUtils {
 	return {
 		context: TypeMoq.Mock.ofType<vscode.ExtensionContext>().object,
@@ -88,7 +68,7 @@ export function createTestUtils(): TestUtils {
 		dacFxMssqlService: TypeMoq.Mock.ofType<vscodeMssql.IDacFxService>(),
 		schemaCompareService: TypeMoq.Mock.ofType<vscodeMssql.ISchemaCompareService>(),
 		outputChannel: TypeMoq.Mock.ofType<vscode.OutputChannel>().object,
-		azureFunctionsExtensionApi: TypeMoq.Mock.ofType(MockAzureFunctionExtensionAPI)
+		azureFunctionsExtensionApi: TypeMoq.Mock.ofType<AzureFunctionsExtensionApi>()
 	};
 }
 

--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -61,6 +61,9 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 }
 
 export function createTestUtils(): TestUtils {
+	// Need to setup then when Promise.resolving a mocked object : https://github.com/florinn/typemoq/issues/66
+	const azureFunctionsExtensionApi = TypeMoq.Mock.ofType<AzureFunctionsExtensionApi>();
+	azureFunctionsExtensionApi.setup((x: any) => x.then).returns(() => undefined);
 	return {
 		context: TypeMoq.Mock.ofType<vscode.ExtensionContext>().object,
 		dacFxService: TypeMoq.Mock.ofType<mssql.IDacFxService>(),
@@ -68,7 +71,7 @@ export function createTestUtils(): TestUtils {
 		dacFxMssqlService: TypeMoq.Mock.ofType<vscodeMssql.IDacFxService>(),
 		schemaCompareService: TypeMoq.Mock.ofType<vscodeMssql.ISchemaCompareService>(),
 		outputChannel: TypeMoq.Mock.ofType<vscode.OutputChannel>().object,
-		azureFunctionsExtensionApi: TypeMoq.Mock.ofType<AzureFunctionsExtensionApi>()
+		azureFunctionsExtensionApi
 	};
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds Azure Function with SQL binding tests specifically for 5 scenarios:
1. Should show info message to install azure functions extension if not installed
2. Should create azure function project using the command from command palette (no connection info)
3. Should create azure function project using command via the sql server table OE
4. Should open link to learn more about SQL bindings when no azure function project found in folder or workspace
5. Should ask the user to choose a folder to use for the azure project and create an azure function with the selected folder

Figma design doc: https://www.figma.com/file/sC2e3Dgitogj04uQZbuL47/SQL-Bindings-0.1.0?node-id=51%3A417

Coverage > 70% (more to come as well :smiley:)
<img width="746" alt="image" src="https://user-images.githubusercontent.com/23587151/170443358-ef0707c2-37e5-47c6-b66d-85da6e18d869.png">
