### PR TITLE
SQL Bindings add telemetry points

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -14,6 +14,7 @@ import { ConnectionDetails, IConnectionInfo } from 'vscode-mssql';
 import { AzureFunctionsExtensionApi } from '../../../types/vscode-azurefunctions.api';
 // https://github.com/microsoft/vscode-azuretools/blob/main/ui/api.d.ts
 import { AzureExtensionApiProvider } from '../../../types/vscode-azuretools.api';
+import { AzureFunctionUtils, TelemetryReporter, TelemetryViews } from './telemetry';
 /**
  * Represents the settings in an Azure function project's locawl.settings.json file
  */
@@ -238,6 +239,7 @@ export function waitForNewHostFile(): IFileFunctionObject {
  * @param selectedProjectFile is the users selected project file path
  */
 export async function addSqlNugetReferenceToProjectFile(selectedProjectFile: string): Promise<void> {
+	TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, AzureFunctionUtils.addSQLNugetPackage).send();
 	await utils.executeCommand(`dotnet add "${selectedProjectFile}" package ${constants.sqlExtensionPackageName} --prerelease`);
 }
 

--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -14,7 +14,7 @@ import { ConnectionDetails, IConnectionInfo } from 'vscode-mssql';
 import { AzureFunctionsExtensionApi } from '../../../types/vscode-azurefunctions.api';
 // https://github.com/microsoft/vscode-azuretools/blob/main/ui/api.d.ts
 import { AzureExtensionApiProvider } from '../../../types/vscode-azuretools.api';
-import { AzureFunctionUtils, TelemetryReporter, TelemetryViews } from './telemetry';
+import { TelemetryActions, TelemetryReporter, TelemetryViews } from './telemetry';
 /**
  * Represents the settings in an Azure function project's locawl.settings.json file
  */
@@ -239,8 +239,8 @@ export function waitForNewHostFile(): IFileFunctionObject {
  * @param selectedProjectFile is the users selected project file path
  */
 export async function addSqlNugetReferenceToProjectFile(selectedProjectFile: string): Promise<void> {
-	TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, AzureFunctionUtils.addSQLNugetPackage).send();
 	await utils.executeCommand(`dotnet add "${selectedProjectFile}" package ${constants.sqlExtensionPackageName} --prerelease`);
+	TelemetryReporter.sendActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.addSQLNugetPackage);
 }
 
 /**

--- a/extensions/sql-bindings/src/common/telemetry.ts
+++ b/extensions/sql-bindings/src/common/telemetry.ts
@@ -29,6 +29,9 @@ export enum TelemetryActions {
 	updateConnectionString = 'updateConnectionString',
 	finishAddSqlBinding = 'finishAddSqlBinding',
 	exitSqlBindingsQuickpick = 'exitSqlBindingsQuickpick',
+
+	// Azure Functions Utils
+	addSQLNugetPackage = 'addSQLNugetPackage',
 }
 
 export enum CreateAzureFunctionStep {
@@ -48,10 +51,6 @@ export enum CreateAzureFunctionStep {
 	getTemplateId = 'getTemplateId',
 	getConnectionStringSettingName = 'getConnectionStringSettingName',
 	promptForIncludePassword = 'promptForIncludePassword',
-}
-
-export enum AzureFunctionUtils {
-	addSQLNugetPackage = 'addSQLNugetPackage',
 }
 
 export enum ExitReason {

--- a/extensions/sql-bindings/src/common/telemetry.ts
+++ b/extensions/sql-bindings/src/common/telemetry.ts
@@ -11,7 +11,8 @@ export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, pack
 
 export enum TelemetryViews {
 	SqlBindingsQuickPick = 'SqlBindingsQuickPick',
-	CreateAzureFunctionWithSqlBinding = 'CreateAzureFunctionWithSqlBinding'
+	CreateAzureFunctionWithSqlBinding = 'CreateAzureFunctionWithSqlBinding',
+	AzureFunctionsUtils = 'AzureFunctionsUtils',
 }
 
 export enum TelemetryActions {
@@ -31,6 +32,7 @@ export enum TelemetryActions {
 }
 
 export enum CreateAzureFunctionStep {
+	noAzureFunctionsExtension = 'noAzureFunctionsExtension',
 	getAzureFunctionProject = 'getAzureFunctionProject',
 	learnMore = 'learnMore',
 	helpCreateAzureFunctionProject = 'helpCreateAzureFunctionProject',
@@ -46,6 +48,10 @@ export enum CreateAzureFunctionStep {
 	getTemplateId = 'getTemplateId',
 	getConnectionStringSettingName = 'getConnectionStringSettingName',
 	promptForIncludePassword = 'promptForIncludePassword',
+}
+
+export enum AzureFunctionUtils {
+	addSQLNugetPackage = 'addSQLNugetPackage',
 }
 
 export enum ExitReason {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds further telemetry points specifically where the user cancels out of the flow. This will help in understanding the cancel/error/success ratio metrics when a user utilizes the Create Azure Function with SQL Binding command.