### PR TITLE
Add uninstall step to manage packages smoke test to clean up installed packages.

### DIFF
--- a/test/automation/src/sql/managePackagesDialog.ts
+++ b/test/automation/src/sql/managePackagesDialog.ts
@@ -61,9 +61,11 @@ export class ManagePackagesDialog extends Dialog {
 		return packageVersion;
 	}
 
-	async removePackage(packageName: string): Promise<void> {
-		const installedPkgTab = `${ManagePackagesDialog.dialogPage} div[class="tab-header"][aria-controls="dialogPane.Manage Packages.0"]`;
-		await this.code.waitAndClick(installedPkgTab);
+	async removePackage(packageName: string, clickOnTab: boolean = false): Promise<void> {
+		if (clickOnTab) {
+			const installedPkgTab = `${ManagePackagesDialog.dialogPage} div[class="tab-header"][aria-controls="dialogPane.Manage Packages.0"]`;
+			await this.code.waitAndClick(installedPkgTab);
+		}
 
 		// Wait for initial loading spinner to disappear
 		const loadingSpinner = `${ManagePackagesDialog.dialogPage} div.modelview-loadingComponent-spinner`;

--- a/test/automation/src/sql/managePackagesDialog.ts
+++ b/test/automation/src/sql/managePackagesDialog.ts
@@ -60,4 +60,34 @@ export class ManagePackagesDialog extends Dialog {
 
 		return packageVersion;
 	}
+
+	async removePackage(packageName: string): Promise<void> {
+		const installedPkgTab = `${ManagePackagesDialog.dialogPage} div[class="tab-header"][aria-controls="dialogPane.Manage Packages.0"]`;
+		await this.code.waitAndClick(installedPkgTab);
+
+		// Wait for initial loading spinner to disappear
+		const loadingSpinner = `${ManagePackagesDialog.dialogPage} div.modelview-loadingComponent-spinner`;
+		await this.code.waitForElement(loadingSpinner);
+		await this.code.waitForElementGone(loadingSpinner);
+
+		// Click on package row in installed packages list to select it for uninstall
+		const packageRow = `${ManagePackagesDialog.dialogPage} .gridcell[aria-label="${packageName}"]`;
+		await this.code.waitAndClick(packageRow);
+
+		// Uninstall package
+		const uninstallButton = `${ManagePackagesDialog.dialogPage} .monaco-text-button[aria-label="Uninstall selected packages"]`;
+		await this.code.waitAndClick(uninstallButton);
+
+		// Click Yes on quick select
+		await this.code.waitAndClick('.quick-input-widget .quick-input-list .monaco-list-row[aria-label="Yes"]');
+
+		// Wait for uninstall loading spinner to disappear
+		await this.code.waitForElement(loadingSpinner);
+		await this.code.waitForElementGone(loadingSpinner);
+
+		// Close dialog
+		const closeButton = '.modal .modal-footer a[class="monaco-button monaco-text-button"][aria-label="Close"][aria-disabled="false"]';
+		await this.code.waitAndClick(closeButton);
+		await this.waitForDialogGone();
+	}
 }

--- a/test/automation/src/sql/managePackagesDialog.ts
+++ b/test/automation/src/sql/managePackagesDialog.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Code } from '../code';
+import { QuickInput } from '../quickinput';
 import { Dialog } from './dialog';
 
 const MANAGE_PACKAGES_DIALOG_TITLE = 'Manage Packages';
