### PR TITLE
Property view labels update when execution plan orientation changes

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
@@ -463,6 +463,8 @@ export class ExecutionPlanComparisonEditorView {
 			this._orientation = 'vertical';
 			this._toggleOrientationAction.class = splitScreenVerticallyIconClassName;
 		}
+
+		this._propertiesView.updatePropertyContainerTitles(this._orientation);
 		this._topPlanContainer.style.flex = '1';
 		this._bottomPlanContainer.style.flex = '1';
 	}

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -17,6 +17,11 @@ import * as sqlExtHostType from 'sql/workbench/api/common/sqlExtHostTypes';
 import { TextWithIconColumn } from 'sql/base/browser/ui/table/plugins/textWithIconColumn';
 
 export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanPropertiesViewBase {
+	private static readonly _topTitleColumnHeader = localize('nodePropertyViewNameValueColumnTopHeader', "Value (Top Plan)");
+	private static readonly _leftTitleColumnHeader = localize('nodePropertyViewNameValueColumnLeftHeader', "Value (Left Plan)");
+	private static readonly _BottomTitleColumnHeader = localize('nodePropertyViewNameValueColumnBottomHeader', "Value (Bottom Plan)");
+	private static readonly _rightTitleColumnHeader = localize('nodePropertyViewNameValueColumnRightHeader', "Value (Right Plan)");
+
 	private _model: ExecutionPlanComparisonPropertiesViewModel;
 	private _topOperationNameContainer: HTMLElement;
 	private _bottomOperationNameContainer: HTMLElement;
@@ -24,6 +29,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 	private _leftTitleText: string;
 	private _bottomTitleText: string;
 	private _rightTitleText: string;
+
 
 	public constructor(
 		parentContainer: HTMLElement,
@@ -85,9 +91,11 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			this._bottomOperationNameContainer.innerText = this._rightTitleText;
 			this._bottomOperationNameContainer.title = this._rightTitleText;
 		}
+
+		this.addDataToTable(orientation);
 	}
 
-	public addDataToTable() {
+	public addDataToTable(orientation: 'vertical' | 'horizontal' = 'vertical') {
 		const columns: Slick.Column<Slick.SlickData>[] = [
 		];
 		if (this._model.topElement) {
@@ -102,7 +110,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			});
 			columns.push({
 				id: 'value',
-				name: localize('nodePropertyViewNameValueColumnTopHeader', "Value (Top Plan)"),
+				name: this.getPropertyViewNameValueColumnTopHeaderForOrientation(orientation),
 				field: 'value1',
 				width: 150,
 				editor: Slick.Editors.Text,
@@ -113,7 +121,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		if (this._model.bottomElement) {
 			columns.push(new TextWithIconColumn({
 				id: 'value',
-				name: localize('nodePropertyViewNameValueColumnBottomHeader', "Value (Bottom Plan)"),
+				name: this.getPropertyViewNameValueColumnBottomHeaderForOrientation(orientation),
 				field: 'value2',
 				width: 150,
 				headerCssClass: 'prop-table-header',
@@ -130,6 +138,24 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		}
 
 		this.populateTable(columns, this.convertPropertiesToTableRows(topProps, bottomProps, -1, 0));
+	}
+
+	private getPropertyViewNameValueColumnTopHeaderForOrientation(orientation: 'horizontal' | 'vertical'): string {
+		if (orientation === 'horizontal') {
+			return ExecutionPlanComparisonPropertiesView._topTitleColumnHeader;
+		}
+		else {
+			return ExecutionPlanComparisonPropertiesView._leftTitleColumnHeader;
+		}
+	}
+
+	private getPropertyViewNameValueColumnBottomHeaderForOrientation(orientation: 'horizontal' | 'vertical'): string {
+		if (orientation === 'horizontal') {
+			return ExecutionPlanComparisonPropertiesView._BottomTitleColumnHeader;
+		}
+		else {
+			return ExecutionPlanComparisonPropertiesView._rightTitleColumnHeader;
+		}
 	}
 
 	public sortPropertiesAlphabetically(props: Map<string, TablePropertiesMapEntry>): Map<string, TablePropertiesMapEntry> {

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -20,6 +20,10 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 	private _model: ExecutionPlanComparisonPropertiesViewModel;
 	private _topOperationNameContainer: HTMLElement;
 	private _bottomOperationNameContainer: HTMLElement;
+	private _topTitleText: string;
+	private _leftTitleText: string;
+	private _bottomTitleText: string;
+	private _rightTitleText: string;
 
 	public constructor(
 		parentContainer: HTMLElement,
@@ -45,9 +49,10 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		} else {
 			target = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
-		const titleText = localize('executionPlanComparisonPropertiesTopOperation', "Top operation: {0}", target);
-		this._topOperationNameContainer.innerText = titleText;
-		this._topOperationNameContainer.title = titleText;
+		this._leftTitleText = localize('executionPlanComparisonPropertiesLeftOperation', "Left operation: {0}", target);
+		this._topTitleText = localize('executionPlanComparisonPropertiesTopOperation', "Top operation: {0}", target);
+		this._topOperationNameContainer.innerText = this._topTitleText;
+		this._topOperationNameContainer.title = this._topTitleText;
 		this.addDataToTable();
 	}
 
@@ -60,12 +65,27 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			target = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		const titleText = localize('executionPlanComparisonPropertiesBottomOperation', "Bottom operation: {0}", target);
-		this._bottomOperationNameContainer.innerText = titleText;
-		this._bottomOperationNameContainer.title = titleText;
+		this._rightTitleText = localize('executionPlanComparisonPropertiesRightOperation', "Right operation: {0}", target);
+		this._bottomTitleText = localize('executionPlanComparisonPropertiesBottomOperation', "Bottom operation: {0}", target);
+		this._bottomOperationNameContainer.innerText = this._bottomTitleText;
+		this._bottomOperationNameContainer.title = this._bottomTitleText;
 		this.addDataToTable();
 	}
 
+	public updatePropertyContainerTitles(orientation: 'horizontal' | 'vertical'): void {
+		if (orientation === 'horizontal') {
+			this._topOperationNameContainer.innerText = this._topTitleText;
+			this._topOperationNameContainer.title = this._topTitleText;
+			this._bottomOperationNameContainer.innerText = this._bottomTitleText;
+			this._bottomOperationNameContainer.title = this._bottomTitleText;
+		}
+		else {
+			this._topOperationNameContainer.innerText = this._leftTitleText;
+			this._topOperationNameContainer.title = this._leftTitleText;
+			this._bottomOperationNameContainer.innerText = this._rightTitleText;
+			this._bottomOperationNameContainer.title = this._rightTitleText;
+		}
+	}
 
 	public addDataToTable() {
 		const columns: Slick.Column<Slick.SlickData>[] = [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Horizontal Orientation:

In the horizontal orientation the properties view will show "Top operation..." and "Bottom operation...".
The column headers to the right of "Name" will also update to "Value (Top Plan)" and "Value (Bottom Plan)".
![image](https://user-images.githubusercontent.com/87730006/177445995-e65f0814-74f0-42f3-b686-9e0a8124d2fa.png)

Vertical Orientation:

In the vertical orientation the properties view will contain "Left operation..." and "Bottom operation...".
The column headers to the right of "Name" will also update to "Value (Left Plan)" and "Value (Right Plan)".
![image](https://user-images.githubusercontent.com/87730006/177446120-292270ae-1eae-4abb-a321-3157c30237ba.png)
