### PR TITLE
Various fixes in Arc extension

### DIFF
--- a/extensions/arc/notebooks/arcDeployment/deploy.sql.existing.arc.ipynb
+++ b/extensions/arc/notebooks/arcDeployment/deploy.sql.existing.arc.ipynb
@@ -99,6 +99,7 @@
                 "print (f'Creating the SQL managed instance - Azure Arc instance')\n",
                 "\n",
                 "is_indirect = arc_data_controller_connection_mode == 'indirect'\n",
+                "is_general_purpose = sql_service_tier == 'GeneralPurpose'\n",
                 "\n",
                 "# Indirect Mode Parameters\n",
                 "retention_days = f' --retention-days \"{sql_retention_days}\"' if is_indirect and sql_retention_days else \"\"\n",
@@ -110,8 +111,11 @@
                 "cores_limit_option = f' --cores-limit \"{sql_cores_limit}\"' if sql_cores_limit else \"\"\n",
                 "memory_request_option = f' --memory-request \"{sql_memory_request}Gi\"' if sql_memory_request else \"\"\n",
                 "memory_limit_option = f' --memory-limit \"{sql_memory_limit}Gi\"' if sql_memory_limit else \"\"\n",
-                "readable_secondaries = f' --readable-secondaries \"{sql_readable_secondaries}\"' if sql_readable_secondaries else \"\"\n",
-                "sync_secondary_to_commit = f' --sync-secondary-to-commit \"{sql_sync_secondary_to_commit}\"' if sql_sync_secondary_to_commit else \"\"\n",
+                "\n",
+                "sql_replicas_option = f' --replicas {sql_replicas}' if sql_replicas and not is_general_purpose else \"\"\n",
+                "readable_secondaries = f' --readable-secondaries \"{sql_readable_secondaries}\"' if sql_readable_secondaries and not is_general_purpose else \"\"\n",
+                "sync_secondary_to_commit = f' --sync-secondary-to-commit \"{sql_sync_secondary_to_commit}\"' if sql_sync_secondary_to_commit and not is_general_purpose else \"\"\n",
+                "\n",
                 "\n",
                 "storage_class_data_option =  f' --storage-class-data \"{sql_storage_class_data}\"'if sql_storage_class_data else \"\"\n",
                 "storage_class_datalogs_option =  f' --storage-class-datalogs \"{sql_storage_class_datalogs}\"'if sql_storage_class_datalogs else \"\"\n",
@@ -130,7 +134,7 @@
                 "\n",
                 "os.environ[\"AZDATA_USERNAME\"] = sql_username\n",
                 "os.environ[\"AZDATA_PASSWORD\"] = os.environ[\"AZDATA_NB_VAR_SQL_PASSWORD\"]\n",
-                "cmd = f'az sql mi-arc create --name {sql_instance_name}{namespace} --replicas {sql_replicas}{cores_request_option}{cores_limit_option}{memory_request_option}{memory_limit_option}{readable_secondaries}{sync_secondary_to_commit}{storage_class_data_option}{storage_class_datalogs_option}{storage_class_logs_option}{storage_class_backup_option}{volume_size_data}{volume_size_datalogs}{volume_size_logs}{volume_size_backups}{retention_days}{service_tier}{dev_use}{license_type}{cores_limit}{use_k8s}'\n",
+                "cmd = f'az sql mi-arc create --name {sql_instance_name}{namespace}{sql_replicas_option}{cores_request_option}{cores_limit_option}{memory_request_option}{memory_limit_option}{readable_secondaries}{sync_secondary_to_commit}{storage_class_data_option}{storage_class_datalogs_option}{storage_class_logs_option}{storage_class_backup_option}{volume_size_data}{volume_size_datalogs}{volume_size_logs}{volume_size_backups}{retention_days}{service_tier}{dev_use}{license_type}{cores_limit}{use_k8s}'\n",
                 "out=run_command()"
             ]
         }

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -246,6 +246,7 @@
                         {
                           "type": "azure_locations",
                           "label": "%arc.data.controller.location%",
+                          "description": "%arc.data.controller.location.description%",
                           "defaultValue": "eastus",
                           "required": true,
                           "locationVariableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_LOCATION",

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -1198,6 +1198,10 @@
                               "defaultValue": "1"
                             }
                           ]
+                        },
+                        "enabled": {
+                          "target": "AZDATA_NB_VAR_SQL_SERVICE_TIER",
+                          "value": "BusinessCritical"
                         }
                       },
                       {

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -38,6 +38,7 @@
 	"arc.data.controller.name": "Data controller name",
 	"arc.data.controller.name.validation.description": "Name must consist of lower case alphanumeric characters, '-' or '.', start/end with an alphanumeric character and be 253 characters or less in length.",
 	"arc.data.controller.location": "Location",
+	"arc.data.controller.location.description": "Location is only used for indirect mode deployment. This field will be ignored for direct mode.",
 	"arc.data.controller.infrastructure": "Infrastructure",
 	"arc.data.controller.custom.location": "Custom Location",
 	"arc.data.controller.custom.location.description": "The name of the custom location. Direct mode only.",


### PR DESCRIPTION
Fixes:
- Added a description to Location field for DC deploy wizard: if direct mode, this field will be disregarded. This is a temp solution to dropdown not being able to do dynamic enablement yet
- If SQL MIAA deployment wizard specifies General Purpose, disable High Availability field
- If SQL MIAA deployment wizard specifies General Purpose, remove the flags for replicas, readable-secondaries, and sync-to-secondary-commit in the notebook