### PR TITLE
Show an error in cell output when trying to load an unsupported output type.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/outputProcessor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/outputProcessor.ts
@@ -8,6 +8,7 @@ import { nb } from 'azdata';
 import { JSONObject, isPrimitive } from 'sql/workbench/services/notebook/common/jsonext';
 import { nbformat } from 'sql/workbench/services/notebook/common/nbformat';
 import { MimeModel } from 'sql/workbench/services/notebook/browser/outputs/mimemodel';
+import * as nls from 'vs/nls';
 
 /**
  * A multiline string.
@@ -46,6 +47,8 @@ export function getData(output: nb.ICellOutput): JSONObject {
 		} else if (output.evalue) {
 			bundle['application/vnd.jupyter.stderr'] = output.ename ? `${output.ename}: ${output.evalue}` : `${output.evalue}`;
 		}
+	} else {
+		bundle['application/vnd.jupyter.stderr'] = nls.localize('notebookInvalidOutputTypeError', "Output type '{0}' not recognized.", output.output_type);
 	}
 	return convertBundle(bundle);
 }

--- a/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import { nb } from 'azdata';
 import * as op from 'sql/workbench/contrib/notebook/browser/models/outputProcessor';
 import { nbformat as nbformat } from 'sql/workbench/services/notebook/common/nbformat';
+import { shouldIncludeHeaders } from 'sql/workbench/services/query/common/queryRunner';
 
 suite('OutputProcessor functions', function (): void {
 	const text = 'An arbitrary text input:!@#$%^&*()_+~`:;,.-_=';
@@ -67,6 +68,20 @@ suite('OutputProcessor functions', function (): void {
 				verifyGetDataForStreamOutput(output);
 			});
 		}
+
+		// unknown output types
+		test('Should report an error for unknown output types', () => {
+			const output = {
+				output_type: 'unknown',
+				data: {
+					'text/html': 'Test text'
+				},
+				metadata: {}
+			};
+			const result = op.getData(<any>output);
+			assert(result['application/vnd.jupyter.stderr'] !== undefined, 'Should set an error message after receiving unknown output type.');
+			assert(result['text/html'] === undefined, 'Should not add any data after receiving unknown output type.');
+		});
 	});
 
 	suite('getMetadata', function (): void {

--- a/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
@@ -7,7 +7,6 @@ import * as assert from 'assert';
 import { nb } from 'azdata';
 import * as op from 'sql/workbench/contrib/notebook/browser/models/outputProcessor';
 import { nbformat as nbformat } from 'sql/workbench/services/notebook/common/nbformat';
-import { shouldIncludeHeaders } from 'sql/workbench/services/query/common/queryRunner';
 
 suite('OutputProcessor functions', function (): void {
 	const text = 'An arbitrary text input:!@#$%^&*()_+~`:;,.-_=';

--- a/src/sql/workbench/services/notebook/common/localContentManager.ts
+++ b/src/sql/workbench/services/notebook/common/localContentManager.ts
@@ -155,8 +155,8 @@ namespace v4 {
 					traceback: output.traceback
 				};
 			default:
-				// Should never get here
-				throw new TypeError(localize('unrecognizedOutput', "Output type {0} not recognized", (<any>output).output_type));
+				// Unknown type, so return as is. If it's unsupported, then an error will be shown later when trying to render it.
+				return output;
 		}
 	}
 
@@ -272,6 +272,7 @@ namespace v3 {
 					name: name,
 					text: v4.demultiline(output.text)
 				};
+			case 'error':
 			case 'pyerr':
 				return <nb.IErrorResult>{
 					output_type: OutputTypes.Error,
@@ -280,7 +281,8 @@ namespace v3 {
 					traceback: output.traceback
 				};
 			default:
-				throw new TypeError(localize('unrecognizedOutputType', "Output type {0} not recognized", output.output_type));
+				// Unknown type, so return as is. If it's unsupported, then an error will be shown later when trying to render it.
+				return output;
 		}
 	};
 


### PR DESCRIPTION
Currently, if we find an unknown output type while loading a notebook, an Error gets thrown which is never surfaced as a notification, and the notebook is opened as an empty tab. This change removes that thrown Error, and instead adds an error message to the output. The original output types are preserved until the user re-runs the cell or clears the output, so that we preserve any output types that are still usable elsewhere.

This PR fixes #18238

Here's an example where I replaced some of the output types in a simple SQL query:
![InvalidOutputTypes](https://user-images.githubusercontent.com/12820011/172738141-81a6f4a4-f25b-41da-ba77-f8d8093e429f.PNG)
