### PR TITLE
fix icon path for ledger history table to be recognized as the correc…

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/media/objectTypes/objecttypes.css
+++ b/src/sql/workbench/services/objectExplorer/browser/media/objectTypes/objecttypes.css
@@ -585,12 +585,6 @@
 	background: url("Table_Ledger.svg") center center no-repeat;
 }
 
-.vs .icon.table_ledgerhistory,
-.vs-dark .icon.table_ledgerhistory,
-.hc-black .icon.table_ledgerhistory {
-	background: url("Table_LedgerHistory.svg") center center no-repeat;
-}
-
 .vs .icon.table_temporal,
 .vs-dark .icon.table_temporal,
 .hc-black .icon.table_temporal {
@@ -607,6 +601,12 @@
 .vs-dark .icon.table_graphedge,
 .hc-black .icon.table_graphedge {
 	background: url("Table_GraphEdge.svg") center center no-repeat;
+}
+
+.vs .icon.historytable_ledgerhistory,
+.vs-dark .icon.historytable_ledgerhistory,
+.hc-black .icon.historytable_ledgerhistory {
+	background: url("Table_LedgerHistory.svg") center center no-repeat;
 }
 
 


### PR DESCRIPTION
This PR fixes #20128 (again)

The definition for the ledger history table icon couldn't be recognized by STS due to the node type of a history table not being "Table" but "HistoryTable". This PR corrects the naming for the icon so it can be displayed for the history table node.

![image](https://user-images.githubusercontent.com/58005768/180338556-c5aa5076-b98c-412c-94fe-7f7df48c6bff.png)

