### PR TITLE
Additional SQL Proj cleanup

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import * as fse from 'fs-extra';
 import { AzureSqlClient } from '../models/deploy/azureSqlClient';
 import { IAccount } from 'vscode-mssql';
-import { IDeploySettings, ILocalDbSetting, IPublishToDockerSettings, ISqlProject } from 'sqldbproj';
+import { ISqlProjectPublishSettings, IDockerSettings, IPublishToDockerSettings, ISqlProject } from 'sqldbproj';
 
 /**
  * Create flow for Deploying a database using only VS Code-native APIs such as QuickPick
@@ -252,7 +252,7 @@ export async function launchCreateAzureServerQuickPick(project: Project, azureSq
 		return undefined;
 	}
 
-	let settings: IDeploySettings | undefined = await getPublishDatabaseSettings(project, false);
+	let settings: ISqlProjectPublishSettings | undefined = await getPublishDatabaseSettings(project, false);
 
 	return {
 		// TODO add tenant
@@ -278,7 +278,7 @@ export async function launchCreateAzureServerQuickPick(project: Project, azureSq
 export async function getPublishToDockerSettings(project: ISqlProject): Promise<IPublishToDockerSettings | undefined> {
 	const target = project.getProjectTargetVersion();
 	const name = uiUtils.getPublishServerName(target);
-	let localDbSetting: ILocalDbSetting | undefined;
+	let localDbSetting: IDockerSettings | undefined;
 	// Deploy to docker selected
 	let portNumber = await vscode.window.showInputBox({
 		title: constants.enterPortNumber(name),
@@ -394,7 +394,7 @@ export async function getPublishToDockerSettings(project: ISqlProject): Promise<
 	localDbSetting.dbName = deploySettings.databaseName;
 
 	return {
-		localDbSetting: localDbSetting,
-		deploySettings: deploySettings,
+		dockerSettings: localDbSetting,
+		sqlProjectPublishSettings: deploySettings,
 	};
 }

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -17,7 +17,7 @@ import { getAgreementDisplayText, getConnectionName, getDockerBaseImages, getPub
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
 import { Deferred } from '../common/promise';
 import { PublishOptionsDialog } from './publishOptionsDialog';
-import { IDeploySettings, IPublishToDockerSettings } from 'sqldbproj';
+import { ISqlProjectPublishSettings, IPublishToDockerSettings } from 'sqldbproj';
 
 interface DataSourceDropdownValue extends azdataType.CategoryValue {
 	dataSource: SqlConnectionDataSource;
@@ -63,9 +63,9 @@ export class PublishDatabaseDialog {
 
 	private toDispose: vscode.Disposable[] = [];
 
-	public publish: ((proj: Project, profile: IDeploySettings) => any) | undefined;
+	public publish: ((proj: Project, profile: ISqlProjectPublishSettings) => any) | undefined;
 	public publishToContainer: ((proj: Project, profile: IPublishToDockerSettings) => any) | undefined;
-	public generateScript: ((proj: Project, profile: IDeploySettings) => any) | undefined;
+	public generateScript: ((proj: Project, profile: ISqlProjectPublishSettings) => any) | undefined;
 	public readPublishProfile: ((profileUri: vscode.Uri) => any) | undefined;
 
 	constructor(private project: Project) {
@@ -224,7 +224,7 @@ export class PublishDatabaseDialog {
 
 	public async publishClick(): Promise<void> {
 		if (this.existingServerSelected) {
-			const settings: IDeploySettings = {
+			const settings: ISqlProjectPublishSettings = {
 				databaseName: this.targetDatabaseName,
 				serverName: this.getServerName(),
 				connectionUri: await this.getConnectionUri(),
@@ -240,7 +240,7 @@ export class PublishDatabaseDialog {
 			const baseImages = getDockerBaseImages(this.project.getProjectTargetVersion());
 			const imageInfo = baseImages.find(x => x.name === dockerBaseImage);
 			const settings: IPublishToDockerSettings = {
-				localDbSetting: {
+				dockerSettings: {
 					dbName: this.targetDatabaseName,
 					dockerBaseImage: dockerBaseImage,
 					dockerBaseImageEula: imageInfo?.agreementInfo?.link?.url || '',
@@ -249,7 +249,7 @@ export class PublishDatabaseDialog {
 					serverName: constants.defaultLocalServerName,
 					userName: constants.defaultLocalServerAdminName
 				},
-				deploySettings: {
+				sqlProjectPublishSettings: {
 					databaseName: this.targetDatabaseName,
 					serverName: constants.defaultLocalServerName,
 					connectionUri: '',
@@ -270,7 +270,7 @@ export class PublishDatabaseDialog {
 		TelemetryReporter.sendActionEvent(TelemetryViews.SqlProjectPublishDialog, TelemetryActions.generateScriptClicked);
 
 		const sqlCmdVars = this.getSqlCmdVariablesForPublish();
-		const settings: IDeploySettings = {
+		const settings: ISqlProjectPublishSettings = {
 			databaseName: this.targetDatabaseName,
 			serverName: this.getServerName(),
 			connectionUri: await this.getConnectionUri(),

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -11,12 +11,12 @@ import { promptForPublishProfile } from './publishDatabaseDialog';
 import { getDefaultPublishDeploymentOptions, getVscodeMssqlApi } from '../common/utils';
 import { IConnectionInfo, IFireWallRuleError } from 'vscode-mssql';
 import { getPublishServerName } from './utils';
-import { IDeploySettings, ISqlProject, SqlTargetPlatform } from 'sqldbproj';
+import { ISqlProjectPublishSettings, ISqlProject, SqlTargetPlatform } from 'sqldbproj';
 
 /**
  * Create flow for Publishing a database using only VS Code-native APIs such as QuickPick
  */
