### PR TITLE
Fix env vars being overwritten in ext unit test script

### DIFF
--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -80,6 +80,7 @@ for (const ext of argv.extensions) {
 		console.log(execSync(command, { stdio: 'inherit'}));
 	} else {
 		const env = {
+			...process.env,
 			VSCODE_CLI: 1,
 			ELECTRON_ENABLE_STACK_DUMPING: 1,
 			ELECTRON_ENABLE_LOGGING: 1


### PR DESCRIPTION
Env vars such as ADS_TEST_GREP weren't being picked up when running the `test-extensions-unit.js` script because the script was setting the env vars directly. Changing it to use all existing env vars and then modifying the values it needs for the tests. 