### PR TITLE
Fix null ref in tree

### DIFF
--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -183,7 +183,7 @@ export class TreeView extends Disposable implements ITreeView {
 				}
 
 				async getChildren(node: ITreeItem): Promise<ITreeItem[]> {
-					let children: ITreeItem[];
+					let children: ITreeItem[] | undefined = undefined;
 					if (node && node.children) {
 						children = node.children;
 					} else {


### PR DESCRIPTION
Started getting an error about reading length of undefined recently and tracked it down to this - `getChildren()` (from line 190) can return undefined so we need to be able to handle that case. 