### PR TITLE
Auto-update arcdata extension and update SQL MIAA create

### DIFF
--- a/extensions/arc/notebooks/arcDeployment/deploy.sql.existing.arc.ipynb
+++ b/extensions/arc/notebooks/arcDeployment/deploy.sql.existing.arc.ipynb
@@ -101,16 +101,11 @@
                 "is_indirect = arc_data_controller_connection_mode == 'indirect'\n",
                 "\n",
                 "# Indirect Mode Parameters\n",
-                "namespace = f' --k8s-namespace {arc_data_controller_namespace}' if is_indirect else ''\n",
                 "retention_days = f' --retention-days \"{sql_retention_days}\"' if is_indirect and sql_retention_days else \"\"\n",
-                "use_k8s = ' --use-k8s' if is_indirect else ''\n",
-                "\n",
-                "# Direct Mode Parameters\n",
-                "resource_group = f' --resource-group {arc_data_controller_resource_group}' if not is_indirect else ''\n",
-                "custom_location = f' --custom-location {arc_data_controller_custom_location}' if not is_indirect else ''\n",
-                "location = f' --location {arc_data_controller_location}' if not is_indirect else ''\n",
                 "\n",
                 "# General Parameters\n",
+                "use_k8s = ' --use-k8s'\n",
+                "namespace = f' --k8s-namespace {arc_data_controller_namespace}' if arc_data_controller_namespace else \"\"\n",
                 "cores_request_option = f' --cores-request \"{sql_cores_request}\"' if sql_cores_request else \"\"\n",
                 "cores_limit_option = f' --cores-limit \"{sql_cores_limit}\"' if sql_cores_limit else \"\"\n",
                 "memory_request_option = f' --memory-request \"{sql_memory_request}Gi\"' if sql_memory_request else \"\"\n",
@@ -135,7 +130,7 @@
                 "\n",
                 "os.environ[\"AZDATA_USERNAME\"] = sql_username\n",
                 "os.environ[\"AZDATA_PASSWORD\"] = os.environ[\"AZDATA_NB_VAR_SQL_PASSWORD\"]\n",
-                "cmd = f'az sql mi-arc create --name {sql_instance_name}{namespace}{resource_group}{location}{custom_location} --replicas {sql_replicas}{cores_request_option}{cores_limit_option}{memory_request_option}{memory_limit_option}{readable_secondaries}{sync_secondary_to_commit}{storage_class_data_option}{storage_class_datalogs_option}{storage_class_logs_option}{storage_class_backup_option}{volume_size_data}{volume_size_datalogs}{volume_size_logs}{volume_size_backups}{retention_days}{service_tier}{dev_use}{license_type}{cores_limit}{use_k8s}'\n",
+                "cmd = f'az sql mi-arc create --name {sql_instance_name}{namespace} --replicas {sql_replicas}{cores_request_option}{cores_limit_option}{memory_request_option}{memory_limit_option}{readable_secondaries}{sync_secondary_to_commit}{storage_class_data_option}{storage_class_datalogs_option}{storage_class_logs_option}{storage_class_backup_option}{volume_size_data}{volume_size_datalogs}{volume_size_logs}{volume_size_backups}{retention_days}{service_tier}{dev_use}{license_type}{cores_limit}{use_k8s}'\n",
                 "out=run_command()"
             ]
         }

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -494,6 +494,7 @@ export async function findAzAndArc(): Promise<IAzTool> {
 /**
  * Find az by searching user's directories. If no az is found, this will error out and no arcdata is found.
  * If az is found, check if arcdata extension exists on it and return true if so, false if not.
+ * Attempt to update arcdata extension.
  * Return the AzTool whether or not an arcdata extension has been found.
  */
 async function findSpecificAzAndArc(): Promise<IAzTool> {
@@ -507,6 +508,9 @@ async function findSpecificAzAndArc(): Promise<IAzTool> {
 	if (arcVersion === undefined) {
 		throw AzureCLIArcExtError;
 	}
+
+	// Quietly attempt to update the arcdata extension to the latest. If it is already the latest, then it will not update.
+	await executeCommand('az', ['extension', 'update', '--name', 'arcdata']);
 
 	return new AzTool(path, <string>parseVersion(versionOutput.stdout), <string>arcVersion);
 }


### PR DESCRIPTION
- Upon startup, if arcdata extension is detected, attempt an update of arcdata quietly. If it is already up to date, nothing will be done. (PM requested feature)
- Update SQL MIAA create in notebook to use --use-k8s and --namespace for direct mode create. Removed location, custom location, and resource group as they are no longer needed.