### PR TITLE
Prevent cell's edit mode from being incorrectly cleared when a text component is initialized.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -195,7 +195,6 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this._register(this.themeService.onDidColorThemeChange(this.updateTheme, this));
 		this.updateTheme(this.themeService.getColorTheme());
 		this.setFocusAndScroll();
-		this.cellModel.isEditMode = false;
 		this._htmlMarkdownConverter = this._instantiationService.createInstance(HTMLMarkdownConverter, this.notebookUri);
 		this._register(this.cellModel.onOutputsChanged(e => {
 			this.updatePreview();

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -274,35 +274,42 @@ export function setup(opts: minimist.ParsedArgs) {
 
 		describe('Cell Toolbar Actions', function () {
 			async function verifyCellToolbarBehavior(app: Application, toolbarAction: () => Promise<void>, selector: string, checkIfGone: boolean = false): Promise<void> {
-				const sampleText: string = 'Test Text';
+				// Run the test for each of the default text editor modes
+				for (let editMode of ['Markdown', 'Split View']) {
+					await app.workbench.settingsEditor.addUserSetting('notebook.defaultTextEditMode', `"${editMode}"`);
+					await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
+					await app.workbench.sqlNotebook.newUntitledNotebook();
+					await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
+					let sampleText = `Markdown Toolbar Test - ${editMode}`;
+					await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
+					await app.workbench.sqlNotebook.selectAllTextInEditor();
 
-				await app.workbench.sqlNotebook.newUntitledNotebook();
-				await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
-				await app.workbench.sqlNotebook.waitForPlaceholderGone();
-				await app.workbench.sqlNotebook.textCellToolbar.changeTextCellView('Split View');
-				await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
-				await app.workbench.sqlNotebook.selectAllTextInEditor();
-
-				await toolbarAction();
-				await app.code.dispatchKeybinding('escape');
-				if (checkIfGone) {
-					await app.workbench.sqlNotebook.waitForTextCellPreviewContentGone(selector);
-				} else {
-					await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, selector);
+					await toolbarAction();
+					await app.code.dispatchKeybinding('escape');
+					if (checkIfGone) {
+						await app.workbench.sqlNotebook.waitForTextCellPreviewContentGone(selector);
+					} else {
+						await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, selector);
+					}
+					await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 				}
 			}
 
 			async function verifyToolbarKeyboardShortcut(app: Application, keyboardShortcut: string, selector: string) {
-				await app.workbench.sqlNotebook.newUntitledNotebook();
-				await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
-				await app.workbench.sqlNotebook.waitForPlaceholderGone();
-				await app.workbench.sqlNotebook.textCellToolbar.changeTextCellView('Markdown View');
-				let testText = 'Markdown Keyboard Shortcut Test';
-				await app.workbench.sqlNotebook.waitForTypeInEditor(testText);
-				await app.workbench.sqlNotebook.selectAllTextInEditor();
-				await app.code.dispatchKeybinding(keyboardShortcut);
-				await app.code.dispatchKeybinding('escape');
-				await app.workbench.sqlNotebook.waitForTextCellPreviewContent(testText, selector);
+				// Run the test for each of the default text editor modes
+				for (let editMode of ['Markdown', 'Split View']) {
+					await app.workbench.settingsEditor.addUserSetting('notebook.defaultTextEditMode', `"${editMode}"`);
+					await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
+					await app.workbench.sqlNotebook.newUntitledNotebook();
+					await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
+					let testText = `Markdown Keyboard Shortcut Test - ${editMode}`;
+					await app.workbench.sqlNotebook.waitForTypeInEditor(testText);
+					await app.workbench.sqlNotebook.selectAllTextInEditor();
+					await app.code.dispatchKeybinding(keyboardShortcut);
+					await app.code.dispatchKeybinding('escape');
+					await app.workbench.sqlNotebook.waitForTextCellPreviewContent(testText, selector);
+					await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
+				}
 			}
 
 			it('can bold selected text', async function () {


### PR DESCRIPTION
This PR fixes #20092

A cell's edit state first gets set from the notebookModel when it's created, but setting the cell's edit mode to false when creating a text component cleared part of this state (cellModel.showMarkdown). So, when checking the current mode of the cell in the markdown toolbar component, the cell would appear to not be in markdown mode, so processing keyboard shortcuts would be skipped. When changing the text cell view or re-opening the cell, the showMarkdown state would get updated correctly, which is why the keyboard shortcuts were only failing when first creating the cell.
