### PR TITLE
Change connection to connectivity, .lower on notebook

### DIFF
--- a/extensions/arc/notebooks/arcDeployment/deploy.arc.data.controller.ipynb
+++ b/extensions/arc/notebooks/arcDeployment/deploy.arc.data.controller.ipynb
@@ -158,7 +158,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "is_indirect = arc_data_controller_connectivity_mode == 'indirect'\n",
+                "is_indirect = arc_data_controller_connectivity_mode.lower() == 'indirect'\n",
                 "\n",
                 "if not is_indirect:\n",
                 "\trun_command('az login')"

--- a/extensions/arc/notebooks/arcDeployment/deploy.sql.existing.arc.ipynb
+++ b/extensions/arc/notebooks/arcDeployment/deploy.sql.existing.arc.ipynb
@@ -98,7 +98,7 @@
             "source": [
                 "print (f'Creating the SQL managed instance - Azure Arc instance')\n",
                 "\n",
-                "is_indirect = arc_data_controller_connection_mode == 'indirect'\n",
+                "is_indirect = arc_data_controller_connectivity_mode.lower() == 'indirect'\n",
                 "is_general_purpose = sql_service_tier == 'GeneralPurpose'\n",
                 "\n",
                 "# Indirect Mode Parameters\n",


### PR DESCRIPTION
Fixes bug found in bug bash where SQL MIAA create is blocked by typo in notebook. Also convert connectivity mode to lowercase before comparison in case users have deployed instances that have capitalized connectivity mode in their configs.