### PR TITLE
add title for column header cell

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/buttonColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/buttonColumn.plugin.ts
@@ -43,6 +43,7 @@ export class ButtonColumn<T extends Slick.SlickData> extends BaseClickableColumn
 				return `<button tabindex=-1 class="${iconCssClasses} ${buttonTypeCssClass}" title="${escapedTitle}" aria-label="${escapedTitle}" ${disabledAttribute}>${buttonText}</button>`;
 			},
 			name: this.options.name,
+			toolTip: this.options.title,
 			resizable: this.options.resizable,
 			selectable: false
 		};

--- a/src/sql/base/browser/ui/table/plugins/rowMoveManager.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/rowMoveManager.plugin.ts
@@ -53,7 +53,8 @@ export class RowMoveManager<T extends Slick.SlickData> extends BaseClickableColu
 			resizable: this.options.resizable,
 			selectable: false,
 			behavior: this.options.behavior,
-			cssClass: this.options.iconCssClass
+			cssClass: this.options.iconCssClass,
+			toolTip: this.options.title
 		};
 	}
 


### PR DESCRIPTION
This PR fixes #19562

for columns without header text, we need to specify the title, so that the column name is announced correctly.

![image](https://user-images.githubusercontent.com/13777222/174194525-0397cb44-47fb-4d98-bb47-b8b39b382ec7.png)

![image](https://user-images.githubusercontent.com/13777222/174194444-7fcc3706-4260-449c-89da-4ea883311cee.png)