### PR TITLE
Add progress notifications for database that would contain lots of tables

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -666,11 +666,20 @@ export async function promptSelectTable(connectionURI: string, bindingType: Bind
 	// Create query to get list of tables from database selected
 	let tableQuery = tablesQuery(selectedDatabase);
 	const params = { ownerUri: connectionURI, queryString: tableQuery };
-	// send SimpleExecuteRequest query to STS to get list of schema and tables based on the connection profile of the user
-	let queryResult: azureFunctionsContracts.SimpleExecuteResult = await vscodeMssqlApi.sendRequest(azureFunctionsContracts.SimpleExecuteRequest.type, params);
+	let queryResult: azureFunctionsContracts.SimpleExecuteResult | undefined;
+	// send SimpleExecuteRequest query to STS to get list of schema and tables based on the connection profile and database of the user
+	await vscode.window.withProgress(
+		{
+			location: vscode.ProgressLocation.Notification,
+			title: constants.tableListProgressTitle,
+			cancellable: false
+		}, async (_progress, _token) => {
+			queryResult = await vscodeMssqlApi.sendRequest(azureFunctionsContracts.SimpleExecuteRequest.type, params);
+		}
+	);
 
 	// Get schema and table names from query result rows
-	const tableNames = queryResult.rows.map(r => r[0].displayValue);
+	const tableNames = queryResult!.rows.map(r => r[0].displayValue);
 	// add manual entry option to table names list for user to choose from as well (with pencil icon)
 	let manuallyEnterObjectName = '$(pencil) ' + userObjectName;
 	tableNames.unshift(manuallyEnterObjectName);

--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -77,6 +77,7 @@ export const connectionProgressTitle = localize('connectionProgressTitle', "Test
 export const enterObjectName = localize('enterObjectName', 'Enter SQL table or view to query');
 export const enterObjectNameToUpsert = localize('enterObjectNameToUpsert', 'Enter SQL table to upsert into');
 export const selectTable = localize('selectTable', 'Select table to use');
+export const tableListProgressTitle = localize('tableListProgressTitle', "Fetching tables for selected database...");
 export const selectConnectionError = (err?: any): string => err ? localize('selectConnectionError', "Failed to set connection string app setting: {0}", utils.getErrorMessage(err)) : localize('unableToSetConnectionString', "Failed to set connection string app setting");
 export function selectBindingType(funcName?: string): string { return funcName ? localize('selectBindingTypeToSpecifiedFunction', "Select type of binding for the function '{0}'", funcName) : localize('selectBindingType', "Select type of binding"); }
 export function settingAlreadyExists(settingName: string): string { return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName); }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19458.
Typically this would only be shown when there are a lot of tables within a selected database. Otherwise, it would just execute quickly and return the below prompt:
<img width="507" alt="image" src="https://user-images.githubusercontent.com/23587151/171257872-dee75dcf-bf6e-40ba-9a3a-78b2f4386ec2.png">

