### PR TITLE
Feat/reenable integration

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -110,19 +110,18 @@ steps:
     displayName: Run unit tests
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
-# skip while fixing
-  # - script: |
-  #     # Figure out the full absolute path of the product we just built
-  #     # including the remote server and configure the integration tests
-  #     # to run with these builds instead of running out of sources.
-  #     set -e
-  #     APP_ROOT=$(agent.builddirectory)/azuredatastudio-darwin-x64
-  #     APP_NAME="`ls $APP_ROOT | head -n 1`"
-  #     INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME/Contents/MacOS/Electron" \
-  #     VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-darwin" \
-  #     ./scripts/test-integration.sh --build --tfs "Integration Tests"
-  #   displayName: Run integration tests (Electron)
-  #   condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+  - script: |
+      # Figure out the full absolute path of the product we just built
+      # including the remote server and configure the integration tests
+      # to run with these builds instead of running out of sources.
+      set -e
+      APP_ROOT=$(agent.builddirectory)/azuredatastudio-darwin-x64
+      APP_NAME="`ls $APP_ROOT | head -n 1`"
+      INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME/Contents/MacOS/Electron" \
+      VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-darwin" \
+      ./scripts/test-integration.sh --build --tfs "Integration Tests"
+    displayName: Run integration tests (Electron)
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -123,19 +123,18 @@ steps:
     displayName: Run unit tests (Electron)
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
-# skip while fixing
-  # - script: |
-  #     # Figure out the full absolute path of the product we just built
-  #     # including the remote server and configure the integration tests
-  #     # to run with these builds instead of running out of sources.
-  #     set -e
-  #     APP_ROOT=$(agent.builddirectory)/azuredatastudio-linux-x64
-  #     APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
-  #     INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
-  #     VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-linux-x64" \
-  #     DISPLAY=:10 ./scripts/test-integration.sh --build --tfs "Integration Tests"
-  #   displayName: Run integration tests (Electron)
-  #   condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+  - script: |
+      # Figure out the full absolute path of the product we just built
+      # including the remote server and configure the integration tests
+      # to run with these builds instead of running out of sources.
+      set -e
+      APP_ROOT=$(agent.builddirectory)/azuredatastudio-linux-x64
+      APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
+      INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
+      VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-linux-x64" \
+      DISPLAY=:10 ./scripts/test-integration.sh --build --tfs "Integration Tests"
+    displayName: Run integration tests (Electron)
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
   - script: |
       # Figure out the full absolute path of the product we just built

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -140,19 +140,18 @@ steps:
   #   displayName: Run unit tests (Electron)
   #   condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
-# skip while fixing
-  # - powershell: |
-  #     # Figure out the full absolute path of the product we just built
-  #     # including the remote server and configure the integration tests
-  #     # to run with these builds instead of running out of sources.
-  #     . build/azure-pipelines/win32/exec.ps1
-  #     $ErrorActionPreference = "Stop"
-  #     $AppRoot = "$(agent.builddirectory)\azuredatastudio-win32-x64"
-  #     $AppProductJson = Get-Content -Raw -Path "$AppRoot\resources\app\product.json" | ConvertFrom-Json
-  #     $AppNameShort = $AppProductJson.nameShort
-  #     # exec { $env:INTEGRATION_TEST_ELECTRON_PATH = "$AppRoot\$AppNameShort.exe"; $env:VSCODE_REMOTE_SERVER_PATH = "$(agent.builddirectory)\azuredatastudio-reh-win32-x64"; .\scripts\test-integration.bat --build --tfs "Integration Tests" }
-  #   displayName: Run integration tests (Electron)
-  #   condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+  - powershell: |
+      # Figure out the full absolute path of the product we just built
+      # including the remote server and configure the integration tests
+      # to run with these builds instead of running out of sources.
+      . build/azure-pipelines/win32/exec.ps1
+      $ErrorActionPreference = "Stop"
+      $AppRoot = "$(agent.builddirectory)\azuredatastudio-win32-x64"
+      $AppProductJson = Get-Content -Raw -Path "$AppRoot\resources\app\product.json" | ConvertFrom-Json
+      $AppNameShort = $AppProductJson.nameShort
+      # exec { $env:INTEGRATION_TEST_ELECTRON_PATH = "$AppRoot\$AppNameShort.exe"; $env:VSCODE_REMOTE_SERVER_PATH = "$(agent.builddirectory)\azuredatastudio-reh-win32-x64"; .\scripts\test-integration.bat --build --tfs "Integration Tests" }
+    displayName: Run integration tests (Electron)
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
   # - powershell: |
   #     . build/azure-pipelines/win32/exec.ps1

