### PR TITLE
Re-enable notebook outputprocessor tests

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
@@ -49,7 +49,7 @@ suite('OutputProcessor functions', function (): void {
 						evalue: evalue,
 						traceback: traceback
 					};
-					test.skip(`test for outputType:'${output.output_type}', ename:'${ename}', evalue:${evalue}, and traceback:${JSON.stringify(traceback)}`, () => {
+					test(`test for outputType:'${output.output_type}', ename:'${ename}', evalue:${evalue}, and traceback:${JSON.stringify(traceback)}`, () => {
 						verifyGetDataForErrorOutput(output);
 					});
 				}
@@ -149,7 +149,7 @@ function verifyGetDataForStreamOutput(output: nbformat.IStream): void {
 
 function verifyGetDataForErrorOutput(output: nbformat.IError): void {
 	const result = op.getData(output);
-	const tracedata = (output.traceback === undefined || output.traceback.length > 0) ? undefined : output.traceback.join('\n');
+	const tracedata = (output.traceback === undefined || output.traceback.length === 0) ? undefined : output.traceback.join('\n');
 	// getData returns an object with single property: 'application/vnd.jupyter.stderr'
 	// this property is assigned to a '\n' delimited traceback data when it is present.
 	// when traceback is absent this property gets ename and evalue information with ': ' as delimiter unless


### PR DESCRIPTION
Part of #19993. Simple fix caused by merge. Here's what it looked like in the merge:

<img width="855" alt="image" src="https://user-images.githubusercontent.com/40371649/178388198-70e4283f-93b9-4290-b08a-8c7e3e32ff36.png">
