### PR TITLE
Add telemetry for Python on Jupyter server startup

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -22,7 +22,7 @@ import { BookTocManager, IBookTocManager, quickPickResults } from './bookTocMana
 import { CreateBookDialog } from '../dialog/createBookDialog';
 import { AddTocEntryDialog } from '../dialog/addTocEntryDialog';
 import { getContentPath } from './bookVersionHandler';
-import { TelemetryReporter, BookTelemetryView, NbTelemetryActions } from '../telemetry';
+import { sendNotebookActionEvent, NbTelemetryView, NbTelemetryAction } from '../telemetry';
 
 interface BookSearchResults {
 	notebookPaths: string[];
@@ -124,7 +124,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 						}
 					});
 				}
-				TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.TrustNotebook);
+				sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.TrustNotebook);
 				void vscode.window.showInformationMessage(loc.msgBookTrusted);
 			} else {
 				void vscode.window.showInformationMessage(loc.msgBookAlreadyTrusted);
@@ -136,7 +136,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		let bookPathToUpdate = bookTreeItem.book?.contentPath;
 		if (bookPathToUpdate) {
 			let pinStatusChanged = await this.bookPinManager.pinNotebook(bookTreeItem);
-			TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.PinNotebook);
+			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.PinNotebook);
+
 			if (pinStatusChanged) {
 				bookTreeItem.contextValue = 'pinnedNotebook';
 			}
@@ -155,7 +156,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 
 	async createBook(): Promise<void> {
 		const dialog = new CreateBookDialog(this.bookTocManager);
-		TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.CreateBook);
+		sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.CreateBook);
 		return dialog.createDialog();
 	}
 
@@ -211,7 +212,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	 * @param treeItems Elements to be moved
 	 */
 	async moveTreeItems(treeItems: BookTreeItem[]): Promise<void> {
-		TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.MoveNotebook);
+		sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.MoveNotebook);
+
 		const selectionResults = await this.bookSectionQuickPick();
 		if (selectionResults) {
 			let pickedSection = selectionResults.quickPickSection;
@@ -250,7 +252,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				await this.showPreviewFile(urlToOpen);
 			}
 
-			TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.OpenBook);
+			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.OpenBook);
+
 		} catch (e) {
 			// if there is an error remove book from context
 			const index = this.books.findIndex(book => book.bookPath === bookPath);
@@ -317,7 +320,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				}
 				this._onDidChangeTreeData.fire(undefined);
 			}
-			TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.CloseBook);
+			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.CloseBook);
+
 		} catch (e) {
 			void vscode.window.showErrorMessage(loc.closeBookError(book.root, e instanceof Error ? e.message : e));
 		} finally {
@@ -402,7 +406,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 					this._visitedNotebooks = this._visitedNotebooks.concat([normalizedResource]);
 				}
 			}
-			TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.OpenNotebookFromBook);
+			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.OpenNotebookFromBook);
+
 		} catch (e) {
 			void vscode.window.showErrorMessage(loc.openNotebookError(resource, e instanceof Error ? e.message : e));
 		}
@@ -754,7 +759,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 
 	async onDrop(sources: vscode.TreeDataTransfer, target: BookTreeItem): Promise<void> {
 		if (target.contextValue === BookTreeItemType.savedBook || target.contextValue === BookTreeItemType.section) {
-			TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.DragAndDrop);
+			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.DragAndDrop);
 			// gets the tree items that are dragged and dropped
 			let treeItems = JSON.parse(await sources.items.get(this.supportedTypes[0])!.asString()) as BookTreeItem[];
 			let rootItems = this.getLocalRoots(treeItems);

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -137,7 +137,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (bookPathToUpdate) {
 			let pinStatusChanged = await this.bookPinManager.pinNotebook(bookTreeItem);
 			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.PinNotebook);
-
 			if (pinStatusChanged) {
 				bookTreeItem.contextValue = 'pinnedNotebook';
 			}
@@ -213,7 +212,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	 */
 	async moveTreeItems(treeItems: BookTreeItem[]): Promise<void> {
 		sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.MoveNotebook);
-
 		const selectionResults = await this.bookSectionQuickPick();
 		if (selectionResults) {
 			let pickedSection = selectionResults.quickPickSection;
@@ -253,7 +251,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			}
 
 			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.OpenBook);
