### PR TITLE
Removing truncation from tab header components to make it match the portal look

### DIFF
--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -50,7 +50,6 @@ panel {
 .tabbedPanel .tabList .tab {
 	cursor: pointer;
 	margin: auto;
-	display: flex;
 	flex-flow: row;
 }
 
@@ -98,7 +97,7 @@ panel {
 	padding-left: 5px;
 	padding-right: 5px;
 	min-width: 65px;
-	flex: 0 0 auto;
+	/* flex: 0 0 auto; */
 }
 
 .tabbedPanel.horizontal > .title .tabList .tab-header {

--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -53,6 +53,10 @@ panel {
 	flex-flow: row;
 }
 
+.tabbedPanel.vertical > .title .tabList .tab {
+	display: flex;
+}
+
 .tabbedPanel.horizontal > .title .tabList .tab .tabLabel {
 	font-size: 12px;
 	max-width: 100px;
@@ -97,7 +101,6 @@ panel {
 	padding-left: 5px;
 	padding-right: 5px;
 	min-width: 65px;
-	/* flex: 0 0 auto; */
 }
 
 .tabbedPanel.horizontal > .title .tabList .tab-header {
@@ -110,6 +113,7 @@ panel {
 	line-height: 35px;
 	padding-left: 24px;
 	padding-right: 24px;
+	flex: 0 0 auto;
 }
 
 .tabbedPanel .tabList .tab .tabIcon.codicon {

--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -50,16 +50,12 @@ panel {
 .tabbedPanel .tabList .tab {
 	cursor: pointer;
 	margin: auto;
-	flex-flow: row;
-}
-
-.tabbedPanel.vertical > .title .tabList .tab {
 	display: flex;
+	flex-flow: row;
 }
 
 .tabbedPanel.horizontal > .title .tabList .tab .tabLabel {
 	font-size: 12px;
-	max-width: 100px;
 }
 
 .tabbedPanel.vertical > .title .tabList .tab .tabLabel {

--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -97,6 +97,7 @@ panel {
 	padding-left: 5px;
 	padding-right: 5px;
 	min-width: 65px;
+	flex: 0 0 auto;
 }
 
 .tabbedPanel.horizontal > .title .tabList .tab-header {
@@ -109,7 +110,6 @@ panel {
 	line-height: 35px;
 	padding-left: 24px;
 	padding-right: 24px;
-	flex: 0 0 auto;
 }
 
 .tabbedPanel .tabList .tab .tabIcon.codicon {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Inspiration:
![image](https://user-images.githubusercontent.com/6816294/174021945-dec140f9-c7c4-4827-a42e-424cb6b40048.png)

Before:
![image](https://user-images.githubusercontent.com/6816294/174022104-ba940ff5-9c84-4cb6-840b-0f3af771dd5f.png)

After:
![image](https://user-images.githubusercontent.com/6816294/174022377-eb00eb2f-5c5f-484a-a916-9217df855e53.png)


This PR fixes #18852
