### PR TITLE
Fix for editData tab switch back when adding new row. (#19634)

### DIFF
--- a/src/typings/slickgrid.d.ts
+++ b/src/typings/slickgrid.d.ts
@@ -876,8 +876,9 @@ declare namespace Slick {
 		/**
 		* Extends grid options with a given hash. If an there is an active edit, the grid will attempt to commit the changes and only continue if the attempt succeeds.
 		* @options An object with configuration options.
+		* @suppressRender A boolean telling setOptions to not rerender the grid upon options being changed.
 		**/
-		public setOptions(options: GridOptions<T>): void;
+		public setOptions(options: GridOptions<T>, suppressRender?: boolean): void;
 
 		/**
 		* Accepts an array of row indices and applies the current selectedCellCssClass to the cells in the row, respecting whether cells have been flagged as selectable.


### PR DESCRIPTION
Port request of #19634, fixes #19620 and #19141

* added filter for AsyncDataProvider Filter crash

* fixed cell switch back for editdata

* Added new setData check

* disable selecting of all columns when new row is being added

* Changed comment

* removed try catch check due to Aasim's PR

* added previous dataset to handlechange

* added feedback changes

* added fix for infinite loop

* changes made as suggested by Alan

* following Charles' feedback

* removed onGridRendered as its pointless jumping

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
