### PR TITLE
Fixed customlocation parsing for connecting DC

### DIFF
--- a/extensions/arc/src/ui/dialogs/connectControllerDialog.ts
+++ b/extensions/arc/src/ui/dialogs/connectControllerDialog.ts
@@ -206,7 +206,7 @@ export class ConnectToControllerDialog extends ControllerDialogBase {
 
 			if (controllerModel.info.connectionMode === ConnectionMode.direct) {
 				const rawCustomLocation = <string>controllerModel.controllerConfig?.metadata.annotations['management.azure.com/customLocation'];
-				const exp = /customlocations\/([\S]*)/;
+				const exp = /customLocations\/([\S]*)/;
 				controllerModel.info.customLocation = <string>exp.exec(rawCustomLocation)?.pop();
 			}
 		} catch (err) {


### PR DESCRIPTION
Bug: SQL MIAA create was not taking the custom location from its data controller
Solution: Connecting DC was not properly parsing out the custom location from the metadata. Fixed regex and now it works fine.