@@ -11,7 +12,7 @@ const MANAGE_PACKAGES_DIALOG_TITLE = 'Manage Packages';
 export class ManagePackagesDialog extends Dialog {
 	private static readonly dialogPage = '.modal .modal-body .dialogModal-pane';
 
-	constructor(code: Code) {
+	constructor(code: Code, private readonly quickInput: QuickInput) {
 		super(MANAGE_PACKAGES_DIALOG_TITLE, code);
 	}
 
@@ -81,7 +82,10 @@ export class ManagePackagesDialog extends Dialog {
 		await this.code.waitAndClick(uninstallButton);
 
 		// Click Yes on quick select
-		await this.code.waitAndClick('.quick-input-widget .quick-input-list .monaco-list-row[aria-label="Yes"]');
+		const quickInputAccept = 'Yes';
+		await this.quickInput.waitForQuickInputOpened();
+		await this.quickInput.waitForQuickInputElements(names => names[0] === quickInputAccept);
+		await this.quickInput.submit(quickInputAccept);
 
 		// Wait for uninstall loading spinner to disappear
 		await this.code.waitForElement(loadingSpinner);

--- a/test/automation/src/sql/managePackagesDialog.ts
+++ b/test/automation/src/sql/managePackagesDialog.ts
@@ -77,9 +77,11 @@ export class ManagePackagesDialog extends Dialog {
 		const packageRow = `${ManagePackagesDialog.dialogPage} div[role="gridcell"][aria-label="${packageName}"]`;
 		await this.code.waitAndClick(packageRow);
 
-		// Uninstall package
-		const uninstallButton = `${ManagePackagesDialog.dialogPage} .monaco-text-button[aria-label="Uninstall selected packages"]`;
-		await this.code.waitAndClick(uninstallButton);
+		// Tab over to uninstall button on the right side of the row. Can't select the uninstall button
+		// directly since it doesn't have any package name info associated with it.
+		await this.code.dispatchKeybinding('tab');
+		await this.code.dispatchKeybinding('tab');
+		await this.code.dispatchKeybinding('enter');
 
 		// Click Yes on quick select
 		const quickInputAccept = 'Yes';

--- a/test/automation/src/sql/managePackagesDialog.ts
+++ b/test/automation/src/sql/managePackagesDialog.ts
@@ -71,7 +71,7 @@ export class ManagePackagesDialog extends Dialog {
 		await this.code.waitForElementGone(loadingSpinner);
 
 		// Click on package row in installed packages list to select it for uninstall
-		const packageRow = `${ManagePackagesDialog.dialogPage} .gridcell[aria-label="${packageName}"]`;
+		const packageRow = `${ManagePackagesDialog.dialogPage} div[role="gridcell"][aria-label="${packageName}"]`;
 		await this.code.waitAndClick(packageRow);
 
 		// Uninstall package

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -34,9 +34,9 @@ export class Notebook {
 		await this.code.waitForElement('.notebookEditor');
 	}
 
-	async newUntitledNotebook(): Promise<void> {
+	async newUntitledNotebook(notebookNumber: number = 0): Promise<void> {
 		await this.code.dispatchKeybinding(`${constants.winOrCtrl}+Alt+n`);
-		await this.editors.waitForActiveTab(`Notebook-0`);
+		await this.editors.waitForActiveTab(`Notebook-${notebookNumber}`);
 		await this.code.waitForElement('.notebookEditor');
 	}
 

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -99,7 +99,7 @@ export class Workbench {
 		this.sqlNotebook = new SqlNotebook(code, this.quickaccess, this.quickinput, this.editors);
 		this.createBookDialog = new CreateBookDialog(code);
 		this.configurePythonDialog = new ConfigurePythonDialog(code);
-		this.managePackagesDialog = new ManagePackagesDialog(code);
+		this.managePackagesDialog = new ManagePackagesDialog(code, this.quickinput);
 		this.addRemoteBookDialog = new AddRemoteBookDialog(code);
 		this.taskPanel = new TaskPanel(code, this.quickaccess);
 		// {{END}}

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -150,6 +150,14 @@ export function setup(opts: minimist.ParsedArgs) {
 				await app.workbench.taskPanel.showTaskPanel();
 				await app.workbench.taskPanel.waitForTaskComplete(`Uninstalling ${testPackageName} ${packageVersion} succeeded`);
 
+				// Open a new notebook to verify that the package is uninstalled, since the old notebook's
+				// python instance retains a cached copy of the successfully imported module.
+				await app.workbench.sqlNotebook.newUntitledNotebook();
+				await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('SQL');
+				await app.workbench.sqlNotebook.notebookToolbar.changeKernel('Python 3');
+				await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('Python 3');
+				await app.workbench.sqlNotebook.addCell('code');
+				await app.workbench.sqlNotebook.waitForTypeInEditor(importTestCode);
 				await app.workbench.sqlNotebook.runActiveCell();
 				await app.workbench.sqlNotebook.waitForJupyterErrorOutput();
 			});

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -152,7 +152,7 @@ export function setup(opts: minimist.ParsedArgs) {
 
 				// Open a new notebook to verify that the package is uninstalled, since the old notebook's
 				// python instance retains a cached copy of the successfully imported module.
-				await app.workbench.sqlNotebook.newUntitledNotebook();
+				await app.workbench.sqlNotebook.newUntitledNotebook(1);
 				await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('SQL');
 				await app.workbench.sqlNotebook.notebookToolbar.changeKernel('Python 3');
 				await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('Python 3');

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -145,6 +145,8 @@ export function setup(opts: minimist.ParsedArgs) {
 				await app.workbench.sqlNotebook.notebookToolbar.managePackages();
 				await app.workbench.managePackagesDialog.waitForManagePackagesDialog();
 				await app.workbench.managePackagesDialog.removePackage(testPackageName);
+				await app.workbench.taskPanel.showTaskPanel();
+				await app.workbench.taskPanel.waitForTaskComplete(`Uninstalling ${testPackageName} ${packageVersion} succeeded`);
 
 				await app.workbench.sqlNotebook.runActiveCell();
 				await app.workbench.sqlNotebook.waitForJupyterErrorOutput();

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -114,7 +114,7 @@ export function setup(opts: minimist.ParsedArgs) {
 				await app.workbench.sqlNotebook.waitForActiveCellResults();
 			});
 
-			it('can add a new package from the Manage Packages wizard', async function () {
+			it('can add and remove new package from the Manage Packages wizard', async function () {
 				// Use arrow package so that it's at the top of the packages list when uninstalling later
 				const testPackageName = 'arrow';
 
@@ -141,7 +141,9 @@ export function setup(opts: minimist.ParsedArgs) {
 				await app.workbench.sqlNotebook.runActiveCell();
 				await app.workbench.sqlNotebook.waitForActiveCellResultsGone();
 
-				// Uninstall package and check if it throws the expected import error
+				// Uninstall package and check if it throws the expected import error.
+				// This also functions as cleanup for subsequent test runs, since the test
+				// assumes the package isn't installed by default.
 				await app.workbench.sqlNotebook.notebookToolbar.managePackages();
 				await app.workbench.managePackagesDialog.waitForManagePackagesDialog();
 				await app.workbench.managePackagesDialog.removePackage(testPackageName);

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -115,6 +115,9 @@ export function setup(opts: minimist.ParsedArgs) {
 			});
 
 			it('can add a new package from the Manage Packages wizard', async function () {
+				// Use arrow package so that it's at the top of the packages list when uninstalling later
+				const testPackageName = 'arrow';
+
 				const app = this.app as Application;
 				await app.workbench.sqlNotebook.newUntitledNotebook();
 				await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('SQL');
@@ -122,20 +125,29 @@ export function setup(opts: minimist.ParsedArgs) {
 				await configurePython(app);
 				await app.workbench.sqlNotebook.notebookToolbar.waitForKernel('Python 3');
 
+				const importTestCode = `import ${testPackageName}`;
 				await app.workbench.sqlNotebook.addCell('code');
-				await app.workbench.sqlNotebook.waitForTypeInEditor('import pyarrow');
+				await app.workbench.sqlNotebook.waitForTypeInEditor(importTestCode);
 				await app.workbench.sqlNotebook.runActiveCell();
 				await app.workbench.sqlNotebook.waitForJupyterErrorOutput();
 
 				await app.workbench.sqlNotebook.notebookToolbar.managePackages();
 				await app.workbench.managePackagesDialog.waitForManagePackagesDialog();
-				let packageVersion = await app.workbench.managePackagesDialog.addNewPackage('pyarrow');
+				let packageVersion = await app.workbench.managePackagesDialog.addNewPackage(testPackageName);
 				await app.workbench.taskPanel.showTaskPanel();
-				await app.workbench.taskPanel.waitForTaskComplete(`Installing pyarrow ${packageVersion} succeeded`);
+				await app.workbench.taskPanel.waitForTaskComplete(`Installing ${testPackageName} ${packageVersion} succeeded`);
 
 				// There should be no error output when running the cell after pyarrow has been installed
 				await app.workbench.sqlNotebook.runActiveCell();
 				await app.workbench.sqlNotebook.waitForActiveCellResultsGone();
+
+				// Uninstall package and check if it throws the expected import error
+				await app.workbench.sqlNotebook.notebookToolbar.managePackages();
+				await app.workbench.managePackagesDialog.waitForManagePackagesDialog();
+				await app.workbench.managePackagesDialog.removePackage(testPackageName);
+
+				await app.workbench.sqlNotebook.runActiveCell();
+				await app.workbench.sqlNotebook.waitForJupyterErrorOutput();
 			});
 
 			it('can open ipynb file, run all, and save notebook with outputs', async function () {


### PR DESCRIPTION
Currently our Manage Packages smoke test fails when run twice in a row because the first run installs an expected package, but doesn't uninstall it afterwards, causing the second test to fail because it expects that package to not be installed by default. This change adds an uninstall step to the existing Manage Packages test in order to (1) clean up that lingering package and (2) add some test coverage for the dialog's uninstall functionality. We can't split up these behaviors into 2 test cases because they would easily break when run independently of each other based on whether a package is already installed or not.