### PR TITLE
Prompt for arcdata install upon extension activation (fix)

### DIFF
--- a/extensions/azcli/src/api.ts
+++ b/extensions/azcli/src/api.ts
@@ -5,9 +5,7 @@
 
 import * as azExt from 'az-ext';
 import { IAzTool } from './az';
-import Logger from './common/logger';
 import { NoAzureCLIError } from './common/utils';
-import * as loc from './localizedConstants';
 import { AzToolService } from './services/azToolService';
 
 /**
@@ -21,7 +19,6 @@ export function validateAz(az: IAzTool | undefined) {
 
 export function throwIfNoAz(localAz: IAzTool | undefined): asserts localAz {
 	if (!localAz) {
-		Logger.log(loc.noAzureCLI);
 		throw new NoAzureCLIError();
 	}
 }

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -447,7 +447,7 @@ export async function checkAndInstallAz(userRequested: boolean = false): Promise
 	try {
 		return await findAzAndArc(); // find currently installed Az
 	} catch (err) {
-		if (err === AzureCLIArcExtError) {
+		if (err.toString() === 'Error: ' + loc.arcdataExtensionNotInstalled) {
 			// Az found but arcdata extension not found. Prompt user to install it, then check again.
 			if (await promptToInstallArcdata(userRequested)) {
 				return await findAzAndArc();
@@ -506,7 +506,7 @@ async function findSpecificAzAndArc(): Promise<IAzTool> {
 	// if no az has been found. If found, check if az arcdata extension exists.
 	const arcVersion = parseArcExtensionVersion(versionOutput.stdout);
 	if (arcVersion === undefined) {
-		throw AzureCLIArcExtError;
+		throw new AzureCLIArcExtError;
 	}
 
 	// Quietly attempt to update the arcdata extension to the latest. If it is already the latest, then it will not update.

--- a/extensions/azcli/src/common/utils.ts
+++ b/extensions/azcli/src/common/utils.ts
@@ -17,7 +17,7 @@ export class NoAzureCLIError extends Error implements azExt.ErrorWithLink {
 	}
 }
 
-export class AzureCLIArcExtError extends Error implements azExt.ErrorWithLink {
+export class NoAzureCLIArcExtError extends Error implements azExt.ErrorWithLink {
 	constructor() {
 		super(loc.arcdataExtensionNotInstalled);
 	}


### PR DESCRIPTION
Fixed a bug where the user would not be prompted to download arcdata if they didn't have it downloaded upon extension startup. Now, if user doesn't have arcdata extension installed on their Azure CLI, they are prompted to download it.
![image](https://user-images.githubusercontent.com/22386690/180893807-cbe0581f-670a-418f-af3e-f0e102d94ec2.png)

This PR fixes https://github.com/microsoft/azuredatastudio/issues/16518
