### PR TITLE
use reliable way to detect createtable statements

### DIFF
--- a/extensions/dacpac/src/test/testDacFxService.ts
+++ b/extensions/dacpac/src/test/testDacFxService.ts
@@ -170,4 +170,7 @@ export class DacFxTestService implements mssql.IDacFxService {
 		};
 		return Promise.resolve(streamingJobValidationResult);
 	}
+	parseTSqlScript(script: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
+		return Promise.resolve({ containsCreateTableStatement: true });
+	}
 }

--- a/extensions/dacpac/src/test/testDacFxService.ts
+++ b/extensions/dacpac/src/test/testDacFxService.ts
@@ -170,7 +170,7 @@ export class DacFxTestService implements mssql.IDacFxService {
 		};
 		return Promise.resolve(streamingJobValidationResult);
 	}
-	parseTSqlScript(script: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
+	parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
 		return Promise.resolve({ containsCreateTableStatement: true });
 	}
 }

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.1.0.8",
+	"version": "4.1.0.9",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.1.0.4",
+	"version": "4.1.0.8",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -546,7 +546,7 @@ export interface ValidateStreamingJobParams {
 }
 
 export interface ParseTSqlScriptParams {
-	script: string;
+	filePath: string;
 	databaseSchemaProvider: string;
 }
 

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -545,6 +545,11 @@ export interface ValidateStreamingJobParams {
 	createStreamingJobTsql: string
 }
 
+export interface ParseTSqlScriptParams {
+	script: string;
+	databaseSchemaProvider: string;
+}
+
 export namespace ExportRequest {
 	export const type = new RequestType<ExportParams, mssql.DacFxResult, void, void>('dacfx/export');
 }
@@ -575,6 +580,10 @@ export namespace GetOptionsFromProfileRequest {
 
 export namespace ValidateStreamingJobRequest {
 	export const type = new RequestType<ValidateStreamingJobParams, mssql.ValidateStreamingJobResult, void, void>('dacfx/validateStreamingJob');
+}
+
+export namespace ParseTSqlScriptRequest {
+	export const type = new RequestType<ParseTSqlScriptParams, mssql.ParseTSqlScriptResult, void, void>('dacfx/parseTSqlScript');
 }
 
 // ------------------------------- </ DacFx > ------------------------------------

--- a/extensions/mssql/src/dacfx/dacFxService.ts
+++ b/extensions/mssql/src/dacfx/dacFxService.ts
@@ -131,13 +131,13 @@ export class DacFxService implements mssql.IDacFxService {
 		);
 	}
 
-	public parseTSqlScript(script: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
-		const params: contracts.ParseTSqlScriptParams = { script, databaseSchemaProvider };
+	public parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
+		const params: contracts.ParseTSqlScriptParams = { filePath, databaseSchemaProvider };
 		return this.client.sendRequest(contracts.ParseTSqlScriptRequest.type, params).then(
 			undefined,
 			e => {
 				this.client.logFailedRequest(contracts.ParseTSqlScriptRequest.type, e);
-				return Promise.resolve(undefined);
+				return Promise.reject(e);
 			}
 		);
 	}

--- a/extensions/mssql/src/dacfx/dacFxService.ts
+++ b/extensions/mssql/src/dacfx/dacFxService.ts
@@ -131,14 +131,14 @@ export class DacFxService implements mssql.IDacFxService {
 		);
 	}
 
-	public parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
+	public async parseTSqlScript(filePath: string, databaseSchemaProvider: string): Promise<mssql.ParseTSqlScriptResult> {
 		const params: contracts.ParseTSqlScriptParams = { filePath, databaseSchemaProvider };
-		return this.client.sendRequest(contracts.ParseTSqlScriptRequest.type, params).then(
-			undefined,
-			e => {
-				this.client.logFailedRequest(contracts.ParseTSqlScriptRequest.type, e);
-				return Promise.reject(e);
-			}
-		);
+		try {
+			const result = await this.client.sendRequest(contracts.ParseTSqlScriptRequest.type, params);
+			return result;
+		} catch (e) {
+			this.client.logFailedRequest(contracts.ParseTSqlScriptRequest.type, e);
+			throw e;
+		}
 	}
 }

--- a/extensions/mssql/src/dacfx/dacFxService.ts
+++ b/extensions/mssql/src/dacfx/dacFxService.ts
@@ -130,4 +130,15 @@ export class DacFxService implements mssql.IDacFxService {
 			}
 		);
 	}
