### PR TITLE
Revert "use reliable way to detect createtable statements (#19897)"

### DIFF
--- a/extensions/dacpac/src/test/testDacFxService.ts
+++ b/extensions/dacpac/src/test/testDacFxService.ts
@@ -170,7 +170,4 @@ export class DacFxTestService implements mssql.IDacFxService {
 		};
 		return Promise.resolve(streamingJobValidationResult);
 	}
-	parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
-		return Promise.resolve({ containsCreateTableStatement: true });
-	}
 }

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.1.0.9",
+	"version": "4.1.0.4",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -545,11 +545,6 @@ export interface ValidateStreamingJobParams {
 	createStreamingJobTsql: string
 }
 
-export interface ParseTSqlScriptParams {
-	filePath: string;
-	databaseSchemaProvider: string;
-}
-
 export namespace ExportRequest {
 	export const type = new RequestType<ExportParams, mssql.DacFxResult, void, void>('dacfx/export');
 }
@@ -580,10 +575,6 @@ export namespace GetOptionsFromProfileRequest {
 
 export namespace ValidateStreamingJobRequest {
 	export const type = new RequestType<ValidateStreamingJobParams, mssql.ValidateStreamingJobResult, void, void>('dacfx/validateStreamingJob');
-}
-
-export namespace ParseTSqlScriptRequest {
-	export const type = new RequestType<ParseTSqlScriptParams, mssql.ParseTSqlScriptResult, void, void>('dacfx/parseTSqlScript');
 }
 
 // ------------------------------- </ DacFx > ------------------------------------

--- a/extensions/mssql/src/dacfx/dacFxService.ts
+++ b/extensions/mssql/src/dacfx/dacFxService.ts
@@ -130,15 +130,4 @@ export class DacFxService implements mssql.IDacFxService {
 			}
 		);
 	}
-
-	public async parseTSqlScript(filePath: string, databaseSchemaProvider: string): Promise<mssql.ParseTSqlScriptResult> {
-		const params: contracts.ParseTSqlScriptParams = { filePath, databaseSchemaProvider };
-		try {
-			const result = await this.client.sendRequest(contracts.ParseTSqlScriptRequest.type, params);
-			return result;
-		} catch (e) {
-			this.client.logFailedRequest(contracts.ParseTSqlScriptRequest.type, e);
-			throw e;
-		}
-	}
 }

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -391,7 +391,6 @@ declare module 'mssql' {
 		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
-		parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<ParseTSqlScriptResult>;
 	}
 
 	export interface DacFxResult extends azdata.ResultStatus {
@@ -407,10 +406,6 @@ declare module 'mssql' {
 	}
 
 	export interface ValidateStreamingJobResult extends azdata.ResultStatus {
-	}
-
-	export interface ParseTSqlScriptResult {
-		containsCreateTableStatement: boolean;
 	}
 
 	export interface ExportParams {

--- a/extensions/sql-database-projects/src/test/testContext.ts
+++ b/extensions/sql-database-projects/src/test/testContext.ts
@@ -140,7 +140,6 @@ export class MockDacFxService implements mssql.IDacFxService {
 	public generateDeployPlan(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<mssql.GenerateDeployPlanResult> { return Promise.resolve(mockDacFxResult); }
 	public getOptionsFromProfile(_: string): Thenable<mssql.DacFxOptionsResult> { return Promise.resolve(mockDacFxOptionsResult); }
 	public validateStreamingJob(_: string, __: string): Thenable<mssql.ValidateStreamingJobResult> { return Promise.resolve(mockDacFxResult); }
-	public parseTSqlScript(_: string, __: string): Thenable<mssql.ParseTSqlScriptResult> { return Promise.resolve({ containsCreateTableStatement: true }); }
 }
 
 export function createContext(): TestContext {

--- a/extensions/sql-database-projects/src/test/testUtils.ts
+++ b/extensions/sql-database-projects/src/test/testUtils.ts
@@ -6,7 +6,6 @@
 import * as path from 'path';
 import * as os from 'os';
 import * as constants from '../common/constants';
-import * as templates from '../templates/templates';
 
 import { promises as fs } from 'fs';
 import should = require('should');
@@ -35,10 +34,6 @@ export async function createTestSqlProjFile(contents: string, folderPath?: strin
 }
 
 export async function createTestProject(contents: string, folderPath?: string): Promise<Project> {
-	const macroDict: Record<string, string> = {
-		'PROJECT_DSP': constants.defaultDSP
-	};
-	contents = templates.macroExpansion(contents, macroDict);
 	return await Project.openProject(await createTestSqlProjFile(contents, folderPath));
 }
 


### PR DESCRIPTION
This reverts commit 9a22c429a9e98cd16909fbac2900b9a78cb3b193.

original PR #19897

I noticed an extension unit test has been failing inconsistently since my commit, reverting it for now and I will investigate the test failure.