### PR TITLE
Exclude AsyncDataProvider from filtering in table

### DIFF
--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -180,10 +180,7 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 			this._data = new TableDataView<T>(data);
 		}
 		this._grid.setData(this._data, true);
-		if (!(data instanceof AsyncDataProvider)) {
-			// AsyncDataProvider does not support filtering currently.
-			this._data.filter(this._grid.getColumns());
-		}
+		this._data.filter(this._grid.getColumns());
 	}
 
 	getData(): IDisposableDataProvider<T> {

--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -180,7 +180,10 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 			this._data = new TableDataView<T>(data);
 		}
 		this._grid.setData(this._data, true);
-		this._data.filter(this._grid.getColumns());
+		if (!(data instanceof AsyncDataProvider)) {
+			// AsyncDataProvider does not support filtering currently.
+			this._data.filter(this._grid.getColumns());
+		}
 	}
 
 	getData(): IDisposableDataProvider<T> {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -501,7 +501,7 @@ export class EditDataGridPanel extends GridParentComponent {
 				this.table.setData(this.gridDataProvider);
 			}
 			catch (e) {
-				this.logService.error('Error encountered while setting or filtering data: ' + e);
+				this.logService.error('Error encountered while setting or filtering data:', e);
 			}
 			this.handleChanges({
 				['dataRows']: { currentValue: this.dataSet.dataRows, firstChange: this.firstLoad, previousValue: this.oldDataRows }

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -497,8 +497,12 @@ export class EditDataGridPanel extends GridParentComponent {
 			this.firstLoad = false;
 		}
 		else {
-
-			this.table.setData(this.gridDataProvider);
+			try {
+				this.table.setData(this.gridDataProvider);
+			}
+			catch (e) {
+				this.logService.error('Error encountered while setting or filtering data: ' + e);
+			}
 			this.handleChanges({
 				['dataRows']: { currentValue: this.dataSet.dataRows, firstChange: this.firstLoad, previousValue: this.oldDataRows }
 			});


### PR DESCRIPTION
AsyncDataProvider does not have filtering implemented, so when it is being called it throws an exception. This breaks the Edit Data Grid Panel as it relies on the Async Data Provider currently and so whenever the data is set, it causes the table to disappear due to the thrown error. To mitigate this, filtering is disabled for now when the data provider is an Async Data Provider.

This fixes #19620 and is absolutely urgent for the functionality of Edit Data as a whole.
