### PR TITLE
Add default value for PITR in SQL MIAA create

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -1552,6 +1552,7 @@
                         "description": "%arc.sql.retention.days.description%",
                         "variableName": "AZDATA_NB_VAR_SQL_RETENTION_DAYS",
                         "type": "number",
+                        "defaultValue": 7,
                         "min": 1,
                         "max": 35,
                         "required": false


### PR DESCRIPTION
Added a default value, 7, for PITR in SQL MIAA create wizard.
![image](https://user-images.githubusercontent.com/22386690/176799423-dc57ae67-ad0b-4a6e-b952-965cb7396620.png)