### PR TITLE
Add telemetry for what users have in publish profile

### DIFF
--- a/extensions/sql-database-projects/src/common/telemetry.ts
+++ b/extensions/sql-database-projects/src/common/telemetry.ts
@@ -44,5 +44,6 @@ export enum TelemetryActions {
 	generateProjectFromOpenApiSpec = 'generateProjectFromOpenApiSpec',
 	publishOptionsOpened = 'publishOptionsOpened',
 	resetOptions = 'resetOptions',
-	optionsChanged = 'optionsChanged'
+	optionsChanged = 'optionsChanged',
+	profileLoaded = 'profileLoaded'
 }

--- a/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
+++ b/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
@@ -59,7 +59,7 @@ export async function load(profileUri: vscode.Uri, dacfxService: utils.IDacFxSer
 	TelemetryReporter.createActionEvent(TelemetryViews.SqlProjectPublishDialog, TelemetryActions.profileLoaded)
 		.withAdditionalProperties({
 			hasTargetDbName: (targetDbName !== '').toString(),
-			hasConnectionString: (profileXmlDoc.documentElement.getElementsByTagName(constants.targetConnectionString).length > 0).toString(),
+			hasConnectionString: (connectionInfo.connectionId !== '').toString(),
 			hasSqlCmdVariables: (Object.keys(sqlCmdVariables).length > 0).toString()
 		}).send();
 

--- a/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
+++ b/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
@@ -58,8 +58,8 @@ export async function load(profileUri: vscode.Uri, dacfxService: utils.IDacFxSer
 
 	TelemetryReporter.createActionEvent(TelemetryViews.SqlProjectPublishDialog, TelemetryActions.profileLoaded)
 		.withAdditionalProperties({
-			hasTargetDbName: (targetDbName !== '').toString(),
-			hasConnectionString: (connectionInfo.connectionId !== '').toString(),
+			hasTargetDbName: (!!targetDbName).toString(),
+			hasConnectionString: (!!connectionInfo?.connectionId).toString(),
 			hasSqlCmdVariables: (Object.keys(sqlCmdVariables).length > 0).toString()
 		}).send();
 

--- a/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
+++ b/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
@@ -12,6 +12,7 @@ import * as vscode from 'vscode';
 
 import { promises as fs } from 'fs';
 import { SqlConnectionDataSource } from '../dataSources/sqlConnectionStringSource';
+import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../../common/telemetry';
 
 // only reading db name, connection string, and SQLCMD vars from profile for now
 export interface PublishProfile {
@@ -54,6 +55,13 @@ export async function load(profileUri: vscode.Uri, dacfxService: utils.IDacFxSer
 
 	// get all SQLCMD variables to include from the profile
 	const sqlCmdVariables = utils.readSqlCmdVariables(profileXmlDoc, true);
+
+	TelemetryReporter.createActionEvent(TelemetryViews.SqlProjectPublishDialog, TelemetryActions.profileLoaded)
+		.withAdditionalProperties({
+			hasTargetDbName: (targetDbName !== '').toString(),
+			hasConnectionString: (profileXmlDoc.documentElement.getElementsByTagName(constants.targetConnectionString).length > 0).toString(),
+			hasSqlCmdVariables: (Object.keys(sqlCmdVariables).length > 0).toString()
+		}).send();
 
 	return {
 		databaseName: targetDbName,


### PR DESCRIPTION
Currently we only have telemetry for if a profile has been loaded when a publish or generate script happens. This adds another event for when a profile gets loaded to get more information on what users are using the profile for.

Publish options get parsed and returned from the STS `dacfxService.getOptionsFromProfile()` call, so we'd have to add logic there to return if there are any publish options specified in the publish profile. When SSDT creates a new profile, IncludeCompositeObjects set to true is added by default to override the default, so almost all publish profiles will have at least this option specified.