### PR TITLE
Fix container cleanup message disappearing - causing apparent hang

### DIFF
--- a/extensions/sql-database-projects/src/models/deploy/deployService.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployService.ts
@@ -181,7 +181,12 @@ export class DeployService {
 		// Clean up existing docker image
 		const containerIds = await this.getCurrentDockerContainer(imageLabel);
 		if (containerIds.length > 0) {
-			const result = await vscode.window.showWarningMessage(constants.containerAlreadyExistForProject, constants.yesString, constants.noString);
+			// TODO - Fix this going away
+			const result = await vscode.window.showQuickPick([constants.yesString, constants.noString],
+				{
+					title: constants.containerAlreadyExistForProject,
+					ignoreFocusOut: true
+				});
 			if (result === constants.yesString) {
 				this.logToOutput(constants.cleaningDockerImagesMessage);
 				await this.cleanDockerObjects(containerIds, ['docker stop', 'docker rm']);

--- a/extensions/sql-database-projects/src/models/deploy/deployService.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployService.ts
@@ -181,7 +181,6 @@ export class DeployService {
 		// Clean up existing docker image
 		const containerIds = await this.getCurrentDockerContainer(imageLabel);
 		if (containerIds.length > 0) {
-			// TODO - Fix this going away
 			const result = await vscode.window.showQuickPick([constants.yesString, constants.noString],
 				{
 					title: constants.containerAlreadyExistForProject,


### PR DESCRIPTION
Toast notifications will disappear automatically after a set amount of time (varies based on type of notification). When this happens they go into the notification tray but otherwise aren't easily visible anymore. This can make the publish process seem like it's hanging since nothing is happening - in reality it's waiting for the notification to be dismissed before moving on.

Updating this to use a quickpick instead, for two reasons : 

1. Fixing the issue described above
2. Making the flow better for users, right now they'll be entering information into the top of the screen and then suddenly have this appear in the notification area which isn't very intuitive

![image](https://user-images.githubusercontent.com/28519865/176977101-2c902beb-58fb-4d18-b6fb-e9cf093dead3.png)
