### PR TITLE
Fix issues with changing SQL notebook connection while a cell is executing

### DIFF
--- a/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
+++ b/src/sql/workbench/api/common/notebooks/vscodeExecuteProvider.ts
@@ -11,6 +11,7 @@ import { addExternalInteractiveKernelMetadata, convertToVSCodeNotebookCell } fro
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { VSCodeNotebookDocument } from 'sql/workbench/api/common/notebooks/vscodeNotebookDocument';
 import { URI } from 'vs/base/common/uri';
+import { notebookMultipleRequestsError } from 'sql/workbench/common/constants';
 
 class VSCodeFuture implements azdata.nb.IFuture {
 	private _inProgress = true;
@@ -149,7 +150,7 @@ class VSCodeKernel implements azdata.nb.IKernel {
 
 	requestExecute(content: azdata.nb.IExecuteRequest, disposeOnDone?: boolean): azdata.nb.IFuture {
 		if (this._activeRequest) {
-			throw new Error(nls.localize('notebookMultipleRequestsError', "Cannot execute code cell. Another cell is currently being executed."));
+			throw new Error(notebookMultipleRequestsError);
 		}
 		let executePromise: Promise<void>;
 		if (this._controller.executeHandler) {

--- a/src/sql/workbench/common/constants.ts
+++ b/src/sql/workbench/common/constants.ts
@@ -6,6 +6,7 @@
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import * as glob from 'vs/base/common/glob';
 import { SearchSortOrder } from 'vs/workbench/services/search/common/search';
+import * as nls from 'vs/nls';
 
 export const FindInNotebooksActionId = 'workbench.action.findInNotebooks';
 export const FocusActiveEditorCommandId = 'notebookSearch.action.focusActiveEditor';
@@ -84,3 +85,5 @@ export const RESULTS_GRID_DEFAULTS = {
 	cellPadding: [5, 8, 4],
 	rowHeight: 24
 };
+
+export const notebookMultipleRequestsError = nls.localize('notebookMultipleRequestsError', "Cannot execute code cell. Another cell is currently being executed.");

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -320,7 +320,7 @@ class SqlKernel extends Disposable implements nb.IKernel {
 	}
 
 	requestExecute(content: nb.IExecuteRequest, disposeOnDone?: boolean): nb.IFuture {
-		// Check if another cell is already running. We can't rely on queryRunner, since it can get cleared when changing the notebook connection.
+		// Check if another cell is already running.
 		if (this._future?.inProgress) {
 			throw new Error(notebookMultipleRequestsError);
 		}
@@ -328,12 +328,6 @@ class SqlKernel extends Disposable implements nb.IKernel {
 		let canRun: boolean = true;
 		let code = this.getCodeWithoutCellMagic(content);
 		if (this._queryRunner && !this._newConnection) {
-			// Cancel any existing query
-			if (this._future && !this._queryRunner.hasCompleted) {
-				this._queryRunner.cancelQuery().then(ok => undefined, error => this._errorMessageService.showDialog(Severity.Error, sqlKernelError, error));
-				// TODO when we can just show error as an output, should show an "execution canceled" error in output
-				this._future.handleDone().catch(err => onUnexpectedError(err));
-			}
 			this._queryRunner.runQuery(code).catch(err => onUnexpectedError(err));
 		} else if (this._currentConnection && this._currentConnectionProfile) {
 			this._newConnection = false;

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -216,6 +216,7 @@ class SqlKernel extends Disposable implements nb.IKernel {
 	private _executionCount: number = 0;
 	private _magicToExecutorMap = new Map<string, ExternalScriptMagic>();
 	private _connectionPath: string;
+	private _newConnection: boolean;
 
 	constructor(private _path: string,
 		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
@@ -308,7 +309,6 @@ class SqlKernel extends Disposable implements nb.IKernel {
 		return info;
 	}
 
-	private _newConnection: boolean;
 	public set connection(conn: IConnectionProfile) {
 		this._currentConnection = conn;
 		this._currentConnectionProfile = new ConnectionProfile(this._capabilitiesService, this._currentConnection);


### PR DESCRIPTION
When changing the connection for a SQL notebook, the underlying session has its queryRunner field nulled out, which causes a few problems. First, running a SQL cell checks for the existence of a queryRunner before executing, so we can get 2 cells running at once when changing the connection after running a cell. Second, trying to cancel a running cell after changing the connection will fail because the queryRunner we're trying to cancel with is now undefined. My fix here was to use a boolean flag when setting a new connection, rather than clearing the queryRunner.

While debugging those issues I also noticed some problems with output routing while running a cell. For example, if you try to run a SQL cell while another is running, the original cell is cancelled, but the query cancellation message shows up in the second cell's output. This is likely because we always use the session's current SQLFuture object when routing messages from a running query runner. So once we click run on a new cell we have a new future object that will pick up events from older query runners. Rather than trying to refactor our output routing logic, I decided to just throw an error when trying to run a cell while another is already running. In the future, we'd ideally add some kind of execute queueing mechanism similar to what VS Code and Jupyter have, rather than just throwing an error.

This PR fixes #19585