+
+	public parseTSqlScript(script: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
+		const params: contracts.ParseTSqlScriptParams = { script, databaseSchemaProvider };
+		return this.client.sendRequest(contracts.ParseTSqlScriptRequest.type, params).then(
+			undefined,
+			e => {
+				this.client.logFailedRequest(contracts.ParseTSqlScriptRequest.type, e);
+				return Promise.resolve(undefined);
+			}
+		);
+	}
 }

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -391,7 +391,7 @@ declare module 'mssql' {
 		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
-		parseTSqlScript(script: string, databaseSchemaProvider: string): Thenable<ParseTSqlScriptResult>;
+		parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<ParseTSqlScriptResult>;
 	}
 
 	export interface DacFxResult extends azdata.ResultStatus {

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -391,6 +391,7 @@ declare module 'mssql' {
 		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
+		parseTSqlScript(script: string, databaseSchemaProvider: string): Thenable<ParseTSqlScriptResult>;
 	}
 
 	export interface DacFxResult extends azdata.ResultStatus {
@@ -406,6 +407,10 @@ declare module 'mssql' {
 	}
 
 	export interface ValidateStreamingJobResult extends azdata.ResultStatus {
+	}
+
+	export interface ParseTSqlScriptResult {
+		containsCreateTableStatement: boolean;
 	}
 
 	export interface ExportParams {

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -255,9 +255,12 @@ export class Project implements ISqlProject {
 
 			if (await utils.exists(fullPath) && utils.getAzdataApi()) {
 				const dacFxService = await utils.getDacFxService() as mssql.IDacFxService;
-				const fileContents = await fs.readFile(fullPath);
-				const result = await dacFxService.parseTSqlScript(fileContents.toString(), this.getProjectTargetVersion());
-				containsCreateTableStatement = result.containsCreateTableStatement;
+				try {
+					const result = await dacFxService.parseTSqlScript(fullPath, this.getProjectTargetVersion());
+					containsCreateTableStatement = result.containsCreateTableStatement;
+				} catch (e) {
+					console.error(utils.getErrorMessage(e));
+				}
 			}
 
 			fileEntries.push(this.createFileProjectEntry(f, EntryType.File, typeEntry ? typeEntry.typeAttribute : undefined, containsCreateTableStatement));

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -253,7 +253,7 @@ export class Project implements ISqlProject {
 			// read file to check if it has a "Create Table" statement
 			const fullPath = path.join(utils.getPlatformSafeFileEntryPath(this.projectFolderPath), utils.getPlatformSafeFileEntryPath(f));
 
-			if (await utils.exists(fullPath) && utils.getAzdataApi()) {
+			if (utils.getAzdataApi()) {
 				const dacFxService = await utils.getDacFxService() as mssql.IDacFxService;
 				try {
 					const result = await dacFxService.parseTSqlScript(fullPath, this.getProjectTargetVersion());

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -10,6 +10,7 @@ import * as utils from '../common/utils';
 import * as xmlFormat from 'xml-formatter';
 import * as os from 'os';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
+import * as mssql from 'mssql';
 
 import { Uri, window } from 'vscode';
 import { EntryType, IDatabaseReferenceProjectEntry, IProjectEntry, ISqlProject, ItemType, SqlTargetPlatform } from 'sqldbproj';
@@ -247,14 +248,16 @@ export class Project implements ISqlProject {
 		const fileEntries: FileProjectEntry[] = [];
 		for (let f of Array.from(filesSet.values())) {
 			const typeEntry = entriesWithType.find(e => e.relativePath === f);
-			let containsCreateTableStatement;
+			let containsCreateTableStatement = false;
 
 			// read file to check if it has a "Create Table" statement
 			const fullPath = path.join(utils.getPlatformSafeFileEntryPath(this.projectFolderPath), utils.getPlatformSafeFileEntryPath(f));
 
-			if (await utils.exists(fullPath)) {
+			if (await utils.exists(fullPath) && utils.getAzdataApi()) {
+				const dacFxService = await utils.getDacFxService() as mssql.IDacFxService;
 				const fileContents = await fs.readFile(fullPath);
-				containsCreateTableStatement = fileContents.toString().toLowerCase().includes('create table');
+				const result = await dacFxService.parseTSqlScript(fileContents.toString(), this.getProjectTargetVersion());
+				containsCreateTableStatement = result.containsCreateTableStatement;
 			}
 
 			fileEntries.push(this.createFileProjectEntry(f, EntryType.File, typeEntry ? typeEntry.typeAttribute : undefined, containsCreateTableStatement));

--- a/extensions/sql-database-projects/src/test/testContext.ts
+++ b/extensions/sql-database-projects/src/test/testContext.ts
@@ -140,6 +140,7 @@ export class MockDacFxService implements mssql.IDacFxService {
 	public generateDeployPlan(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<mssql.GenerateDeployPlanResult> { return Promise.resolve(mockDacFxResult); }
 	public getOptionsFromProfile(_: string): Thenable<mssql.DacFxOptionsResult> { return Promise.resolve(mockDacFxOptionsResult); }
 	public validateStreamingJob(_: string, __: string): Thenable<mssql.ValidateStreamingJobResult> { return Promise.resolve(mockDacFxResult); }
+	public parseTSqlScript(_: string, __: string): Thenable<mssql.ParseTSqlScriptResult> { return Promise.resolve({ containsCreateTableStatement: true }); }
 }
 
 export function createContext(): TestContext {

--- a/extensions/sql-database-projects/src/test/testUtils.ts
+++ b/extensions/sql-database-projects/src/test/testUtils.ts
@@ -6,6 +6,7 @@
 import * as path from 'path';
 import * as os from 'os';
 import * as constants from '../common/constants';
+import * as templates from '../templates/templates';
 
 import { promises as fs } from 'fs';
 import should = require('should');
@@ -34,6 +35,10 @@ export async function createTestSqlProjFile(contents: string, folderPath?: strin
 }
 
 export async function createTestProject(contents: string, folderPath?: string): Promise<Project> {
+	const macroDict: Record<string, string> = {
+		'PROJECT_DSP': constants.defaultDSP
+	};
+	contents = templates.macroExpansion(contents, macroDict);
 	return await Project.openProject(await createTestSqlProjFile(contents, folderPath));
 }
 


### PR DESCRIPTION
This PR fixes #19600

previously, we were using string search to determine whether a script file contains create table statement. this would not work if:
1. the string is commented out.
2. there are more whitespaces between `create` and `table`.

we need a more reliable way to do the detection, in dacfx, there is a script parser that does the job, so adding a new API to DacFx service and made it extensible for other similar scenarios in the future.

below are the changes in STS since 4.1.0.4

@Charles-Gagnon @ssreerama  @smartguest , please confirm these changes are ready to be brought to ADS.
![image](https://user-images.githubusercontent.com/13777222/176792882-57a224d9-ad65-4b10-8971-fe10f9ccd7ce.png)


