### PR TITLE
add message as aria-description

### DIFF
--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -154,6 +154,9 @@ export class ErrorMessageDialog extends Modal {
 		} else {
 			this._copyButton!.element.style.visibility = 'hidden';
 		}
+		if (this._message) {
+			this._bodyContainer.setAttribute('aria-description', this._message);
+		}
 		this.resetActions();
 		if (actions && actions.length > 0) {
 			for (let i = 0; i < maxActions && i < actions.length; i++) {


### PR DESCRIPTION
This PR fixes #19413 

similar to the alert dialog, I think it is reasonable to expect the error message to be read out. 

the error message dialog:
![image](https://user-images.githubusercontent.com/13777222/173942663-c9b87db5-2609-41b6-88e0-e89617938349.png)

with this change the message will also be announced:

![image](https://user-images.githubusercontent.com/13777222/173942740-0e758100-fcfd-465a-b49c-8e7f1b16d81c.png)


