### PR TITLE
Make connection mode a displayname

### DIFF
--- a/extensions/arc/notebooks/arcDeployment/deploy.arc.data.controller.ipynb
+++ b/extensions/arc/notebooks/arcDeployment/deploy.arc.data.controller.ipynb
@@ -158,7 +158,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "is_indirect = arc_data_controller_connectivity_mode == 'Indirect'\n",
+                "is_indirect = arc_data_controller_connectivity_mode == 'indirect'\n",
                 "\n",
                 "if not is_indirect:\n",
                 "\trun_command('az login')"

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -210,6 +210,10 @@
                             },
                             "defaultValue": "azure-arc-aks-default-storage",
                             "optionsType": "dropdown"
+                          },
+                          "enabled": {
+                            "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
+                            "value": "Indirect"
                           }
                         }
                       ]

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -252,7 +252,11 @@
                             "uksouth",
                             "westeurope",
                             "westus2"
-                          ]
+                          ],
+                          "enabled": {
+                            "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
+                            "value": "Indirect"
+                          }
                         }
                       ]
                     }
@@ -268,25 +272,6 @@
                           "type": "readonly_text",
                           "label": "%arc.data.controller.details.description%",
                           "labelWidth": "600px"
-                        },
-                        {
-                          "type": "text",
-                          "label": "%arc.data.controller.namespace%",
-                          "validations": [
-                            {
-                              "type": "regex_match",
-                              "regex": "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$",
-                              "description": "%arc.data.controller.namespace.validation.description%"
-                            }
-                          ],
-                          "defaultValue": "",
-                          "required": true,
-                          "variableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_NAMESPACE",
-                          "enabled": {
-                            "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Indirect"
-                          },
-                          "description": "%arc.data.controller.namespace.description%"
                         },
                         {
                           "type": "text",
@@ -334,6 +319,25 @@
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
                             "value": "Direct"
                           }
+                        },
+                        {
+                          "type": "text",
+                          "label": "%arc.data.controller.namespace%",
+                          "validations": [
+                            {
+                              "type": "regex_match",
+                              "regex": "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$",
+                              "description": "%arc.data.controller.namespace.validation.description%"
+                            }
+                          ],
+                          "defaultValue": "",
+                          "required": true,
+                          "variableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_NAMESPACE",
+                          "enabled": {
+                            "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
+                            "value": "Indirect"
+                          },
+                          "description": "%arc.data.controller.namespace.description%"
                         },
                         {
                           "type": "text",

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -177,10 +177,16 @@
                           "variableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
                           "options": {
                             "values": [
-                              "Indirect",
-                              "Direct"
+                              {
+                                "name": "indirect",
+                                "displayName": "%arc.data.controller.indirect.display.name%"
+                              },
+                              {
+                                "name": "direct",
+                                "displayName": "%arc.data.controller.direct.display.name%"
+                              }
                             ],
-                            "defaultValue": "Indirect",
+                            "defaultValue": "indirect",
                             "optionsType": "radio"
                           }
                         },
@@ -193,7 +199,7 @@
                           "configFileVariableName": "AZDATA_NB_VAR_ARC_CONFIG_FILE",
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Indirect"
+                            "value": "indirect"
                           }
                         },
                         {
@@ -213,7 +219,7 @@
                           },
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Indirect"
+                            "value": "indirect"
                           }
                         }
                       ]
@@ -259,7 +265,7 @@
                           ],
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Indirect"
+                            "value": "indirect"
                           }
                         }
                       ]
@@ -321,7 +327,7 @@
                           "variableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CLUSTER_NAME",
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Direct"
+                            "value": "direct"
                           }
                         },
                         {
@@ -339,7 +345,7 @@
                           "variableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_NAMESPACE",
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Indirect"
+                            "value": "indirect"
                           },
                           "description": "%arc.data.controller.namespace.description%"
                         },
