### PR TITLE
ML Extension - Validate was not called for the last page causing import for invalid model

### DIFF
--- a/extensions/machine-learning/src/views/models/manageModels/importModelWizard.ts
+++ b/extensions/machine-learning/src/views/models/manageModels/importModelWizard.ts
@@ -55,7 +55,7 @@ export class ImportModelWizard extends ModelViewBase {
 		wizard.displayPageTitles = true;
 		wizard.registerNavigationValidator(async (pageInfo: azdata.window.WizardPageChangeInfo) => {
 			let validated: boolean = true;
-			if (pageInfo.newPage > pageInfo.lastPage) {
+			if (pageInfo.newPage === undefined || pageInfo.newPage > pageInfo.lastPage) {
 				validated = this.wizardView ? await this.wizardView.validate(pageInfo) : false;
 			}
 			if (validated && pageInfo.newPage === undefined) {


### PR DESCRIPTION
Fixing a bug with validate was not called for the last page causing import for invalid model

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
