### PR TITLE
Update typings for getAzureFunctions request

### DIFF
--- a/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
@@ -44,7 +44,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined):
 	}
 
 	// get all the Azure functions in the file
-	const azureFunctions = getAzureFunctionsResult.azureFunctions;
+	const azureFunctions = getAzureFunctionsResult.azureFunctions.map(af => typeof (af) === 'string' ? af : af.name);
 
 	if (azureFunctions.length === 0) {
 		void vscode.window.showErrorMessage(constants.noAzureFunctionsInFile);

--- a/extensions/sql-bindings/src/sql-bindings.d.ts
+++ b/extensions/sql-bindings/src/sql-bindings.d.ts
@@ -121,14 +121,26 @@ declare module 'sql-bindings' {
 		filePath: string;
 	}
 
+	export interface AzureFunction {
+		/**
+		 * The name of the function
+		 */
+		name: string;
+		/**
+		 * The route of the function if it has an HTTP trigger with a route specified
+		 */
+		route?: string | undefined;
+	}
+
 	/**
 	 * Result from a get Azure Functions request
 	 */
-	export interface GetAzureFunctionsResult extends ResultStatus {
+	export interface GetAzureFunctionsResult {
 		/**
-		 * Array of names of Azure Functions in the file
+		 * Array of Azure Functions in the file
+		 * Note : The string list response will eventually be deprecated and replaced completely with the AzureFunction list
 		 */
-		azureFunctions: string[];
+		azureFunctions: string[] | AzureFunction[];
 	}
 
 	/**


### PR DESCRIPTION
Goes along with https://github.com/microsoft/sqltoolsservice/pull/1521

This is technically early since it requires using a newer version of STS that has the updates from the other PR, but I'm doing this now since I'll be using these newer typings in the stuff I'm working on and want to keep the typings file in sync. 

Once there's a version of STS out with those changes I'll update VSCode-MSSQL to use the new version, and then once that's released to the marketplace I'll come back in and remove the string[] type from the response. 