### PR TITLE
Reverted changes to Radio buttons default value

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -186,7 +186,7 @@
                                 "displayName": "%arc.data.controller.direct.display.name%"
                               }
                             ],
-                            "defaultValue": "indirect",
+                            "defaultValue": "%arc.data.controller.indirect.display.name%",
                             "optionsType": "radio"
                           }
                         },
@@ -1149,10 +1149,7 @@
                               "displayName": "%arc.sql.service.tier.general.purpose%"
                             }
                           ],
-                          "defaultValue": {
-                            "name": "BusinessCritical",
-                            "displayName": "%arc.sql.service.tier.business.critical%"
-                          },
+                          "defaultValue": "%arc.sql.service.tier.business.critical%",
                           "optionsType": "radio"
                         }
                       },
@@ -1184,10 +1181,7 @@
                               "displayName": "%arc.sql.three.replicas%"
                             }
                           ],
-                          "defaultValue": {
-                            "name": "3",
-                            "displayName": "%arc.sql.three.replicas%"
-                          },
+                          "defaultValue": "%arc.sql.three.replicas%",
                           "optionsType": "radio"
                         },
                         "dynamicOptions": {
@@ -1201,10 +1195,7 @@
                                   "displayName": "%arc.sql.one.replica%"
                                 }
                               ],
-                              "defaultValue": {
-                                "name": "1",
-                                "displayName": "%arc.sql.one.replica%"
-                              }
+                              "defaultValue": "%arc.sql.one.replica%"
                             }
                           ]
                         },

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -285,7 +285,7 @@ export interface IOptionsSource {
 export interface OptionsInfo {
 	values?: string[] | azdata.CategoryValue[],
 	source?: IOptionsSource,
-	defaultValue: string | ResourceTypeOptionValue,
+	defaultValue: string,
 	optionsType?: OptionsType
 }
 

--- a/extensions/resource-deployment/src/ui/radioGroupLoadingComponentBuilder.ts
+++ b/extensions/resource-deployment/src/ui/radioGroupLoadingComponentBuilder.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { OptionsInfo, FieldInfo, instanceOfDynamicEnablementInfo, ResourceTypeOptionValue } from '../interfaces';
+import { OptionsInfo, FieldInfo, instanceOfDynamicEnablementInfo } from '../interfaces';
 import { getErrorMessage } from '../common/utils';
 
 export class RadioGroupLoadingComponentBuilder implements azdata.ComponentBuilder<azdata.LoadingComponent, azdata.LoadingComponentProperties> {
@@ -45,12 +45,7 @@ export class RadioGroupLoadingComponentBuilder implements azdata.ComponentBuilde
 			}
 
 			let options: (string[] | azdata.CategoryValue[]) = optionsInfo.values!;
-			let defaultValue: string | ResourceTypeOptionValue = optionsInfo.defaultValue!;
-			if (typeof optionsInfo.defaultValue === 'string') {
-				defaultValue = optionsInfo.defaultValue;
-			} else {
-				defaultValue = optionsInfo.defaultValue.displayName;
-			}
+			let defaultValue: string = optionsInfo.defaultValue;
 			options.forEach((op: string | azdata.CategoryValue) => {
 				const option: azdata.CategoryValue = (typeof op === 'string')
 					? { name: op, displayName: op }

--- a/extensions/resource-deployment/src/ui/radioGroupLoadingComponentBuilder.ts
+++ b/extensions/resource-deployment/src/ui/radioGroupLoadingComponentBuilder.ts
@@ -45,7 +45,7 @@ export class RadioGroupLoadingComponentBuilder implements azdata.ComponentBuilde
 			}
 
 			let options: (string[] | azdata.CategoryValue[]) = optionsInfo.values!;
-			let defaultValue: string = optionsInfo.defaultValue;
+			let defaultValue: string = optionsInfo.defaultValue!;
 			options.forEach((op: string | azdata.CategoryValue) => {
 				const option: azdata.CategoryValue = (typeof op === 'string')
 					? { name: op, displayName: op }


### PR DESCRIPTION
Seems that CategoryValue and ResourceTypeOptionsValue are nearly the same thing, and loadOptions for radiobuttons already checks for CategoryValue. This change was not necessary, the bug was in arc extension code.