### PR TITLE
support recent closed feature for query editor and notebook

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/fileNotebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/fileNotebookInput.ts
@@ -10,6 +10,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { NotebookInput } from 'sql/workbench/contrib/notebook/browser/models/notebookInput';
 import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
+import { IResourceEditorInput } from 'vs/platform/editor/common/editor';
 
 export class FileNotebookInput extends NotebookInput {
 	public static ID: string = 'workbench.editorinputs.fileNotebookInput';
@@ -49,5 +50,11 @@ export class FileNotebookInput extends NotebookInput {
 
 	public getEncoding(): string | undefined {
 		return this.textInput.getEncoding();
+	}
+
+	override toUntyped(): IResourceEditorInput {
+		return <IResourceEditorInput>{
+			resource: this.resource
+		};
 	}
 }

--- a/src/sql/workbench/contrib/query/browser/fileQueryEditorInput.ts
+++ b/src/sql/workbench/contrib/query/browser/fileQueryEditorInput.ts
@@ -17,6 +17,7 @@ import { URI } from 'vs/base/common/uri';
 import { FILE_QUERY_EDITOR_TYPEID } from 'sql/workbench/common/constants';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
+import { IResourceEditorInput } from 'vs/platform/editor/common/editor';
 
 export class FileQueryEditorInput extends QueryEditorInput {
 
@@ -119,5 +120,11 @@ export class FileQueryEditorInput extends QueryEditorInput {
 				return newEditorInput;
 			}
 		}
+	}
+
+	override toUntyped(): IResourceEditorInput {
+		return <IResourceEditorInput>{
+			resource: this.resource,
+		};
 	}
 }


### PR DESCRIPTION
This PR fixes #20103 

notebook and query editor didn't implement the `toUntyped()` method that is used by vscode to determine whether an editor should be added to the recent closed list when an editor is getting closed.

https://github.com/microsoft/azuredatastudio/blob/main/src/vs/workbench/services/history/browser/history.ts#L724

I am not adding this to the untitled query editor and notebook because the underlying resource can't be mapped to the correct  input, it doesn't seem to be trivial to implement. giving the fact that open a new query editor and new notebook is easy enough, i am going to leave these 2 scenarios as is.


![recent-sql](https://user-images.githubusercontent.com/13777222/181397065-22970bf7-8e44-4b71-b6e3-83664871bf7f.gif)

![recent-notebook](https://user-images.githubusercontent.com/13777222/181397084-f95f095b-b564-45d9-8f8a-adaa2eda70ef.gif)
