### PR TITLE
Updated htmlReportGenerator to work with 4 levels severity model

### DIFF
--- a/extensions/sql-assessment/package.json
+++ b/extensions/sql-assessment/package.json
@@ -2,7 +2,7 @@
   "name": "sql-assessment",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-assessment/src/htmlReportGenerator.ts
+++ b/extensions/sql-assessment/src/htmlReportGenerator.ts
@@ -97,7 +97,10 @@ export class HTMLReportBuilder {
 		<div>
 			<div class="target">${targetResults[0].targetType === azdata.sqlAssessment.SqlAssessmentTargetType.Server ? LocalizedStrings.RESULTS_FOR_INSTANCE : LocalizedStrings.RESULTS_FOR_DATABASE}: ${targetResults[0].targetName}</div>
 			${this.buildSeveritySection(LocalizedStrings.REPORT_ERROR, targetResults.filter(item => item.level === 'Error'))}
+			${this.buildSeveritySection(LocalizedStrings.REPORT_HIGH, targetResults.filter(item => item.level === 'High'))}
 			${this.buildSeveritySection(LocalizedStrings.REPORT_WARNING, targetResults.filter(item => item.level === 'Warning'))}
+			${this.buildSeveritySection(LocalizedStrings.REPORT_MEDIUM, targetResults.filter(item => item.level === 'Medium'))}
+			${this.buildSeveritySection(LocalizedStrings.REPORT_LOW, targetResults.filter(item => item.level === 'Low'))}
 			${this.buildSeveritySection(LocalizedStrings.REPORT_INFO, targetResults.filter(item => item.level === 'Information'))}
 		</div>`;
 		return content;

--- a/extensions/sql-assessment/src/localized.ts
+++ b/extensions/sql-assessment/src/localized.ts
@@ -25,7 +25,10 @@ export const LocalizedStrings = {
 	RESULTS_FOR_DATABASE: localize('asmt.sqlReport.resultForDatabase', "Results for database"),
 	RESULTS_FOR_INSTANCE: localize('asmt.sqlReport.resultForInstance', "Results for server"),
 	REPORT_ERROR: localize('asmt.sqlReport.Error', "Error"),
+	REPORT_HIGH: localize('asmt.sqlReport.High', "High"),
 	REPORT_WARNING: localize('asmt.sqlReport.Warning', "Warning"),
+	REPORT_MEDIUM: localize('asmt.sqlReport.Medium', "Medium"),
+	REPORT_LOW: localize('asmt.sqlReport.Low', "Low"),
 	REPORT_INFO: localize('asmt.sqlReport.Info', "Information"),
 	HELP_LINK_COLUMN_NAME: localize('asmt.column.helpLink', "Help Link"),
 	REPORT_SEVERITY_MESSAGE: function (severity: string, count: number) {


### PR DESCRIPTION
Our recent update of the Sql Server Assessment has changed severity levels of the assessment results.
This PR makes the Sql Assessment extension handle these new levels properly. 
