### PR TITLE
Revert query-history version back to 0.2.0

### DIFF
--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -2,7 +2,7 @@
   "name": "query-history",
   "displayName": "%queryHistory.displayName%",
   "description": "%queryHistory.description%",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",


### PR DESCRIPTION
Didn't notice that this had already been bumped from what was listed in the gallery (0.1.0 currently). So reverting back to 0.2.0 until after the next version is released.
