### PR TITLE
Run hygiene separately

### DIFF
--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -77,9 +77,11 @@ steps:
     node build/azure-pipelines/mixin
   displayName: Mix in quality
 
+# Run these separately to avoid OOM errors on pipeline machines
 - script: |
     set -e
-    yarn npm-run-all -lp core-ci extensions-ci hygiene eslint valid-layers-check
+    yarn npm-run-all -lp core-ci extensions-ci
+    yarn npm-run-all -lp hygiene eslint valid-layers-check
   displayName: Compile & Hygiene
 
 - script: |


### PR DESCRIPTION
This is to fix the docker errors we've been seeing recently (exit code 137, OOM)

In a recent PR I did I added additional linting to extensions, specifically adding a rule that requires parsing the extension projects (many of which weren't being parsed before). This extra parsing required bumping up the memory used for the tasks, which then started hitting the limits of the container when all these were run in parallel.

https://github.com/microsoft/azuredatastudio/pull/19571

Splitting these out into separate calls should fix this, with the cost being a slightly longer build time (~15min -> ~20min)