### PR TITLE
update STS to bring in a table designer fix

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.0.0.11",
+	"version": "4.0.1.1",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
This PR fixes #19656

changes since current version are in the red rectangle. 

![image](https://user-images.githubusercontent.com/13777222/172733363-c88641f7-aa93-43ef-92f7-871745b9cf38.png)

the vbump change I did was to update the version to 4.0.1.x

BTW, this is not technically a port from main branch since this build is produced from a release branch of STS. but to follow the process of making changes in release branch, I am still adding the `Port Request` label here.