### PR TITLE
Parallelize gallery checks

### DIFF
--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -87,9 +87,7 @@ async function validateResults(galleryFilePath, resultsJson) {
     if (!resultsJson.extensions || !resultsJson.extensions.length) {
         throw new Error(`${galleryFilePath} - No extensions\n${JSON.stringify(resultsJson)}`)
     }
-    for (const extension of resultsJson.extensions) {
-        await validateExtension(galleryFilePath, extension);
-    }
+    await Promise.all(resultsJson.extensions.map(e => validateExtension(galleryFilePath, e)));
 
     if (!resultsJson.resultMetadata || !resultsJson.resultMetadata.length) {
         throw new Error(`${galleryFilePath} - No resultMetadata\n${JSON.stringify(resultsJson)}`)


### PR DESCRIPTION
Currently we're running the extension checks sequentially, which now that we're downloading and unpacking the VSIXs for each extension can take a long time. These can all be done in parallel though - they don't have any impact on each other. 