### PR TITLE
update azdata dependency for schema-compare and sql-database-projects

### DIFF
--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -7,7 +7,7 @@
   "preview": false,
   "engines": {
     "vscode": "^1.25.0",
-    "azdata": ">=1.35.0"
+    "azdata": ">=1.38.0"
   },
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -7,7 +7,7 @@
   "preview": true,
   "engines": {
     "vscode": "^1.30.1",
-    "azdata": ">=1.37.0"
+    "azdata": ">=1.38.0"
   },
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/sqlDatabaseProjects.png",


### PR DESCRIPTION
Need to update the azdata dependency of these extensions because of recent STS changes for DacFx deployment options. They will no longer work with older versions of ADS because of the options changes.