### PR TITLE
Validate package.json metadata against gallery metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.downloaded-extensions

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -14,14 +14,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.47.0",
+							"version": "0.48.0",
 							"lastUpdated": "4/16/2020",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/agent/agent-0.47.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/agent/agent-0.48.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -47,11 +47,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.8.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -108,11 +108,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.26.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": "*"
+									"value": ">=1.11.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -169,7 +169,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.26.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -535,7 +535,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": "0.10.x"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -553,7 +553,7 @@
 				},
 				{
 					"extensionId": "19",
-					"extensionName": "sqldw-insights",
+					"extensionName": "sql-dw",
 					"displayName": "Azure SQL Data Warehouse Insights",
 					"shortDescription": "Azure SQL Data Warehouse Insights for Azure Data Studio",
 					"publisher": {
@@ -596,7 +596,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.23.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1263,11 +1263,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": "*"
+									"value": ">=1.15.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1507,11 +1507,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.37.0"
+									"value": ">=1.35.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1568,7 +1568,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": ">=1.53.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1629,7 +1629,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.26.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1690,7 +1690,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1751,7 +1751,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.30.1"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2641,7 +2641,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.30.1"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2759,11 +2759,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.29.1"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.12.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2820,7 +2820,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.48.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3121,7 +3121,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3178,11 +3178,11 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -3288,7 +3288,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3464,6 +3464,10 @@
 								{
 									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
 									"value": "Microsoft.schema-compare"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": ">=1.30.1"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3646,15 +3650,11 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": "*"
+									"value": ">=1.28.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
 									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.28.0"
 								}
 							]
 						}
@@ -3773,10 +3773,6 @@
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
 									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.25.0"
 								}
 							]
 						}
