### PR TITLE
Adds "Execution Plan" prefix to Execution Plan commands

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
@@ -101,7 +101,7 @@ MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 			value: localize('executionPlanCompareCommandValue', "Compare execution plans"),
 			original: localize('executionPlanCompareCommandOriginalValue', "Compare execution plans")
 		},
-		category: 'Execution Plan'
+		category: localize('ExecutionPlan', 'Execution Plan')
 	}
 });
 

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -208,7 +208,7 @@ export class CopyQueryWithResultsKeyboardAction extends Action {
 
 export class EstimatedExecutionPlanKeyboardAction extends Action {
 	public static ID = 'estimatedExecutionPlanKeyboardAction';
-	public static LABEL = nls.localize('estimatedExecutionPlanKeyboardAction', "Execution Plan: Display Estimated Execution Plan");
+	public static LABEL = nls.localize('estimatedExecutionPlanKeyboardAction', "Display Estimated Execution Plan");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -208,7 +208,7 @@ export class CopyQueryWithResultsKeyboardAction extends Action {
 
 export class EstimatedExecutionPlanKeyboardAction extends Action {
 	public static ID = 'estimatedExecutionPlanKeyboardAction';
-	public static LABEL = nls.localize('estimatedExecutionPlanKeyboardAction', "Display Estimated Execution Plan");
+	public static LABEL = nls.localize('estimatedExecutionPlanKeyboardAction', "Execution Plan: Display Estimated Execution Plan");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -142,7 +142,8 @@ actionRegistry.registerWorkbenchAction(
 		EstimatedExecutionPlanKeyboardAction.LABEL,
 		{ primary: KeyMod.CtrlCmd | KeyCode.KEY_L }
 	),
-	EstimatedExecutionPlanKeyboardAction.LABEL
+	EstimatedExecutionPlanKeyboardAction.LABEL,
+	localize('ExecutionPlan', 'Execution Plan')
 );
 
 actionRegistry.registerWorkbenchAction(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds an "Execution Plan" prefix to commands, so that they're easier to find. 
![image](https://user-images.githubusercontent.com/87730006/176062527-563a80f7-cfdd-46ee-bdae-b6147e07f56a.png)
![image](https://user-images.githubusercontent.com/87730006/176062571-c3ff8a6e-2c24-4cf3-9c0f-417d73537d71.png)


NOTE: The actual execution plan command is being adjusted in a different PR (https://github.com/microsoft/azuredatastudio/pull/19840) since that action will no longer execute queries.