### PR TITLE
[SQL Migration] Remove faulty SQL VM state validation

### DIFF
--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -620,19 +620,10 @@ export async function getVirtualMachinesDropdownValues(virtualMachines: azure.Sq
 	if (location && resourceGroup) {
 		virtualMachines.forEach((virtualMachine) => {
 			if (virtualMachine.location.toLowerCase() === location.name.toLowerCase() && azure.getResourceGroupFromId(virtualMachine.id).toLowerCase() === resourceGroup.name.toLowerCase()) {
-				let virtualMachineValue: CategoryValue;
-				if (virtualMachine.properties.provisioningState === ProvisioningState.Succeeded) {
-					virtualMachineValue = {
-						name: virtualMachine.id,
-						displayName: virtualMachine.name
-					};
-				} else {
-					virtualMachineValue = {
-						name: virtualMachine.id,
-						displayName: constants.UNAVAILABLE_TARGET_PREFIX(virtualMachine.name)
-					};
-				}
-				virtualMachineValues.push(virtualMachineValue);
+				virtualMachineValues.push({
+					name: virtualMachine.id,
+					displayName: virtualMachine.name
+				});
 			}
 		});
 	}

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -303,9 +303,6 @@ export function ACCOUNT_ACCESS_ERROR(account: AzureAccount, error: Error) {
 export function MI_NOT_READY_ERROR(miName: string, state: string): string {
 	return localize('sql.migration.mi.not.ready', "The managed instance '{0}' is unavailable for migration because it is currently in the '{1}' state. To continue, select an available managed instance.", miName, state);
 }
-export function VM_NOT_READY_ERROR(miName: string, state: string): string {
-	return localize('sql.migration.vm.not.ready', "The virtual machine '{0}' is unavailable for migration because it is currently in the '{1}' state. To continue, select an available virtual machine.", miName, state);
-}
 
 export const SELECT_AN_ACCOUNT = localize('sql.migration.select.service.select.a.', "Sign into Azure and select an account");
 export const SELECT_A_TENANT = localize('sql.migration.select.service.select.a.tenant', "Select a tenant");

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -149,10 +149,6 @@ export class TargetSelectionPage extends MigrationWizardPage {
 						errors.push(constants.INVALID_VIRTUAL_MACHINE_ERROR);
 						break;
 					}
-					if (targetVm.properties.provisioningState !== ProvisioningState.Succeeded) {
-						errors.push(constants.VM_NOT_READY_ERROR(targetVm.name, targetVm.properties.provisioningState));
-						break;
-					}
 					break;
 				}
 			}
@@ -411,18 +407,6 @@ export class TargetSelectionPage extends MigrationWizardPage {
 						const selectedVm = this.migrationStateModel._targetSqlVirtualMachines.find(vm => vm.name === value || constants.UNAVAILABLE_TARGET_PREFIX(vm.name) === value);
 						if (selectedVm) {
 							this.migrationStateModel._targetServerInstance = utils.deepClone(selectedVm)! as SqlVMServer;
-
-							if (this.migrationStateModel._targetServerInstance.properties.provisioningState !== ProvisioningState.Succeeded) {
-								this.wizard.message = {
-									text: constants.VM_NOT_READY_ERROR(this.migrationStateModel._targetServerInstance.name, this.migrationStateModel._targetServerInstance.properties.provisioningState),
-									level: azdata.window.MessageLevel.Error
-								};
-							} else {
-								this.wizard.message = {
-									text: '',
-									level: azdata.window.MessageLevel.Error
-								};
-							}
 						}
 						break;
 

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -14,7 +14,6 @@ import { WIZARD_INPUT_COMPONENT_WIDTH } from './wizardController';
 import * as utils from '../api/utils';
 import { azureResource } from 'azurecore';
 import { SqlVMServer } from '../api/azure';
-import { ProvisioningState } from '../models/migrationLocalStorage';
 
 export class TargetSelectionPage extends MigrationWizardPage {
 	private _view!: azdata.ModelView;
@@ -404,7 +403,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 
 				switch (this.migrationStateModel._targetType) {
 					case MigrationTargetType.SQLVM:
-						const selectedVm = this.migrationStateModel._targetSqlVirtualMachines.find(vm => vm.name === value || constants.UNAVAILABLE_TARGET_PREFIX(vm.name) === value);
+						const selectedVm = this.migrationStateModel._targetSqlVirtualMachines.find(vm => vm.name === value);
 						if (selectedVm) {
 							this.migrationStateModel._targetServerInstance = utils.deepClone(selectedVm)! as SqlVMServer;
 						}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Previously, we had added client-side validation in the SQL Migration extension to ensure that users would not select a target Azure SQL MI/VM that was in a state that was not ready for migration. In order to do so, when fetching the list of available target resources to show to the user, we also look at the resources' properties. 

For SQL MI, we look at the `state` property, which correctly reports the state of the managed instance, which we can use for pre-migration validation by making sure it equals 'Ready'. However, for SQL VM, since such a `state` property doesn't exist, we instead looked at the `provisioningState` property, which is in fact not a property we should look at for determining the readiness of the target VM. 

This is because, for example, if a migration is attempted against a SQL VM which fails (e.g. because the target database already exists), then the `provisioningState` will change to Failed, even though the VM itself is actually still fine:

![image](https://user-images.githubusercontent.com/11844501/171963275-2b739de0-d73b-4159-840e-ec0f93b4ee2d.png)

This means that it's possible for one failed migration to make the VM impossible to select for any future migrations moving forwards.

In this PR, we remove the state validation for SQL VM specifically, until we can find a better way of performing this check (like perhaps some sort of validation API from the SQL VM side).

Before: (note, this VM is actually perfectly ready for migration)
![image](https://user-images.githubusercontent.com/11844501/171964342-588fdb77-c441-4526-b8b5-72929b1da11b.png)

After:
![image](https://user-images.githubusercontent.com/11844501/171964376-f9e55158-b2c6-4a12-8bb0-e8b668a04407.png)

Testing:
- validated a successful end-to-end SQL VM migration against a target VM which was previously unselectable because of a prior failed migration