### PR TITLE
Fix sql database projects vscode telemetry

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "Enables users to develop and publish database schemas for MSSQL Databases",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -359,8 +359,9 @@ export function getPackageInfo(packageJson?: any): IPackageInfo | undefined {
 		return undefined;
 	}
 
-	// when the extension is packaged, the extension.js copies the content of package.json in place, but this happens before the package.vscode.json values
-	// get replaced in the package.json for the sql-database-projects-vscode extension
+	// When the extension is compiled and packaged, the content of package.json get copied here in the extension.js. This happens before the
+	// package.vscode.json values replace the corresponding values in the package.json for the sql-database-projects-vscode extension
+	// so we need to read these values directly from the package.vscode.json to get the correct extension and publisher names
 	const extensionName = azdataApi ? packageJson.name : vscodePackageJson.name;
 	const publisher = azdataApi ? packageJson.publisher : vscodePackageJson.publisher;
 

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -352,16 +352,27 @@ export function getPackageInfo(packageJson?: any): IPackageInfo | undefined {
 		packageJson = require('../../package.json');
 	}
 
-	if (packageJson) {
-		return {
-			name: packageJson.name,
-			fullName: `${packageJson.publisher}.${packageJson.name}`,
-			version: packageJson.version,
-			aiKey: packageJson.aiKey
-		};
+	const vscodePackageJson = require('../../package.vscode.json');
+	const azdataApi = getAzdataApi();
+
+	if (!packageJson || !azdataApi && !vscodePackageJson) {
+		return undefined;
 	}
 
-	return undefined;
+	// when the extension is packaged, the extension.js copies the content of package.json in place, but this happens before the package.vscode.json values
+	// get replaced in the package.json for the sql-database-projects-vscode extension
+	const extensionName = azdataApi ? packageJson.name : vscodePackageJson.name;
+	const publisher = azdataApi ? packageJson.publisher : vscodePackageJson.publisher;
+
+	console.error('ext name: ' + extensionName);
+	console.error('publisher: ' + publisher);
+
+	return {
+		name: extensionName,
+		fullName: `${publisher}.${extensionName}`,
+		version: packageJson.version,
+		aiKey: packageJson.aiKey
+	};
 }
 
 /**

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -364,9 +364,6 @@ export function getPackageInfo(packageJson?: any): IPackageInfo | undefined {
 	const extensionName = azdataApi ? packageJson.name : vscodePackageJson.name;
 	const publisher = azdataApi ? packageJson.publisher : vscodePackageJson.publisher;
 
-	console.error('ext name: ' + extensionName);
-	console.error('publisher: ' + publisher);
-
 	return {
 		name: extensionName,
 		fullName: `${publisher}.${extensionName}`,


### PR DESCRIPTION
The usage numbers for the sql database projects vscode extension have been very low, so I took a look at the telemetry for actions that are only available in the vscode extension and was surprised to find that there are several users where the vscode version is greater than 1.59.0, the [current version ADS](https://github.com/microsoft/azuredatastudio/blob/c121eeec4d7ad67ff064f11f9d70ed03ca5421d4/product.json#L40) is on. That's only possible is if they're using vscode, but then the extension name associated with these events was sql-database-projects, not sql-database-projects-vscode.

When looking at what extension name was actually getting sent from by the vscode extension using fiddler, it was indeed the wrong extension name: sql-database-projects. This was confusing since the package.json of the sql-database-projects-vscode extension in the marketplace did have the correct extension name and the code here reads the extension info from that file. 

Turns out when the code gets compiled and packaged up, statements like `require('../../package.json')` turn into the contents of that file being copied directly into the extension.js with all the extension's code. There are values in package.vscode.json, like extension and publisher name, that replace the corresponding values in package.json when creating the vscode extension, but that's happening after the extension.js is created so it had the incorrect extension information. 