-
 		} catch (e) {
 			// if there is an error remove book from context
 			const index = this.books.findIndex(book => book.bookPath === bookPath);
@@ -321,7 +318,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				this._onDidChangeTreeData.fire(undefined);
 			}
 			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.CloseBook);
-
 		} catch (e) {
 			void vscode.window.showErrorMessage(loc.closeBookError(book.root, e instanceof Error ? e.message : e));
 		} finally {
@@ -407,7 +403,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				}
 			}
 			sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.OpenNotebookFromBook);
-
 		} catch (e) {
 			void vscode.window.showErrorMessage(loc.openNotebookError(resource, e instanceof Error ? e.message : e));
 		}

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -20,7 +20,7 @@ import { IconPathHelper } from './common/iconHelper';
 import { ExtensionContextHelper } from './common/extensionContextHelper';
 import { BookTreeItem } from './book/bookTreeItem';
 import Logger from './common/logger';
-import { TelemetryReporter, BookTelemetryView, NbTelemetryActions } from './telemetry';
+import { sendNotebookActionEvent, NbTelemetryView, NbTelemetryAction } from './telemetry';
 
 const localize = nls.loadMessageBundle();
 
@@ -81,7 +81,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.openRemoteBook', async () => {
 		let dialog = new RemoteBookDialog(remoteBookController);
-		TelemetryReporter.sendActionEvent(BookTelemetryView, NbTelemetryActions.AddRemoteBook);
+		sendNotebookActionEvent(NbTelemetryView.Book, NbTelemetryAction.AddRemoteBook);
 		return dialog.createDialog();
 	}));
 

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -16,6 +16,7 @@ import { IServerInstance } from './common';
 import { JupyterServerInstallation } from './jupyterServerInstallation';
 import * as utils from '../common/utils';
 import * as constants from '../common/constants';
+import { sendNotebookActionEvent, NbTelemetryView, NbTelemetryAction } from '../telemetry';
 
 const NotebookConfigFilename = 'jupyter_notebook_config.py';
 const CustomJsFilename = 'custom.js';
@@ -218,6 +219,7 @@ export class PerFolderServerInstance implements IServerInstance {
 
 		// Execute the command
 		await this.executeStartCommand(startCommand);
+		sendNotebookActionEvent(NbTelemetryView.Jupyter, NbTelemetryAction.JupyterServerStarted, { pythonVersion: this.options.install.installedPythonVersion, usingExistingPython: String(JupyterServerInstallation.getExistingPythonSetting()), usingConda: String(this.options.install.usingConda) });
 	}
 
 	private executeStartCommand(startCommand: string): Promise<void> {

--- a/extensions/notebook/src/telemetry.ts
+++ b/extensions/notebook/src/telemetry.ts
@@ -3,14 +3,17 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
+import AdsTelemetryReporter, { TelemetryEventMeasures, TelemetryEventProperties } from '@microsoft/ads-extension-telemetry';
 
 const packageJson = require('../package.json');
 export const TelemetryReporter = new AdsTelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
 
-export const BookTelemetryView = 'Book';
+export enum NbTelemetryView {
+	Book = 'Book',
+	Jupyter = 'Jupyter'
+}
 
-export enum NbTelemetryActions {
+export enum NbTelemetryAction {
 	OpenNotebook = 'NotebookOpened',
 	OpenMarkdown = 'MarkdownOpened',
 	OpenBook = 'BookOpened',
@@ -22,6 +25,14 @@ export enum NbTelemetryActions {
 	OpenNotebookFromBook = 'NotebookOpenedFromBook',
 	MoveNotebook = 'MoveNotebook',
 	DragAndDrop = 'DragAndDrop',
-	AddRemoteBook = 'AddRemoteBook'
+	AddRemoteBook = 'AddRemoteBook',
+	JupyterServerStarted = 'JupyterServerStarted'
+}
+
+export function sendNotebookActionEvent(telemetryView: NbTelemetryView, telemetryAction: NbTelemetryAction, additionalProps?: TelemetryEventProperties, additionalMeasurements?: TelemetryEventMeasures): void {
+	TelemetryReporter.createActionEvent(telemetryView, telemetryAction)
+		.withAdditionalProperties(additionalProps)
+		.withAdditionalMeasurements(additionalMeasurements)
+		.send();
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds a telemetry event for when a Jupyter server is started. 
The event includes
- python version
- usingExistingPython (false if user is using python installed from ADS)
- usingConda (false if using pip)
