### PR TITLE
Fixed default value for radio options builder if using resourceType displayName

### DIFF
--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -285,7 +285,7 @@ export interface IOptionsSource {
 export interface OptionsInfo {
 	values?: string[] | azdata.CategoryValue[],
 	source?: IOptionsSource,
-	defaultValue: string,
+	defaultValue: string | ResourceTypeOptionValue,
 	optionsType?: OptionsType
 }
 

--- a/extensions/resource-deployment/src/ui/radioGroupLoadingComponentBuilder.ts
+++ b/extensions/resource-deployment/src/ui/radioGroupLoadingComponentBuilder.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { OptionsInfo, FieldInfo, instanceOfDynamicEnablementInfo } from '../interfaces';
+import { OptionsInfo, FieldInfo, instanceOfDynamicEnablementInfo, ResourceTypeOptionValue } from '../interfaces';
 import { getErrorMessage } from '../common/utils';
 
 export class RadioGroupLoadingComponentBuilder implements azdata.ComponentBuilder<azdata.LoadingComponent, azdata.LoadingComponentProperties> {
@@ -45,7 +45,14 @@ export class RadioGroupLoadingComponentBuilder implements azdata.ComponentBuilde
 			}
 
 			let options: (string[] | azdata.CategoryValue[]) = optionsInfo.values!;
-			let defaultValue: string = optionsInfo.defaultValue!;
+			let defaultValue: string | ResourceTypeOptionValue = optionsInfo.defaultValue!;
+			if (optionsInfo.defaultValue) {
+				if ((<ResourceTypeOptionValue>optionsInfo.defaultValue).displayName) {
+					defaultValue = (<ResourceTypeOptionValue>optionsInfo.defaultValue).displayName;
+				} else {
+					defaultValue = optionsInfo.defaultValue;
+				}
+			}
 			options.forEach((op: string | azdata.CategoryValue) => {
 				const option: azdata.CategoryValue = (typeof op === 'string')
 					? { name: op, displayName: op }


### PR DESCRIPTION
Problem: Default values were not showing if fields used resourceType displayName in radio options fields.
Solution: Added ResourceTypeOptionValue as a type for radio options' defaultValue. When generating component, use the displayName as the defaultValue.

![image](https://user-images.githubusercontent.com/22386690/179634064-66683219-74f0-41c9-a1f6-e81dc37dfd78.png)
![image](https://user-images.githubusercontent.com/22386690/179634080-a5ebca6f-4f81-45ce-b71d-17345c14a342.png)
