### PR TITLE
Dispose underlying text model when disposing notebook editor model

### DIFF
--- a/extensions/notebook/src/test/common/notebookUtils.test.ts
+++ b/extensions/notebook/src/test/common/notebookUtils.test.ts
@@ -91,15 +91,6 @@ describe('notebookUtils Tests', function (): void {
 			await notebookUtils.openNotebook();
 			should(showErrorMessageSpy.calledOnce).be.true('showErrorMessage should have been called');
 		});
-
-		it('closing and opening an untitled notebook shows correct contents', async function (): Promise<void> {
-			await notebookUtils.newNotebook();
-			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-			let expectedContent = 'untitled notebook test';
-			let editor = await notebookUtils.newNotebook({ initialContent: expectedContent });
-			should(editor.document.cells.length).be.greaterThan(0);
-			should(editor.document.cells[0].contents.source).be.equal(expectedContent);
-		});
 	});
 
 	describe('runActiveCell', function () {

--- a/extensions/notebook/src/test/common/notebookUtils.test.ts
+++ b/extensions/notebook/src/test/common/notebookUtils.test.ts
@@ -91,6 +91,15 @@ describe('notebookUtils Tests', function (): void {
 			await notebookUtils.openNotebook();
 			should(showErrorMessageSpy.calledOnce).be.true('showErrorMessage should have been called');
 		});
+
+		it('closing and opening an untitled notebook shows correct contents', async function (): Promise<void> {
+			await notebookUtils.newNotebook();
+			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+			let expectedContent = 'untitled notebook test';
+			let editor = await notebookUtils.newNotebook({ initialContent: expectedContent });
+			should(editor.document.cells.length).be.greaterThan(0);
+			should(editor.document.cells[0].contents.source).be.equal(expectedContent);
+		});
 	});
 
 	describe('runActiveCell', function () {

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -102,6 +102,7 @@ export class NotebookEditorModel extends EditorModel {
 			}
 		}
 		this._dirty = this.textEditorModel instanceof TextResourceEditorModel ? false : this.textEditorModel.isDirty();
+		this._register(this.textEditorModel);
 	}
 
 	public get contentString(): string {

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -77,6 +77,7 @@ export class NotebookEditorModel extends EditorModel {
 				}, err => undefined);
 			}
 		}));
+		this._register(this.textEditorModel);
 		if (this.textEditorModel instanceof UntitledTextEditorModel) {
 			this._register(this.textEditorModel.onDidChangeDirty(e => {
 				let dirty = this.textEditorModel instanceof TextResourceEditorModel ? false : this.textEditorModel.isDirty();
@@ -102,7 +103,6 @@ export class NotebookEditorModel extends EditorModel {
 			}
 		}
 		this._dirty = this.textEditorModel instanceof TextResourceEditorModel ? false : this.textEditorModel.isDirty();
-		this._register(this.textEditorModel);
 	}
 
 	public get contentString(): string {

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -421,6 +421,7 @@ export abstract class NotebookInput extends EditorInput implements INotebookInpu
 				}
 			} else {
 				const textEditorModelReference = await this.textModelService.createModelReference(this.resource);
+				this._register(textEditorModelReference);
 				textEditorModelReference.object.textEditorModel.onBeforeAttached();
 				await textEditorModelReference.object.resolve();
 				textOrUntitledEditorModel = textEditorModelReference.object as TextFileEditorModel | TextResourceEditorModel;


### PR DESCRIPTION
This PR fixes #13227

We weren't disposing the underlying text model when closing a notebook, so when trying to open a new untitled notebook with the same name as a closed one it would open as empty. This is because the untitledTextEditorService caches the text models until they're disposed, and when opening another untitled file with the same name it returns the pre-existing one without updating its contents. See this line for where that happens:  https://github.com/microsoft/azuredatastudio/blob/main/src/vs/workbench/services/untitled/common/untitledTextEditorService.ts#L171
