### PR TITLE
Add Notebook telemetry events

### DIFF
--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -20,6 +20,7 @@ import { IconPathHelper } from './common/iconHelper';
 import { ExtensionContextHelper } from './common/extensionContextHelper';
 import { BookTreeItem } from './book/bookTreeItem';
 import Logger from './common/logger';
+import { TelemetryReporter, BookTelemetryView, NbTelemetryActions } from './telemetry';
 
 const localize = nls.loadMessageBundle();
 
@@ -80,6 +81,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.openRemoteBook', async () => {
 		let dialog = new RemoteBookDialog(remoteBookController);
+		TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.AddRemoteBook);
 		return dialog.createDialog();
 	}));
 

--- a/extensions/notebook/src/telemetry.ts
+++ b/extensions/notebook/src/telemetry.ts
@@ -21,6 +21,7 @@ export enum NbTelemetryActions {
 	PinNotebook = 'NotebookPinned',
 	OpenNotebookFromBook = 'NotebookOpenedFromBook',
 	MoveNotebook = 'MoveNotebook',
-	DragAndDrop = 'DragAndDrop'
+	DragAndDrop = 'DragAndDrop',
+	AddRemoteBook = 'AddRemoteBook'
 }
 

--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -121,7 +121,9 @@ export const enum NbTelemetryAction {
 	NewNotebookFromConnections = 'NewNotebookWithConnectionProfile',
 	UndoCell = 'UndoCell',
 	RedoCell = 'RedoCell',
-	MIMETypeRendererNotFound = 'MIMETypeRendererNotFound'
+	MoveCell = 'MoveCell',
+	MIMETypeRendererNotFound = 'MIMETypeRendererNotFound',
+	CellExecutionFailed = 'CellExecutionFailed'
 }
 
 export const enum TelemetryPropertyName {

--- a/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
@@ -18,6 +18,7 @@ import { INotebookService } from 'sql/workbench/services/notebook/browser/notebo
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { CellEditModes, MoveDirection } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 const moreActionsLabel = localize('moreActionsLabel', "More");
 
 export class EditCellAction extends ToggleableAction {
@@ -105,6 +106,7 @@ export class MoveCellAction extends CellActionBase {
 		let moveDirection = this._cssClass.includes('move-down') ? MoveDirection.Down : MoveDirection.Up;
 		try {
 			context.model.moveCell(context.cell, moveDirection);
+			context.model.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.MoveCell, { moveDirection: moveDirection });
 		} catch (error) {
 			let message = getErrorMessage(error);
 

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -602,6 +602,7 @@ export class CellModel extends Disposable implements ICellModel {
 	}
 
 	public async runCell(notificationService?: INotificationService, connectionManagementService?: IConnectionManagementService): Promise<boolean> {
+		let kernel;
 		try {
 			// Allow screen reader to announce when cell execution is started
 			alert(localize('cellExecutionStarted', "Cell execution started"));
@@ -618,7 +619,7 @@ export class CellModel extends Disposable implements ICellModel {
 				// for this property
 				return false;
 			}
-			let kernel = await this.getOrStartKernel(notificationService);
+			kernel = await this.getOrStartKernel(notificationService);
 			if (!kernel) {
 				return false;
 			}
@@ -705,6 +706,7 @@ export class CellModel extends Disposable implements ICellModel {
 			} else {
 				message = getErrorMessage(error);
 			}
+			this.notebookModel.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.CellExecutionFailed, { kernel: kernel, errorMessage: message });
 			this.sendNotification(notificationService, Severity.Error, message);
 			// TODO track error state for the cell
 		} finally {

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -602,7 +602,7 @@ export class CellModel extends Disposable implements ICellModel {
 	}
 
 	public async runCell(notificationService?: INotificationService, connectionManagementService?: IConnectionManagementService): Promise<boolean> {
-		let kernel;
+		let kernel: nb.IKernel | undefined;
 		try {
 			// Allow screen reader to announce when cell execution is started
 			alert(localize('cellExecutionStarted', "Cell execution started"));
@@ -706,7 +706,7 @@ export class CellModel extends Disposable implements ICellModel {
 			} else {
 				message = getErrorMessage(error);
 			}
-			this.notebookModel.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.CellExecutionFailed, { kernel: kernel, errorMessage: message });
+			this.notebookModel.sendNotebookTelemetryActionEvent(TelemetryKeys.NbTelemetryAction.CellExecutionFailed, { kernel: kernel, reason: error.message === 'Canceled' ? 'Canceled' : 'Other' });
 			this.sendNotification(notificationService, Severity.Error, message);
 			// TODO track error state for the cell
 		} finally {


### PR DESCRIPTION
This PR adds telemetry events for: 
- Add Remote Jupyter Book
- Cell Execution Failed (including kernel type and error message)
- Move Cell (including move direction)
