### PR TITLE
Switch query events to just send ranges instead of full query text

### DIFF
--- a/extensions/query-history/src/queryHistoryProvider.ts
+++ b/extensions/query-history/src/queryHistoryProvider.ts
@@ -27,6 +27,8 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 			onQueryEvent: async (type: azdata.queryeditor.QueryEventType, document: azdata.queryeditor.QueryDocument, args: azdata.ResultSetSummary | string | undefined, queryInfo?: azdata.queryeditor.QueryInfo) => {
 				if (this._captureEnabled && queryInfo && type === 'queryStop') {
 					const textDocuments = vscode.workspace.textDocuments;
+					// We need to compare URIs, but the event Uri comes in as string so while it should be in the same format as
+					// the textDocument uri.toString() we parse it into a vscode.Uri first to be absolutely sure.
 					const textDocument = textDocuments.find(e => e.uri.toString() === vscode.Uri.parse(document.uri).toString());
 					if (!textDocument) {
 						// If we couldn't find the document then we can't get the text so just log the error and move on
@@ -34,7 +36,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 						return;
 					}
 					// Combine all the text from the batches back together
-					const queryText = queryInfo.range.map(r => textDocument?.getText(r) ?? '').join(EOL);
+					const queryText = queryInfo.range.map(r => textDocument.getText(r) ?? '').join(EOL);
 					const connProfile = await azdata.connection.getConnection(document.uri);
 					const isError = queryInfo.messages.find(m => m.isError) ? false : true;
 					// Add to the front of the list so the new item appears at the top

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -5014,31 +5014,20 @@ declare module 'azdata' {
 			onQueryEvent(type: QueryEventType, document: QueryDocument, args: ResultSetSummary | string | undefined): void;
 		}
 
+		// new extensibility interfaces
 		export interface QueryDocument {
-			/**
-			 * The ID of the connection provider for this query document
-			 */
 			providerId: string;
 
-			/**
-			 * The URI identifying this document
-			 */
 			uri: string;
 
-			/**
-			 * Set the document's execution options, which will be used whenever a query is executed.
-			 * @param options The execution options
-			 */
+			// set the document's execution options
 			setExecutionOptions(options: Map<string, any>): Thenable<void>;
 
 			// tab content is build using the modelview UI builder APIs
 			// probably should rename DialogTab class since it is useful outside dialogs
 			createQueryTab(tab: window.DialogTab): void;
 
-			/**
-			 * Connect the query document using the given connection profile
-			 * @param connectionProfile The profile to use as the connection
-			 */
+			// connect the query document using the given connection profile
 			connect(connectionProfile: connection.ConnectionProfile): Thenable<void>;
 		}
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -5014,20 +5014,31 @@ declare module 'azdata' {
 			onQueryEvent(type: QueryEventType, document: QueryDocument, args: ResultSetSummary | string | undefined): void;
 		}
 
-		// new extensibility interfaces
 		export interface QueryDocument {
+			/**
+			 * The ID of the connection provider for this query document
+			 */
 			providerId: string;
 
+			/**
+			 * The URI identifying this document
+			 */
 			uri: string;
 
-			// set the document's execution options
+			/**
+			 * Set the document's execution options, which will be used whenever a query is executed.
+			 * @param options The execution options
+			 */
 			setExecutionOptions(options: Map<string, any>): Thenable<void>;
 
 			// tab content is build using the modelview UI builder APIs
 			// probably should rename DialogTab class since it is useful outside dialogs
 			createQueryTab(tab: window.DialogTab): void;
 
-			// connect the query document using the given connection profile
+			/**
+			 * Connect the query document using the given connection profile
+			 * @param connectionProfile The profile to use as the connection
+			 */
 			connect(connectionProfile: connection.ConnectionProfile): Thenable<void>;
 		}
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1542,7 +1542,7 @@ declare module 'azdata' {
 	}
 	export namespace queryeditor {
 
-		export interface IQueryMessage {
+		export interface QueryMessage {
 			/**
 			 * The message string
 			 */
@@ -1560,15 +1560,15 @@ declare module 'azdata' {
 		/**
 		 * Information about a query that was executed
 		 */
-		export interface IQueryInfo {
+		export interface QueryInfo {
 			/**
 			 * Any messages that have been received from the query provider
 			 */
-			messages: IQueryMessage[];
+			messages: QueryMessage[];
 			/**
-			 * The text of the query statement
+			 * The ranges for each batch that has executed so far
 			 */
-			queryText?: string;
+			range: vscode.Range[];
 		}
 
 		export interface QueryEventListener {
@@ -1584,7 +1584,7 @@ declare module 'azdata' {
 			 * visualize: ResultSetSummary (the result set to be visualized)
 			 * @param queryInfo The information about the query that triggered this event
 			 */
-			onQueryEvent(type: QueryEventType, document: QueryDocument, args: ResultSetSummary | string | undefined, queryInfo: IQueryInfo): void;
+			onQueryEvent(type: QueryEventType, document: QueryDocument, args: ResultSetSummary | string | undefined, queryInfo: QueryInfo): void;
 		}
 	}
 }

--- a/src/sql/workbench/api/common/extHostQueryEditor.ts
+++ b/src/sql/workbench/api/common/extHostQueryEditor.ts
@@ -9,7 +9,8 @@ import * as azdata from 'azdata';
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { Disposable } from 'vs/workbench/api/common/extHostTypes';
 import { URI } from 'vs/base/common/uri';
-import { IExtHostQueryEvent } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { IQueryEvent } from 'sql/workbench/services/query/common/queryModel';
+import * as sqlTypeConverters from 'sql/workbench/api/common/sqlExtHostTypeConverters';
 
 class ExtHostQueryDocument implements azdata.queryeditor.QueryDocument {
 	constructor(
@@ -64,11 +65,11 @@ export class ExtHostQueryEditor implements ExtHostQueryEditorShape {
 		});
 	}
 
-	public $onQueryEvent(providerId: string, handle: number, fileUri: string, event: IExtHostQueryEvent): void {
+	public $onQueryEvent(providerId: string, handle: number, fileUri: string, event: IQueryEvent): void {
 		let listener: azdata.queryeditor.QueryEventListener = this._queryListeners[handle];
 		if (listener) {
 			let params = event.params && event.params.planXml ? event.params.planXml : event.params;
-			listener.onQueryEvent(event.type, new ExtHostQueryDocument(providerId, fileUri, this._proxy), params, event.queryInfo);
+			listener.onQueryEvent(event.type, new ExtHostQueryDocument(providerId, fileUri, this._proxy), params, sqlTypeConverters.QueryInfo.to(event.queryInfo));
 		}
 	}
 

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -23,14 +23,14 @@ import {
 	IModelViewWizardDetails, IModelViewWizardPageDetails, IExecuteManagerDetails, INotebookSessionDetails,
 	INotebookKernelDetails, INotebookFutureDetails, FutureMessageType, INotebookFutureDone, INotebookEditOperation,
 	NotebookChangeKind,
-	ISerializationManagerDetails,
-	IExtHostQueryEvent
+	ISerializationManagerDetails
 } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IUndoStopOptions } from 'vs/workbench/api/common/extHost.protocol';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { EditorViewColumn } from 'vs/workbench/api/common/shared/editor';
 import { TreeDataTransferDTO } from 'vs/workbench/api/common/shared/treeDataTransfer';
 import { ITelemetryEventProperties } from 'sql/platform/telemetry/common/telemetry';
+import { IQueryEvent } from 'sql/workbench/services/query/common/queryModel';
 
 export abstract class ExtHostAzureBlobShape {
 	public $createSas(connectionUri: string, blobContainerUri: string, blobStorageKey: string, storageAccountName: string, expirationDate: string): Thenable<mssql.CreateSasResponse> { throw ni(); }
@@ -921,7 +921,7 @@ export interface MainThreadModelViewDialogShape extends IDisposable {
 	$setDirty(handle: number, isDirty: boolean): void;
 }
 export interface ExtHostQueryEditorShape {
-	$onQueryEvent(providerId: string, handle: number, fileUri: string, event: IExtHostQueryEvent): void;
+	$onQueryEvent(providerId: string, handle: number, fileUri: string, event: IQueryEvent): void;
 }
 
 export interface MainThreadQueryEditorShape extends IDisposable {

--- a/src/sql/workbench/api/common/sqlExtHostTypeConverters.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypeConverters.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as azdata from 'azdata';
+import { IQueryInfo } from 'sql/workbench/services/query/common/queryModel';
+import * as typeConverters from 'vs/workbench/api/common/extHostTypeConverters';
+
+export namespace QueryInfo {
+
+	export function to(queryInfo: IQueryInfo | undefined): azdata.queryeditor.QueryInfo | undefined {
+		if (!queryInfo) {
+			return undefined;
+		}
+		return {
+			messages: queryInfo.messages,
+			range: queryInfo.range.map(r => typeConverters.Range.to(r))
+		};
+	}
+}

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -1057,14 +1057,3 @@ export namespace executionPlan {
 		None = 4
 	}
 }
-
-/**
- * Query event info to send to the extension host. This is a separate type from IQueryEvent
- * since this has the query text ranges converted into the actual query text.
- */
-export interface IExtHostQueryEvent {
-	type: azdata.queryeditor.QueryEventType;
-	uri: string;
-	queryInfo: azdata.queryeditor.IQueryInfo;
-	params?: any;
-}

--- a/src/sql/workbench/services/query/common/queryModelService.ts
+++ b/src/sql/workbench/services/query/common/queryModelService.ts
@@ -35,23 +35,23 @@ export interface QueryEvent {
 export class QueryInfo {
 	public queryRunner?: EditQueryRunner;
 	public dataService?: DataService;
-	public queryEventQueue?: QueryEvent[];
-	public range?: Array<IRange>;
+	public queryEventQueue: QueryEvent[] = [];
+	public range: Array<IRange> = [];
 	public selectionSnippet?: string;
 
 	// Notes if the angular components have obtained the DataService. If not, all messages sent
 	// via the data service will be lost.
-	public dataServiceReady?: boolean;
+	public dataServiceReady?: boolean = false;
 
-	constructor() {
-		this.dataServiceReady = false;
-		this.queryEventQueue = [];
-		this.range = [];
-	}
+	constructor() { }
 
 	public set uri(newUri: string) {
-		this.queryRunner.uri = newUri;
-		this.dataService.uri = newUri;
+		if (this.queryRunner) {
+			this.queryRunner.uri = newUri;
+		}
+		if (this.dataService) {
+			this.dataService.uri = newUri;
+		}
 	}
 }
 
@@ -271,7 +271,7 @@ export class QueryModelService implements IQueryModelService {
 						text: strings.format(nls.localize('runQueryBatchStartLine', "Line {0}"), b.range.startLineNumber)
 					};
 				}
-				info.range!.push(b.range);
+				info.range.push(b.range);
 			}
 			let message = {
 				message: messageText,
@@ -293,7 +293,7 @@ export class QueryModelService implements IQueryModelService {
 				uri: queryRunner.uri,
 				queryInfo:
 				{
-					range: info.range!,
+					range: info.range,
 					messages: info.queryRunner!.messages
 				}
 			};
@@ -311,7 +311,7 @@ export class QueryModelService implements IQueryModelService {
 				uri: queryRunner.uri,
 				queryInfo:
 				{
-					range: info.range!,
+					range: info.range,
 					messages: info.queryRunner!.messages
 				}
 			};
@@ -327,7 +327,7 @@ export class QueryModelService implements IQueryModelService {
 				uri: queryRunner.uri,
 				queryInfo:
 				{
-					range: info.range!,
+					range: info.range,
 					messages: info.queryRunner!.messages
 				}
 			};
@@ -343,7 +343,7 @@ export class QueryModelService implements IQueryModelService {
 				uri: planInfo.fileUri,
 				queryInfo:
 				{
-					range: info.range!,
+					range: info.range,
 					messages: info.queryRunner!.messages
 				},
 				params: planInfo
@@ -358,7 +358,7 @@ export class QueryModelService implements IQueryModelService {
 				uri: qp2Info.fileUri,
 				queryInfo:
 				{
-					range: info.range!,
+					range: info.range,
 					messages: info.queryRunner!.messages
 				},
 				params: qp2Info.planGraphs
@@ -372,7 +372,7 @@ export class QueryModelService implements IQueryModelService {
 				uri: queryRunner.uri,
 				queryInfo:
 				{
-					range: info.range!,
+					range: info.range,
 					messages: info.queryRunner!.messages
 				},
 				params: resultSetInfo
@@ -514,7 +514,7 @@ export class QueryModelService implements IQueryModelService {
 					uri: ownerUri,
 					queryInfo:
 					{
-						range: info.range!,
+						range: info.range,
 						messages: info.queryRunner!.messages
 					},
 				};
@@ -531,7 +531,7 @@ export class QueryModelService implements IQueryModelService {
 					uri: ownerUri,
 					queryInfo:
 					{
-						range: info.range!,
+						range: info.range,
 						messages: info.queryRunner!.messages
 					},
 				};

--- a/src/sql/workbench/services/query/common/queryModelService.ts
+++ b/src/sql/workbench/services/query/common/queryModelService.ts
@@ -41,7 +41,7 @@ export class QueryInfo {
 
 	// Notes if the angular components have obtained the DataService. If not, all messages sent
 	// via the data service will be lost.
-	public dataServiceReady?: boolean = false;
+	public dataServiceReady: boolean = false;
 
 	constructor() { }
 


### PR DESCRIPTION
Sending over the entire query text each time has perf implications - and it turns out there's no need for this since the extension can just get the text from the range directly. The extension host keeps its own copy of the text documents locally so it doesn't have go ever go outside of the process when doing it this way. This allowed me to greatly simplify the event logic as well.

Note that there are still perf issues with executing queries for large documents (I started hitting issues in the 100MB range). But I didn't see any noticeable impact from having these events firing (even with query history enabled) compared to stable ADS.

- Changed IQueryInfo/IQueryMessage to just QueryInfo and QueryMessage to more align with how VS code extensibility names their types
- Fixed core logic typing for the range - it was defined as optional but there's currently no way it'll ever be undefined so removing that makes things a lot simpler
- Fixed the extension to properly handle batches - previously (and in current stable) I was only getting the first batch since I hadn't realized that the range array had multiple entries when there were batched executions

