### PR TITLE
Fixing macos test results publishing warnings

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -213,7 +213,7 @@ steps:
     condition: always()
 
   - task: PublishTestResults@2
-    displayName: 'Publish Test Results test-results.xml'
+    displayName: 'Publish Test Results'
     inputs:
       testResultsFiles: "*-results.xml"
       searchFolder: "$(Build.ArtifactStagingDirectory)/test-results"

--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -215,8 +215,8 @@ steps:
   - task: PublishTestResults@2
     displayName: 'Publish Test Results test-results.xml'
     inputs:
-      testResultsFiles: 'test-results.xml'
-      searchFolder: '$(Build.SourcesDirectory)'
+      testResultsFiles: "*-results.xml"
+      searchFolder: "$(Build.ArtifactStagingDirectory)/test-results"
     continueOnError: true
     condition: and(succeededOrFailed(), eq(variables['RUN_TESTS'], 'true'))
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6816294/178054959-faceb54a-ac69-45c4-a4f8-56b7e022544b.png)

Now: 
![image](https://user-images.githubusercontent.com/6816294/178054863-2473ac5c-7ac8-404c-8c1f-07098437132c.png)

Working task
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=162205&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=22325323-cbb2-580d-876a-9766e4a9c105&l=1