### PR TITLE
adjust the grid's height in table designer

### DIFF
--- a/src/sql/workbench/browser/designer/designerTableUtil.ts
+++ b/src/sql/workbench/browser/designer/designerTableUtil.ts
@@ -9,7 +9,8 @@ import { deepClone } from 'vs/base/common/objects';
 
 export const TableRowHeight = 25;
 export const TableHeaderRowHeight = 28;
-const minHeight = getTableHeight(2);
+export const ScrollbarSize = 15;
+const minHeight = getTableHeight(1);
 
 /**
  * Layout the table, the height will be determined by the number of rows in it.
@@ -33,5 +34,5 @@ export function layoutDesignerTable(table: Table<Slick.SlickData>, width: number
 }
 
 function getTableHeight(rows: number): number {
-	return rows * TableRowHeight + TableHeaderRowHeight;
+	return rows * TableRowHeight + TableHeaderRowHeight + ScrollbarSize;
 }


### PR DESCRIPTION
This PR fixes #19403

issue: there shouldn't be a vertical scrollbar inside the table.
fix: when setting the height of the table, we also need to consider the horizontal scrollbar. 

before:
![table-size-before](https://user-images.githubusercontent.com/13777222/170601556-b81ee96a-1699-4868-8a62-06d612aaa44a.gif)


after:
![table-size-after](https://user-images.githubusercontent.com/13777222/170601577-d667ac17-8251-4376-ab91-9236baf88ecb.gif)
