### PR TITLE
Actual Execution Plan No Longer Executes Queries

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
@@ -22,6 +22,7 @@ import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { localize } from 'vs/nls';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { CATEGORIES } from 'sql/workbench/contrib/query/browser/queryActions';
 
 // Execution Plan editor registration
 
@@ -101,7 +102,7 @@ MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 			value: localize('executionPlanCompareCommandValue', "Compare execution plans"),
 			original: localize('executionPlanCompareCommandOriginalValue', "Compare execution plans")
 		},
-		category: 'Execution Plan'
+		category: CATEGORIES.ExecutionPlan.value
 	}
 });
 

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -229,7 +229,7 @@ export class EstimatedExecutionPlanKeyboardAction extends Action {
 
 export class RunCurrentQueryWithActualPlanKeyboardAction extends Action {
 	public static ID = 'runCurrentQueryWithActualPlanKeyboardAction';
-	public static LABEL = nls.localize('runCurrentQueryWithActualPlanKeyboardAction', "Run Current Query with Actual Plan");
+	public static LABEL = nls.localize('runCurrentQueryWithActualPlanKeyboardAction', "Execution Plan: Enable/Disable Actual Plan");
 
 	constructor(
 		id: string,
@@ -242,9 +242,12 @@ export class RunCurrentQueryWithActualPlanKeyboardAction extends Action {
 
 	public override run(): Promise<void> {
 		const editor = this._editorService.activeEditorPane;
+
 		if (editor instanceof QueryEditor) {
-			editor.runCurrentQueryWithActualPlan();
+			let toActualPlanState = !editor.input.state.isActualExecutionPlanMode;
+			editor.input.state.isActualExecutionPlanMode = toActualPlanState;
 		}
+
 		return Promise.resolve(null);
 	}
 }

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -229,7 +229,7 @@ export class EstimatedExecutionPlanKeyboardAction extends Action {
 
 export class ToggleActualPlanKeyboardAction extends Action {
 	public static ID = 'ToggleActualPlanKeyboardAction';
-	public static LABEL = nls.localize('ToggleActualPlanKeyboardAction', "Execution Plan: Enable/Disable Actual Execution Plan");
+	public static LABEL = nls.localize('ToggleActualPlanKeyboardAction', "Enable/Disable Actual Execution Plan");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -229,7 +229,7 @@ export class EstimatedExecutionPlanKeyboardAction extends Action {
 
 export class ToggleActualPlanKeyboardAction extends Action {
 	public static ID = 'ToggleActualPlanKeyboardAction';
-	public static LABEL = nls.localize('ToggleActualPlanKeyboardAction', "Enable/Disable Actual Execution Plan");
+	public static LABEL = nls.localize('ToggleActualPlanKeyboardAction', "Display Actual Execution Plan");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -229,7 +229,7 @@ export class EstimatedExecutionPlanKeyboardAction extends Action {
 
 export class RunCurrentQueryWithActualPlanKeyboardAction extends Action {
 	public static ID = 'runCurrentQueryWithActualPlanKeyboardAction';
-	public static LABEL = nls.localize('runCurrentQueryWithActualPlanKeyboardAction', "Execution Plan: Enable/Disable Actual Plan");
+	public static LABEL = nls.localize('runCurrentQueryWithActualPlanKeyboardAction', "Execution Plan: Enable/Disable Actual Execution Plan");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -227,9 +227,9 @@ export class EstimatedExecutionPlanKeyboardAction extends Action {
 	}
 }
 
-export class RunCurrentQueryWithActualPlanKeyboardAction extends Action {
-	public static ID = 'runCurrentQueryWithActualPlanKeyboardAction';
-	public static LABEL = nls.localize('runCurrentQueryWithActualPlanKeyboardAction', "Execution Plan: Enable/Disable Actual Execution Plan");
+export class ToggleActualPlanKeyboardAction extends Action {
+	public static ID = 'ToggleActualPlanKeyboardAction';
+	public static LABEL = nls.localize('ToggleActualPlanKeyboardAction', "Execution Plan: Enable/Disable Actual Execution Plan");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -229,7 +229,7 @@ export class EstimatedExecutionPlanKeyboardAction extends Action {
 
 export class ToggleActualPlanKeyboardAction extends Action {
 	public static ID = 'ToggleActualPlanKeyboardAction';
-	public static LABEL = nls.localize('ToggleActualPlanKeyboardAction', "Display Actual Execution Plan");
+	public static LABEL = nls.localize('ToggleActualPlanKeyboardAction', "Enable/Disable Actual Execution Plan");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -152,7 +152,8 @@ actionRegistry.registerWorkbenchAction(
 		ToggleActualPlanKeyboardAction.LABEL,
 		{ primary: KeyMod.CtrlCmd | KeyCode.KEY_M }
 	),
-	ToggleActualPlanKeyboardAction.LABEL
+	ToggleActualPlanKeyboardAction.LABEL,
+	localize('ExecutionPlan', 'Execution Plan')
 );
 
 actionRegistry.registerWorkbenchAction(

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -154,7 +154,7 @@ actionRegistry.registerWorkbenchAction(
 		{ primary: KeyMod.CtrlCmd | KeyCode.KEY_M }
 	),
 	ToggleActualPlanKeyboardAction.LABEL,
-	localize('ExecutionPlan', 'Execution Plan')
+	CATEGORIES.ExecutionPlan.value
 );
 
 actionRegistry.registerWorkbenchAction(

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -34,7 +34,7 @@ import { FileQueryEditorInput } from 'sql/workbench/contrib/query/browser/fileQu
 import { FileQueryEditorSerializer, QueryEditorLanguageAssociation, UntitledQueryEditorSerializer } from 'sql/workbench/contrib/query/browser/queryEditorFactory';
 import { UntitledQueryEditorInput } from 'sql/base/query/browser/untitledQueryEditorInput';
 import { ILanguageAssociationRegistry, Extensions as LanguageAssociationExtensions } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
-import { NewQueryTask, OE_NEW_QUERY_ACTION_ID, DE_NEW_QUERY_COMMAND_ID } from 'sql/workbench/contrib/query/browser/queryActions';
+import { NewQueryTask, OE_NEW_QUERY_ACTION_ID, DE_NEW_QUERY_COMMAND_ID, CATEGORIES } from 'sql/workbench/contrib/query/browser/queryActions';
 import { TreeNodeContextKey } from 'sql/workbench/services/objectExplorer/common/treeNodeContextKey';
 import { MssqlNodeContext } from 'sql/workbench/services/objectExplorer/browser/mssqlNodeContext';
 import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
@@ -142,7 +142,8 @@ actionRegistry.registerWorkbenchAction(
 		EstimatedExecutionPlanKeyboardAction.LABEL,
 		{ primary: KeyMod.CtrlCmd | KeyCode.KEY_L }
 	),
-	EstimatedExecutionPlanKeyboardAction.LABEL
+	EstimatedExecutionPlanKeyboardAction.LABEL,
+	CATEGORIES.ExecutionPlan.value
 );
 
 actionRegistry.registerWorkbenchAction(

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -19,7 +19,7 @@ import { QueryResultsInput } from 'sql/workbench/common/editor/query/queryResult
 import * as queryContext from 'sql/workbench/contrib/query/common/queryContext';
 import {
 	RunQueryKeyboardAction, RunCurrentQueryKeyboardAction, CancelQueryKeyboardAction, RefreshIntellisenseKeyboardAction, ToggleQueryResultsKeyboardAction,
-	RunQueryShortcutAction, RunCurrentQueryWithActualPlanKeyboardAction, CopyQueryWithResultsKeyboardAction, FocusOnCurrentQueryKeyboardAction, ParseSyntaxAction, ToggleFocusBetweenQueryEditorAndResultsAction, EstimatedExecutionPlanKeyboardAction
+	RunQueryShortcutAction, ToggleActualPlanKeyboardAction, CopyQueryWithResultsKeyboardAction, FocusOnCurrentQueryKeyboardAction, ParseSyntaxAction, ToggleFocusBetweenQueryEditorAndResultsAction, EstimatedExecutionPlanKeyboardAction
 } from 'sql/workbench/contrib/query/browser/keyboardQueryActions';
 import * as gridActions from 'sql/workbench/contrib/editData/browser/gridActions';
 import * as gridCommands from 'sql/workbench/contrib/editData/browser/gridCommands';
@@ -147,12 +147,12 @@ actionRegistry.registerWorkbenchAction(
 
 actionRegistry.registerWorkbenchAction(
 	SyncActionDescriptor.create(
-		RunCurrentQueryWithActualPlanKeyboardAction,
-		RunCurrentQueryWithActualPlanKeyboardAction.ID,
-		RunCurrentQueryWithActualPlanKeyboardAction.LABEL,
+		ToggleActualPlanKeyboardAction,
+		ToggleActualPlanKeyboardAction.ID,
+		ToggleActualPlanKeyboardAction.LABEL,
 		{ primary: KeyMod.CtrlCmd | KeyCode.KEY_M }
 	),
-	RunCurrentQueryWithActualPlanKeyboardAction.LABEL
+	ToggleActualPlanKeyboardAction.LABEL
 );
 
 actionRegistry.registerWorkbenchAction(

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -893,3 +893,7 @@ export class ExportAsNotebookAction extends QueryTaskbarAction {
 		this._commandService.executeCommand('mssql.exportSqlAsNotebook', this.editor.input.uri);
 	}
 }
+
+export const CATEGORIES = {
+	ExecutionPlan: { value: nls.localize('ExecutionPlan', 'Execution Plan'), original: 'Execution Plan' }
+};


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adjusts the `ctrl`/`cmd` + `M` shortcut, so that it no longer executes queries automatically. The intention behind this is to prevent a user from executing a query unexpectedly.

Clicking on or using a shortcut to execute this command:
![image](https://user-images.githubusercontent.com/87730006/176058565-184dcdb2-9d7f-43fb-82a3-c9a90574c740.png)


Toggles the state of this Enable/Disable Actual Plan button: 
![image](https://user-images.githubusercontent.com/87730006/176056192-d698103d-d06d-48f5-a42a-48cbada29fd2.png) 
![image](https://user-images.githubusercontent.com/87730006/176056551-9f8a3e20-1c5c-4100-810c-7a11defd1891.png)



