### PR TITLE
check state before saving

### DIFF
--- a/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
+++ b/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
@@ -183,6 +183,9 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 	}
 
 	async save(): Promise<void> {
+		if (!this.isDirty()) {
+			return;
+		}
 		if (this.tableDesignerView?.useAdvancedSaveMode) {
 			await this.openPublishDialog();
 		} else {


### PR DESCRIPTION
This PR fixes #19285

the save button is disabled when there are no changes, but CTRL+S can still trigger the save action. 
