### PR TITLE
Fix null ref in contributed tree views

### DIFF
--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -197,7 +197,7 @@ export class TreeView extends Disposable implements ITreeView {
 							this._onDidChangeEmpty.fire();
 						}
 					}
-					return children;
+					return children ?? [];
 				}
 			};
 			if (this._dataProvider.onDidChangeEmpty) {


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/20137

In the VS Code merge last year the `ITreeViewDataProvider` interface changed getChildren to also be able to return undefined. 

https://github.com/Microsoft/azuredatastudio/commit/2bc6a0cd012de69504061a876070cfa43533fedc#diff-38a5184ff0054efc3aad42bd72ab863dc19354fa8706990b4eb27b74139f9db9L826

In our code we have a custom shim provider (for handling data explorer/OE stuff) that wraps this provider : https://github.com/Microsoft/azuredatastudio/blob/29811faeb0f451c933052310ac90d6850a4013ec/src/sql/workbench/contrib/views/browser/treeView.ts#L190

But during the merge it wasn't updated to take into account the new possibly-undefined value, and it's expected to always return a non-undefined value.

Note this is the same root cause that broke BDC : https://github.com/microsoft/azuredatastudio/pull/20116

The fix I did there worked but was more of a workaround solution that happened to fix the issue - this time I actually dug into the root cause and am fixing that here. 