### PR TITLE
support build pipeline that only produces extension vsix files

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -229,7 +229,6 @@ steps:
       set -e
       ./build/azure-pipelines/linux/createDrop.sh
     displayName: Create Drop
-    condition: and(succeeded(), ne(variables['EXTENSIONS_ONLY'], 'true'))
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -121,7 +121,7 @@ steps:
       set -e
       DISPLAY=:10 ./scripts/test.sh --build --tfs "Unit Tests" --coverage
     displayName: Run unit tests (Electron)
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'), eq(variables['EXTENSIONS_ONLY'], 'false'))
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'), ne(variables['EXTENSIONS_ONLY'], 'true'))
 
   - script: |
       # Figure out the full absolute path of the product we just built
@@ -134,7 +134,7 @@ steps:
       VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-linux-x64" \
       DISPLAY=:10 ./scripts/test-integration.sh --build --tfs "Integration Tests"
     displayName: Run integration tests (Electron)
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'), eq(variables['EXTENSIONS_ONLY'], 'false'))
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'), ne(variables['EXTENSIONS_ONLY'], 'true'))
 
   - script: |
       # Figure out the full absolute path of the product we just built
@@ -178,13 +178,13 @@ steps:
       set -e
       yarn gulp vscode-linux-x64-build-deb
     displayName: Build Deb
-    condition: and(succeeded(), eq(variables['EXTENSIONS_ONLY'], 'false'))
+    condition: and(succeeded(), ne(variables['EXTENSIONS_ONLY'], 'true'))
 
   - script: |
       set -e
       yarn gulp vscode-linux-x64-build-rpm
     displayName: Build Rpm
-    condition: and(succeeded(), eq(variables['EXTENSIONS_ONLY'], 'false'))
+    condition: and(succeeded(), ne(variables['EXTENSIONS_ONLY'], 'true'))
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core sdk for signing'
@@ -229,7 +229,7 @@ steps:
       set -e
       ./build/azure-pipelines/linux/createDrop.sh
     displayName: Create Drop
-    condition: and(succeeded(), eq(variables['EXTENSIONS_ONLY'], 'false'))
+    condition: and(succeeded(), ne(variables['EXTENSIONS_ONLY'], 'true'))
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -121,7 +121,7 @@ steps:
       set -e
       DISPLAY=:10 ./scripts/test.sh --build --tfs "Unit Tests" --coverage
     displayName: Run unit tests (Electron)
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'), eq(variables['EXTENSIONS_ONLY'], 'false'))
 
   - script: |
       # Figure out the full absolute path of the product we just built
@@ -134,7 +134,7 @@ steps:
       VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-linux-x64" \
       DISPLAY=:10 ./scripts/test-integration.sh --build --tfs "Integration Tests"
     displayName: Run integration tests (Electron)
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'), eq(variables['EXTENSIONS_ONLY'], 'false'))
 
   - script: |
       # Figure out the full absolute path of the product we just built
@@ -178,11 +178,13 @@ steps:
       set -e
       yarn gulp vscode-linux-x64-build-deb
     displayName: Build Deb
+    condition: and(succeeded(), eq(variables['EXTENSIONS_ONLY'], 'false'))
 
   - script: |
       set -e
       yarn gulp vscode-linux-x64-build-rpm
     displayName: Build Rpm
+    condition: and(succeeded(), eq(variables['EXTENSIONS_ONLY'], 'false'))
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core sdk for signing'
@@ -227,6 +229,7 @@ steps:
       set -e
       ./build/azure-pipelines/linux/createDrop.sh
     displayName: Create Drop
+    condition: and(succeeded(), eq(variables['EXTENSIONS_ONLY'], 'false'))
 
   - script: |
       set -e


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio-docs/issues/131

I created a new pipeline to only run the steps that are needed to produce vsix files for extensions.

test run: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=163917&view=results


run existing pipeline against the branch with the new variable: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=163941&view=results