### PR TITLE
Removing filter from table component set Data

### DIFF
--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -180,7 +180,6 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 			this._data = new TableDataView<T>(data);
 		}
 		this._grid.setData(this._data, true);
-		this._data.filter(this._grid.getColumns());
 	}
 
 	getData(): IDisposableDataProvider<T> {


### PR DESCRIPTION
Issue: #19620

This PR remove the filter from table component as it is not needed anymore. The treeGrid component used by execution plan already has this filter. 