### PR TITLE
Fix error when installing extensions from gallery

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -112,7 +112,7 @@ export abstract class AbstractExtensionManagementService extends Disposable impl
 			throw error;
 		}
 
-		/* {{SQL CARBON EDIT}} Remove this check as we don't want to enforce the manifest versions matching since those are often coming directly from Github
+		/* {{SQL CARBON EDIT}} Remove this check as we don't want to enforce the manifest versions matching since those are often coming directly from the main branch
 		if (manifest.version !== extension.version) {
 			const error = new ExtensionManagementError(`Cannot install '${extension.identifier.id}' extension because of version mismatch in Marketplace`, ExtensionManagementErrorCode.Invalid);
 			this.logService.error(error.message);

--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -112,12 +112,14 @@ export abstract class AbstractExtensionManagementService extends Disposable impl
 			throw error;
 		}
 
+		/* {{SQL CARBON EDIT}} Remove this check as we don't want to enforce the manifest versions matching since those are often coming directly from Github
 		if (manifest.version !== extension.version) {
 			const error = new ExtensionManagementError(`Cannot install '${extension.identifier.id}' extension because of version mismatch in Marketplace`, ExtensionManagementErrorCode.Invalid);
 			this.logService.error(error.message);
 			reportTelemetry(this.telemetryService, 'extensionGallery:install', getGalleryExtensionTelemetryData(extension), undefined, error);
 			throw error;
 		}
+		*/
 
 		return this.installExtension(manifest, extension, options);
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/20010

This check was brought in with the merge : https://github.com/Microsoft/azuredatastudio/commit/26455e9113fb97398b2c86273af64c42d218a71a#diff-eda12cac0da646fd0c78db7e7e614af77c58dd83fe8404abdd70e890594f7183R115

Currently nearly all of our manifests point to the main branch - e.g. https://github.com/microsoft/azuredatastudio/blob/release/extensions/extensionsGallery-insider.json#L36

So now that we're checking the versions that is usually going to fail since the main branch is ahead of the current released version typically.

Another option would be to enforce updating the manifest every time we update an extension to point to a specific commit, but ensuring that it'll always stay correct is going to be difficult and so I think it's best to just revert back to previous behavior and remove this check for now. There is (and always has been) a small chance of someone being confused if the package.json has new content that hasn't been released yet, but we haven't gotten any complaints and it shouldn't affect any actual functionality so should be fine to keep as it is for now and follow up later if we think we need to improve this more.