### PR TITLE
workaround for the dashboard resets zooming issue

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
@@ -22,6 +22,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IMenuService } from 'vs/platform/actions/common/actions';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export class DatabaseDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
@@ -52,9 +53,10 @@ export class DatabaseDashboardPage extends DashboardPage implements OnInit {
 		@Inject(IContextKeyService) contextKeyService: IContextKeyService,
 		@Inject(IMenuService) menuService: IMenuService,
 		@Inject(IWorkbenchThemeService) themeService: IWorkbenchThemeService,
-		@Inject(IInstantiationService) instantiationService: IInstantiationService
+		@Inject(IInstantiationService) instantiationService: IInstantiationService,
+		@Inject(IConfigurationService) configurationService: IConfigurationService
 	) {
-		super(dashboardService, el, _cd, notificationService, angularEventingService, logService, commandService, contextKeyService, menuService, themeService, instantiationService);
+		super(dashboardService, el, _cd, notificationService, angularEventingService, logService, commandService, contextKeyService, menuService, themeService, instantiationService, configurationService);
 		this._register(dashboardService.onUpdatePage(() => {
 			this.refresh(true);
 			this._cd.detectChanges();

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
@@ -24,6 +24,7 @@ import { IMenuService } from 'vs/platform/actions/common/actions';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export class ServerDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
@@ -55,9 +56,10 @@ export class ServerDashboardPage extends DashboardPage implements OnInit {
 		@Inject(IContextKeyService) contextKeyService: IContextKeyService,
 		@Inject(IMenuService) menuService: IMenuService,
 		@Inject(IWorkbenchThemeService) themeService: IWorkbenchThemeService,
-		@Inject(IInstantiationService) instantiationService: IInstantiationService
+		@Inject(IInstantiationService) instantiationService: IInstantiationService,
+		@Inject(IConfigurationService) configurationService: IConfigurationService
 	) {
-		super(dashboardService, el, _cd, notificationService, angularEventingService, logService, commandService, contextKeyService, menuService, themeService, instantiationService);
+		super(dashboardService, el, _cd, notificationService, angularEventingService, logService, commandService, contextKeyService, menuService, themeService, instantiationService, configurationService);
 
 		// special-case handling for MSSQL data provider
 		const connInfo = this.dashboardService.connectionManagementService.connectionInfo;


### PR DESCRIPTION
workaround for https://github.com/microsoft/azuredatastudio/issues/14128

based on the debugging in ADS, the zoom reset happened during the Angular's internal processing, I'll debug electron and figure out the root cause. but the actual fix most likely won't make it to June release.

the workaround is not perfect since you will still see the zoom level being changed by the dashboard, but definitely better than what it was before.


before
![zoom-before](https://user-images.githubusercontent.com/13777222/171299575-e8fe27d1-87e4-459d-91bb-e011dff8c811.gif)

after
![zoom-after](https://user-images.githubusercontent.com/13777222/171299585-a59d3e7a-5c73-45a8-b5b7-2913b977c830.gif)
