### PR TITLE
fix selected state of select boxes

### DIFF
--- a/src/sql/base/browser/ui/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/browser/ui/editableDropdown/browser/dropdown.ts
@@ -315,7 +315,8 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 
 	private _updateDropDownList(): void {
 		this._selectList.splice(0, this._selectList.length, this._dataSource.filteredValues.map(v => { return { text: v }; }));
-		this._selectList.setSelection([this._dataSource.filteredValues.indexOf(this.value)]);
+		const selectedIndex = this._dataSource.filteredValues.indexOf(this.value);
+		this._selectList.setSelection(selectedIndex !== -1 ? [selectedIndex] : []);
 
 		let width = this._inputContainer.clientWidth;
 

--- a/src/sql/base/browser/ui/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/browser/ui/editableDropdown/browser/dropdown.ts
@@ -315,6 +315,7 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 
 	private _updateDropDownList(): void {
 		this._selectList.splice(0, this._selectList.length, this._dataSource.filteredValues.map(v => { return { text: v }; }));
+		this._selectList.setSelection([this._dataSource.filteredValues.indexOf(this.value)]);
 
 		let width = this._inputContainer.clientWidth;
 

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1279,6 +1279,7 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		private _options: IListOptions<T> = DefaultOptions
 	) {
 		const role = this._options.accessibilityProvider && this._options.accessibilityProvider.getWidgetRole ? this._options.accessibilityProvider?.getWidgetRole() : 'list';
+		// {{SQL CARBON EDIT}} - Change the parameter from 'role !== listbox' to 'role !== list', according to the doc https://www.w3.org/WAI/PF/HTML/wiki/RoleAttribute, list role is non-interactive.
 		this.selection = new SelectionTrait(role !== 'list');
 
 		mixin(_options, defaultStyles, false);

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1279,7 +1279,7 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		private _options: IListOptions<T> = DefaultOptions
 	) {
 		const role = this._options.accessibilityProvider && this._options.accessibilityProvider.getWidgetRole ? this._options.accessibilityProvider?.getWidgetRole() : 'list';
-		this.selection = new SelectionTrait(role !== 'listbox');
+		this.selection = new SelectionTrait(role !== 'list');
 
 		mixin(_options, defaultStyles, false);
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -271,7 +271,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		// Populate select list for non-native select mode
 		if (this.selectList) {
 			this.selectList.splice(0, this.selectList.length, this.options);
-			this.selectList.setSelection([this.selected]);
+			this.selectList.setSelection([this.selected]); // {{SQL CARBON EDIT}} - Set the selected indexes.
 		}
 	}
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -271,7 +271,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		// Populate select list for non-native select mode
 		if (this.selectList) {
 			this.selectList.splice(0, this.selectList.length, this.options);
-			this.selectList.setSelection([this.selected]); // {{SQL CARBON EDIT}} - Set the selected indexes.
+			this.selectList?.setSelection(this.selected !== -1 ? [this.selected] : []); // {{SQL CARBON EDIT}} - Set the selected indexes.
 		}
 	}
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -271,6 +271,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		// Populate select list for non-native select mode
 		if (this.selectList) {
 			this.selectList.splice(0, this.selectList.length, this.options);
+			this.selectList.setSelection([this.selected]);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #19412
This PR fixes #19676 

1. the selectionTrait was disabled for listbox role, which I believe is a mistake. searched in the code and all references are providing a value, none of them are using list role.
2. set the selection properly for the list before it is displayed

@Charles-Gagnon @aasimkhan30 I created a PR in vscode: https://github.com/microsoft/vscode/pull/152274, but I don't want to be blocked on that, I'll get this PR into ADS first and then cherry-pick the changes from VSCode to ADS once it is merged.

Screenshots:
For normal select box, I am using Output channels dropdown as an example 

![image](https://user-images.githubusercontent.com/13777222/173964841-6b5f6af5-32f4-4f23-8220-aceda120bc69.png)

I highlighted a few of them using white line in screenshot below
![image](https://user-images.githubusercontent.com/13777222/173965089-68a51bea-f2a6-4df2-bd5f-51aee0e9cdb5.png)

for editable dropdown:

![image](https://user-images.githubusercontent.com/13777222/173965499-466e88df-8a66-4190-8bb1-39766411fdc5.png)


![image](https://user-images.githubusercontent.com/13777222/173965482-a79f3c36-3b6c-4c54-8f5a-a314991f73ea.png)

