### PR TITLE
Disabling options button for the release

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -172,7 +172,7 @@ export class PublishDatabaseDialog {
 								title: constants.selectConnectionRadioButtonsTitle,
 								component: selectConnectionRadioButtons
 							},*/
-							/* TODO : enable using this when data source creation is enabled
+							/* TODO : Disabling deployment options for the July release
 							{
 								component: displayOptionsButton,
 								title: ''

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -145,6 +145,7 @@ export class PublishDatabaseDialog {
 			this.connectionRow = this.createConnectionRow(view);
 			this.databaseRow = this.createDatabaseRow(view);
 			const displayOptionsButton = this.createOptionsButton(view);
+			displayOptionsButton.enabled = false;
 
 			const horizontalFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
 			horizontalFormSection.addItems([profileRow, this.databaseRow]);
@@ -171,10 +172,12 @@ export class PublishDatabaseDialog {
 								title: constants.selectConnectionRadioButtonsTitle,
 								component: selectConnectionRadioButtons
 							},*/
+							/* TODO : enable using this when data source creation is enabled
 							{
 								component: displayOptionsButton,
 								title: ''
 							}
+							*/
 						]
 					}
 				], {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR disables the publish tab 'advanced publish options' button for the upcoming the next release, as the options is planned to release in August release and there are some more options coming to the tab.

![image](https://user-images.githubusercontent.com/74571829/179096045-ab56c577-c336-4065-a00c-fb2fb339afe6.png)![image](https://user-images.githubusercontent.com/74571829/179075684-84cd9f7e-3bc2-4e54-bfbb-cb6cb321945c.png)
