### PR TITLE
[SQL Bindings] Delete progress notification not needed

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -617,19 +617,9 @@ export async function promptSelectDatabase(connectionURI: string): Promise<strin
 
 export async function getConnectionURI(connectionInfo: IConnectionInfo): Promise<string | undefined> {
 	const vscodeMssqlApi = await utils.getVscodeMssqlApi();
-
 	let connectionURI: string = '';
 	try {
-		await vscode.window.withProgress(
-			{
-				location: vscode.ProgressLocation.Notification,
-				title: constants.connectionProgressTitle,
-				cancellable: false
-			}, async (_progress, _token) => {
-				// show progress bar while connecting to the users selected connection profile
-				connectionURI = await vscodeMssqlApi.connect(connectionInfo!);
-			}
-		);
+		connectionURI = await vscodeMssqlApi.connect(connectionInfo);
 	} catch (e) {
 		// mssql connection error will be shown to the user
 		return undefined;

--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -73,7 +73,6 @@ export const userPasswordLater = localize('userPasswordLater', 'In order to user
 export const openFile = localize('openFile', "Open File");
 export const closeButton = localize('closeButton', "Close");
 export const enterPasswordPrompt = localize('enterPasswordPrompt', '(Optional) Enter connection password to save in local.settings.json');
-export const connectionProgressTitle = localize('connectionProgressTitle', "Testing SQL Server connection...");
 export const enterTableName = localize('enterTableName', 'Enter SQL table to query');
 export const enterViewName = localize('enterViewName', 'Enter SQL view to query');
 export const enterTableNameToUpsert = localize('enterTableNameToUpsert', 'Enter SQL table to upsert into');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Not intended for July release. 

This PR addresses changes that were made in vscode-mssql [PR](https://github.com/microsoft/vscode-mssql/pull/17350). 

Mainly adds progress notification when the user selects a connection profile via vscode-mssql. 

Also, if the user uses `Creates Connection Profile`:
<img width="504" alt="image" src="https://user-images.githubusercontent.com/23587151/179323667-09e4be04-3634-4e91-9856-57ac57e45571.png">

If it fails to connect then the user can cancel out of the error (shown below via `x`), then we prompt them the list of connection profiles (shown above) instead of canceling out of the entire flow.
<img width="394" alt="image" src="https://user-images.githubusercontent.com/23587151/179323487-03e2e286-21d3-4d69-bbd1-8805cc00bee9.png">
