### PR TITLE
Fix restore dialog null references

### DIFF
--- a/src/sql/workbench/services/restore/browser/restoreDialog.ts
+++ b/src/sql/workbench/services/restore/browser/restoreDialog.ts
@@ -287,7 +287,7 @@ export class RestoreDialog extends Modal {
 			ariaLabel: LocalizedStrings.TARGETDATABASE,
 			placeholder: localize('targetDatabaseTooltip', "Please enter target database name"),
 			validationOptions: {
-				validation: (value: string) => this.viewModel.databases.includes(value) ? ({ type: MessageType.ERROR, content: localize('restoreDialog.targetDatabaseAlreadyExists', "Target database already exists") }) : null
+				validation: (value: string) => this.viewModel.databases?.includes(value) ? ({ type: MessageType.ERROR, content: localize('restoreDialog.targetDatabaseAlreadyExists', "Target database already exists") }) : null
 			},
 		}));
 
@@ -666,7 +666,7 @@ export class RestoreDialog extends Modal {
 		this._register(attachTableStyler(this._restorePlanTable!, this._themeService));
 
 		this._register(this._targetDatabaseInputBox.onDidChange(dbName => {
-			if (!this.viewModel.databases.includes(dbName)) {
+			if (!this.viewModel.databases?.includes(dbName)) {
 				if (this.viewModel.targetDatabaseName !== dbName) {
 					this.viewModel.targetDatabaseName = dbName;
 					this.validateRestore();

--- a/src/sql/workbench/services/restore/browser/restoreViewModel.ts
+++ b/src/sql/workbench/services/restore/browser/restoreViewModel.ts
@@ -48,7 +48,7 @@ export class RestoreViewModel {
 	public selectedBackupSets?: string[];
 	public defaultBackupFolder?: string;
 	public deviceType?: MediaDeviceType;
-	public databases: string[];
+	public databases?: string[];
 
 	private _onSetLastBackupTaken = new Emitter<string>();
 	public onSetLastBackupTaken: Event<string> = this._onSetLastBackupTaken.event;


### PR DESCRIPTION
This avoids some null reference exceptions introduced by https://github.com/microsoft/azuredatastudio/commit/65ef41d53d635c50faadf9b04386df694a8db01c in the case that there are no non-system databases on a server.  This is to fix https://github.com/microsoft/azuredatastudio/issues/19783.