### PR TITLE
Add telemetry for schema compare and sql database projects options dialogs

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -10,6 +10,7 @@ import * as loc from '../localizedConstants';
 import { SchemaCompareMainWindow } from '../schemaCompareMainWindow';
 import { isNullOrUndefined } from 'util';
 import { SchemaCompareOptionsModel } from '../models/schemaCompareOptionsModel';
+import { TelemetryReporter, TelemetryViews } from '../telemetry';
 
 export class SchemaCompareOptionsDialog {
 	public dialog: azdata.window.Dialog;
@@ -82,7 +83,10 @@ export class SchemaCompareOptionsDialog {
 					this.schemaComparison.startCompare();
 				}
 			});
+
+			TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareOptionsDialog, 'OptionsChanged').send();
 		}
+
 		this.disposeListeners();
 	}
 
@@ -106,6 +110,8 @@ export class SchemaCompareOptionsDialog {
 		await this.updateObjectsTable();
 		this.objectTypesFlexBuilder.removeItem(this.objectsTable);
 		this.objectTypesFlexBuilder.addItem(this.objectsTable, { CSSStyles: { 'overflow': 'scroll', 'height': '80vh' } });
+
+		TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareOptionsDialog, 'ResetOptions').send();
 	}
 
 	private initializeSchemaCompareOptionsDialogTab(): void {

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -84,7 +84,7 @@ export class SchemaCompareOptionsDialog {
 				}
 			});
 
-			TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareOptionsDialog, 'OptionsChanged').send();
+			TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareOptionsDialog, 'OptionsChanged');
 		}
 
 		this.disposeListeners();
