### PR TITLE
Add new cells after the current one when adding a cell from the notebook toolbar.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -80,9 +80,12 @@ export class AddCellAction extends Action {
 				context.model.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.AddCell, { cell_type: this.cellType });
 			}
 		} else {
-			//Add Cell after current selected cell.
+			// Add cell after currently selected cell, or at the end of the notebook if no cell is selected
 			const editor = this._notebookService.findNotebookEditor(context);
-			const index = editor.cells?.findIndex(cell => cell.active) ?? 0;
+			if (editor.cells) {
+				let currentCellIndex = editor.cells.findIndex(cell => cell.active);
+				index = currentCellIndex !== -1 ? currentCellIndex + 1 : editor.cells.length;
+			}
 			editor.addCell(this.cellType, index);
 			editor.model.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.AddCell, { cell_type: this.cellType });
 		}


### PR DESCRIPTION
Noticed that our Add Cell behavior differs between the notebook toolbar and the cell toolbar. The cell toolbar always adds the new cell after the current one, but the notebook toolbar adds it before, or at the beginning of the notebook if no cell is selected. I fixed the toolbar behavior so it adds cells after, and then for extra consistency changed the default behavior to add a cell to the end of the notebook rather than the beginning.