### PR TITLE
fix schema compare diff editor colors not getting reversed after vscode merge

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -2516,6 +2516,7 @@ function validateDiffEditorOptions(options: Readonly<IDiffEditorOptions>, defaul
 		diffCodeLens: validateBooleanOption(options.diffCodeLens, defaults.diffCodeLens),
 		renderOverviewRuler: validateBooleanOption(options.renderOverviewRuler, defaults.renderOverviewRuler),
 		diffWordWrap: validateDiffWordWrap(options.diffWordWrap, defaults.diffWordWrap),
+		reverse: validateBooleanOption(options.reverse, defaults.reverse), // {{SQL CARBON EDIT}}
 	};
 	return outOptions;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #20117. Schema compare uses the diffEditor.component, which reverses the coloring of the diff editor [here](https://github.com/microsoft/azuredatastudio/blob/26455e9113fb97398b2c86273af64c42d218a71a/src/sql/workbench/browser/modelComponents/diffeditor.component.ts#L80). This got broken in the vscode merge where the way `this._options` was getting set changed in diffEditorWidget.ts. Instead of getting set directly to the options passed in, the `validateDiffEditorOptions()` function was added, which didn't have the additional reverse option so it wasn't getting set anymore.
![image](https://user-images.githubusercontent.com/31145923/180063492-1ba8fbce-a57d-4e0f-a333-09e947a8105b.png)


Schema compare diff editor has correct reversed colors now:
![image](https://user-images.githubusercontent.com/31145923/180062537-f1d6be0e-1cc4-4620-acce-b97c03993035.png)

Normal diff editor (not reversed):
![image](https://user-images.githubusercontent.com/31145923/180062694-4527be94-f002-4e8c-8c59-2c546fa80b5b.png)