@@ -111,7 +111,7 @@ export class SchemaCompareOptionsDialog {
 		this.objectTypesFlexBuilder.removeItem(this.objectsTable);
 		this.objectTypesFlexBuilder.addItem(this.objectsTable, { CSSStyles: { 'overflow': 'scroll', 'height': '80vh' } });
 
-		TelemetryReporter.createActionEvent(TelemetryViews.SchemaCompareOptionsDialog, 'ResetOptions').send();
+		TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareOptionsDialog, 'ResetOptions');
 	}
 
 	private initializeSchemaCompareOptionsDialogTab(): void {

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -53,7 +53,7 @@ export class SchemaCompareMainWindow {
 	protected comparisonResult: mssql.SchemaCompareResult;
 	private sourceNameComponent: azdata.InputBoxComponent;
 	private targetNameComponent: azdata.InputBoxComponent;
-	public deploymentOptions: mssql.DeploymentOptions;
+	private deploymentOptions: mssql.DeploymentOptions;
 	private schemaCompareOptionDialog: SchemaCompareOptionsDialog;
 	private tablelistenersToDispose: vscode.Disposable[] = [];
 	private originalSourceExcludes = new Map<string, mssql.DiffEntry>();

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -53,7 +53,7 @@ export class SchemaCompareMainWindow {
 	protected comparisonResult: mssql.SchemaCompareResult;
 	private sourceNameComponent: azdata.InputBoxComponent;
 	private targetNameComponent: azdata.InputBoxComponent;
-	private deploymentOptions: mssql.DeploymentOptions;
+	public deploymentOptions: mssql.DeploymentOptions;
 	private schemaCompareOptionDialog: SchemaCompareOptionsDialog;
 	private tablelistenersToDispose: vscode.Disposable[] = [];
 	private originalSourceExcludes = new Map<string, mssql.DiffEntry>();

--- a/extensions/schema-compare/src/telemetry.ts
+++ b/extensions/schema-compare/src/telemetry.ts
@@ -15,5 +15,6 @@ export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, pack
 
 export enum TelemetryViews {
 	SchemaCompareMainWindow = 'SchemaCompareMainWindow',
-	SchemaCompareDialog = 'SchemaCompareDialog'
+	SchemaCompareDialog = 'SchemaCompareDialog',
+	SchemaCompareOptionsDialog = 'SchemaCompareOptionsDialog'
 }

--- a/extensions/sql-database-projects/src/common/telemetry.ts
+++ b/extensions/sql-database-projects/src/common/telemetry.ts
@@ -16,6 +16,7 @@ export enum TelemetryViews {
 	ProjectController = 'ProjectController',
 	SqlProjectPublishDialog = 'SqlProjectPublishDialog',
 	ProjectTree = 'ProjectTree',
+	PublishOptionsDialog = 'PublishOptionsDialog'
 }
 
 export enum TelemetryActions {
@@ -41,5 +42,7 @@ export enum TelemetryActions {
 	publishToContainer = 'publishToContainer',
 	publishToNewAzureServer = 'publishToNewAzureServer',
 	generateProjectFromOpenApiSpec = 'generateProjectFromOpenApiSpec',
-	publishConfigureOptionsClicked = 'PublishConfigureOptionsClicked'
+	publishOptionsOpened = 'publishOptionsOpened',
+	resetOptions = 'resetOptions',
+	optionsChanged = 'optionsChanged'
 }

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -916,7 +916,7 @@ export class PublishDatabaseDialog {
 		const optionsRow = view.modelBuilder.flexContainer().withItems([this.optionsButton], { CSSStyles: { flex: '0 0 auto', 'margin': '6px 0 0 287px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
 
 		this.toDispose.push(this.optionsButton.onDidClick(async () => {
-			TelemetryReporter.sendActionEvent(TelemetryViews.SqlProjectPublishDialog, TelemetryActions.publishConfigureOptionsClicked);
+			TelemetryReporter.sendActionEvent(TelemetryViews.SqlProjectPublishDialog, TelemetryActions.publishOptionsOpened);
 			// Create fresh options dialog with default selections each time when creating the 'configure options' button
 			this.publishOptionsDialog = new PublishOptionsDialog(this.deploymentOptions!, this);
 			this.publishOptionsDialog.openDialog();

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -10,6 +10,7 @@ import * as utils from '../common/utils';
 import type * as azdataType from 'azdata';
 import { PublishDatabaseDialog } from './publishDatabaseDialog';
 import { DeployOptionsModel } from '../models/options/deployOptionsModel';
+import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
 
 export class PublishOptionsDialog {
 
@@ -21,6 +22,7 @@ export class PublishOptionsDialog {
 	private optionsTable: azdataType.TableComponent | undefined;
 	public optionsModel: DeployOptionsModel;
 	private optionsFlexBuilder: azdataType.FlexContainer | undefined;
+	private optionsChanged: boolean = false;
 
 	constructor(defaultOptions: mssql.DeploymentOptions, private publish: PublishDatabaseDialog) {
 		this.optionsModel = new DeployOptionsModel(defaultOptions);
@@ -85,6 +87,7 @@ export class PublishOptionsDialog {
 				if (checkboxState && checkboxState.row !== undefined) {
 					const label = this.optionsModel.optionsLabels[checkboxState.row];
 					this.optionsModel.optionsLookup[label] = checkboxState.checked;
+					this.optionsChanged = true;
 				}
 			}));
 
@@ -137,6 +140,10 @@ export class PublishOptionsDialog {
 		this.optionsModel.setDeploymentOptions();
 		this.publish.setDeploymentOptions(this.optionsModel.deploymentOptions);
 		this.disposeListeners();
+
+		if (this.optionsChanged) {
+			TelemetryReporter.createActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.optionsChanged).send();
+		}
 	}
 
 	/*
@@ -159,6 +166,8 @@ export class PublishOptionsDialog {
 		await this.updateOptionsTable();
 		this.optionsFlexBuilder?.removeItem(this.optionsTable!);
 		this.optionsFlexBuilder?.insertItem(this.optionsTable!, 0, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh' } });
+
+		TelemetryReporter.createActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.resetOptions).send();
 	}
 
 	private disposeListeners(): void {

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -142,7 +142,7 @@ export class PublishOptionsDialog {
 		this.disposeListeners();
 
 		if (this.optionsChanged) {
-			TelemetryReporter.createActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.optionsChanged).send();
+			TelemetryReporter.sendActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.optionsChanged);
 		}
 	}
 
@@ -167,7 +167,7 @@ export class PublishOptionsDialog {
 		this.optionsFlexBuilder?.removeItem(this.optionsTable!);
 		this.optionsFlexBuilder?.insertItem(this.optionsTable!, 0, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh' } });
 
-		TelemetryReporter.createActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.resetOptions).send();
+		TelemetryReporter.sendActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.resetOptions);
 	}
 
 	private disposeListeners(): void {


### PR DESCRIPTION
Previously, there was only telemetry for when the options dialogs were opened. This adds telemetry in these two extensions for when:
- options are reset
- user changes at least one option and clicks "Ok"
