### PR TITLE
Update extension integration test guide

### DIFF
--- a/extensions/integration-tests/readme.md
+++ b/extensions/integration-tests/readme.md
@@ -1,8 +1,8 @@
-## Extension Integration tests
+## Integration tests
 
 This extension is for running tests against specific features that require a connection to an actual server.
 
-Unit tests that don't require this should be added as tests to the extensions themselves.
+Unit tests that don't require this should be added as tests to the extensions or core directly.
 
 Tests that require user interaction should be added to the smoke tests - see https://github.com/microsoft/azuredatastudio/blob/main/test/smoke/README.md for more information.
 

--- a/extensions/integration-tests/readme.md
+++ b/extensions/integration-tests/readme.md
@@ -1,34 +1,35 @@
-## Integration tests
-The integration-tests suite is based on the extension testing feature provided by VS Code, We can use this for:
-* Commands for setting up the environment for feature testing.
-* Adding test cases that do not need UI interaction or the test scenarios not supported by the UI automation framework (e.g. object explorer context menu – not html based)
+## Extension Integration tests
+
+This extension is for running tests against specific features that require a connection to an actual server.
+
+Unit tests that don't require this should be added as tests to the extensions themselves.
+
+Tests that require user interaction should be added to the smoke tests - see https://github.com/microsoft/azuredatastudio/blob/main/test/smoke/README.md for more information.
 
 ##### Folders
-* extensionInstallers folder: Copy the VISX installers for the extensions we would like to run the tests with.
-* src folder: This is where the test file for features should be added, name the file like this: feature.test.ts. e.g. objectExplorer.test.ts
-
-## UI automation testing
-The UI automation test cases should be added under $root/test/smoke/src/sql folder. Each feature should create its own folder and add 2 files, one for accessing the feature and the other for the test cases. For example: objectExplorer.ts and objectExplorer.test.ts. only tested on Windows for now.
-
-For both Smoke test and Integration test, ADS will be launched using new temp folders: extension folder and data folder so that your local dev environment won't be changed.
+* `extensionInstallers` folder: VSIX packages of non-builtin extensions should be put here for the tests to run with, they will be installed upon startup of the tests.
+* `src/test` folder: This is where the test files for features should be added, name the file like this: `feature.test.ts` e.g. `objectExplorer.test.ts`
 
 ## How to run the test
+
+When these tests are ran, Azure Data Studio will be launched using new temp folders for installed extensions and data so that your local dev environment won't be changed.
+
 1. In the build pipeline:
 The integration test suite has been added to ADS windows pipeline to run the test and report the results, you can find the test results under the test tab.
 
 2. Local environment:
 	1. Close all currently active VS Code windows
-	1. open a terminal window/command line window
-	1. navigate to this folder and then run 'node setEnvironmentVariables.js', there are different options, by default VSCode will be opened.
+	1. Open a terminal window/command line window
+	1. Navigate to this folder and then run 'node setEnvironmentVariables.js', there are different options, by default VS Code will be opened.
 		1. Terminal(Mac)/CMD(Windows): node setEnvironmentVariables.js Terminal
 		2. Git-Bash on Windows: node setEnvironmentVariables.js BashWin
 	1. Follow the instructions in the window: you will be prompted to login to azure portal.
 	1. A new window will be opened based on your selection and the new window will have the required environment variables set.
-	1. Run the Test:
-		1. For Integration Test: in the new window navigate to the scripts folder and run sql-test-integration.bat or sql-test-integration.sh based on your environment.
-		2. Smoke Test can be launched in 2 ways:
-			1. In the new window navigate to the test/smoke folder and run: node smoke/index.js
-			2. Or, In a VSCode window opened by step above, open AzureDataStudio folder and then select the 'Launch Smoke Test' option.
+	2. In the new window navigate to the scripts folder and run sql-test-integration.[bat|sh]
+
+## Skipping Python Installation Tests
+
+The integration tests contain some tests that test the Python installation for Notebooks. This can take a long time to run and so if you do not need to run them you can skip them by setting the `SKIP_PYTHON_INSTALL_TEST` environment variable to `1`
 
 ## How to debug the tests
 1. Set the debug target to `Attach to Extension Host`
@@ -38,6 +39,6 @@ The integration test suite has been added to ADS windows pipeline to run the tes
 
 ## Code Coverage
 
-Code coverage for these tests is enabled by default. After running the tests you can find the results in the `coverage` folder at the root of this extension.
+Code coverage is enabled by default. After running the tests you can find the results in the `coverage` folder at the root of this extension.
 
 This code coverage covers extension code only - it will not instrument code from the core.


### PR DESCRIPTION
Tried to clean this up to make it a lot clearer, and then added a section on skipping the python installation tests. 

I also removed everything about the smoke tests and instead just provided a link to the README for those to keep things simpler. 