### PR TITLE
Adding arialive to flex and div container

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2763,13 +2763,12 @@ declare module 'azdata' {
 		withProps(properties: TPropertyBag): ComponentBuilder<TComponent, TPropertyBag>;
 		withValidation(validation: (component: TComponent) => boolean | Thenable<boolean>): ComponentBuilder<TComponent, TPropertyBag>;
 	}
-	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ComponentProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
-		withProps(properties: TPropertyBag): ComponentBuilder<TComponent, TPropertyBag>;
+	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ContainerProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
 		withLayout(layout: TLayout): ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag>;
 		withItems(components: Array<Component>, itemLayout?: TItemLayout): ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag>;
 	}
 
-	export interface FlexBuilder extends ContainerBuilder<FlexContainer, FlexLayout, FlexItemLayout, ComponentProperties> {
+	export interface FlexBuilder extends ContainerBuilder<FlexContainer, FlexLayout, FlexItemLayout, ContainerProperties> {
 	}
 
 	// Building on top of flex item
@@ -3818,7 +3817,7 @@ declare module 'azdata' {
 		loadingCompletedText?: string | undefined;
 	}
 
-	export interface DivContainerProperties extends ComponentProperties {
+	export interface DivContainerProperties extends ContainerProperties {
 		/**
 		 * Matches the overflow-y CSS property and its available values.
 		 */

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2764,6 +2764,7 @@ declare module 'azdata' {
 		withValidation(validation: (component: TComponent) => boolean | Thenable<boolean>): ComponentBuilder<TComponent, TPropertyBag>;
 	}
 	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ComponentProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
+		withProps(properties: TPropertyBag): ComponentBuilder<TComponent, TPropertyBag>;
 		withLayout(layout: TLayout): ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag>;
 		withItems(components: Array<Component>, itemLayout?: TItemLayout): ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag>;
 	}
@@ -3350,6 +3351,7 @@ declare module 'azdata' {
 
 	export interface InputBoxProperties extends ComponentProperties {
 		value?: string | undefined;
+		ariaLive?: string | undefined;
 		placeHolder?: string | undefined;
 		inputType?: InputBoxInputType | undefined;
 		required?: boolean | undefined;

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3350,7 +3350,6 @@ declare module 'azdata' {
 
 	export interface InputBoxProperties extends ComponentProperties {
 		value?: string | undefined;
-		ariaLive?: string | undefined;
 		placeHolder?: string | undefined;
 		inputType?: InputBoxInputType | undefined;
 		required?: boolean | undefined;

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2692,7 +2692,7 @@ declare module 'azdata' {
 	 * Supports defining a model that can be instantiated as a view in the UI
 	 */
 	export interface ModelBuilder {
-		navContainer(): ContainerBuilder<NavContainer, any, any, ComponentProperties>;
+		navContainer(): ContainerBuilder<NavContainer, any, any, ContainerProperties>;
 		divContainer(): DivBuilder;
 		flexContainer(): FlexBuilder;
 		splitViewContainer(): SplitViewBuilder;
@@ -2772,7 +2772,7 @@ declare module 'azdata' {
 	}
 
 	// Building on top of flex item
-	export interface SplitViewBuilder extends ContainerBuilder<SplitViewContainer, SplitViewLayout, FlexItemLayout, ComponentProperties> {
+	export interface SplitViewBuilder extends ContainerBuilder<SplitViewContainer, SplitViewLayout, FlexItemLayout, ContainerProperties> {
 	}
 
 	export interface DivBuilder extends ContainerBuilder<DivContainer, DivLayout, DivItemLayout, DivContainerProperties> {
@@ -2781,8 +2781,8 @@ declare module 'azdata' {
 	export interface GroupBuilder extends ContainerBuilder<GroupContainer, GroupLayout, GroupItemLayout, GroupContainerProperties> {
 	}
 
-	export interface ToolbarBuilder extends ContainerBuilder<ToolbarContainer, ToolbarLayout, any, ComponentProperties> {
-		withToolbarItems(components: ToolbarComponent[]): ContainerBuilder<ToolbarContainer, ToolbarLayout, any, ComponentProperties>;
+	export interface ToolbarBuilder extends ContainerBuilder<ToolbarContainer, ToolbarLayout, any, ContainerProperties> {
+		withToolbarItems(components: ToolbarComponent[]): ContainerBuilder<ToolbarContainer, ToolbarLayout, any, ContainerProperties>;
 
 		/**
 		 * Creates a collection of child components and adds them all to this container
@@ -2807,7 +2807,7 @@ declare module 'azdata' {
 		withItem(component: Component): LoadingComponentBuilder;
 	}
 
-	export interface FormBuilder extends ContainerBuilder<FormContainer, FormLayout, FormItemLayout, ComponentProperties> {
+	export interface FormBuilder extends ContainerBuilder<FormContainer, FormLayout, FormItemLayout, ContainerProperties> {
 		withFormItems(components: (FormComponent | FormComponentGroup)[], itemLayout?: FormItemLayout): FormBuilder;
 
 		/**
@@ -3324,6 +3324,13 @@ declare module 'azdata' {
 		CSSStyles?: CssStyles | undefined;
 	}
 
+	/**
+	 * Common properties for container components such as {@link DivContainer} or {@link FlexContainer}
+	 */
+	export interface ContainerProperties extends ComponentProperties {
+
+	}
+
 	export type ThemedIconPath = { light: string | vscode.Uri; dark: string | vscode.Uri };
 	export type IconPath = string | vscode.Uri | ThemedIconPath;
 
@@ -3544,7 +3551,7 @@ declare module 'azdata' {
 	export interface ImageComponentProperties extends ComponentWithIconProperties {
 	}
 
-	export interface GroupContainerProperties extends ComponentProperties {
+	export interface GroupContainerProperties extends ContainerProperties {
 		collapsed: boolean;
 	}
 
@@ -4357,12 +4364,12 @@ declare module 'azdata' {
 	/**
 	 * Builder for TabbedPanelComponent
 	 */
-	export interface TabbedPanelComponentBuilder extends ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any, ComponentProperties> {
+	export interface TabbedPanelComponentBuilder extends ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any, ContainerProperties> {
 		/**
 		 * Add the tabs to the component
 		 * @param tabs tabs/tab groups to be added
 		 */
-		withTabs(tabs: (Tab | TabGroup)[]): ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any, ComponentProperties>;
+		withTabs(tabs: (Tab | TabGroup)[]): ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any, ContainerProperties>;
 	}
 
 	export interface SliderComponentProperties extends ComponentProperties {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1531,6 +1531,6 @@ declare module 'azdata' {
 	}
 
 	export interface ComponentProperties {
-		ariaLive?: 'off' | 'polite' | 'assertive';
+		ariaLive?: string;
 	}
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1526,11 +1526,18 @@ declare module 'azdata' {
 		link: LinkArea;
 	}
 
-	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ComponentProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
+	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ContainerProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
+		/**
+		 * Sets the initial set of properties for the container being created
+		 * @param properties The properties to apply to the container
+		 */
 		withProps(properties: TPropertyBag): ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag>;
 	}
 
-	export interface ComponentProperties {
+	export interface ContainerProperties extends ComponentProperties {
+		/**
+		 * Corresponds to the aria-live accessibility attribute for this component
+		 */
 		ariaLive?: string;
 	}
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1525,4 +1525,12 @@ declare module 'azdata' {
 		 */
 		link: LinkArea;
 	}
+
+	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ComponentProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
+		withProps(properties: TPropertyBag): ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag>;
+	}
+
+	export interface ComponentProperties {
+		ariaLive?: 'off' | 'polite' | 'assertive';
+	}
 }

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -348,7 +348,8 @@ class ContainerBuilderImpl<TComponent extends azdata.Component, TLayout, TItemLa
 	}
 
 	override withProps(properties: TPropertyBag): azdata.ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag> {
-		this._component.properties = Object.assign({}, this._component.properties, properties);
+		// We use the same basic logic to set the properties but return this so we can return the container object type
+		super.withProps(properties);
 		return this;
 	}
 

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -347,6 +347,11 @@ class ContainerBuilderImpl<TComponent extends azdata.Component, TLayout, TItemLa
 		super(componentWrapper);
 	}
 
+	override withProps(properties: TPropertyBag): azdata.ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag> {
+		this._component.properties = Object.assign({}, this._component.properties, properties);
+		return this;
+	}
+
 	withLayout(layout: TLayout): azdata.ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag> {
 		this._component.layout = layout;
 		return this;
@@ -997,10 +1002,10 @@ class InputBoxWrapper extends ComponentWrapper implements azdata.InputBoxCompone
 		this.setProperty('value', v);
 	}
 
-	public get ariaLive(): string {
+	public get ariaLive(): 'off' | 'polite' | 'assertive' {
 		return this.properties['ariaLive'];
 	}
-	public set ariaLive(v: string) {
+	public set ariaLive(v: 'off' | 'polite' | 'assertive') {
 		this.setProperty('ariaLive', v);
 	}
 

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -50,7 +50,7 @@ class ModelBuilderImpl implements azdata.ModelBuilder {
 
 	flexContainer(): azdata.FlexBuilder {
 		let id = this.getNextComponentId();
-		let container: GenericContainerBuilder<azdata.FlexContainer, any, any, azdata.ComponentProperties> = new GenericContainerBuilder<azdata.FlexContainer, azdata.FlexLayout, azdata.FlexItemLayout, azdata.ComponentProperties>(this._proxy, this._handle, ModelComponentTypes.FlexContainer, id, this.logService);
+		let container: GenericContainerBuilder<azdata.FlexContainer, any, any, azdata.ContainerProperties> = new GenericContainerBuilder<azdata.FlexContainer, azdata.FlexLayout, azdata.FlexItemLayout, azdata.ContainerProperties>(this._proxy, this._handle, ModelComponentTypes.FlexContainer, id, this.logService);
 		this._componentBuilders.set(id, container);
 		return container;
 	}
@@ -342,7 +342,7 @@ class ComponentBuilderImpl<T extends azdata.Component, TPropertyBag extends azda
 	}
 }
 
-class ContainerBuilderImpl<TComponent extends azdata.Component, TLayout, TItemLayout, TPropertyBag extends azdata.ComponentProperties> extends ComponentBuilderImpl<TComponent, TPropertyBag> implements azdata.ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag> {
+class ContainerBuilderImpl<TComponent extends azdata.Component, TLayout, TItemLayout, TPropertyBag extends azdata.ContainerProperties> extends ComponentBuilderImpl<TComponent, TPropertyBag> implements azdata.ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag> {
 	constructor(componentWrapper: ComponentWrapper) {
 		super(componentWrapper);
 	}
@@ -366,7 +366,7 @@ class ContainerBuilderImpl<TComponent extends azdata.Component, TLayout, TItemLa
 	}
 }
 
-class GenericContainerBuilder<T extends azdata.Component, TLayout, TItemLayout, TPropertyBag extends azdata.ComponentProperties> extends ContainerBuilderImpl<T, TLayout, TItemLayout, TPropertyBag> {
+class GenericContainerBuilder<T extends azdata.Component, TLayout, TItemLayout, TPropertyBag extends azdata.ContainerProperties> extends ContainerBuilderImpl<T, TLayout, TItemLayout, TPropertyBag> {
 	constructor(proxy: MainThreadModelViewShape, handle: number, type: ModelComponentTypes, id: string, logService: ILogService) {
 		super(new ComponentWrapper(proxy, handle, type, id, logService));
 	}

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1002,10 +1002,10 @@ class InputBoxWrapper extends ComponentWrapper implements azdata.InputBoxCompone
 		this.setProperty('value', v);
 	}
 
-	public get ariaLive(): 'off' | 'polite' | 'assertive' {
+	public get ariaLive(): string {
 		return this.properties['ariaLive'];
 	}
-	public set ariaLive(v: 'off' | 'polite' | 'assertive') {
+	public set ariaLive(v: string) {
 		this.setProperty('ariaLive', v);
 	}
 

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -201,12 +201,12 @@ export abstract class ComponentBase<TPropertyBag extends azdata.ComponentPropert
 		this.setPropertyFromUI<boolean>((props, value) => props.ariaHidden = value, newValue);
 	}
 
-	public get ariaLive(): 'off' | 'polite' | 'assertive' | undefined {
-		return this.getPropertyOrDefault<'off' | 'polite' | 'assertive'>((props) => props.ariaLive, undefined);
+	public get ariaLive(): string | undefined {
+		return this.getPropertyOrDefault<string>((props) => props.ariaLive, undefined);
 	}
 
-	public set ariaLive(newValue: 'off' | 'polite' | 'assertive' | undefined) {
-		this.setPropertyFromUI<'off' | 'polite' | 'assertive'>((props, value) => props.ariaLive = value, newValue);
+	public set ariaLive(newValue: string | undefined) {
+		this.setPropertyFromUI<string>((props, value) => props.ariaLive = value, newValue);
 	}
 
 	public get CSSStyles(): azdata.CssStyles {

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -201,6 +201,14 @@ export abstract class ComponentBase<TPropertyBag extends azdata.ComponentPropert
 		this.setPropertyFromUI<boolean>((props, value) => props.ariaHidden = value, newValue);
 	}
 
+	public get ariaLive(): 'off' | 'polite' | 'assertive' | undefined {
+		return this.getPropertyOrDefault<'off' | 'polite' | 'assertive'>((props) => props.ariaLive, undefined);
+	}
+
+	public set ariaLive(newValue: 'off' | 'polite' | 'assertive' | undefined) {
+		this.setPropertyFromUI<'off' | 'polite' | 'assertive'>((props, value) => props.ariaLive = value, newValue);
+	}
+
 	public get CSSStyles(): azdata.CssStyles {
 		return this.getPropertyOrDefault<azdata.CssStyles>((props) => props.CSSStyles, {});
 	}

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -201,14 +201,6 @@ export abstract class ComponentBase<TPropertyBag extends azdata.ComponentPropert
 		this.setPropertyFromUI<boolean>((props, value) => props.ariaHidden = value, newValue);
 	}
 
-	public get ariaLive(): string | undefined {
-		return this.getPropertyOrDefault<string>((props) => props.ariaLive, undefined);
-	}
-
-	public set ariaLive(newValue: string | undefined) {
-		this.setPropertyFromUI<string>((props, value) => props.ariaLive = value, newValue);
-	}
-
 	public get CSSStyles(): azdata.CssStyles {
 		return this.getPropertyOrDefault<azdata.CssStyles>((props) => props.CSSStyles, {});
 	}
@@ -287,7 +279,7 @@ export abstract class ComponentBase<TPropertyBag extends azdata.ComponentPropert
 	}
 }
 
-export abstract class ContainerBase<T, TPropertyBag extends azdata.ComponentProperties = azdata.ComponentProperties> extends ComponentBase<TPropertyBag> {
+export abstract class ContainerBase<T, TPropertyBag extends azdata.ContainerProperties = azdata.ContainerProperties> extends ComponentBase<TPropertyBag> {
 	protected items: ItemDescriptor<T>[];
 
 	@ViewChildren(ModelComponentWrapper) protected _componentWrappers: QueryList<ModelComponentWrapper>;
@@ -402,5 +394,13 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ComponentProp
 	}
 
 	protected onItemLayoutUpdated(item: ItemDescriptor<T>): void {
+	}
+
+	public get ariaLive(): string | undefined {
+		return this.getPropertyOrDefault<string>((props) => props.ariaLive, undefined);
+	}
+
+	public set ariaLive(newValue: string | undefined) {
+		this.setPropertyFromUI<string>((props, value) => props.ariaLive = value, newValue);
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/divContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/divContainer.component.ts
@@ -27,7 +27,7 @@ class DivItem {
 
 @Component({
 	template: `
-		<div #divContainer *ngIf="items" [ngClass] = "{'divContainer': true, 'clickable-divContainer': clickable}" [ngStyle]="CSSStyles" [style.height]="height" [style.width]="width" [style.display]="display" (keydown)="onKey($event)" [attr.role]="ariaRole" [attr.aria-selected]="ariaSelected">
+		<div #divContainer *ngIf="items" [ngClass] = "{'divContainer': true, 'clickable-divContainer': clickable}" [ngStyle]="CSSStyles" [style.height]="height" [style.width]="width" [style.display]="display" (keydown)="onKey($event)" [attr.role]="ariaRole" [attr.aria-selected]="ariaSelected" [attr.aria-live]="ariaLive">
 			<div *ngFor="let item of items" [style.order]="getItemOrder(item)" [ngStyle]="getItemStyles(item)">
 				<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore">
 				</model-component-wrapper>

--- a/src/sql/workbench/browser/modelComponents/flexContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/flexContainer.component.ts
@@ -23,7 +23,7 @@ export class FlexItem {
 @Component({
 	template: `
 		<div *ngIf="items" class="flexContainer" [ngStyle]="CSSStyles" [style.display]="display" [style.flexFlow]="flexFlow" [style.justifyContent]="justifyContent" [style.position]="position"
-				[style.alignItems]="alignItems" [style.alignContent]="alignContent" [style.height]="height" [style.width]="width" [style.flex-wrap]="flexWrap" [attr.role]="ariaRole">
+				[style.alignItems]="alignItems" [style.alignContent]="alignContent" [style.height]="height" [style.width]="width" [style.flex-wrap]="flexWrap" [attr.role]="ariaRole" [attr.aria-live] = "ariaLive">
 			<div *ngFor="let item of items" [style.flex]="getItemFlex(item)" [style.textAlign]="textAlign" [style.order]="getItemOrder(item)" [ngStyle]="getItemStyles(item)">
 				<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore">
 				</model-component-wrapper>

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -256,8 +256,8 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 		this.setPropertyFromUI<string>((props, value) => props.value = value, newValue);
 	}
 
-	public get ariaLive() {
-		return this.getPropertyOrDefault<string>((props) => props.ariaLive, '');
+	public override get ariaLive() {
+		return this.getPropertyOrDefault<'off' | 'polite' | 'assertive'>((props) => props.ariaLive, undefined);
 	}
 
 	public get placeHolder(): string {

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -257,7 +257,7 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 	}
 
 	public override get ariaLive() {
-		return this.getPropertyOrDefault<'off' | 'polite' | 'assertive'>((props) => props.ariaLive, undefined);
+		return this.getPropertyOrDefault<string>((props) => props.ariaLive, '');
 	}
 
 	public get placeHolder(): string {

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -256,7 +256,7 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 		this.setPropertyFromUI<string>((props, value) => props.value = value, newValue);
 	}
 
-	public override get ariaLive() {
+	public get ariaLive() {
 		return this.getPropertyOrDefault<string>((props) => props.ariaLive, '');
 	}
 


### PR DESCRIPTION
This PR fixes #19581

The UI should alert the description text at the bottom. For that, we need to add aria-live attribute to the description container. This PR adds that attribute to flex/div modelview container.
![image](https://user-images.githubusercontent.com/6816294/174185650-52e2e94a-79dc-4359-a9d3-3cbdff488d64.png)