### PR TITLE
Fix connection sorting by name in OE

### DIFF
--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -48,6 +48,7 @@ export class ConnectionConfig {
 		const config = this.configurationService.inspect<IConnectionProfileGroup[]>(GROUPS_CONFIG_KEY);
 		let { userValue } = config;
 		const { workspaceValue } = config;
+		const sortBy = this.configurationService.getValue<string>(CONNECTIONS_SORT_BY_CONFIG_KEY);
 
 		if (userValue) {
 			if (workspaceValue) {
@@ -57,23 +58,8 @@ export class ConnectionConfig {
 			allGroups = allGroups.concat(userValue);
 		}
 
-		const sortBy = this.configurationService.getValue<string>(CONNECTIONS_SORT_BY_CONFIG_KEY);
-		let sortFunc: (a: IConnectionProfileGroup, b: IConnectionProfileGroup) => number;
-
 		if (sortBy === ConnectionsSortOrder.displayName) {
-			sortFunc = ((a, b) => {
-				if (a.name < b.name) {
-					return -1;
-				} else if (a.name > b.name) {
-					return 1;
-				} else {
-					return 0;
-				}
-			});
-		}
-
-		if (sortFunc) {
-			allGroups.sort(sortFunc);
+			allGroups.sort((a, b) => a.name.localeCompare(b.name));
 		}
 
 		return deepClone(allGroups).map(g => {
@@ -249,24 +235,10 @@ export class ConnectionConfig {
 		let connectionProfiles = this.getIConnectionProfileStores(getWorkspaceConnections).map(p => {
 			return ConnectionProfile.createFromStoredProfile(p, this._capabilitiesService);
 		});
-
 		const sortBy = this.configurationService.getValue<string>(CONNECTIONS_SORT_BY_CONFIG_KEY);
-		let sortFunc: (a: ConnectionProfile, b: ConnectionProfile) => number;
 
 		if (sortBy === ConnectionsSortOrder.displayName) {
-			sortFunc = ((a, b) => {
-				if (a.title < b.title) {
-					return -1;
-				} else if (a.title > b.title) {
-					return 1;
-				} else {
-					return 0;
-				}
-			});
-		}
-
-		if (sortFunc) {
-			connectionProfiles.sort(sortFunc);
+			connectionProfiles.sort((a, b) => a.title.localeCompare(b.title));
 		}
 
 		return connectionProfiles;

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -250,7 +250,7 @@ suite('ConnectionConfig', () => {
 
 		assert.strictEqual(allGroups.length, testGroups.length, 'did not meet the expected length');
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
-		assert.ok(allGroups.slice(1).every((item, i) => allGroups[i].name <= item.name), 'the groups are not sorted correctly');
+		assert.ok(allGroups.slice(1).every((item, i) => allGroups[i].name.localeCompare(item.name) <= 0), 'the groups are not sorted correctly');
 	});
 
 	test('getAllGroups should return groups sorted by date added given datasource.connectionsSortOrder is set to \'' + ConnectionsSortOrder.dateAdded + '\'', () => {
@@ -420,7 +420,7 @@ suite('ConnectionConfig', () => {
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(true);
 		assert.strictEqual(allConnections.length, testConnections.length, 'The result connections length is invalid');
-		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title), 'The connections are not sorted correctly');
+		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title.localeCompare(item.title) <= 0), 'The connections are not sorted correctly');
 	});
 
 	test('getConnections should return connections sorted by date added given datasource.connectionsSortOrder is set to \'' + ConnectionsSortOrder.dateAdded + '\'', () => {


### PR DESCRIPTION
This PR fixes #19984 
Previously, if `Connections Sort Order` is set to `displayName`, we do a case-sensitive sorting by connection name. This PR changes sorting to case-insensitive using`localeCompare`

Before: (with `Connections Sort Order` set to displayName)
![image](https://user-images.githubusercontent.com/21186993/178352419-d4844e8c-b9fc-4b9c-9899-32034369a6ff.png)
After:  (with `Connections Sort Order` set to displayName)
![image](https://user-images.githubusercontent.com/21186993/178352637-2b34fa5f-527b-4310-ac3d-bae31ceea83b.png)

