### PR TITLE
Fix git integration test failure

### DIFF
--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -56,7 +56,9 @@ suite('git smoke test', function () {
 		git = ext!.exports.getAPI(1);
 
 		if (git.repositories.length === 0) {
-			await eventToPromise(git.onDidOpenRepository);
+			const onDidOpenRepository = eventToPromise(git.onDidOpenRepository);
+			await commands.executeCommand('git.openRepository', cwd);
+			await onDidOpenRepository;
 		}
 
 		assert.strictEqual(git.repositories.length, 1);


### PR DESCRIPTION
Occasionally see failures like this 

```
[File Watcher (parcel)] Unexpected error: inotify_add_watch failed: No such file or directory (EUNKNOWN) (path: /tmp/tmp.rmbCWxi6yu)
[File Watcher (parcel)] restarting watcher after error: inotify_add_watch failed: No such file or directory
[3247:0715/074318.539234:INFO:CONSOLE(29)] "%c WARN color: #993 SharedProcess: createWorker found an existing worker that will be terminated (window: 1, moduleId: vs/platform/files/node/watcher/parcel/watcherApp)", source: vscode-file://vscode-app/__w/1/azuredatastudio-linux-x64/resources/app/out/vs/code/electron-browser/sharedProcess/sharedProcessMain.js (29)
[3247:0715/074318.540765:INFO:CONSOLE(29)] "%c INFO color: #33f Worker process with pid 3371 terminated normally (type: watcherServiceParcelSharedProcess, window: 1).", source: vscode-file://vscode-app/__w/1/azuredatastudio-linux-x64/resources/app/out/vs/code/electron-browser/sharedProcess/sharedProcessMain.js (29)
[3247:0715/074318.547332:INFO:CONSOLE(29)] "%c INFO color: #33f Starting worker process with pid 3448 (type: watcherServiceParcelSharedProcess, window: 1).", source: vscode-file://vscode-app/__w/1/azuredatastudio-linux-x64/resources/app/out/vs/code/electron-browser/sharedProcess/sharedProcessMain.js (29)
...
  1) git smoke test
       "before all" hook for "reflects working tree changes":
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/__w/1/s/extensions/git/out/test/smoke.test.js)
```

VS Code had same issue, so porting over the fix here. https://github.com/microsoft/vscode/pull/136933