### PR TITLE
Make publish to docker settings properties required

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -320,35 +320,28 @@ export class ProjectsController {
 		const project: Project = this.getProjectFromContext(context);
 		// Removing the path separator from the image base name to be able to add that in the telemetry. With the separator the name is flagged as user path which is not true
 		// We only need to know the image base parts so it's ok to use a different separator when adding to telemetry
-		const dockerImageNameForTelemetry = deployProfile.dockerSettings?.dockerBaseImage ? deployProfile.dockerSettings.dockerBaseImage.replace(/\//gi, '_') : '';
+		const dockerImageNameForTelemetry = deployProfile.dockerSettings.dockerBaseImage.replace(/\//gi, '_');
 		try {
 			TelemetryReporter.createActionEvent(TelemetryViews.ProjectController, TelemetryActions.publishToContainer)
 				.withAdditionalProperties({ dockerBaseImage: dockerImageNameForTelemetry })
 				.send();
 
-			if (deployProfile && deployProfile.sqlProjectPublishSettings) {
-				let connectionUri: string | undefined;
-				if (deployProfile.dockerSettings) {
-					void utils.showInfoMessageWithOutputChannel(constants.publishingProjectMessage, this._outputChannel);
-					connectionUri = await this.deployService.deployToContainer(deployProfile, project);
-					if (connectionUri) {
-						deployProfile.sqlProjectPublishSettings.connectionUri = connectionUri;
-					}
-				}
+			void utils.showInfoMessageWithOutputChannel(constants.publishingProjectMessage, this._outputChannel);
+			const connectionUri = await this.deployService.deployToContainer(deployProfile, project);
+			if (connectionUri) {
+				deployProfile.sqlProjectPublishSettings.connectionUri = connectionUri;
+			}
 
-				if (deployProfile.sqlProjectPublishSettings.connectionUri) {
-					const publishResult = await this.publishOrScriptProject(project, deployProfile.sqlProjectPublishSettings, true);
-					if (publishResult && publishResult.success) {
-						if (deployProfile.dockerSettings) {
-							await this.connectionService.getConnection(deployProfile.dockerSettings, true, deployProfile.dockerSettings.dbName);
-						}
-						void vscode.window.showInformationMessage(constants.publishProjectSucceed);
-					} else {
-						void utils.showErrorMessageWithOutputChannel(constants.publishToContainerFailed, publishResult?.errorMessage || '', this._outputChannel);
-					}
+			if (deployProfile.sqlProjectPublishSettings.connectionUri) {
+				const publishResult = await this.publishOrScriptProject(project, deployProfile.sqlProjectPublishSettings, true);
+				if (publishResult && publishResult.success) {
+					await this.connectionService.getConnection(deployProfile.dockerSettings, true, deployProfile.dockerSettings.dbName);
+					void vscode.window.showInformationMessage(constants.publishProjectSucceed);
 				} else {
-					void utils.showErrorMessageWithOutputChannel(constants.publishToContainerFailed, constants.deployProjectFailedMessage, this._outputChannel);
+					void utils.showErrorMessageWithOutputChannel(constants.publishToContainerFailed, publishResult?.errorMessage || '', this._outputChannel);
 				}
+			} else {
+				void utils.showErrorMessageWithOutputChannel(constants.publishToContainerFailed, constants.deployProjectFailedMessage, this._outputChannel);
 			}
 		} catch (error) {
 			void utils.showErrorMessageWithOutputChannel(constants.publishToContainerFailed, error, this._outputChannel);
@@ -399,10 +392,12 @@ export class ProjectsController {
 		}
 
 		if (publishTarget === constants.PublishTargetType.docker) {
-			const deployProfile = await getPublishToDockerSettings(project);
-			if (deployProfile?.sqlProjectPublishSettings && deployProfile?.dockerSettings) {
-				await this.publishToDockerContainer(project, deployProfile);
+			const publishToDockerSettings = await getPublishToDockerSettings(project);
+			if (!publishToDockerSettings) {
+				// User cancelled
+				return;
 			}
+			await this.publishToDockerContainer(project, publishToDockerSettings);
 		} else if (publishTarget === constants.PublishTargetType.newAzureServer) {
 			try {
 				const settings = await launchCreateAzureServerQuickPick(project, this.azureSqlClient);

--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
@@ -278,7 +278,7 @@ export async function launchCreateAzureServerQuickPick(project: Project, azureSq
 export async function getPublishToDockerSettings(project: ISqlProject): Promise<IPublishToDockerSettings | undefined> {
 	const target = project.getProjectTargetVersion();
 	const name = uiUtils.getPublishServerName(target);
-	let localDbSetting: IDockerSettings | undefined;
+	let dockerSettings: IDockerSettings | undefined;
 	// Deploy to docker selected
 	let portNumber = await vscode.window.showInputBox({
 		title: constants.enterPortNumber(name),
@@ -370,7 +370,7 @@ export async function getPublishToDockerSettings(project: ISqlProject): Promise<
 		imageName = `${imageName}:${imageTag.label}`;
 	}
 
-	localDbSetting = {
+	dockerSettings = {
 		serverName: constants.defaultLocalServerName,
 		userName: constants.defaultLocalServerAdminName,
 		dbName: project.projectFileName,
@@ -388,13 +388,13 @@ export async function getPublishToDockerSettings(project: ISqlProject): Promise<
 	}
 
 	// Server name should be set to localhost
-	deploySettings.serverName = localDbSetting.serverName;
+	deploySettings.serverName = dockerSettings.serverName;
 
 	// Get the database name from deploy settings
-	localDbSetting.dbName = deploySettings.databaseName;
+	dockerSettings.dbName = deploySettings.databaseName;
 
 	return {
-		dockerSettings: localDbSetting,
+		dockerSettings,
 		sqlProjectPublishSettings: deploySettings,
 	};
 }

--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
@@ -278,7 +278,6 @@ export async function launchCreateAzureServerQuickPick(project: Project, azureSq
 export async function getPublishToDockerSettings(project: ISqlProject): Promise<IPublishToDockerSettings | undefined> {
 	const target = project.getProjectTargetVersion();
 	const name = uiUtils.getPublishServerName(target);
-	let dockerSettings: IDockerSettings | undefined;
 	// Deploy to docker selected
 	let portNumber = await vscode.window.showInputBox({
 		title: constants.enterPortNumber(name),
@@ -370,7 +369,7 @@ export async function getPublishToDockerSettings(project: ISqlProject): Promise<
 		imageName = `${imageName}:${imageTag.label}`;
 	}
 
-	dockerSettings = {
+	const dockerSettings: IDockerSettings = {
 		serverName: constants.defaultLocalServerName,
 		userName: constants.defaultLocalServerAdminName,
 		dbName: project.projectFileName,

--- a/extensions/sql-database-projects/src/models/deploy/deployService.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployService.ts
@@ -92,10 +92,6 @@ export class DeployService {
 
 	public async deployToContainer(profile: IPublishToDockerSettings, project: Project): Promise<string | undefined> {
 		return await this.executeTask(constants.deployDbTaskName, async () => {
-			if (!profile.dockerSettings) {
-				return undefined;
-			}
-
 			await this.verifyDocker();
 			this.logToOutput(constants.dockerImageMessage);
 			this.logToOutput(profile.dockerSettings.dockerBaseImage);

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -316,8 +316,8 @@ declare module 'sqldbproj' {
 	 * Settings for publishing a SQL Project to a docker container
 	 */
 	export interface IPublishToDockerSettings {
-		dockerSettings?: IDockerSettings;
-		sqlProjectPublishSettings?: ISqlProjectPublishSettings;
+		dockerSettings: IDockerSettings;
+		sqlProjectPublishSettings: ISqlProjectPublishSettings;
 	}
 
 	export type DeploymentOptions = mssqlDeploymentOptions | vscodeMssqlDeploymentOptions;

--- a/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
+++ b/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
@@ -72,6 +72,11 @@ describe('deploy service', function (): void {
 	it('Should deploy a database to docker container successfully', async function (): Promise<void> {
 		const testContext = createContext();
 		const deployProfile: IPublishToDockerSettings = {
+			sqlProjectPublishSettings: {
+				databaseName: 'dbName',
+				serverName: 'serverName',
+				connectionUri: 'connectionUri'
+			},
 			dockerSettings: {
 				dbName: 'test',
 				password: 'PLACEHOLDER',
@@ -102,6 +107,11 @@ describe('deploy service', function (): void {
 	it('Should fail the deploy if docker is not running', async function (): Promise<void> {
 		const testContext = createContext();
 		const deployProfile: IPublishToDockerSettings = {
+			sqlProjectPublishSettings: {
+				databaseName: 'dbName',
+				serverName: 'serverName',
+				connectionUri: 'connectionUri'
+			},
 			dockerSettings: {
 				dbName: 'test',
 				password: 'PLACEHOLDER',


### PR DESCRIPTION
It's annoying having to deal with checking these properties everywhere and it doesn't seem to make sense to have them optional - we should always have these properties both exist when we finish gathering the publish options. 