### PR TITLE
fix tab header width

### DIFF
--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -98,7 +98,7 @@ panel {
 	padding-left: 5px;
 	padding-right: 5px;
 	min-width: 65px;
-	flex: 0 0;
+	flex: 0 0 auto;
 }
 
 .tabbedPanel.horizontal > .title .tabList .tab-header {


### PR DESCRIPTION
made a mistake in my previous PR: https://github.com/microsoft/azuredatastudio/pull/19731

Forgot to add back the 'auto' value after testing.  

without it, the tab headers will be collapsed:
![image](https://user-images.githubusercontent.com/13777222/173903082-fdf420ba-c054-4db7-9348-f623693fc87a.png)

after:
![image](https://user-images.githubusercontent.com/13777222/173903134-aee7f81b-e9f0-4072-a753-a270f9f5a97c.png)
