### PR TITLE
Resource refresh buttons in Azure SQL migration extension.

### DIFF
--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -576,11 +576,25 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 				}
 			}).component();
 
+		const refreshBlobTable = this._view.modelBuilder.button()
+			.withProps({
+				iconPath: IconPathHelper.refresh,
+				label: constants.REFRESH_BUTTON_LABEL,
+				width: 90,
+				height: 24,
+				CSSStyles: {
+					...styles.BODY_CSS,
+					'margin': "12px 0 4px 0"
+				}
+			})
+			.component();
+
 		this._blobTableContainer = this._view.modelBuilder.flexContainer().withItems([
 			blobTableText,
 			allFieldsRequiredLabel,
 			azureStoragePrivateEndpointInfoBox,
-			this._blobContainerTargetDatabaseNamesTable
+			this._blobContainerTargetDatabaseNamesTable,
+			refreshBlobTable
 		]).withProps({
 			CSSStyles: {
 				'display': 'none',

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -589,6 +589,10 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 			})
 			.component();
 
+		this._disposables.push(refreshBlobTable.onDidClick(async (event) => {
+			await this.getSubscriptionValues();
+		}));
+
 		this._blobTableContainer = this._view.modelBuilder.flexContainer().withItems([
 			blobTableText,
 			allFieldsRequiredLabel,

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -584,7 +584,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 				height: 24,
 				CSSStyles: {
 					...styles.BODY_CSS,
-					'margin': "12px 0 4px 0"
+					'margin': '12px 0 4px 0'
 				}
 			})
 			.component();

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -594,8 +594,8 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 			for (const [index, _db] of this.migrationStateModel._databasesForMigration.entries()) {
 				const BlobStorageDropdown = this._blobContainerStorageAccountDropdowns[index];
 				const ResourceGroupDropdownValue = this._blobContainerResourceGroupDropdowns[index].value;
-				if (ResourceGroupDropdownValue !== undefined && typeof ResourceGroupDropdownValue !== 'string') {
-					await this.updateBlobResourceGroup(index, ResourceGroupDropdownValue.displayName, BlobStorageDropdown);
+				if (ResourceGroupDropdownValue !== undefined) {
+					await this.updateBlobResourceGroup(index, ResourceGroupDropdownValue, BlobStorageDropdown);
 				}
 				const BlobContainerDropdown = this._blobContainerDropdowns[index];
 				const BlobStorageDropdownValue = this._blobContainerStorageAccountDropdowns[index].value;
@@ -1333,7 +1333,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 	}
 
 	// Updates resource group dropdown and loads storage account dropdown for blob container backup
-	private async updateBlobResourceGroup(index: number, value: string, blobContainerStorageAccountDropdown: azdata.DropDownComponent): Promise<void> {
+	private async updateBlobResourceGroup(index: number, value: azdata.DropDownProperties['value'], blobContainerStorageAccountDropdown: azdata.DropDownComponent): Promise<void> {
 		if (value && value !== 'undefined' && this.migrationStateModel._resourceGroups) {
 			const valueString = this.dropdownValueToString(value);
 			const selectedResourceGroup = this.migrationStateModel._resourceGroups.find(rg => rg.name === valueString);

--- a/extensions/sql-migration/src/wizard/integrationRuntimePage.ts
+++ b/extensions/sql-migration/src/wizard/integrationRuntimePage.ts
@@ -233,6 +233,24 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			await this.populateDms();
 		}));
 
+		const refreshMigrationServiceButton = this._view.modelBuilder.button()
+			.withProps({
+				iconPath: IconPathHelper.refresh,
+				label: constants.REFRESH_BUTTON_LABEL,
+				width: 90,
+				height: 24,
+				CSSStyles: {
+					...styles.BODY_CSS,
+					'margin': '12px 0 4px 0'
+				}
+			})
+		.component();
+
+		this._disposables.push(refreshMigrationServiceButton.onDidClick(async (e) => {
+			await this.loadResourceGroupDropdown();
+			await this.populateDms();
+		}));
+
 		const flexContainer = this._view.modelBuilder.flexContainer().withItems([
 			descriptionText,
 			subscriptionLabel,
@@ -243,7 +261,8 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			this._resourceGroupDropdown,
 			migrationServiceDropdownLabel,
 			this._dmsDropdown,
-			createNewMigrationService
+			createNewMigrationService,
+			refreshMigrationServiceButton
 		]).withLayout({
 			flexFlow: 'column'
 		}).component();

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -11,6 +11,7 @@ import { MigrationStateModel, MigrationTargetType, StateChangeEvent } from '../m
 import * as constants from '../constants/strings';
 import * as styles from '../constants/styles';
 import { WIZARD_INPUT_COMPONENT_WIDTH } from './wizardController';
+import { IconPathHelper } from '../constants/iconPathHelper';
 import * as utils from '../api/utils';
 import { azureResource } from 'azurecore';
 import { SqlVMServer } from '../api/azure';
@@ -448,12 +449,15 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			}
 		}));
 
-		const refreshResourceButton = this._view.modelBuilder.hyperlink()
+		const refreshResourceButton = this._view.modelBuilder.button()
 			.withProps({
-				label: constants.REFRESH,
-				url: '',
+				iconPath: IconPathHelper.refresh,
+				label: constants.REFRESH_BUTTON_LABEL,
+				width: 90,
+				height: 24,
 				CSSStyles: {
-					...styles.BODY_CSS
+					...styles.BODY_CSS,
+					'margin': '12px 0 4px 0'
 				}
 			})
 			.component();

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -460,7 +460,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 					'margin': '12px 0 4px 0'
 				}
 			})
-			.component();
+		.component();
 
 		this._disposables.push(refreshResourceButton.onDidClick(async (event) => {
 			await this.populateSubscriptionDropdown();

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -458,6 +458,13 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			})
 			.component();
 
+		this._disposables.push(refreshResourceButton.onDidClick(async (event) => {
+			await this.populateSubscriptionDropdown();
+			await this.populateLocationDropdown();
+			await this.populateResourceGroupDropdown();
+			await this.populateResourceInstanceDropdown();
+		}));
+
 		return this._view.modelBuilder.flexContainer().withItems(
 			[
 				subscriptionDropdownLabel,

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -448,6 +448,16 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			}
 		}));
 
+		const refreshResourceButton = this._view.modelBuilder.hyperlink()
+			.withProps({
+				label: constants.REFRESH,
+				url: '',
+				CSSStyles: {
+					...styles.BODY_CSS
+				}
+			})
+			.component();
+
 		return this._view.modelBuilder.flexContainer().withItems(
 			[
 				subscriptionDropdownLabel,
@@ -457,7 +467,8 @@ export class TargetSelectionPage extends MigrationWizardPage {
 				azureResourceGroupLabel,
 				this._azureResourceGroupDropdown,
 				this._azureResourceDropdownLabel,
-				this._azureResourceDropdown
+				this._azureResourceDropdown,
+				refreshResourceButton
 			]
 		).withLayout({
 			flexFlow: 'column',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses resource refresh functionality in the Azure SQL migration extension. Currently, when a user is in the middle of a migration wizard session and creates a new Azure resource, they must either go back and forth between pages or restart the wizard completely to reload the newly created resources and be able to select them. This PR adds refresh buttons at the target selection, blob container selection, and DMS selection steps to reload the corresponding resource without leaving the page.

Example with target MI selection:

![image](https://user-images.githubusercontent.com/54997940/172704440-8c64993e-9e7b-4e26-9a70-08d5b3c84044.png)

This is a draft PR and will be changed as UI/UX is yet to be finalized.





