### PR TITLE
Skip automation out dir for linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,6 +18,7 @@
 /extensions/**/dist/**
 /extensions/types
 /extensions/typescript-language-features/test-workspace/**
+/test/automation/out
 
 # These files are not linted by `yarn eslint`, so we exclude them from being linted in the editor.
 # This ensures that if we add new rules and they pass CI, the are also no errors in the editor.


### PR DESCRIPTION
Has a bunch of generated files which fail linting that should just ignore