### PR TITLE
Converting all SQL MIAA commands to use K8s API commands

### DIFF
--- a/extensions/arc/src/models/controllerModel.ts
+++ b/extensions/arc/src/models/controllerModel.ts
@@ -6,7 +6,6 @@
 import { ControllerInfo, ResourceType } from 'arc';
 import * as azExt from 'az-ext';
 import * as vscode from 'vscode';
-import { ConnectionMode } from '../constants';
 import * as loc from '../localizedConstants';
 import { AzureArcTreeDataProvider } from '../ui/tree/azureArcTreeDataProvider';
 
@@ -69,15 +68,6 @@ export class ControllerModel {
 	}
 
 	public async refresh(showErrors: boolean = true, namespace: string): Promise<void> {
-		await this.refreshController(showErrors, namespace);
-		if (this._controllerConfig?.spec.settings.azure.connectionMode.toLowerCase() === ConnectionMode.direct) {
-			await this.refreshDirectMode(this._controllerConfig?.spec.settings.azure.resourceGroup, namespace);
-		} else {
-			await this.refreshIndirectMode(namespace);
-		}
-	}
-
-	public async refreshController(showErrors: boolean = true, namespace: string): Promise<void> {
 		await Promise.all([
 			this._azApi.az.arcdata.dc.config.show(namespace, this.azAdditionalEnvVars).then(result => {
 				this._controllerConfig = result.stdout;
@@ -108,38 +98,6 @@ export class ControllerModel {
 				throw err;
 			})
 		]);
-	}
-
-	public async refreshDirectMode(resourceGroup: string, namespace: string): Promise<void> {
-		const newRegistrations: Registration[] = [];
-		await Promise.all([
-			this._azApi.az.postgres.arcserver.list(namespace, this.azAdditionalEnvVars).then(result => {
-				newRegistrations.push(...result.stdout.map(r => {
-					return {
-						instanceName: r.name,
-						state: r.state,
-						instanceType: ResourceType.postgresInstances
-					};
-				}));
-			}),
-			this._azApi.az.sql.miarc.list({ resourceGroup: resourceGroup, namespace: undefined }, this.azAdditionalEnvVars).then(result => {
-				newRegistrations.push(...result.stdout.map(r => {
-					return {
-						instanceName: r.name,
-						state: r.state,
-						instanceType: ResourceType.sqlManagedInstances
-					};
-				}));
-
-			})
-		]).then(() => {
-			this._registrations = newRegistrations;
-			this.registrationsLastUpdated = new Date();
-			this._onRegistrationsUpdated.fire(this._registrations);
-		});
-	}
-
-	public async refreshIndirectMode(namespace: string): Promise<void> {
 		const newRegistrations: Registration[] = [];
 		await Promise.all([
 			this._azApi.az.postgres.arcserver.list(namespace, this.azAdditionalEnvVars).then(result => {

--- a/extensions/arc/src/models/miaaModel.ts
+++ b/extensions/arc/src/models/miaaModel.ts
@@ -15,7 +15,6 @@ import { ConnectToMiaaSqlDialog } from '../ui/dialogs/connectMiaaDialog';
 import { AzureArcTreeDataProvider } from '../ui/tree/azureArcTreeDataProvider';
 import { ControllerModel, Registration } from './controllerModel';
 import { ResourceModel } from './resourceModel';
-import { ConnectionMode } from '../constants';
 
 export type DatabaseModel = { name: string, status: string, earliestBackup: string, lastBackup: string };
 export type RPModel = { recoveryPointObjective: string, retentionDays: string };
@@ -100,25 +99,14 @@ export class MiaaModel extends ResourceModel {
 		try {
 			try {
 				let result;
-				if (this.controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
-					result = await this._azApi.az.sql.miarc.show(
-						this.info.name,
-						{
-							resourceGroup: this.controllerModel.info.resourceGroup,
-							namespace: undefined
-						},
-						this.controllerModel.azAdditionalEnvVars
-					);
-				} else {
-					result = await this._azApi.az.sql.miarc.show(
-						this.info.name,
-						{
-							resourceGroup: undefined,
-							namespace: this.controllerModel.info.namespace
-						},
-						this.controllerModel.azAdditionalEnvVars
-					);
-				}
+				result = await this._azApi.az.sql.miarc.show(
+					this.info.name,
+					{
+						resourceGroup: undefined,
+						namespace: this.controllerModel.info.namespace
+					},
+					this.controllerModel.azAdditionalEnvVars
+				);
 				this._config = result.stdout;
 				this.configLastUpdated = new Date();
 				this.rpSettings.retentionDays = this._config?.spec?.backup?.retentionPeriodInDays?.toString() ?? '';

--- a/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as azExt from 'az-ext';
 import * as loc from '../../../localizedConstants';
-import { IconPathHelper, cssStyles, ConnectionMode } from '../../../constants';
+import { IconPathHelper, cssStyles } from '../../../constants';
 import { DashboardPage } from '../../components/dashboardPage';
 import { MiaaModel, RPModel, DatabaseModel, systemDbs } from '../../../models/miaaModel';
 import { ControllerModel } from '../../../models/controllerModel';
@@ -220,23 +220,13 @@ export class MiaaBackupsPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token): Promise<void> => {
-								if (this._miaaModel.controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
-									await this._azApi.az.sql.miarc.update(
-										this._miaaModel.info.name,
-										this._saveArgs,
-										this._miaaModel.controllerModel.info.resourceGroup,
-										undefined, // Indirect mode argument - namespace
-										undefined, // Indirect mode argument - usek8s
-										this._miaaModel.controllerModel.azAdditionalEnvVars);
-								} else {
-									await this._azApi.az.sql.miarc.update(
-										this._miaaModel.info.name,
-										this._saveArgs,
-										undefined, // Direct mode argument - resourceGroup
-										this._miaaModel.controllerModel.info.namespace,
-										true,
-										this._miaaModel.controllerModel.azAdditionalEnvVars);
-								}
+								await this._azApi.az.sql.miarc.update(
+									this._miaaModel.info.name,
+									this._saveArgs,
+									undefined, // Direct mode argument - resourceGroup
+									this._miaaModel.controllerModel.info.namespace,
+									true,
+									this._miaaModel.controllerModel.azAdditionalEnvVars);
 								try {
 									await this._miaaModel.refresh();
 								} catch (error) {

--- a/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as azExt from 'az-ext';
 import * as loc from '../../../localizedConstants';
-import { IconPathHelper, cssStyles, ConnectionMode } from '../../../constants';
+import { IconPathHelper, cssStyles } from '../../../constants';
 import { DashboardPage } from '../../components/dashboardPage';
 import { convertToGibibyteString } from '../../../common/utils';
 import { MiaaModel } from '../../../models/miaaModel';
@@ -132,23 +132,13 @@ export class MiaaComputeAndStoragePage extends DashboardPage {
 						},
 						async (_progress, _token): Promise<void> => {
 							try {
-								if (this._miaaModel.controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
-									await this._azApi.az.sql.miarc.update(
-										this._miaaModel.info.name,
-										this.saveArgs,
-										this._miaaModel.controllerModel.info.resourceGroup,
-										undefined, // Indirect mode argument - namespace
-										undefined, // Indirect mode argument - usek8s
-										this._miaaModel.controllerModel.azAdditionalEnvVars);
-								} else {
-									await this._azApi.az.sql.miarc.update(
-										this._miaaModel.info.name,
-										this.saveArgs,
-										undefined, // Direct mode argument - resourceGroup
-										this._miaaModel.controllerModel.info.namespace,
-										true,
-										this._miaaModel.controllerModel.azAdditionalEnvVars);
-								}
+								await this._azApi.az.sql.miarc.update(
+									this._miaaModel.info.name,
+									this.saveArgs,
+									undefined, // Direct mode argument - resourceGroup
+									this._miaaModel.controllerModel.info.namespace,
+									true,
+									this._miaaModel.controllerModel.azAdditionalEnvVars);
 							} catch (err) {
 								this.saveButton!.enabled = true;
 								throw err;

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -8,7 +8,7 @@ import * as azExt from 'az-ext';
 import * as azurecore from 'azurecore';
 import * as vscode from 'vscode';
 import { getDatabaseStateDisplayText, promptForInstanceDeletion } from '../../../common/utils';
-import { ConnectionMode, cssStyles, IconPathHelper, miaaTroubleshootDocsUrl } from '../../../constants';
+import { cssStyles, IconPathHelper, miaaTroubleshootDocsUrl } from '../../../constants';
 import * as loc from '../../../localizedConstants';
 import { ControllerModel } from '../../../models/controllerModel';
 import { MiaaModel } from '../../../models/miaaModel';
@@ -243,25 +243,14 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token) => {
-								if (this._controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
-									return await this._azApi.az.sql.miarc.delete(
-										this._miaaModel.info.name,
-										{
-											resourceGroup: this._controllerModel.info.resourceGroup,
-											namespace: undefined,
-										},
-										this._controllerModel.azAdditionalEnvVars
-									);
-								} else {
-									return await this._azApi.az.sql.miarc.delete(
-										this._miaaModel.info.name,
-										{
-											resourceGroup: undefined,
-											namespace: this._controllerModel.info.namespace,
-										},
-										this._controllerModel.azAdditionalEnvVars
-									);
-								}
+								return await this._azApi.az.sql.miarc.delete(
+									this._miaaModel.info.name,
+									{
+										resourceGroup: undefined,
+										namespace: this._controllerModel.info.namespace,
+									},
+									this._controllerModel.azAdditionalEnvVars
+								);
 							}
 						);
 						await this._controllerModel.refreshTreeNode();

--- a/extensions/arc/src/ui/dashboards/miaa/miaaUpgradeManagementPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaUpgradeManagementPage.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as azExt from 'az-ext';
 import * as loc from '../../../localizedConstants';
-import { IconPathHelper, cssStyles, ConnectionMode } from '../../../constants';
+import { IconPathHelper, cssStyles } from '../../../constants';
 import { DashboardPage } from '../../components/dashboardPage';
 import { ControllerModel } from '../../../models/controllerModel';
 import { UpgradeSqlMiaa } from '../../dialogs/upgradeSqlMiaa';
@@ -160,25 +160,14 @@ export class MiaaUpgradeManagementPage extends DashboardPage {
 	private async getMiaaVersion(): Promise<string | undefined> {
 		try {
 			let miaaShowResult;
-			if (this._controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct || this._controllerModel.controllerConfig?.spec.settings.azure.connectionMode.toLowerCase() === ConnectionMode.direct) {
-				miaaShowResult = await this._azApi.az.sql.miarc.show(
-					this._miaaModel.info.name,
-					{
-						resourceGroup: this._controllerModel.info.resourceGroup,
-						namespace: undefined
-					},
-					this._controllerModel.azAdditionalEnvVars
-				);
-			} else {
-				miaaShowResult = await this._azApi.az.sql.miarc.show(
-					this._miaaModel.info.name,
-					{
-						resourceGroup: undefined,
-						namespace: this._controllerModel.info.namespace
-					},
-					this._controllerModel.azAdditionalEnvVars
-				);
-			}
+			miaaShowResult = await this._azApi.az.sql.miarc.show(
+				this._miaaModel.info.name,
+				{
+					resourceGroup: undefined,
+					namespace: this._controllerModel.info.namespace
+				},
+				this._controllerModel.azAdditionalEnvVars
+			);
 			return miaaShowResult.stdout.status.runningVersion;
 		} catch (e) {
 			console.error(loc.showMiaaError, e);
@@ -263,51 +252,27 @@ export class MiaaUpgradeManagementPage extends DashboardPage {
 					try {
 						upgradeButton.enabled = false;
 						vscode.window.showInformationMessage(loc.upgradingMiaa('kubectl get sqlmi -A\' should not be localized.'));
-						if (this._controllerModel.info.connectionMode.toLowerCase() === ConnectionMode.direct) {
-							await vscode.window.withProgress(
-								{
-									location: vscode.ProgressLocation.Notification,
-									title: loc.upgradingDirectMiaa(this._miaaModel.info.name, this._controllerModel.info.resourceGroup),
-									cancellable: true
-								},
-								async (_progress, _token): Promise<void> => {
-									await this._azApi.az.sql.miarc.upgrade(
-										this._miaaModel.info.name,
-										{
-											resourceGroup: this._controllerModel.info.resourceGroup,
-											namespace: undefined
-										}
-									);
-									try {
-										await this._controllerModel.refresh(false, this._controllerModel.info.namespace);
-									} catch (error) {
-										vscode.window.showErrorMessage(loc.refreshFailed(error));
+						await vscode.window.withProgress(
+							{
+								location: vscode.ProgressLocation.Notification,
+								title: loc.upgradingIndirectMiaa(this._miaaModel.info.name, this._controllerModel.info.namespace),
+								cancellable: true
+							},
+							async (_progress, _token): Promise<void> => {
+								await this._azApi.az.sql.miarc.upgrade(
+									this._miaaModel.info.name,
+									{
+										resourceGroup: undefined,
+										namespace: this._controllerModel.info.namespace,
 									}
+								);
+								try {
+									await this._controllerModel.refresh(false, this._controllerModel.info.namespace);
+								} catch (error) {
+									vscode.window.showErrorMessage(loc.refreshFailed(error));
 								}
-							);
-						} else {
-							await vscode.window.withProgress(
-								{
-									location: vscode.ProgressLocation.Notification,
-									title: loc.upgradingIndirectMiaa(this._miaaModel.info.name, this._controllerModel.info.namespace),
-									cancellable: true
-								},
-								async (_progress, _token): Promise<void> => {
-									await this._azApi.az.sql.miarc.upgrade(
-										this._miaaModel.info.name,
-										{
-											resourceGroup: undefined,
-											namespace: this._controllerModel.info.namespace,
-										}
-									);
-									try {
-										await this._controllerModel.refresh(false, this._controllerModel.info.namespace);
-									} catch (error) {
-										vscode.window.showErrorMessage(loc.refreshFailed(error));
-									}
-								}
-							);
-						}
+							}
+						);
 					} catch (error) {
 						console.log(error);
 					}

--- a/extensions/azcli/src/api.ts
+++ b/extensions/azcli/src/api.ts
@@ -117,9 +117,9 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 				delete: async (
 					name: string,
 					args: {
-						// Direct mode arguments
+						// ARM API arguments
 						resourceGroup?: string;
-						// Indirect mode arguments
+						// K8s API arguments
 						namespace?: string;
 					},
 					additionalEnvVars?: azExt.AdditionalEnvVars
@@ -130,9 +130,9 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 				},
 				list: async (
 					args: {
-						// Direct mode arguments
+						// ARM API arguments
 						resourceGroup?: string;
-						// Indirect mode arguments
+						// K8s API arguments
 						namespace?: string;
 					},
 					additionalEnvVars?: azExt.AdditionalEnvVars
@@ -144,9 +144,9 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 				show: async (
 					name: string,
 					args: {
-						// Direct mode arguments
+						// ARM API arguments
 						resourceGroup?: string;
-						// Indirect mode arguments
+						// K8s API arguments
 						namespace?: string;
 					},
 					// Additional arguments
@@ -166,9 +166,9 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 						noWait?: boolean;
 						syncSecondaryToCommit?: string;
 					},
-					// Direct mode arguments
+					// ARM API arguments
 					resourceGroup?: string,
-					// Indirect mode arguments
+					// K8s API arguments
 					namespace?: string,
 					usek8s?: boolean,
 					// Additional arguments
@@ -181,9 +181,9 @@ export function getAzApi(localAzDiscovered: Promise<IAzTool | undefined>, azTool
 				upgrade: async (
 					name: string,
 					args: {
-						// Direct mode arguments
+						// ARM API arguments
 						resourceGroup?: string;
-						// Indirect mode arguments
+						// K8s API arguments
 						namespace?: string;
 					},
 					// Additional arguments

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -116,7 +116,7 @@ export class AzTool implements azExt.IAzApi {
 				const argsArray = ['arcdata', 'dc', 'upgrade', '--desired-version', desiredVersion, '--name', name];
 				// Direct mode argument
 				if (resourceGroup) { argsArray.push('--resource-group', resourceGroup); }
-				// Indirect mode arguments
+				// K8s API arguments
 				if (namespace) {
 					argsArray.push('--k8s-namespace', namespace);
 					argsArray.push('--use-k8s');
@@ -180,9 +180,9 @@ export class AzTool implements azExt.IAzApi {
 			delete: (
 				name: string,
 				args: {
-					// Direct mode arguments
+					// ARM API arguments
 					resourceGroup?: string,
-					// Indirect mode arguments
+					// K8s API arguments
 					namespace?: string
 					// Additional arguments
 				},
@@ -200,9 +200,9 @@ export class AzTool implements azExt.IAzApi {
 			},
 			list: (
 				args: {
-					// Direct mode arguments
+					// ARM API arguments
 					resourceGroup?: string,
-					// Indirect mode arguments
+					// K8s API arguments
 					namespace?: string
 					// Additional arguments
 				},
@@ -221,9 +221,9 @@ export class AzTool implements azExt.IAzApi {
 			show: (
 				name: string,
 				args: {
-					// Direct mode arguments
+					// ARM API arguments
 					resourceGroup?: string,
-					// Indirect mode arguments
+					// K8s API arguments
 					namespace?: string
 					// Additional arguments
 				},
@@ -250,9 +250,9 @@ export class AzTool implements azExt.IAzApi {
 					retentionDays?: string,
 					syncSecondaryToCommit?: string
 				},
-				// Direct mode arguments
+				// ARM API arguments
 				resourceGroup?: string,
-				// Indirect mode arguments
+				// K8s API arguments
 				namespace?: string,
 				usek8s?: boolean,
 				// Additional arguments
@@ -273,9 +273,9 @@ export class AzTool implements azExt.IAzApi {
 			upgrade: (
 				name: string,
 				args: {
-					// Direct mode arguments
+					// ARM API arguments
 					resourceGroup?: string,
-					// Indirect mode arguments
+					// K8s API arguments
 					namespace?: string
 					// Additional arguments
 				},

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -575,9 +575,9 @@ declare module 'az-ext' {
 				delete(
 					name: string,
 					args: {
-						// Direct mode arguments
+						// ARM API arguments
 						resourceGroup?: string,
-						// Indirect mode arguments
+						// K8s API arguments
 						namespace?: string
 						},
 						// Additional arguments
@@ -585,9 +585,9 @@ declare module 'az-ext' {
 				): Promise<AzOutput<void>>,
 				list(
 					args: {
-					// Direct mode arguments
+					// ARM API arguments
 					resourceGroup?: string,
-					// Indirect mode arguments
+					// K8s API arguments
 					namespace?: string
 					},
 					// Additional arguments
@@ -596,9 +596,9 @@ declare module 'az-ext' {
 				show(
 					name: string,
 					args: {
-						// Direct mode arguments
+						// ARM API arguments
 						resourceGroup?: string,
-						// Indirect mode arguments
+						// K8s API arguments
 						namespace?: string
 					},
 					// Additional arguments
@@ -615,9 +615,9 @@ declare module 'az-ext' {
 						retentionDays?: string, //5
 						syncSecondaryToCommit?: string //2
 					},
-					// Direct mode arguments
+					// ARM API arguments
 					resourceGroup?: string,
-					// Indirect mode arguments
+					// K8s API arguments
 					namespace?: string,
 					usek8s?: boolean,
 					// Additional arguments
@@ -626,9 +626,9 @@ declare module 'az-ext' {
 				upgrade(
 					name: string,
 					args: {
-						// Direct mode arguments
+						// ARM API arguments
 						resourceGroup?: string,
-						// Indirect mode arguments
+						// K8s API arguments
 						namespace?: string
 					},
 					// Additional arguments


### PR DESCRIPTION
- Direct mode commands are now supported by the Kubernetes API
- This change makes all SQL MIAA commands, such as create, delete, update, show, list, and upgrade, use the Kubernetes API for both direct and indirect connectivity mode. 
- Comments that used to say "Indirect mode arguments" or "Direct mode arguments" now say "K8s API arguments" or "ARM API arguments" respectively, because we are shifting the language we use to describe the "mode" of resources. 
- Even though ARM API arguments are not being used right now, I left them in the Azure Arc API within ADS because we may implement ARM in ADS in the future.