### PR TITLE
Replace checkbox for SQL MIAA create with terms of use text.

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -1606,6 +1606,18 @@
                 "label": "%arc.agreement.sql.help.text.learn.more.ariaLabel%"
               },
               "url": "https://go.microsoft.com/fwlink/?linkid=2141849"
+            },
+            {
+              "text": "%arc.agreement.sql.help.text.azure.marketplace.terms%",
+              "url": "https://go.microsoft.com/fwlink/?linkid=2045624"
+            },
+            {
+              "text": "%arc.agreement.sql.help.text.terms.of.use%",
+              "url": "https://go.microsoft.com/fwlink/?linkid=2045708"
+            },
+            {
+              "text": "%arc.agreement.sql.help.text.privacy.policy%",
+              "url": "https://go.microsoft.com/fwlink/?linkid=512132"
             }
           ],
           "when": "mi-type=arc-mi"

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -1597,20 +1597,6 @@
           ],
           "when": "mi-type=arc-mi"
         },
-        "agreement": {
-          "template": "%arc.agreement%",
-          "links": [
-            {
-              "text": "%microsoft.agreement.privacy.statement%",
-              "url": "https://go.microsoft.com/fwlink/?LinkId=853010"
-            },
-            {
-              "text": "%arc.agreement.sql.terms.conditions%",
-              "url": "https://go.microsoft.com/fwlink/?linkid=2045708"
-            }
-          ],
-          "when": "mi-type=arc-mi"
-        },
         "helpText": {
           "template": "%arc.agreement.sql.help.text%",
           "links": [

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -230,8 +230,11 @@
 	"cores.limit.greater.than.or.equal.to.requested.cores": "Cores limit must be greater than or equal to requested cores",
 	"requested.memory.less.than.or.equal.to.memory.limit": "Requested memory must be less than or equal to memory limit",
 	"memory.limit.greater.than.or.equal.to.requested.memory": "Memory limit must be greater than or equal to requested memory",
-	"arc.agreement.sql.help.text": "Azure Arc enabled Managed Instance provides SQL Server access and feature compatibility that can be deployed on the infrastructure of your choice. {0}",
+	"arc.agreement.sql.help.text": "Azure Arc enabled Managed Instance provides SQL Server access and feature compatibility that can be deployed on the infrastructure of your choice. {0}. \n \n By clicking 'Script to notebook' or 'Deploy', I (a) agree to the legal terms and privacy statement(s) associated with the Marketplace offering(s) listed below; (b) authorize Microsoft to bill my current payment method for the fees associated with the offering(s), with the same billing frequency as my Azure subscription; and (c) agree that Microsoft may share my contact, usage and transactional information with the provider(s) of the offering(s) for support, billing and other transactional activities. Microsoft does not provide rights for third-party offerings. For additional details see {1}, {2}, and {3}.",
 	"arc.agreement.sql.help.text.learn.more": "Learn more",
 	"arc.agreement.sql.help.text.learn.more.ariaLabel": "Learn more about Azure Arc enabled Managed Instance",
-	"arc.sql.pitr.retention.description":"Configure retention for point-in-time backups. {0}"
+	"arc.sql.pitr.retention.description": "Configure retention for point-in-time backups. {0}",
+	"arc.agreement.sql.help.text.terms.of.use": "Terms of use",
+	"arc.agreement.sql.help.text.privacy.policy": "Privacy policy",
+	"arc.agreement.sql.help.text.azure.marketplace.terms": "Azure Marketplace Terms"
 }

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -81,7 +81,6 @@
 	"arc.data.controller.summary.data.controller.infrastructure": "Data controller infrastructure",
 	"arc.data.controller.summary.controller": "Controller",
 	"arc.data.controller.summary.location": "Location",
-	"arc.data.controller.agreement": "I accept {0} and {1}.",
 	"arc.data.controller.readmore": "Read more",
 	"microsoft.agreement.privacy.statement":"Microsoft Privacy Statement",
 	"deploy.script.action":"Script to notebook",


### PR DESCRIPTION
Removing the checkbox for "Accept terms of use" and opting for agreement text instead.
![image](https://user-images.githubusercontent.com/22386690/179125654-9693c291-ef2c-4a87-9151-b019ce61fe5b.png)

The checkbox will actually be removed when[ this PR ](https://github.com/microsoft/azuredatastudio/pull/20047)gets merged in to fix the bug where a title for "Accept terms of use" stays even when agreement item is removed in package.json