### PR TITLE
Attempt to Fix Unstable Notebooks Tests

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -709,7 +709,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 
 	getUntitledNotebookUri(resource: string): vscode.Uri {
 		let untitledFileName = vscode.Uri.parse(`untitled:${resource}`);
-		if (!this.currentBook.getAllNotebooks().get(untitledFileName.fsPath) && !this.currentBook.getAllNotebooks().get(path.basename(untitledFileName.fsPath))) {
+		if (this.currentBook && !this.currentBook.getAllNotebooks().get(untitledFileName.fsPath) && !this.currentBook.getAllNotebooks().get(path.basename(untitledFileName.fsPath))) {
 			let notebook = this.currentBook.getAllNotebooks().get(resource);
 			this.currentBook.getAllNotebooks().set(path.basename(untitledFileName.fsPath), notebook);
 		}


### PR DESCRIPTION
Fixes #19222.

Attempting to fix the always-failing "unstable" tests.

Turned on exceptions, and got the `cannot read property 'getAllNotebooks' of undefined` message, indicating that `currentBook` wasn't set in this case.

Just adding a quick check against this appears to allow these tests to pass again. This should be safe because all that it does is prevent this exception from being thrown in product code.

Will continue looking at unstable tests over the next few weeks to see how unstable they really are. 