### PR TITLE
designer table improvements

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/buttonColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/buttonColumn.plugin.ts
@@ -45,7 +45,8 @@ export class ButtonColumn<T extends Slick.SlickData> extends BaseClickableColumn
 			name: this.options.name,
 			toolTip: this.options.title,
 			resizable: this.options.resizable,
-			selectable: false
+			selectable: false,
+			cssClass: 'slick-plugin-button-cell'
 		};
 	}
 }

--- a/src/sql/base/browser/ui/table/plugins/media/buttonColumn.plugin.css
+++ b/src/sql/base/browser/ui/table/plugins/media/buttonColumn.plugin.css
@@ -7,9 +7,7 @@
 	cursor: pointer;
 	height: 100%;
 	text-align: center;
-	padding-right: 0px;
-	padding-top: 0px;
-	padding-bottom: 0px;
+	padding: 0px;
 }
 
 .slick-plugin-button:disabled {
@@ -31,4 +29,8 @@
 .slick-plugin-button.slick-plugin-image-only-button {
 	border-width: 0px;
 	background-color: transparent;
+}
+
+.slick-plugin-button-cell {
+	text-align: center;
 }

--- a/src/sql/workbench/browser/designer/designer.ts
+++ b/src/sql/workbench/browser/designer/designer.ts
@@ -16,7 +16,7 @@ import { Orientation, Sizing, SplitView } from 'vs/base/browser/ui/splitview/spl
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { IInputBoxStyles, InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import 'vs/css!./media/designer';
-import { ITableMouseEvent, ITableStyles } from 'sql/base/browser/ui/table/interfaces';
+import { ITableStyles } from 'sql/base/browser/ui/table/interfaces';
 import { IThemable } from 'vs/base/common/styler';
 import { Checkbox, ICheckboxStyles } from 'sql/base/browser/ui/checkbox/checkbox';
 import { Table } from 'sql/base/browser/ui/table/table';
@@ -850,21 +850,15 @@ export class Designer extends Disposable implements IThemable {
 					this._actionsMap.get(taskbar).map(a => a.table = table);
 				}
 				const columns: Slick.Column<Slick.SlickData>[] = [];
-				if (tableProperties.canInsertRows || tableProperties.canMoveRows) {
-					// Add move context menu actions
-					this._register(table.onContextMenu((e) => {
-						this.openContextMenu(table, e, propertyPath, view, tableProperties);
-					}));
-				}
 				if (tableProperties.canMoveRows) {
 					// Add row move drag and drop
 					const moveRowsPlugin = new RowMoveManager({
 						cancelEditOnDrag: true,
 						id: 'moveRow',
 						iconCssClass: Codicon.grabber.classNames,
-						title: localize('designer.moveRowText', 'Move Row'),
-						width: 20,
-						resizable: false,
+						name: localize('designer.moveRowText', 'Move'),
+						width: 50,
+						resizable: true,
 						isFontIcon: true,
 						behavior: 'selectAndMove'
 					});
@@ -928,12 +922,14 @@ export class Designer extends Disposable implements IThemable {
 					}
 				}));
 				if (tableProperties.canRemoveRows) {
+					const removeText = localize('designer.removeRowText', "Remove");
 					const deleteRowColumn = new ButtonColumn({
 						id: 'deleteRow',
 						iconCssClass: Codicon.trash.classNames,
-						title: localize('designer.removeRowText', "Remove"),
-						width: 20,
-						resizable: false,
+						name: removeText,
+						title: removeText,
+						width: 60,
+						resizable: true,
 						isFontIcon: true,
 						enabledField: CanBeDeletedProperty
 					});
@@ -956,6 +952,27 @@ export class Designer extends Disposable implements IThemable {
 					});
 					table.registerPlugin(deleteRowColumn);
 					columns.push(deleteRowColumn.definition);
+				}
+				if (tableProperties.canInsertRows || tableProperties.canMoveRows) {
+					const moreActionsText = localize('designer.actions', "More Actions");
+					const actionsColumn = new ButtonColumn({
+						id: 'actions',
+						iconCssClass: Codicon.ellipsis.classNames,
+						name: moreActionsText,
+						title: moreActionsText,
+						width: 100,
+						resizable: true,
+						isFontIcon: true
+					});
+					this._register(actionsColumn.onClick(async (e) => {
+						this.openContextMenu(table, e.row, e.position, propertyPath, view, tableProperties);
+					}));
+					table.registerPlugin(actionsColumn);
+					columns.push(actionsColumn.definition);
+					// Add move context menu actions
+					this._register(table.onContextMenu((e) => {
+						this.openContextMenu(table, e.cell.row, e.anchor, propertyPath, view, tableProperties);
+					}));
 				}
 				table.columns = columns;
 				table.grid.onBeforeEditCell.subscribe((e, data): boolean => {
@@ -1029,12 +1046,12 @@ export class Designer extends Disposable implements IThemable {
 
 	private openContextMenu(
 		table: Table<Slick.SlickData>,
-		event: ITableMouseEvent,
+		rowIndex: number,
+		anchor: HTMLElement | { x: number, y: number },
 		propertyPath: DesignerPropertyPath,
 		view: DesignerUIArea,
 		tableProperties: DesignerTableProperties
 	): void {
-		const rowIndex = event.cell.row;
 		const tableActionContext: DesignerTableActionContext = {
 			table: table,
 			path: propertyPath,
@@ -1053,7 +1070,7 @@ export class Designer extends Disposable implements IThemable {
 			}
 		});
 		this._contextMenuService.showContextMenu({
-			getAnchor: () => event.anchor,
+			getAnchor: () => anchor,
 			getActions: () => actions,
 			getActionsContext: () => (tableActionContext)
 		});

--- a/src/sql/workbench/browser/designer/designer.ts
+++ b/src/sql/workbench/browser/designer/designer.ts
@@ -964,7 +964,7 @@ export class Designer extends Disposable implements IThemable {
 						resizable: true,
 						isFontIcon: true
 					});
-					this._register(actionsColumn.onClick(async (e) => {
+					this._register(actionsColumn.onClick((e) => {
 						this.openContextMenu(table, e.row, e.position, propertyPath, view, tableProperties);
 					}));
 					table.registerPlugin(actionsColumn);


### PR DESCRIPTION
#19562

1. set header text for action columns
2. add a new column to make the row's context menu easier to access, previously user can use the context menu key to open the menu, but on certain cells, it is not possible, because the cell will enter edit mode and the context menu will be for the text editor.

before:
![image](https://user-images.githubusercontent.com/13777222/174687581-05ec9536-c548-4278-97f3-596a1956256d.png)


after:
![image](https://user-images.githubusercontent.com/13777222/174687288-3093e101-b3aa-4562-87ac-92f875eef317.png)

this PR fixes #19329 