@@ -4557,11 +4553,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.59.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.36.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -4614,11 +4610,11 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.58.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.36.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -4744,11 +4740,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.39.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.37.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -47,11 +47,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.8.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -108,11 +108,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.26.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": "*"
+									"value": ">=1.11.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -169,7 +169,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.26.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -535,7 +535,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": "0.10.x"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -553,7 +553,7 @@
 				},
 				{
 					"extensionId": "19",
-					"extensionName": "sqldw-insights",
+					"extensionName": "sql-dw",
 					"displayName": "Azure SQL Data Warehouse Insights",
 					"shortDescription": "Azure SQL Data Warehouse Insights for Azure Data Studio",
 					"publisher": {
@@ -596,7 +596,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.23.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1263,11 +1263,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": "*"
+									"value": ">=1.15.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1507,7 +1507,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1568,7 +1568,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.53.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1629,7 +1629,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.26.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1690,7 +1690,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1751,7 +1751,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.30.1"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2641,7 +2641,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.30.1"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2759,11 +2759,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.29.1"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.12.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2820,7 +2820,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.48.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3121,7 +3121,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3178,11 +3178,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -3288,7 +3288,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.25.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3464,6 +3464,10 @@
 								{
 									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
 									"value": "Microsoft.schema-compare"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": ">=1.30.1"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3764,7 +3768,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.25.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -4549,11 +4553,11 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.59.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.36.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -4606,11 +4610,11 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
+									"value": ">=1.58.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.36.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "type": "module",
+  "scripts": {
+    "validate": "node ./scripts/validateGalleries.js"
+  },
   "devDependencies": {
-    "got": "^11.8.2"
+    "got": "^12.0.4",
+    "stream": "^0.0.2",
+    "yauzl-promise": "^2.1.3"
   }
 }

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -9,10 +9,24 @@ import * as path from 'path';
 import * as url from 'url';
 import * as fs from 'fs';
 import got from 'got';
+import * as stream from 'stream';
+import { promisify } from 'util';
+const pipeline = promisify(stream.pipeline);
+import { mkdir, rm, rmdir } from 'fs/promises';
+import yauzl from 'yauzl-promise';
+
 const ROOT_DIR = path.join(path.dirname(url.fileURLToPath(import.meta.url)), '..');
+const DOWNLOADED_EXT_DIR = path.join(ROOT_DIR, '.downloaded-extensions');
 
 const MICROSOFT_SQLOPS_DOWNLOADPAGE = 'Microsoft.SQLOps.DownloadPage';
 const MICROSOFT_VISUALSTUDIO_SERVICES_VSIXPACKAGE = 'Microsoft.VisualStudio.Services.VSIXPackage';
+const MICROSOFT_VISUALSTUDIO_CODE_ENGINE = 'Microsoft.VisualStudio.Code.Engine';
+const MICROSOFT_AZDATAENGINE = 'Microsoft.AzDataEngine';
+
+const STABLE = 'extensionsGallery';
+const STABLE_DOWNLOADED_EXT_DIR = path.join(DOWNLOADED_EXT_DIR, STABLE);
+const INSIDERS = 'extensionsGallery-insider';
+const INSIDERS_DOWNLOADED_EXT_DIR = path.join(DOWNLOADED_EXT_DIR, INSIDERS);
 
 /**
  * This file is for validating the extension gallery files to ensure that they adhere to the expected schema defined in
@@ -117,8 +131,11 @@ async function validateExtension(galleryFilePath, extensionJson) {
     if (!extensionJson.versions || !extensionJson.versions.length) {
         throw new Error(`${galleryFilePath} - Invalid versions\n${JSON.stringify(extensionJson)}`)
     }
+    if (extensionJson.versions.length !== 1) {
+        throw new Error(`${galleryFilePath} - Only one version is currently supported\n${JSON.stringify(extensionJson)}`)
+    }
     for (const version of extensionJson.versions) {
-        await validateVersion(galleryFilePath, extensionName, version);
+        await validateVersion(galleryFilePath, extensionName, extensionJson, version);
     }
 
     if (!extensionJson.statistics || extensionJson.statistics.length === undefined) {
@@ -159,7 +176,7 @@ function validateExtensionStatistics(galleryFilePath, extensionName, extensionSt
  *     properties?: IRawGalleryExtensionProperty[];
  * }
  */
-async function validateVersion(galleryFilePath, extensionName, extensionVersionJson) {
+async function validateVersion(galleryFilePath, extensionName, extensionJson, extensionVersionJson) {
     if (!extensionVersionJson.version) {
         throw new Error(`${galleryFilePath} - ${extensionName} - No version\n${JSON.stringify(extensionVersionJson)}`)
     }
@@ -182,17 +199,13 @@ async function validateVersion(galleryFilePath, extensionName, extensionVersionJ
     validateHasRequiredAssets(galleryFilePath, extensionName, extensionVersionJson.files);
 
     for (const file of extensionVersionJson.files) {
-        await validateExtensionFile(galleryFilePath, extensionName, file);
+        await validateExtensionFile(galleryFilePath, extensionName, extensionJson, file);
     }
     if (extensionVersionJson.properties && extensionVersionJson.properties.length) {
         extensionVersionJson.properties.forEach(property => validateExtensionProperty(galleryFilePath, extensionName, property));
-        const azdataEngineVersion = extensionVersionJson.properties.find(property => property.key === 'Microsoft.AzDataEngine' && (property.value.startsWith('>=') || property.value === '*'))
+        const azdataEngineVersion = extensionVersionJson.properties.find(property => property.key === MICROSOFT_AZDATAENGINE && (property.value.startsWith('>=') || property.value === '*'))
         if (!azdataEngineVersion) {
             throw new Error(`${galleryFilePath} - ${extensionName} - No valid Microsoft.AzdataEngine property found. Value must be either * or >=x.x.x where x.x.x is the minimum Azure Data Studio version the extension requires\n${JSON.stringify(extensionVersionJson.properties)}`)
-        }
-        const vscodeEngineVersion = extensionVersionJson.properties.find(property => property.key === 'Microsoft.VisualStudio.Code.Engine');
-        if (vscodeEngineVersion && vscodeEngineVersion.value.startsWith('>=') && azdataEngineVersion.value.startsWith('>=')) {
-            throw new Error(`${galleryFilePath} - ${extensionName} - Both Microsoft.AzDataEngine and Microsoft.VisualStudio.Code.Engine should not have minimum versions. Each Azure Data Studio version is tied to a specific VS Code version and so having both is redundant.`)
         }
     } else {
         throw new Error(`${galleryFilePath} - ${extensionName} - No properties, extensions must have an AzDataEngine version defined`)
@@ -279,9 +292,10 @@ const allowedHosts = [
  *     assetType: string;
  *     source: string;
  * }
- * Will also validate that the source URL provided is valid.
+ * Will also validate that the source URL provided is valid, and if it's a direct VSIX link that the
+ * package metadata matches what's in the gallery.
  */
-async function validateExtensionFile(galleryFilePath, extensionName, extensionFileJson) {
+async function validateExtensionFile(galleryFilePath, extensionName, extensionJson, extensionFileJson) {
     if (!extensionFileJson.assetType) {
         throw new Error(`${galleryFilePath} - ${extensionName} - No assetType\n${JSON.stringify(extensionFileJson)}`)
     }
@@ -297,13 +311,125 @@ async function validateExtensionFile(galleryFilePath, extensionName, extensionFi
     }
 
     // Validate the source URL
-    try {
-        const response = await got(extensionFileJson.source);
-        if (response.statusCode !== 200) {
-            throw new Error(`${response.statusCode}: ${response.statusMessage}`);
+    if (extensionFileJson.assetType === MICROSOFT_VISUALSTUDIO_SERVICES_VSIXPACKAGE) {
+        const downloadVsixPath = path.join(DOWNLOADED_EXT_DIR, path.basename(galleryFilePath, '.json'), `${extensionName}.vsix`);
+        // Download VSIX into temp download location
+        try {
+            const vsixDownloadStream = got.stream(extensionFileJson.source);
+            const vsixWriteStream = fs.createWriteStream(downloadVsixPath);
+            await pipeline(vsixDownloadStream, vsixWriteStream);
+            vsixWriteStream.close();
+        } catch (err) {
+            throw new Error(`${galleryFilePath} - ${extensionName} - Error downloading ${extensionFileJson.assetType} with URL ${extensionFileJson.source}. ${err}`);
         }
-    } catch (err) {
-        throw new Error(`${galleryFilePath} - ${extensionName} - Error fetching ${extensionFileJson.assetType} with URL ${extensionFileJson.source}. ${err}`);
+
+        const vsixUnzipDir = path.join(DOWNLOADED_EXT_DIR, path.basename(galleryFilePath, '.json'), extensionName);
+        const packageJsonWritePath = path.join(vsixUnzipDir, 'package.json');
+        // Extract the package.json from the downloaded VSIX
+        try {
+            const vsix = await yauzl.open(downloadVsixPath, { autoClose: true });
+            await mkdir(vsixUnzipDir);
+            await vsix.walkEntries(async (entry) => {
+                // We only care about the root package.json for right now
+                if (entry.fileName == 'extension/package.json') {
+                    await mkdir(path.dirname(packageJsonWritePath), { recursive: true });
+                    const entryWriteStream = fs.createWriteStream(packageJsonWritePath);
+                    const entryReadStream = await entry.openReadStream({ autoClose: true });
+                    await pipeline(entryReadStream, entryWriteStream);
+                    entryWriteStream.close();
+                }
+            });
+        } catch (err) {
+            throw new Error(`${galleryFilePath} - ${extensionName} - Error extracting package.json from ${downloadVsixPath}. ${err}`);
+        }
+
+        // Validate that the package.json metadata matches the gallery metadata
+        try {
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonWritePath));
+            validatePackageJson(extensionJson, packageJson);
+        } catch (err) {
+            throw new Error(`${galleryFilePath} - ${extensionName} - Error validating package.json. ${err}`);
+        }
+    } else {
+        try {
+            const response = await got(extensionFileJson.source);
+            if (response.statusCode !== 200) {
+                throw new Error(`${response.statusCode}: ${response.statusMessage}`);
+            }
+        } catch (err) {
+            throw new Error(`${galleryFilePath} - ${extensionName} - Error fetching ${extensionFileJson.assetType} with URL ${extensionFileJson.source}. ${err}`);
+        }
+    }
+}
+
+/**
+ * Mappings of publisher IDs in the extension gallery to the list of valid aliases for that publisher in the package.json
+ */
+const publisherMappings = {
+    'Microsoft': ['ms-vscode', 'VisualStudioExptTeam']
+}
+
+/**
+ * Validates that the entries in the package.json for the given extension matches those specified in the extension gallery.
+ *
+ * @param extensionJson The JSON object for this extension from the gallery
+ * @param packageJson The JSON object for this extension from the package.json of the extension
+ */
+function validatePackageJson(extensionJson, packageJson) {
+    // Check names match
+    if (extensionJson.extensionName !== packageJson.name) {
+        throw new Error(`Extension name in gallery (${extensionJson.extensionName}) does not match extension name in package.json (${packageJson.name})`);
+    }
+
+    // Check publishers match
+    if (extensionJson.publisher.publisherId !== packageJson.publisher && publisherMappings[extensionJson.publisher.publisherId]?.find(m => m === packageJson.publisher) === undefined) {
+        throw new Error(`Publisher in gallery (${extensionJson.publisher.publisherId}) does not match publisher in package.json (${packageJson.publisher})`);
+    }
+
+    // Check versions match
+    const extensionJsonVersion = extensionJson.versions[0].version;
+    if (extensionJsonVersion !== packageJson.version) {
+        throw new Error(`Version in gallery (${extensionJsonVersion}) does not match version in package.json (${packageJson.version})`);
+    }
+
+    // Check vs code engine matches
+    const extensionVsCodeEngine = extensionJson.versions[0].properties.find(p => p.key === MICROSOFT_VISUALSTUDIO_CODE_ENGINE)?.value;
+    const packageVsCodeEngine = packageJson.engines?.vscode;
+    validateEngineVersionMatches(MICROSOFT_VISUALSTUDIO_CODE_ENGINE, 'vscode', extensionVsCodeEngine, packageVsCodeEngine);
+
+
+    // Check azdata engine matches
+    const extensionAzdataEngine = extensionJson.versions[0].properties.find(p => p.key === MICROSOFT_AZDATAENGINE)?.value;
+    const packageAzdataEngine = packageJson.engines?.azdata;
+    validateEngineVersionMatches(MICROSOFT_AZDATAENGINE, 'azdata', extensionAzdataEngine, packageAzdataEngine);
+}
+
+function validateEngineVersionMatches(extensionGalleryEngineName, packageEngineName, extensionGalleryVersion, packageVersion) {
+    // Normalize the engine versions since both ^ and >= are supported
+    const normalizedExtensionGalleryVersion = extensionGalleryVersion?.replace(">=", "^");
+    const normalizedPackageVersion = packageVersion?.replace(">=", "^");
+
+    // Treat * and undefined as equal
+    if (normalizedExtensionGalleryVersion === '*' && normalizedPackageVersion === undefined) {
+        return;
+    }
+
+    if (normalizedExtensionGalleryVersion === undefined && normalizedPackageVersion === '*') {
+        return;
+    }
+
+    // Package.json has non-* version but gallery doesn't
+    if (normalizedExtensionGalleryVersion === undefined && normalizedPackageVersion !== undefined) {
+        throw new Error(`Extension gallery does not have engine version specified (${extensionGalleryEngineName}) but package.json has ${packageVersion} (${packageEngineName})`);
+    }
+
+    // Gallery has non-* version but package.json doesn't
+    if (normalizedExtensionGalleryVersion !== undefined && normalizedPackageVersion === undefined) {
+        throw new Error(`package.json does not have engine version specified (${packageEngineName}) but extension gallery has ${extensionGalleryVersion} (${extensionGalleryEngineName})`);
+    }
+
+    if (normalizedExtensionGalleryVersion !== normalizedPackageVersion) {
+        throw new Error(`package.json version ${packageVersion} (${packageEngineName}) does not match extension gallery version ${extensionGalleryVersion} (${extensionGalleryEngineName})`);
     }
 }
 
@@ -336,6 +462,21 @@ function validateResultMetadata(galleryFilePath, extensionCount, resultMetadataJ
         }
     })
 }
+
+async function cleanDownloadedExtensionFolder(downloadedExtDir) {
+    // Delete folder if it exists
+    try {
+        await rm(downloadedExtDir, { recursive: true, force: true });
+    } catch (err) {
+        if (err.code !== 'ENOENT') {
+            throw err;
+        }
+    }
+    await mkdir(downloadedExtDir, { recursive: true });
+}
+
+await cleanDownloadedExtensionFolder(STABLE_DOWNLOADED_EXT_DIR);
+await cleanDownloadedExtensionFolder(INSIDERS_DOWNLOADED_EXT_DIR);
 
 await Promise.all([
     validateExtensionGallery(path.join(ROOT_DIR, 'extensionsGallery.json')),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,19 @@
 # yarn lockfile v1
 
 
-"@sindresorhus/is@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
-  integrity sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==
+"@sindresorhus/is@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@szmarczak/http-timer@^4.0.5":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
-  integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
+"@szmarczak/http-timer@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-5.0.1.tgz#c7c1bf1141cdd4751b0399c8fc7b8b664cd5be3a"
+  integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
   dependencies:
-    defer-to-connect "^2.0.0"
+    defer-to-connect "^2.0.1"
 
-"@types/cacheable-request@^6.0.1":
+"@types/cacheable-request@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.2.tgz#c324da0197de0a98a2312156536ae262429ff6b9"
   integrity sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==
@@ -48,12 +48,17 @@
   dependencies:
     "@types/node" "*"
 
-cacheable-lookup@^5.0.3:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
-  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
-cacheable-request@^7.0.1:
+cacheable-lookup@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz#65c0e51721bb7f9f2cb513aed6da4a1b93ad7dc8"
+  integrity sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A==
+
+cacheable-request@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
   integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
@@ -80,10 +85,15 @@ decompress-response@^6.0.0:
   dependencies:
     mimic-response "^3.1.0"
 
-defer-to-connect@^2.0.0:
+defer-to-connect@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
+
+emitter-component@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/emitter-component/-/emitter-component-1.1.1.tgz#065e2dbed6959bf470679edabeaf7981d1003ab6"
+  integrity sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -92,6 +102,23 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+events-intercept@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/events-intercept/-/events-intercept-2.0.0.tgz#adbf38681c5a4b2011c41ee41f61a34cba448897"
+  integrity sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q==
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
+
+form-data-encoder@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.1.tgz#ac80660e4f87ee0d3d3c3638b7da8278ddb8ec96"
+  integrity sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==
+
 get-stream@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
@@ -99,21 +126,28 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-got@^11.8.2:
-  version "11.8.2"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.2.tgz#7abb3959ea28c31f3576f1576c1effce23f33599"
-  integrity sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==
+get-stream@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+got@^12.0.4:
+  version "12.0.4"
+  resolved "https://registry.yarnpkg.com/got/-/got-12.0.4.tgz#e3b6bf6992425f904076fd71aac7030da5122de8"
+  integrity sha512-2Eyz4iU/ktq7wtMFXxzK7g5p35uNYLLdiZarZ5/Yn3IJlNEpBd5+dCgcAyxN8/8guZLszffwe3wVyw+DEVrpBg==
   dependencies:
-    "@sindresorhus/is" "^4.0.0"
-    "@szmarczak/http-timer" "^4.0.5"
-    "@types/cacheable-request" "^6.0.1"
+    "@sindresorhus/is" "^4.6.0"
+    "@szmarczak/http-timer" "^5.0.1"
+    "@types/cacheable-request" "^6.0.2"
     "@types/responselike" "^1.0.0"
-    cacheable-lookup "^5.0.3"
-    cacheable-request "^7.0.1"
+    cacheable-lookup "^6.0.4"
+    cacheable-request "^7.0.2"
     decompress-response "^6.0.0"
-    http2-wrapper "^1.0.0-beta.5.2"
-    lowercase-keys "^2.0.0"
-    p-cancelable "^2.0.0"
+    form-data-encoder "1.7.1"
+    get-stream "^6.0.1"
+    http2-wrapper "^2.1.10"
+    lowercase-keys "^3.0.0"
+    p-cancelable "^3.0.0"
     responselike "^2.0.0"
 
 http-cache-semantics@^4.0.0:
@@ -121,13 +155,13 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
-http2-wrapper@^1.0.0-beta.5.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
-  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+http2-wrapper@^2.1.10:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-2.1.11.tgz#d7c980c7ffb85be3859b6a96c800b2951ae257ef"
+  integrity sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==
   dependencies:
     quick-lru "^5.1.1"
-    resolve-alpn "^1.0.0"
+    resolve-alpn "^1.2.0"
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -145,6 +179,11 @@ lowercase-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+
+lowercase-keys@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
+  integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
 
 mimic-response@^1.0.0:
   version "1.0.1"
@@ -168,10 +207,15 @@ once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-p-cancelable@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
-  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
+p-cancelable@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-3.0.0.tgz#63826694b54d61ca1c20ebcb6d3ecf5e14cd8050"
+  integrity sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -186,10 +230,10 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-resolve-alpn@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.1.2.tgz#30b60cfbb0c0b8dc897940fe13fe255afcdd4d28"
-  integrity sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA==
+resolve-alpn@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
+  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
 
 responselike@^2.0.0:
   version "2.0.0"
@@ -198,7 +242,37 @@ responselike@^2.0.0:
   dependencies:
     lowercase-keys "^2.0.0"
 
+stream@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stream/-/stream-0.0.2.tgz#7f5363f057f6592c5595f00bc80a27f5cec1f0ef"
+  integrity sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=
+  dependencies:
+    emitter-component "^1.1.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+yauzl-clone@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/yauzl-clone/-/yauzl-clone-1.0.4.tgz#8bc6d293b17cc98802bbbed2e289d18e7697c96c"
+  integrity sha1-i8bSk7F8yYgCu77S4onRjnaXyWw=
+  dependencies:
+    events-intercept "^2.0.0"
+
+yauzl-promise@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/yauzl-promise/-/yauzl-promise-2.1.3.tgz#17467845db89fc6592ca987ca2ecfee8c381ae3d"
+  integrity sha1-F0Z4RduJ/GWSyph8ouz+6MOBrj0=
+  dependencies:
+    yauzl "^2.9.1"
+    yauzl-clone "^1.0.4"
+
+yauzl@^2.9.1:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"


### PR DESCRIPTION
Validates that the package.json metadata matches what's in the gallery files. 

Currently checks : 

1. VS Code engine version
2. Azdata engine version
3. Extension name
4. Publisher ID
5. Extension version

Couple other things : 
* I noticed Agent version in insiders was also incorrect, stable was updated to .48 a while ago but apparently insiders was missed
* I removed the check for only allowing either azdata or vs code engine version (not both). While many extensions should only have one or the other, some may want to keep both if they publish to both VS Code and ADS. Trying to keep up with that list of special cases was going to be annoying, and in general having both isn't breaking or anything so it's fine to allow. 
* @kisantia @Benjin The schema-compare extension was updated to have azdata engine version >= 1.37 in insiders gallery but the package.json still has 1.35. So that's something that should be fixed (update the package.json and then the next time you publish you can update the gallery engine version too)

Future improvements : 
- VS Code engine version specified is correct for given azdata version
- Extension dependencies
- Preview flag