### PR TITLE
fix table designer error when sql project has folders

### DIFF
--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -103,7 +103,7 @@ export default class MainController implements vscode.Disposable {
 					isNewTable: false,
 					tableScriptPath: filePath,
 					projectFilePath: projectPath,
-					allScripts: projectNode.project.files.filter(entry => path.extname(entry.fsUri.fsPath) === constants.sqlFileExtension)
+					allScripts: projectNode.project.files.filter(entry => path.extname(entry.fsUri.fsPath).toLowerCase() === constants.sqlFileExtension)
 						.map(entry => entry.fsUri.fsPath),
 					targetVersion: targetVersion
 				}, {

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -103,7 +103,7 @@ export default class MainController implements vscode.Disposable {
 					isNewTable: false,
 					tableScriptPath: filePath,
 					projectFilePath: projectPath,
-					allScripts: projectNode.project.files.filter(entry => path.extname(entry.fsUri.fsPath).toLowerCase() === constants.sqlFileExtension)
+					allScripts: projectNode.project.files.filter(entry => entry.type === EntryType.File && path.extname(entry.fsUri.fsPath).toLowerCase() === constants.sqlFileExtension)
 						.map(entry => entry.fsUri.fsPath),
 					targetVersion: targetVersion
 				}, {

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -103,7 +103,8 @@ export default class MainController implements vscode.Disposable {
 					isNewTable: false,
 					tableScriptPath: filePath,
 					projectFilePath: projectPath,
-					allScripts: projectNode.project.files.filter(entry => entry.type === EntryType.File).map(entry => entry.fsUri.fsPath),
+					allScripts: projectNode.project.files.filter(entry => path.extname(entry.fsUri.fsPath) === constants.sqlFileExtension)
+						.map(entry => entry.fsUri.fsPath),
 					targetVersion: targetVersion
 				}, {
 					'ProjectTargetVersion': targetVersion

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -20,6 +20,7 @@ import { GenerateProjectFromOpenApiSpecOptions, ItemType } from 'sqldbproj';
 import { TableFileNode } from '../models/tree/fileFolderTreeItem';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { getAzdataApi } from '../common/utils';
+import { EntryType } from '../models/projectEntry';
 
 /**
  * The main controller class that initializes the extension
@@ -102,7 +103,7 @@ export default class MainController implements vscode.Disposable {
 					isNewTable: false,
 					tableScriptPath: filePath,
 					projectFilePath: projectPath,
-					allScripts: projectNode.project.files.map(entry => entry.fsUri.fsPath),
+					allScripts: projectNode.project.files.filter(entry => entry.type === EntryType.File).map(entry => entry.fsUri.fsPath),
 					targetVersion: targetVersion
 				}, {
 					'ProjectTargetVersion': targetVersion


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #19666. The project.files contains both the files and the folders of the project, which is a little confusing and it's one of the code cleanup items to split them up to be separate. The model building on the DacFx end was failing when passed folders because it's only expecting to get .sql files.

Before:
![folderError](https://user-images.githubusercontent.com/31145923/172480126-3405e7f0-1479-4b53-93ed-17f53d335811.gif)

Fixed:
![folderFixed](https://user-images.githubusercontent.com/31145923/172480141-a0532e38-f560-49e7-91f0-df3477b102bb.gif)

