### PR TITLE
disable publish profile input box

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -515,7 +515,8 @@ export class PublishDatabaseDialog {
 		this.loadProfileTextBox = view.modelBuilder.inputBox().withProps({
 			placeHolder: constants.loadProfilePlaceholderText,
 			ariaLabel: constants.profile,
-			width: cssStyles.publishDialogTextboxWidth
+			width: cssStyles.publishDialogTextboxWidth,
+			enabled: false
 		}).component();
 
 		const profileLabel = view.modelBuilder.text().withProps({


### PR DESCRIPTION
As discussed today, this input box shouldn't be editable since the folder button needs to be used to load a profile and  nothing actually happens when the text in this input box is changed.

without loaded profile:
![image](https://user-images.githubusercontent.com/31145923/174679268-d4be6ebd-4775-4696-ab86-46ec390bd9e1.png)

with loaded profile:
![image](https://user-images.githubusercontent.com/31145923/174679278-7e07e7c8-9e06-405b-beb8-ee98a03e910a.png)