--- a/scripts/test-integration.bat
+++ b/scripts/test-integration.bat
@@ -65,7 +65,7 @@ set ALL_PLATFORMS_API_TESTS_EXTRA_ARGS=--disable-telemetry --skip-welcome --skip
 :: call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\vscode-colorize-tests\test --extensionDevelopmentPath=%~dp0\..\extensions\vscode-colorize-tests --extensionTestsPath=%~dp0\..\extensions\vscode-colorize-tests\out %ALL_PLATFORMS_API_TESTS_EXTRA_ARGS%
 :: if %errorlevel% neq 0 exit /b %errorlevel%
 
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\typescript-language-features\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\typescript-language-features --extensionTestsPath=%~dp0\..\extensions\typescript-language-features\out\test\unit %ALL_PLATFORMS_API_TESTS_EXTRA_ARGS%
+:: call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\typescript-language-features\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\typescript-language-features --extensionTestsPath=%~dp0\..\extensions\typescript-language-features\out\test\unit %ALL_PLATFORMS_API_TESTS_EXTRA_ARGS%
 :: if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\markdown-language-features\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\markdown-language-features --extensionTestsPath=%~dp0\..\extensions\markdown-language-features\out\test %ALL_PLATFORMS_API_TESTS_EXTRA_ARGS%

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -84,7 +84,7 @@ ALL_PLATFORMS_API_TESTS_EXTRA_ARGS="--disable-telemetry --skip-welcome --skip-re
 # "$INTEGRATION_TEST_ELECTRON_PATH" $LINUX_EXTRA_ARGS $ROOT/extensions/vscode-colorize-tests/test --extensionDevelopmentPath=$ROOT/extensions/vscode-colorize-tests --extensionTestsPath=$ROOT/extensions/vscode-colorize-tests/out $ALL_PLATFORMS_API_TESTS_EXTRA_ARGS
 # after_suite
 
-"$INTEGRATION_TEST_ELECTRON_PATH" $LINUX_EXTRA_ARGS $ROOT/extensions/typescript-language-features/test-workspace --extensionDevelopmentPath=$ROOT/extensions/typescript-language-features --extensionTestsPath=$ROOT/extensions/typescript-language-features/out/test/unit $ALL_PLATFORMS_API_TESTS_EXTRA_ARGS
+# "$INTEGRATION_TEST_ELECTRON_PATH" $LINUX_EXTRA_ARGS $ROOT/extensions/typescript-language-features/test-workspace --extensionDevelopmentPath=$ROOT/extensions/typescript-language-features --extensionTestsPath=$ROOT/extensions/typescript-language-features/out/test/unit $ALL_PLATFORMS_API_TESTS_EXTRA_ARGS
 # after_suite
 
 # "$INTEGRATION_TEST_ELECTRON_PATH" $LINUX_EXTRA_ARGS $ROOT/extensions/markdown-language-features/test-workspace --extensionDevelopmentPath=$ROOT/extensions/markdown-language-features --extensionTestsPath=$ROOT/extensions/markdown-language-features/out/test $ALL_PLATFORMS_API_TESTS_EXTRA_ARGS


### PR DESCRIPTION
vscode merge follow-up.  restores test-integration scripts to what they were prior to the merge.
