### PR TITLE
enable the ParallelMessageProcessing by default

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -387,7 +387,7 @@
         "mssql.parallelMessageProcessing": {
           "type": "boolean",
           "description": "%mssql.parallelMessageProcessing%",
-          "default": false
+          "default": true
         }
       }
     },


### PR DESCRIPTION
We have been testing with this flag turned on for a while and I also received confirmation from users that enabling this haven't caused any issue for them. 

In this PR, I am turning it on by default so that we can have more users test it out.