### PR TITLE
Fix split cell not working with attachments

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -1099,6 +1099,25 @@ suite('Cell Model', function (): void {
 		assert.notDeepStrictEqual(model.attachments, contents.attachments, 'Unused attachments are not removed after updating cell source');
 	});
 
+	test('Should not remove attachments that are still referenced in cell after updating the cell source', async function () {
+		const cellAttachment = JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}');
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Markdown,
+			source: '![ads.png](attachment:ads.png)',
+			attachments: cellAttachment
+		};
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+
+		model.source = '![ads.png](attachment:ads.png) \n Test';
+
+		assert.deepStrictEqual(model.attachments, contents.attachments, 'Attachments referenced in cell were removed');
+	});
+
 	test('Should update cell attachments', async function () {
 		const cellAttachment = JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}');
 		let notebookModel = new NotebookModelStub({
@@ -1114,6 +1133,23 @@ suite('Cell Model', function (): void {
 		model.updateAttachmentsFromSource('![ads.png](attachment:ads.png)', cellAttachment);
 
 		assert.deepStrictEqual(model.attachments, cellAttachment, 'Cell attachments are not updated correctly');
+	});
+
+	test('Should not update cell attachments if they are not referenced in cell source', async function () {
+		const cellAttachment = JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}');
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Markdown,
+			source: '![ads.png](attachment:ads.png)'
+		};
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		model.updateAttachmentsFromSource('test', cellAttachment);
+
+		assert.notDeepStrictEqual(model.attachments, cellAttachment, 'Cell attachments are updated when they are not referenced in cell source');
 	});
 
 	test('Should not have cache chart data after new cell created', async function () {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -1079,6 +1079,43 @@ suite('Cell Model', function (): void {
 		assert.deepStrictEqual(serializedCell.attachments, undefined, 'JSON should not include attachments if attachments do not exist');
 	});
 
+	test('Should remove unused attachments name when updating cell source', async function () {
+		const cellAttachment = JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}');
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Markdown,
+			source: '',
+			attachments: cellAttachment
+		};
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		assert.deepStrictEqual(model.attachments, contents.attachments, 'Attachments do not match in cellModel');
+
+		model.source = 'Test';
+
+		assert.notDeepStrictEqual(model.attachments, contents.attachments, 'Unused attachments are not removed after updating cell source');
+	});
+
+	test('Should update cell attachments', async function () {
+		const cellAttachment = JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}');
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Markdown,
+			source: '![ads.png](attachment:ads.png)'
+		};
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		model.updateAttachmentsFromSource('![ads.png](attachment:ads.png)', cellAttachment);
+
+		assert.deepStrictEqual(model.attachments, cellAttachment, 'Cell attachments are not updated correctly');
+	});
+
 	test('Should not have cache chart data after new cell created', async function () {
 		let notebookModel = new NotebookModelStub({
 			name: '',

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -1152,6 +1152,23 @@ suite('Cell Model', function (): void {
 		assert.notDeepStrictEqual(model.attachments, cellAttachment, 'Cell attachments are updated when they are not referenced in cell source');
 	});
 
+	test('Should not update cell attachments if the attachment reference is not in the correct format', async function () {
+		const cellAttachment = JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}');
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Markdown,
+			source: '![ads.png](attachment:ads.png)'
+		};
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		model.updateAttachmentsFromSource('ads.png', cellAttachment);
+
+		assert.notDeepStrictEqual(model.attachments, cellAttachment, 'Cell attachments are updated when the reference is not in the correct format');
+	});
+
 	test('Should not have cache chart data after new cell created', async function () {
 		let notebookModel = new NotebookModelStub({
 			name: '',

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -346,6 +346,22 @@ export class CellModel extends Disposable implements ICellModel {
 		this._preventNextChartCache = true;
 	}
 
+	public attachImageToNewCell(newSource: string | string[]) {
+		// Find existing attachments in the form ![...](attachment:...) so that we can make sure we keep those attachments
+		const attachmentRegex = /!\[.*?\]\(attachment:(.*?)\)/g;
+		const source = Array.isArray(newSource) ? newSource.join() : newSource;
+		let match = attachmentRegex.exec(source);
+		// const uri = FileAccess.asBrowserUri(URI.file(imageCalloutResult.imagePath));
+		// let base64String = await this.getFileContentBase64(uri);
+		// let mimeType = await this.getFileMimeType(uri);
+		// const originalImageName: string = path.basename(imageCalloutResult.imagePath).replace(/\s/g, '');
+		// let attachmentName = this.cellModel.addAttachment(mimeType, base64String, originalImageName);
+		while (match) {
+			//this.addAttachment()
+
+		}
+	}
+
 	private attachImageFromSource(newSource: string | string[]): string | string[] {
 		if (!Array.isArray(newSource) && this.isValidBase64OctetStream(newSource)) {
 			let results;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -346,22 +346,6 @@ export class CellModel extends Disposable implements ICellModel {
 		this._preventNextChartCache = true;
 	}
 
-	public attachImageToNewCell(newSource: string | string[]) {
-		// Find existing attachments in the form ![...](attachment:...) so that we can make sure we keep those attachments
-		const attachmentRegex = /!\[.*?\]\(attachment:(.*?)\)/g;
-		const source = Array.isArray(newSource) ? newSource.join() : newSource;
-		let match = attachmentRegex.exec(source);
-		// const uri = FileAccess.asBrowserUri(URI.file(imageCalloutResult.imagePath));
-		// let base64String = await this.getFileContentBase64(uri);
-		// let mimeType = await this.getFileMimeType(uri);
-		// const originalImageName: string = path.basename(imageCalloutResult.imagePath).replace(/\s/g, '');
-		// let attachmentName = this.cellModel.addAttachment(mimeType, base64String, originalImageName);
-		while (match) {
-			//this.addAttachment()
-
-		}
-	}
-
 	private attachImageFromSource(newSource: string | string[]): string | string[] {
 		if (!Array.isArray(newSource) && this.isValidBase64OctetStream(newSource)) {
 			let results;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -334,7 +334,7 @@ export class CellModel extends Disposable implements ICellModel {
 	}
 
 	public set source(newSource: string | string[]) {
-		this.cleanUnusedAttachments(Array.isArray(newSource) ? newSource.join() : newSource);
+		this.updateAttachmentsFromSource(Array.isArray(newSource) ? newSource.join() : newSource);
 		newSource = this.attachImageFromSource(newSource);
 		newSource = this.getMultilineSource(newSource);
 		if (this._source !== newSource) {
@@ -358,12 +358,8 @@ export class CellModel extends Disposable implements ICellModel {
 		return newSource;
 	}
 
-	/**
-	 * Cleans up the attachments, removing any ones that aren't being currently used in the specified source string.
-	 * @param source The new source string to check for attachments being used
-	 */
-	private cleanUnusedAttachments(source: string): void {
-		const originalAttachments = this._attachments;
+	public updateAttachmentsFromSource(source: string, attachments?: nb.ICellAttachments): void {
+		const originalAttachments = attachments ? attachments : this._attachments;
 		this._attachments = {};
 		// Find existing attachments in the form ![...](attachment:...) so that we can make sure we keep those attachments
 		const attachmentRegex = /!\[.*?\]\(attachment:(.*?)\)/g;

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -554,6 +554,13 @@ export interface ICellModel {
 	 * Returns the name of the attachment added to metadata.
 	 */
 	addAttachment(mimeType: string, base64Encoding: string, name: string): string;
+	/**
+	 * Updates the current cell attachments with the attachments provided.
+	 * If no attachments are passed in then it cleans up the current cell attachments and removes any ones that aren't being currently used in the specified source string.
+	 * @param source The new source string to check for attachments being used
+	 * @param attachments (Optional) The new attachments for the cell
+	 */
+	updateAttachmentsFromSource(source: string, attachments?: nb.ICellAttachments): void;
 	richTextCursorPosition: ICaretPosition;
 	markdownCursorPosition: IPosition;
 	/**

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -608,8 +608,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						partialSource = source.slice(selection.startLineNumber - 1, selection.startLineNumber)[0].slice(0, selection.startColumn - 1);
 						headsource = headsource.concat(partialSource.toString());
 					}
-					// save attachments before updating the cell contents
+					// Save attachments before updating cell contents
 					attachments = this.cells[index].attachments;
+					// No need to update attachments, since unused attachments are removed when updating the cell source
 					this.cells[index].source = headsource;
 					splitCells.push({ cell: this.cells[index], prefix: undefined });
 				}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -574,6 +574,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				let newCellIndex = index;
 				let tailCellIndex = index;
 				let splitCells: SplitCell[] = [];
+				let attachments = {};
 
 				// Save UI state
 				let showMarkdown = this.cells[index].showMarkdown;
@@ -607,7 +608,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						partialSource = source.slice(selection.startLineNumber - 1, selection.startLineNumber)[0].slice(0, selection.startColumn - 1);
 						headsource = headsource.concat(partialSource.toString());
 					}
+					attachments = this.cells[index].attachments;
 					this.cells[index].source = headsource;
+					// reset attachments
+					// if(attachments && !Object.keys(this.cells[index].attachments).some(attachment => headsource.includes(attachment))) {
+					// 	this.cells[index].attachments = undefined;
+					// }
 					splitCells.push({ cell: this.cells[index], prefix: undefined });
 				}
 
@@ -651,6 +657,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					if (tailSource[0] === '\r\n' || tailSource[0] === '\n') {
 						newlinesBeforeTailCellContent = tailSource.splice(0, 1)[0];
 					}
+					tailCell.attachments = attachments;
 					tailCell.source = tailSource;
 					tailCellIndex = newCellIndex + 1;
 					this.insertCell(tailCell, tailCellIndex, false);

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -631,6 +631,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					//If the selection is not from the start of the cell, create a new cell.
 					if (headContent.length) {
 						newCell = this.createCell(cellType, language);
+						newCell.attachments = attachments;
 						newCell.source = newSource;
 						newCellIndex++;
 						this.insertCell(newCell, newCellIndex, false);

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -608,12 +608,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						partialSource = source.slice(selection.startLineNumber - 1, selection.startLineNumber)[0].slice(0, selection.startColumn - 1);
 						headsource = headsource.concat(partialSource.toString());
 					}
+					// save attachments before updating the cell contents
 					attachments = this.cells[index].attachments;
 					this.cells[index].source = headsource;
-					// reset attachments
-					// if(attachments && !Object.keys(this.cells[index].attachments).some(attachment => headsource.includes(attachment))) {
-					// 	this.cells[index].attachments = undefined;
-					// }
 					splitCells.push({ cell: this.cells[index], prefix: undefined });
 				}
 

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -570,7 +570,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				let range = model.getFullModelRange();
 				let selection = editorControl.getSelection();
 				let source = this.cells[index].source;
-				let newCell = undefined, tailCell = undefined, partialSource = undefined;
+				let newCell: ICellModel = undefined, tailCell: ICellModel = undefined, partialSource = undefined;
 				let newCellIndex = index;
 				let tailCellIndex = index;
 				let splitCells: SplitCell[] = [];
@@ -631,7 +631,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					//If the selection is not from the start of the cell, create a new cell.
 					if (headContent.length) {
 						newCell = this.createCell(cellType, language);
-						newCell.attachments = this.getCellAttachmentFromSource(newSource, attachments);
+						newCell.updateAttachmentsFromSource(newSource.join(), attachments);
 						newCell.source = newSource;
 						newCellIndex++;
 						this.insertCell(newCell, newCellIndex, false);
@@ -655,7 +655,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					if (tailSource[0] === '\r\n' || tailSource[0] === '\n') {
 						newlinesBeforeTailCellContent = tailSource.splice(0, 1)[0];
 					}
-					tailCell.attachments = this.getCellAttachmentFromSource(tailSource, attachments);
+					tailCell.updateAttachmentsFromSource(tailSource.join(), attachments);
 					tailCell.source = tailSource;
 					tailCellIndex = newCellIndex + 1;
 					this.insertCell(tailCell, tailCellIndex, false);
@@ -683,17 +683,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			}
 		}
 		return undefined;
-	}
-
-	private getCellAttachmentFromSource(source: string | string[], attachments: nb.ICellAttachments): nb.ICellAttachments {
-		let newCellAttachment = {};
-		let newSource = Array.isArray(source) ? source.join() : source;
-		for (let key of Object.keys(attachments)) {
-			if (newSource.includes(`![${key}](attachment:${key})`)) {
-				newCellAttachment[key] = attachments[key];
-			}
-		}
-		return newCellAttachment;
 	}
 
 	public mergeCells(cells: SplitCell[]): void {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -689,7 +689,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		let newCellAttachment = {};
 		let newSource = Array.isArray(source) ? source.join() : source;
 		for (let key of Object.keys(attachments)) {
-			if (newSource.includes(key)) {
+			if (newSource.includes(`![${key}](attachment:${key})`)) {
 				newCellAttachment[key] = attachments[key];
 			}
 		}


### PR DESCRIPTION
Set attachments to the created cell after splitting a cell. We don't need to remove the attachments, because we clean the unused attachments after updating the cell source .
This PR fixes #19519
