### PR TITLE
Added az command message to the upgrade experience. Check connectivity mode with .toLowerCase().

### DIFF
--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -253,6 +253,10 @@ export function deletingInstance(name: string): string { return localize('arc.de
 export function installingExtension(name: string): string { return localize('arc.installingExtension', "Installing extension '{0}'...", name); }
 export function extensionInstalled(name: string): string { return localize('arc.extensionInstalled', "Extension '{0}' has been installed.", name); }
 export function updatingInstance(name: string): string { return localize('arc.updatingInstance', "Updating instance '{0}'...", name); }
+export function upgradingDirectDC(name: string, desiredVersion: string, resourceGroup: string): string { return localize('arc.upgradingDirectDC', "Upgrading data controller '{0}' with command 'az arcdata dc upgrade --desired-version {1} --name {0} --resource-group {2}'", name, desiredVersion, resourceGroup); }
+export function upgradingIndirectDC(name: string, desiredVersion: string, namespace: string): string { return localize('arc.upgradingIndirectDC', "Upgrading data controller '{0}' with command 'az arcdata dc upgrade --desired-version {1} --name {0} --k8s-namespace {2} --use-k8s'", name, desiredVersion, namespace); }
+export function upgradingDirectMiaa(name: string, resourceGroup: string): string { return localize('arc.upgradingDirectMiaa', "Upgrading SQL MIAA '{0}' with command 'az sql mi-arc upgrade --name {0} --resource-group {1}'", name, resourceGroup); }
+export function upgradingIndirectMiaa(name: string, namespace: string): string { return localize('arc.upgradingIndirectMiaa', "Upgrading SQL MIAA '{0}' with command 'az sql mi-arc upgrade --name {0} --k8s-namespace {1} --use-k8s'", name, namespace); }
 export function instanceDeleted(name: string): string { return localize('arc.instanceDeleted', "Instance '{0}' deleted", name); }
 export function instanceUpdated(name: string): string { return localize('arc.instanceUpdated', "Instance '{0}' updated", name); }
 export function extensionsDropped(name: string): string { return localize('arc.extensionsDropped', "Extensions '{0}' dropped", name); }

--- a/extensions/arc/src/models/miaaModel.ts
+++ b/extensions/arc/src/models/miaaModel.ts
@@ -100,7 +100,7 @@ export class MiaaModel extends ResourceModel {
 		try {
 			try {
 				let result;
-				if (this.controllerModel.info.connectionMode === ConnectionMode.direct) {
+				if (this.controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
 					result = await this._azApi.az.sql.miarc.show(
 						this.info.name,
 						{

--- a/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
@@ -220,7 +220,7 @@ export class MiaaBackupsPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token): Promise<void> => {
-								if (this._miaaModel.controllerModel.info.connectionMode === ConnectionMode.direct) {
+								if (this._miaaModel.controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
 									await this._azApi.az.sql.miarc.update(
 										this._miaaModel.info.name,
 										this._saveArgs,

--- a/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
@@ -132,7 +132,7 @@ export class MiaaComputeAndStoragePage extends DashboardPage {
 						},
 						async (_progress, _token): Promise<void> => {
 							try {
-								if (this._miaaModel.controllerModel.info.connectionMode === ConnectionMode.direct) {
+								if (this._miaaModel.controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
 									await this._azApi.az.sql.miarc.update(
 										this._miaaModel.info.name,
 										this.saveArgs,

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -243,7 +243,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token) => {
-								if (this._controllerModel.info.connectionMode === ConnectionMode.direct) {
+								if (this._controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
 									return await this._azApi.az.sql.miarc.delete(
 										this._miaaModel.info.name,
 										{

--- a/extensions/arc/src/ui/dialogs/connectControllerDialog.ts
+++ b/extensions/arc/src/ui/dialogs/connectControllerDialog.ts
@@ -204,7 +204,7 @@ export class ConnectToControllerDialog extends ControllerDialogBase {
 			controllerModel.info.connectionMode = <string>controllerModel.controllerConfig?.spec.settings.azure.connectionMode.toLowerCase();
 			controllerModel.info.location = <string>controllerModel.controllerConfig?.spec.settings.azure.location;
 
-			if (controllerModel.info.connectionMode === ConnectionMode.direct) {
+			if (controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
 				const rawCustomLocation = <string>controllerModel.controllerConfig?.metadata.annotations['management.azure.com/customLocation'];
 				const exp = /custom[lL]ocations\/([\S]*)/;
 				controllerModel.info.customLocation = <string>exp.exec(rawCustomLocation)?.pop();


### PR DESCRIPTION
- When checking connectivity mode, check using .toLowerCase() because some DC configs may have been made with capital 'Direct' or 'Indirect'
- Upgrade message now specifies the exact command and params used in the Azure CLI command, rather than just "Updating instance 'dc1'... 
![image](https://user-images.githubusercontent.com/22386690/181391393-35bfd385-6cc9-423c-9789-c445c5165aad.png)
![image](https://user-images.githubusercontent.com/22386690/181394056-d1f2366c-02b2-4620-86ef-49e305522dd8.png)