@@ -351,7 +357,7 @@
                           "variableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CUSTOM_LOCATION",
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Direct"
+                            "value": "direct"
                           }
                         },
                         {
@@ -362,7 +368,7 @@
                           "defaultValue": false,
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Direct"
+                            "value": "direct"
                           }
                         },
                         {
@@ -373,7 +379,7 @@
                           "defaultValue": false,
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "Direct"
+                            "value": "direct"
                           }
                         },
                         {

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -29,6 +29,8 @@
 	"arc.data.controller.project.details.description": "Select the subscription to manage deployed resources and costs. Use resource groups like folders to organize and manage all your resources.",
 	"arc.data.controller.details.title": "Data controller details",
 	"arc.data.controller.details.description": "For indirect mode, provide a namespace, name and storage class for your Azure Arc data controller. This name will be used to identify your Arc instance for remote management and monitoring. For direct mode you do not need to provide a namespace, but please provide the custom location name.",
+	"arc.data.controller.indirect.display.name": "Indirect",
+	"arc.data.controller.direct.display.name": "Direct",
 	"arc.data.controller.connectivity.mode": "Connectivity mode",
 	"arc.data.controller.namespace": "Data controller namespace",
 	"arc.data.controller.namespace.description": "Data controller namespace. Indirect mode only.",

--- a/extensions/arc/src/models/controllerModel.ts
+++ b/extensions/arc/src/models/controllerModel.ts
@@ -70,7 +70,7 @@ export class ControllerModel {
 
 	public async refresh(showErrors: boolean = true, namespace: string): Promise<void> {
 		await this.refreshController(showErrors, namespace);
-		if (this._controllerConfig?.spec.settings.azure.connectionMode === ConnectionMode.direct) {
+		if (this._controllerConfig?.spec.settings.azure.connectionMode.toLowerCase() === ConnectionMode.direct) {
 			await this.refreshDirectMode(this._controllerConfig?.spec.settings.azure.resourceGroup, namespace);
 		} else {
 			await this.refreshIndirectMode(namespace);

--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -7,7 +7,7 @@ import { ResourceType } from 'arc';
 import * as azdata from 'azdata';
 import * as azurecore from 'azurecore';
 import * as vscode from 'vscode';
-import { getConnectionModeDisplayText, getResourceTypeIcon, resourceTypeToDisplayName } from '../../../common/utils';
+import { getResourceTypeIcon, resourceTypeToDisplayName } from '../../../common/utils';
 import { cssStyles, IconPathHelper, controllerTroubleshootDocsUrl, iconSize } from '../../../constants';
 import * as loc from '../../../localizedConstants';
 import { ControllerModel } from '../../../models/controllerModel';
@@ -218,7 +218,7 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 		this.controllerProperties.resourceGroupName = config?.spec.settings.azure.resourceGroup || this.controllerProperties.resourceGroupName;
 		this.controllerProperties.location = this._azurecoreApi.getRegionDisplayName(config?.spec.settings.azure.location) || this.controllerProperties.location;
 		this.controllerProperties.subscriptionId = config?.spec.settings.azure.subscription || this.controllerProperties.subscriptionId;
-		this.controllerProperties.connectionMode = getConnectionModeDisplayText(config?.spec.settings.azure.connectionMode) || this.controllerProperties.connectionMode;
+		this.controllerProperties.connectionMode = config?.spec.settings.azure.connectionMode.toLowerCase() || this.controllerProperties.connectionMode.toLowerCase();
 		this.controllerProperties.instanceNamespace = config?.metadata.namespace || this.controllerProperties.instanceNamespace;
 		this.controllerProperties.status = config?.status.state || this.controllerProperties.status;
 		this.refreshDisplayedProperties();

--- a/extensions/arc/src/ui/dashboards/miaa/miaaUpgradeManagementPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaUpgradeManagementPage.ts
@@ -160,7 +160,7 @@ export class MiaaUpgradeManagementPage extends DashboardPage {
 	private async getMiaaVersion(): Promise<string | undefined> {
 		try {
 			let miaaShowResult;
-			if (this._controllerModel.info.connectionMode === ConnectionMode.direct || this._controllerModel.controllerConfig?.spec.settings.azure.connectionMode === ConnectionMode.direct) {
+			if (this._controllerModel.info.connectionMode === ConnectionMode.direct || this._controllerModel.controllerConfig?.spec.settings.azure.connectionMode.toLowerCase() === ConnectionMode.direct) {
 				miaaShowResult = await this._azApi.az.sql.miarc.show(
 					this._miaaModel.info.name,
 					{

--- a/extensions/arc/src/ui/dialogs/connectControllerDialog.ts
+++ b/extensions/arc/src/ui/dialogs/connectControllerDialog.ts
@@ -201,10 +201,10 @@ export class ConnectToControllerDialog extends ControllerDialogBase {
 			// default info.name to the name of the controller instance if the user did not specify their own and to a pre-canned default if for some weird reason controller endpoint returned instanceName is also not a valid value
 			controllerModel.info.name = controllerModel.info.name || controllerModel.controllerConfig?.metadata.name || loc.defaultControllerName;
 			controllerModel.info.resourceGroup = <string>controllerModel.controllerConfig?.spec.settings.azure.resourceGroup;
-			controllerModel.info.connectionMode = <string>controllerModel.controllerConfig?.spec.settings.azure.connectionMode;
+			controllerModel.info.connectionMode = <string>controllerModel.controllerConfig?.spec.settings.azure.connectionMode.toLowerCase();
 			controllerModel.info.location = <string>controllerModel.controllerConfig?.spec.settings.azure.location;
 
-			if (controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct.toLowerCase()) {
+			if (controllerModel.info.connectionMode === ConnectionMode.direct) {
 				const rawCustomLocation = <string>controllerModel.controllerConfig?.metadata.annotations['management.azure.com/customLocation'];
 				const exp = /custom[lL]ocations\/([\S]*)/;
 				controllerModel.info.customLocation = <string>exp.exec(rawCustomLocation)?.pop();

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -394,6 +394,9 @@ async function hookUpDynamicEnablement(context: WizardPageContext): Promise<void
 					if ('required' in fieldComponent.component) {
 						fieldComponent.component.required = isRequired;
 					}
+					if ('requiredIndicator' in fieldComponent.component) {
+						fieldComponent.component.requiredIndicator = isRequired;
+					}
 					// When we disable the field then remove the placeholder if it exists so it's clear this field isn't needed
 					// We only do this for dynamic enablement since if a field is disabled through the JSON directly then it can't
 					// be modified anyways and so just should not use a placeholder value if they don't want one

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -394,9 +394,6 @@ async function hookUpDynamicEnablement(context: WizardPageContext): Promise<void
 					if ('required' in fieldComponent.component) {
 						fieldComponent.component.required = isRequired;
 					}
-					if ('requiredIndicator' in fieldComponent.component) {
-						fieldComponent.component.requiredIndicator = isRequired;
-					}
 					// When we disable the field then remove the placeholder if it exists so it's clear this field isn't needed
 					// We only do this for dynamic enablement since if a field is disabled through the JSON directly then it can't
 					// be modified anyways and so just should not use a placeholder value if they don't want one


### PR DESCRIPTION
Make connection mode in Data Controller deploy wizard use displayNames Direct and Indirect and actual values direct and indirect respectively. This will make the Azure CLI commands generated in the notebook lowercase and thus the config info of the DC will be lowercase. 