### PR TITLE
fix: image disappear issue

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -1079,6 +1079,25 @@ suite('Cell Model', function (): void {
 		assert.deepStrictEqual(serializedCell.attachments, undefined, 'JSON should not include attachments if attachments do not exist');
 	});
 
+	test('Should not include image in attachments if image is added in html image tag', async function () {
+		const cellAttachment = JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}');
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Markdown,
+			source: '![ads.png](attachment:ads.png)',
+			attachments: cellAttachment
+		};
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		let imageElement = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAggg=="';
+		model.source = '![ads.png](attachment:ads.png) \n Test image: ' + imageElement;
+
+		assert.deepStrictEqual(model.attachments, contents.attachments, 'Should not add the image represented in html tag to the attachments of cell source');
+	});
+
 	test('Should remove unused attachments name when updating cell source', async function () {
 		const cellAttachment = JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}');
 		let notebookModel = new NotebookModelStub({

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -349,8 +349,9 @@ export class CellModel extends Disposable implements ICellModel {
 	private attachImageFromSource(newSource: string | string[]): string | string[] {
 		if (!Array.isArray(newSource) && this.isValidBase64OctetStream(newSource)) {
 			let results;
-			while ((results = validBase64OctetStreamRegex.exec(newSource)) !== null) {
-				let imageName = this.addAttachment(results[1], results[0], 'image.png');
+			// only replace the base64 value if it's from markdown [](base64value) not html tags <img src="base64value"
+			while ((results = validBase64OctetStreamRegex.exec(newSource)) !== null && newSource.substring(newSource.indexOf(results[0]) - 9, newSource.indexOf(results[0]) - 2) !== 'img src') {
+				let imageName = this.addAttachment(results[1], results[0], 'image0.png');
 				newSource = newSource.replace(validBase64OctetStreamRegex, `attachment:${imageName}`);
 			}
 			return newSource;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -352,7 +352,8 @@ export class CellModel extends Disposable implements ICellModel {
 			// only replace the base64 value if it's from markdown [](base64value) not html tags <img src="base64value">
 			let validImageTag = /<img\s+[^>]*src="([^"]*)"[^>]*>/;
 			let imageResults;
-			// Note: It would not add image attachments from makrdown below the html tags.
+			// Note: Currently this will not process any markdown image attachments that are below an HTML img element.
+			// This is acceptable for now given the low risk of this happening and an easy workaround being to just changing the img element to a markdown embedded image instead
 			while ((results = validBase64OctetStreamRegex.exec(newSource)) !== null && ((imageResults = validImageTag.exec(newSource)) !== null && this.isValidBase64OctetStream(imageResults[1]) && results[0] !== imageResults[1])) {
 				let imageName = this.addAttachment(results[1], results[0], 'image.png');
 				newSource = newSource.replace(validBase64OctetStreamRegex, `attachment:${imageName}`);

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -349,9 +349,11 @@ export class CellModel extends Disposable implements ICellModel {
 	private attachImageFromSource(newSource: string | string[]): string | string[] {
 		if (!Array.isArray(newSource) && this.isValidBase64OctetStream(newSource)) {
 			let results;
-			// only replace the base64 value if it's from markdown [](base64value) not html tags <img src="base64value"
-			while ((results = validBase64OctetStreamRegex.exec(newSource)) !== null && newSource.substring(newSource.indexOf(results[0]) - 9, newSource.indexOf(results[0]) - 2) !== 'img src') {
-				let imageName = this.addAttachment(results[1], results[0], 'image0.png');
+			// only replace the base64 value if it's from markdown [](base64value) not html tags <img src="base64value">
+			let validImageTag = /<img\s+[^>]*src="([^"]*)"[^>]*>/;
+			let imageResults;
+			while ((results = validBase64OctetStreamRegex.exec(newSource)) !== null && ((imageResults = validImageTag.exec(newSource)) !== null && this.isValidBase64OctetStream(imageResults[1]) && results[0] !== imageResults[1])) {
+				let imageName = this.addAttachment(results[1], results[0], 'image.png');
 				newSource = newSource.replace(validBase64OctetStreamRegex, `attachment:${imageName}`);
 			}
 			return newSource;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -352,6 +352,7 @@ export class CellModel extends Disposable implements ICellModel {
 			// only replace the base64 value if it's from markdown [](base64value) not html tags <img src="base64value">
 			let validImageTag = /<img\s+[^>]*src="([^"]*)"[^>]*>/;
 			let imageResults;
+			// Note: It would not add image attachments from makrdown below the html tags.
 			while ((results = validBase64OctetStreamRegex.exec(newSource)) !== null && ((imageResults = validImageTag.exec(newSource)) !== null && this.isValidBase64OctetStream(imageResults[1]) && results[0] !== imageResults[1])) {
 				let imageName = this.addAttachment(results[1], results[0], 'image.png');
 				newSource = newSource.replace(validBase64OctetStreamRegex, `attachment:${imageName}`);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19546 

Issue: When user pastes an image in wysiwyg mode and goes out of the edit mode, the image disappears.
Why: When user pastes an image into a notebook that already has html tags in it, the image is added as html inside span tags. And when we parse for attachments, we're replacing the valid base64 value of the image with attachment:imageName inside the image tags src attribute, which renders the image broken.

Fix: Check if the image is added as an html image element before adding it to the list of attachments of the cell. ( By checking if the valid base64 value being added to the attachments is in an image tag)
Also tried to add it as an actual attachment and replacing the entire image tag with markdown attachment syntax. But since that's embedded in-between other html tags, it doesn't seem to work. So refrained from adding it as an attachment and just skipping it.
