### PR TITLE
Fix azdata.connection.getConnection

### DIFF
--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -321,8 +321,6 @@ export interface IConnectionManagementService {
 	 * @returns array of connections
 	 */
 	getConnections(activeConnectionsOnly?: boolean): ConnectionProfile[];
-
-	getConnection(uri: string): ConnectionProfile;
 }
 
 export enum RunQueryOnConnectionMode {

--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -96,7 +96,7 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 	}
 
 	public $getConnection(uri: string): Thenable<azdata.connection.ConnectionProfile> {
-		let profile = this._connectionManagementService.getConnection(uri);
+		const profile = this._connectionManagementService.getConnectionProfile(uri);
 		if (!profile) {
 			return Promise.resolve(undefined);
 		}

--- a/src/sql/workbench/contrib/assessment/test/browser/asmtActions.test.ts
+++ b/src/sql/workbench/contrib/assessment/test/browser/asmtActions.test.ts
@@ -31,6 +31,7 @@ import { TestFileService, TestEnvironmentService, TestFileDialogService } from '
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { URI } from 'vs/base/common/uri';
 import { IFileService } from 'vs/platform/files/common/files';
+import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
 /**
  * Class to test Assessment Management Actions
  */
@@ -120,7 +121,7 @@ suite('Assessment Actions', () => {
 		let connectionManagementService = TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService);
 		connectionManagementService.setup(c => c.listDatabases(TypeMoq.It.isAny())).returns(() => Promise.resolve(dbListResult));
 		connectionManagementService.setup(c => c.getConnectionUriFromId(TypeMoq.It.isAny())).returns(() => '');
-		connectionManagementService.setup(c => c.getConnection(TypeMoq.It.isAny())).returns(() => connectionProfile.object);
+		connectionManagementService.setup(c => c.getConnectionProfile(TypeMoq.It.isAny())).returns(() => connectionProfile.object);
 		connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.isAny())).returns(() => Promise.resolve(''));
 
 		return connectionManagementService;
@@ -133,7 +134,12 @@ suite('Assessment Actions', () => {
 
 		const connectionManagementService = createConnectionManagementService(dbListResult);
 
-		const action = new AsmtServerSelectItemsAction(connectionManagementService.object, new NullLogService(), mockAssessmentService.object, new NullAdsTelemetryService());
+		const action = new AsmtServerSelectItemsAction(
+			connectionManagementService.object,
+			new TestCapabilitiesService(),
+			new NullLogService(),
+			mockAssessmentService.object,
+			new NullAdsTelemetryService());
 		assert.strictEqual(action.id, AsmtServerSelectItemsAction.ID, 'Get Server Rules id action mismatch');
 		assert.strictEqual(action.label, AsmtServerSelectItemsAction.LABEL, 'Get Server Rules label action mismatch');
 
@@ -156,7 +162,12 @@ suite('Assessment Actions', () => {
 
 		const connectionManagementService = createConnectionManagementService(dbListResult);
 
-		const action = new AsmtServerInvokeItemsAction(connectionManagementService.object, new NullLogService(), mockAssessmentService.object, new NullAdsTelemetryService());
+		const action = new AsmtServerInvokeItemsAction(
+			connectionManagementService.object,
+			new TestCapabilitiesService(),
+			new NullLogService(),
+			mockAssessmentService.object,
+			new NullAdsTelemetryService());
 		assert.strictEqual(action.id, AsmtServerInvokeItemsAction.ID, 'Invoke Server Assessment id action mismatch');
 		assert.strictEqual(action.label, AsmtServerInvokeItemsAction.LABEL, 'Invoke Server Assessment label action mismatch');
 

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1634,20 +1634,6 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		return connections;
 	}
 
-	public getConnection(uri: string): ConnectionProfile {
-		const connections = this.getActiveConnections();
-		if (connections) {
-			for (let connection of connections) {
-				let connectionUri = this.getConnectionUriFromId(connection.id);
-				if (connectionUri === uri) {
-					return connection;
-				}
-			}
-		}
-
-		return undefined;
-	}
-
 	private getConnectionsInGroup(group: ConnectionProfileGroup): ConnectionProfile[] {
 		const connections = [];
 		if (group) {

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -781,8 +781,8 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		await connect(uri, options, true, profile);
 		// invalid uri check.
-		assert.strictEqual(connectionManagementService.getConnection(badString), undefined);
-		let returnedProfile = connectionManagementService.getConnection(uri);
+		assert.strictEqual(connectionManagementService.getConnectionProfile(badString), undefined);
+		let returnedProfile = connectionManagementService.getConnectionProfile(uri);
 		assert.strictEqual(returnedProfile.groupFullName, profile.groupFullName);
 		assert.strictEqual(returnedProfile.groupId, profile.groupId);
 	});


### PR DESCRIPTION
I was trying to use this in an extension and noticed that it didn't always work - for example if I open a new query window, enter a query, execute it and then select a connection then `azdata.connection.getConnection(<editor URI>)` would return undefined.

The root of the issue was that `getActiveConnections` filters down the list of connections so that only a single connection per ID exists - but this means we can easily lose the connection we're trying to find if there's multiple things using the same base profile (for example multiple editors). 

While investigating this I noticed that getConnection is barely even used anywhere - and we already had a `getConnectionProfile` which does basically the same thing but doesn't have the above issue (it looks at all connections for the one with the URI we expect). So I just switched to using that and then deleted the "broken" one. 