### PR TITLE
Updates azdataGraph version to 0.0.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
     "applicationinsights": "1.0.8",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.32",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.33",
     "chart.js": "^2.9.4",
     "chokidar": "3.5.1",
     "graceful-fs": "4.2.8",

--- a/remote/package.json
+++ b/remote/package.json
@@ -17,7 +17,7 @@
     "applicationinsights": "1.0.8",
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.32",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.33",
     "chart.js": "^2.9.4",
     "cookie": "^0.4.0",
     "graceful-fs": "4.2.8",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -15,7 +15,7 @@
 		"@vscode/vscode-languagedetection": "1.0.21",
 		"angular2-grid": "2.0.6",
 		"ansi_up": "^5.1.0",
-		"azdataGraph": "github:Microsoft/azdataGraph#0.0.32",
+		"azdataGraph": "github:Microsoft/azdataGraph#0.0.33",
 		"chart.js": "^2.9.4",
 		"gridstack": "^3.1.3",
 		"kburtram-query-plan": "2.6.1",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -150,9 +150,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.32":
-  version "0.0.32"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/96bc3b9c61e060ea3a4fa7ed2e556e814cf0060e"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.33":
+  version "0.0.33"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/03b12598831a85f977f5e58f22cbd7ff37e16b04"
 
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -198,9 +198,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.32":
-  version "0.0.32"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/96bc3b9c61e060ea3a4fa7ed2e556e814cf0060e"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.33":
+  version "0.0.33"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/03b12598831a85f977f5e58f22cbd7ff37e16b04"
 
 bindings@^1.5.0:
   version "1.5.0"

--- a/src/sql/workbench/contrib/executionPlan/browser/azdataGraphView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/azdataGraphView.ts
@@ -38,7 +38,16 @@ export class AzdataGraphView {
 	) {
 		this._parentContainer.tabIndex = 0;
 		this._diagramModel = this.populate(this._executionPlan.root);
-		this._diagram = new azdataGraph.azdataQueryPlan(this._parentContainer, this._diagramModel, executionPlanNodeIconPaths, badgeIconPaths, collapseExpandNodeIconPaths);
+
+		let queryPlanConfiguration = {
+			container: this._parentContainer,
+			queryPlanGraph: this._diagramModel,
+			iconPaths: executionPlanNodeIconPaths,
+			badgeIconPaths: badgeIconPaths,
+			expandCollapsePaths: collapseExpandNodeIconPaths
+		};
+		this._diagram = new azdataGraph.azdataQueryPlan(queryPlanConfiguration);
+
 		this.setGraphProperties();
 		this.selectElement(this._executionPlan.root);
 		this._cellInFocus = this._diagram.graph.getSelectionCell();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,9 +1891,9 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.32":
-  version "0.0.32"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/96bc3b9c61e060ea3a4fa7ed2e556e814cf0060e"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.33":
+  version "0.0.33"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/03b12598831a85f977f5e58f22cbd7ff37e16b04"
 
 bach@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This azdataGraph version update changes the constructor signature for azdataQueryPlan's to take a single object as an argument instead of several arguments.