### PR TITLE
Changed default values for high availability and service tier to accommodate resource-deployment fix

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -1134,7 +1134,10 @@
                               "displayName": "%arc.sql.service.tier.general.purpose%"
                             }
                           ],
-                          "defaultValue": "BusinessCritical",
+                          "defaultValue": {
+                            "name": "BusinessCritical",
+                            "displayName": "%arc.sql.service.tier.business.critical%"
+                          },
                           "optionsType": "radio"
                         }
                       },
@@ -1166,7 +1169,10 @@
                               "displayName": "%arc.sql.three.replicas%"
                             }
                           ],
-                          "defaultValue": "3",
+                          "defaultValue": {
+                            "name": "3",
+                            "displayName": "%arc.sql.three.replicas%"
+                          },
                           "optionsType": "radio"
                         },
                         "dynamicOptions": {
@@ -1180,7 +1186,10 @@
                                   "displayName": "%arc.sql.one.replica%"
                                 }
                               ],
-                              "defaultValue": "1"
+                              "defaultValue": {
+                                "name": "1",
+                                "displayName": "%arc.sql.one.replica%"
+                              }
                             }
                           ]
                         }


### PR DESCRIPTION
Gave High Availability and Service Tier fields in SQL MIAA create wizard default values:
![image](https://user-images.githubusercontent.com/22386690/179634064-66683219-74f0-41c9-a1f6-e81dc37dfd78.png)
![image](https://user-images.githubusercontent.com/22386690/179634080-a5ebca6f-4f81-45ce-b71d-17345c14a342.png)

Related to this PR: https://github.com/microsoft/azuredatastudio/pull/20070