-export async function getPublishDatabaseSettings(project: ISqlProject, promptForConnection: boolean = true): Promise<IDeploySettings | undefined> {
+export async function getPublishDatabaseSettings(project: ISqlProject, promptForConnection: boolean = true): Promise<ISqlProjectPublishSettings | undefined> {
 
 	// 1. Select publish settings file (optional)
 	// Create custom quickpick so we can control stuff like displaying the loading indicator
@@ -207,7 +207,7 @@ export async function getPublishDatabaseSettings(project: ISqlProject, promptFor
 	}
 
 	// 6. Generate script/publish
-	let settings: IDeploySettings = {
+	let settings: ISqlProjectPublishSettings = {
 		databaseName: databaseName,
 		serverName: connectionProfile?.server || '',
 		connectionUri: connectionUri || '',

--- a/extensions/sql-database-projects/src/models/deploy/deployProfile.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployProfile.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as azdataType from 'azdata';
-import { IDeploySettings, ISqlConnectionProperties } from 'sqldbproj';
+import { ISqlProjectPublishSettings, ISqlConnectionProperties } from 'sqldbproj';
 import { IAzureAccountSession } from 'vscode-mssql';
 
 export enum AppSettingType {
@@ -14,7 +14,7 @@ export enum AppSettingType {
 
 export interface ISqlDbDeployProfile {
 	sqlDbSetting?: ISqlDbSetting;
-	deploySettings?: IDeploySettings;
+	deploySettings?: ISqlProjectPublishSettings;
 }
 
 export interface IDeployAppIntegrationProfile {

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -25,7 +25,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 * Gets the project tree data provider
 	 * @param projectFilePath The project file Uri
 	 */
-	async getProjectTreeDataProvider(projectFilePath: vscode.Uri): Promise<vscode.TreeDataProvider<BaseProjectTreeItem>> {
+	public async getProjectTreeDataProvider(projectFilePath: vscode.Uri): Promise<vscode.TreeDataProvider<BaseProjectTreeItem>> {
 		const provider = new SqlDatabaseProjectTreeViewProvider();
 		const project = await Project.openProject(projectFilePath.fsPath);
 		provider.load([project]);
@@ -35,7 +35,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	/**
 	 * Gets the supported project types
 	 */
-	get supportedProjectTypes(): dataworkspace.IProjectType[] {
+	public get supportedProjectTypes(): dataworkspace.IProjectType[] {
 		return [
 			{
 				id: constants.emptyAzureDbSqlDatabaseProjectTypeId,
@@ -80,7 +80,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 * @param sdkStyle whether project is sdk-style. Default is false
 	 * @returns Uri of the newly created project file
 	 */
-	async createProject(name: string, location: vscode.Uri, projectTypeId: string, targetPlatform?: sqldbproj.SqlTargetPlatform, sdkStyle: boolean = false): Promise<vscode.Uri> {
+	public async createProject(name: string, location: vscode.Uri, projectTypeId: string, targetPlatform?: sqldbproj.SqlTargetPlatform, sdkStyle: boolean = false): Promise<vscode.Uri> {
 
 		if (!targetPlatform) {
 			const projectType = this.supportedProjectTypes.find(x => x.id === projectTypeId);
@@ -102,7 +102,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	/**
 	 * Opens and loads a .sqlproj file
 	 */
-	openProject(projectFilePath: string): Promise<sqldbproj.ISqlProject> {
+	public openProject(projectFilePath: string): Promise<sqldbproj.ISqlProject> {
 		return Project.openProject(projectFilePath);
 	}
 
@@ -113,7 +113,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	/**
 	 * Gets the project actions to be placed on the dashboard toolbar
 	 */
-	get projectToolbarActions(): (dataworkspace.IProjectAction | dataworkspace.IProjectActionGroup)[] {
+	public get projectToolbarActions(): (dataworkspace.IProjectAction | dataworkspace.IProjectActionGroup)[] {
 		const addItemAction: dataworkspace.IProjectAction = {
 			id: constants.addItemAction,
 			icon: IconPathHelper.add,
@@ -152,7 +152,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	/**
 	 * Gets the data to be displayed in the project dashboard
 	 */
-	getDashboardComponents(projectFile: string): dataworkspace.IDashboardTable[] {
+	public getDashboardComponents(projectFile: string): dataworkspace.IDashboardTable[] {
 		const width = 200;
 		const publishInfo: dataworkspace.IDashboardTable = {
 			name: constants.PublishHistory,
@@ -177,11 +177,11 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 		return [publishInfo, buildInfo];
 	}
 
-	get image(): ThemedIconPath {
+	public get image(): ThemedIconPath {
 		return IconPathHelper.dashboardSqlProj;
 	}
 
-	async openSqlNewProjectDialog(allowedTargetPlatforms?: sqldbproj.SqlTargetPlatform[]): Promise<vscode.Uri | undefined> {
+	public openSqlNewProjectDialog(allowedTargetPlatforms?: sqldbproj.SqlTargetPlatform[]): Promise<vscode.Uri | undefined> {
 		let targetPlatforms = Array.from(constants.targetPlatformToVersion.keys());
 		if (allowedTargetPlatforms) {
 			targetPlatforms = targetPlatforms.filter(p => allowedTargetPlatforms.toString().includes(p));
@@ -205,22 +205,22 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 * Gets the list of .sql scripts contained in a project
 	 * @param projectFilePath
 	 */
-	async getProjectScriptFiles(projectFilePath: string): Promise<string[]> {
-		return await this.projectController.getProjectScriptFiles(projectFilePath);
+	public getProjectScriptFiles(projectFilePath: string): Promise<string[]> {
+		return this.projectController.getProjectScriptFiles(projectFilePath);
 	}
 
 	/**
 	 * Gets the Database Schema Provider version for a SQL project
 	 */
-	public async getProjectDatabaseSchemaProvider(projectFilePath: string): Promise<string> {
-		return await this.projectController.getProjectDatabaseSchemaProvider(projectFilePath);
+	public getProjectDatabaseSchemaProvider(projectFilePath: string): Promise<string> {
+		return this.projectController.getProjectDatabaseSchemaProvider(projectFilePath);
 	}
 
-	public async generateProjectFromOpenApiSpec(options?: sqldbproj.GenerateProjectFromOpenApiSpecOptions): Promise<sqldbproj.ISqlProject | undefined> {
-		return await this.projectController.generateProjectFromOpenApiSpec(options);
+	public generateProjectFromOpenApiSpec(options?: sqldbproj.GenerateProjectFromOpenApiSpecOptions): Promise<sqldbproj.ISqlProject | undefined> {
+		return this.projectController.generateProjectFromOpenApiSpec(options);
 	}
 
-	getPublishToDockerSettings(project: sqldbproj.ISqlProject): Promise<sqldbproj.IPublishToDockerSettings | undefined> {
+	public getPublishToDockerSettings(project: sqldbproj.ISqlProject): Promise<sqldbproj.IPublishToDockerSettings | undefined> {
 		return getPublishToDockerSettings(project);
 	}
 }

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -304,19 +304,28 @@ declare module 'sqldbproj' {
 		connectionRetryTimeout?: number
 	}
 
-	export interface ILocalDbSetting extends ISqlConnectionProperties {
+	/**
+	 * Settings for creating the docker container a project is being published to
+	 */
+	export interface IDockerSettings extends ISqlConnectionProperties {
 		dockerBaseImage: string,
 		dockerBaseImageEula: string,
 	}
 
+	/**
+	 * Settings for publishing a SQL Project to a docker container
+	 */
 	export interface IPublishToDockerSettings {
-		localDbSetting?: ILocalDbSetting;
-		deploySettings?: IDeploySettings;
+		dockerSettings?: IDockerSettings;
+		sqlProjectPublishSettings?: ISqlProjectPublishSettings;
 	}
 
 	export type DeploymentOptions = mssqlDeploymentOptions | vscodeMssqlDeploymentOptions;
 
-	export interface IDeploySettings {
+	/**
+	 * Settings to use when publishing a SQL Project
+	 */
+	export interface ISqlProjectPublishSettings {
 		databaseName: string;
 		serverName: string;
 		connectionUri: string;

--- a/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
+++ b/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
@@ -72,7 +72,7 @@ describe('deploy service', function (): void {
 	it('Should deploy a database to docker container successfully', async function (): Promise<void> {
 		const testContext = createContext();
 		const deployProfile: IPublishToDockerSettings = {
-			localDbSetting: {
+			dockerSettings: {
 				dbName: 'test',
 				password: 'PLACEHOLDER',
 				port: 1433,
@@ -102,7 +102,7 @@ describe('deploy service', function (): void {
 	it('Should fail the deploy if docker is not running', async function (): Promise<void> {
 		const testContext = createContext();
 		const deployProfile: IPublishToDockerSettings = {
-			localDbSetting: {
+			dockerSettings: {
 				dbName: 'test',
 				password: 'PLACEHOLDER',
 				port: 1433,

--- a/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
@@ -17,7 +17,7 @@ import { Project } from '../../models/project';
 import { ProjectsController } from '../../controllers/projectController';
 import { emptySqlDatabaseProjectTypeId } from '../../common/constants';
 import { createContext, mockDacFxOptionsResult, TestContext } from '../testContext';
-import { IDeploySettings, IPublishToDockerSettings } from 'sqldbproj';
+import { ISqlProjectPublishSettings, IPublishToDockerSettings } from 'sqldbproj';
 
 let testContext: TestContext;
 describe('Publish Database Dialog', () => {
@@ -75,9 +75,9 @@ describe('Publish Database Dialog', () => {
 		dialog.object.publishToExistingServer = true;
 		dialog.callBase = true;
 
-		let profile: IDeploySettings | undefined;
+		let profile: ISqlProjectPublishSettings | undefined;
 
-		const expectedPublish: IDeploySettings = {
+		const expectedPublish: ISqlProjectPublishSettings = {
 			databaseName: 'MockDatabaseName',
 			serverName: 'MockServer',
 			connectionUri: 'Mock|Connection|Uri',
@@ -94,7 +94,7 @@ describe('Publish Database Dialog', () => {
 
 		should(profile).deepEqual(expectedPublish);
 
-		const expectedGenScript: IDeploySettings = {
+		const expectedGenScript: ISqlProjectPublishSettings = {
 			databaseName: 'MockDatabaseName',
 			serverName: 'MockServer',
 			connectionUri: 'Mock|Connection|Uri',
@@ -112,7 +112,7 @@ describe('Publish Database Dialog', () => {
 		should(profile).deepEqual(expectedGenScript);
 
 		const expectedContainerPublishProfile: IPublishToDockerSettings = {
-			localDbSetting: {
+			dockerSettings: {
 				dbName: 'MockDatabaseName',
 				dockerBaseImage: '',
 				password: '',
@@ -122,7 +122,7 @@ describe('Publish Database Dialog', () => {
 				dockerBaseImageEula: ''
 
 			},
-			deploySettings: {
+			sqlProjectPublishSettings: {
 				databaseName: 'MockDatabaseName',
 				serverName: 'localhost',
 				connectionUri: '',


### PR DESCRIPTION
Follow up to previous PR : 

1. Adding visibility modifier to rest of ProjectProvider functions. Not necessary but I find it better to be explicit for this kind of stuff
2. Removing redundant awaits in ProjectProvider
3. Rename some of the interfaces/properties in the typings file to more clearly indicate their purpose