### PR TITLE
Fix data workspace vscode telemetry

### DIFF
--- a/extensions/data-workspace/src/common/utils.ts
+++ b/extensions/data-workspace/src/common/utils.ts
@@ -40,15 +40,23 @@ export interface IPackageInfo {
 }
 
 export function getPackageInfo(packageJson: any): IPackageInfo | undefined {
-	if (packageJson) {
-		return {
-			name: packageJson.name,
-			version: packageJson.version,
-			aiKey: packageJson.aiKey
-		};
+	const vscodePackageJson = require('../../package.vscode.json');
+	const azdataApi = getAzdataApi();
+
+	if (!packageJson || !azdataApi && !vscodePackageJson) {
+		return undefined;
 	}
 
-	return undefined;
+	// When the extension is compiled and packaged, the content of package.json get copied here in the extension.js. This happens before the
+	// package.vscode.json values replace the corresponding values in the package.json for the data-workspace-vscode extension
+	// so we need to read these values directly from the package.vscode.json to get the correct extension and publisher names
+	const extensionName = azdataApi ? packageJson.name : vscodePackageJson.name;
+
+	return {
+		name: extensionName,
+		version: packageJson.version,
+		aiKey: packageJson.aiKey
+	};
 }
 
 // Try to load the azdata API - but gracefully handle the failure in case we're running

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -342,7 +342,6 @@ export async function getDefaultPublishDeploymentOptions(project: Project): Prom
 
 export interface IPackageInfo {
 	name: string;
-	fullName: string;
 	version: string;
 	aiKey: string;
 }
@@ -363,11 +362,9 @@ export function getPackageInfo(packageJson?: any): IPackageInfo | undefined {
 	// package.vscode.json values replace the corresponding values in the package.json for the sql-database-projects-vscode extension
 	// so we need to read these values directly from the package.vscode.json to get the correct extension and publisher names
 	const extensionName = azdataApi ? packageJson.name : vscodePackageJson.name;
-	const publisher = azdataApi ? packageJson.publisher : vscodePackageJson.publisher;
 
 	return {
 		name: extensionName,
-		fullName: `${publisher}.${extensionName}`,
 		version: packageJson.version,
 		aiKey: packageJson.aiKey
 	};


### PR DESCRIPTION
Finally got around to fixing and verifying sending the correct extension name with the data workspace vscode extension's telemetry. Similar to the fix done in https://github.com/microsoft/azuredatastudio/pull/19645. 

I also noticed the fullName in IPackageInfo in the sql database projects extension was never getting used, so removing that to clean up.