### PR TITLE
change icon for dashboard

### DIFF
--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -1865,7 +1865,7 @@
 		"todo": "_todo",
 		"npm-debug.log": "_npm_ignored",
 		// {{SQL CARBON EDIT}}
-		"dashboard": "_shell",
+		"dashboard": "_default",
 		"profiler": "_csv",
 		"Schema Compare": "scmp_dark",
 		"table-basic": "table-basic",
@@ -2336,7 +2336,7 @@
 			"procfile": "_heroku_light",
 			"npm-debug.log": "_npm_ignored_light",
 			// {{SQL CARBON EDIT}}
-			"dashboard": "_shell_light",
+			"dashboard": "_default_light",
 			"profiler": "_csv_light",
 			"Schema Compare": "scmp"
 		}


### PR DESCRIPTION
This PR fixes #20043
the icon for shell has changed in recent vscode merge, which is no longer appropriate to represent dashboard, I am using the default icon for now and will request a new icon for it.

before:
![image](https://user-images.githubusercontent.com/13777222/179091591-fb953a78-ba19-4858-b591-414e029c4bf7.png)

after:
![image](https://user-images.githubusercontent.com/13777222/179120081-dc1f253c-93f4-47c1-913b-eee982537ff3.png)

