### PR TITLE
Fix gallery list reminder action for PRs from forks

### DIFF
--- a/.github/workflows/update-galleries-list-reminder.yml
+++ b/.github/workflows/update-galleries-list-reminder.yml
@@ -1,6 +1,6 @@
 name: Update Extension Gallery Reminder
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'extensionsGallery.json'
     branches:


### PR DESCRIPTION
Same as https://github.com/microsoft/sqltoolsservice/pull/1590 - pull_request actions don't have write permissions so we need to use pull_request_target instead. 