### PR TITLE
vBump query history

### DIFF
--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -2,7 +2,7 @@
   "name": "query-history",
   "displayName": "%queryHistory.displayName%",
   "description": "%queryHistory.description%",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",


### PR DESCRIPTION
Main branch is being bumped to 0.3.0 to get ahead of current release (0.2.*)