### PR TITLE
remove the tracing

### DIFF
--- a/src/sql/workbench/services/query/common/queryRunner.ts
+++ b/src/sql/workbench/services/query/common/queryRunner.ts
@@ -437,7 +437,6 @@ export default class QueryRunner extends Disposable {
 	}
 
 	public override dispose() {
-		this.logService.info(`Disposing the query runner of: '${this.uri}'', call stack: ${new Error().stack}`);
 		this._batchSets = undefined!;
 		super.dispose();
 		this._isDisposed = true;


### PR DESCRIPTION
This PR fixes #18067

I added this a while back to debug the query editor crash issue, but based on the user's reply, the call stack is always the same as per conversation in this issue: https://github.com/microsoft/azuredatastudio/issues/6763, so removing it to avoid confusion. 

btw, user is happy with what we have implemented to prevent the data loss, so we don't have an immediate need to figure out what is causing the early disposal of the query runner object.
