### PR TITLE
Toggle reset button on option change

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -58,6 +58,7 @@ export class PublishDatabaseDialog {
 	private serverName: string | undefined;
 	protected optionsButton: azdataType.ButtonComponent | undefined;
 	private publishOptionsDialog: PublishOptionsDialog | undefined;
+	public publishOptionsModified: boolean = false;
 
 	private completionPromise: Deferred = new Deferred();
 

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -49,7 +49,7 @@ export class PublishOptionsDialog {
 		let resetButton = utils.getAzdataApi()!.window.createButton(constants.ResetButton);
 		resetButton.onClick(async () => await this.reset());
 		// If options values already modified then enable the reset button
-		resetButton.enabled = this.publish.publishOptionsModified!;
+		resetButton.enabled = this.publish.publishOptionsModified;
 		this.dialog.customButtons = [resetButton];
 
 		utils.getAzdataApi()!.window.openDialog(this.dialog);
@@ -94,7 +94,7 @@ export class PublishOptionsDialog {
 					const displayName = this.optionsTable?.data[checkboxState.row][1];
 					this.optionsModel.setOptionValue(displayName, checkboxState.checked);
 					this.optionsChanged = true;
-					// customButton[0] is the reset button, enablling it when option checkbox is changed
+					// customButton[0] is the reset button, enabling it when option checkbox is changed
 					this.dialog.customButtons[0].enabled = true;
 				}
 			}));
@@ -150,11 +150,13 @@ export class PublishOptionsDialog {
 		// Set the publish deploymentoptions with the updated table component values
 		this.publish.setDeploymentOptions(this.optionsModel.deploymentOptions);
 		this.disposeListeners();
+
 		if (this.optionsChanged) {
 			TelemetryReporter.sendActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.optionsChanged);
 		}
-		// When options are Reset to default and clicked Ok, seting optionsChanged flag to false, if not set the state of the option change
-		this.publish.publishOptionsModified = this.isResetOptionsClicked ? false : (this.optionsChanged || this.publish.publishOptionsModified);
+		// When options are Reset to default and clicked Ok, seting optionsChanged flag to false
+		// When options are Reset to default and options are changed and then clicked Ok, seting optionsChanged flag to the state of the option change
+		this.publish.publishOptionsModified = this.isResetOptionsClicked && !this.optionsChanged ? false : (this.optionsChanged || this.publish.publishOptionsModified);
 	}
 
 	/*
@@ -178,7 +180,10 @@ export class PublishOptionsDialog {
 		this.optionsFlexBuilder?.removeItem(this.optionsTable!);
 		this.optionsFlexBuilder?.insertItem(this.optionsTable!, 0, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh', 'padding-top': '2px' } });
 		TelemetryReporter.sendActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.resetOptions);
+
+		// setting optionsChanged to false when reset click, if optionsChanged is true during execute, that means there is an option changed after reset
 		this.isResetOptionsClicked = true;
+		this.optionsChanged = false;
 	}
 
 	private disposeListeners(): void {

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -23,6 +23,7 @@ export class PublishOptionsDialog {
 	public optionsModel: DeployOptionsModel;
 	private optionsFlexBuilder: azdataType.FlexContainer | undefined;
 	private optionsChanged: boolean = false;
+	private isResetOptionsClicked: boolean = false;
 
 	constructor(defaultOptions: mssql.DeploymentOptions, private publish: PublishDatabaseDialog) {
 		this.optionsModel = new DeployOptionsModel(defaultOptions);
@@ -47,6 +48,8 @@ export class PublishOptionsDialog {
 
 		let resetButton = utils.getAzdataApi()!.window.createButton(constants.ResetButton);
 		resetButton.onClick(async () => await this.reset());
+		// If options values already modified then enable the reset button
+		resetButton.enabled = this.publish.publishOptionsModified!;
 		this.dialog.customButtons = [resetButton];
 
 		utils.getAzdataApi()!.window.openDialog(this.dialog);
@@ -91,6 +94,8 @@ export class PublishOptionsDialog {
 					const displayName = this.optionsTable?.data[checkboxState.row][1];
 					this.optionsModel.setOptionValue(displayName, checkboxState.checked);
 					this.optionsChanged = true;
+					// customButton[0] is the reset button, enablling it when option checkbox is changed
+					this.dialog.customButtons[0].enabled = true;
 				}
 			}));
 
@@ -145,10 +150,11 @@ export class PublishOptionsDialog {
 		// Set the publish deploymentoptions with the updated table component values
 		this.publish.setDeploymentOptions(this.optionsModel.deploymentOptions);
 		this.disposeListeners();
-
 		if (this.optionsChanged) {
 			TelemetryReporter.sendActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.optionsChanged);
 		}
+		// When options are Reset to default and clicked Ok, seting optionsChanged flag to false, if not set the state of the option change
+		this.publish.publishOptionsModified = this.isResetOptionsClicked ? false : (this.optionsChanged || this.publish.publishOptionsModified);
 	}
 
 	/*
@@ -172,6 +178,7 @@ export class PublishOptionsDialog {
 		this.optionsFlexBuilder?.removeItem(this.optionsTable!);
 		this.optionsFlexBuilder?.insertItem(this.optionsTable!, 0, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh', 'padding-top': '2px' } });
 		TelemetryReporter.sendActionEvent(TelemetryViews.PublishOptionsDialog, TelemetryActions.resetOptions);
+		this.isResetOptionsClicked = true;
 	}
 
 	private disposeListeners(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR Adds the ability to toggle the reset button on option updates.
1. Enables when the option is changed.
2. Disables when the defaults are set.

Total scenarios: 
Operations - Reset state (Disable)
1. Opens options tab first time- disabled
2. Options changes - enable instantly
3. Options changes + ok - Enables
4. Options changes + cancel - Disable (or depends on prev state)
5. Options changed + reset clicked + cancel - Disable (or depends on prev state)
6. Options changed + reset clicked + ok - Disable
7. Reset clicked followed by ok clicked - Disable
8. Reset clicked +option changed + cancel- Disable (or depends on prev state)
9. Reset clicked + option changed +ok - Enable

When no option is changed:
![image](https://user-images.githubusercontent.com/74571829/178091695-71f175a0-38b6-49b0-a4ed-0d432a0bb1b4.png)

When there is a change identified through the publish process:
![image](https://user-images.githubusercontent.com/74571829/178091740-a5ec9519-5305-4976-a7a9-a0faad640af0.png)
