### PR TITLE
fix the grid goes blank issue

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -127,7 +127,7 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 				} else {
 					ranges = [new Slick.Range(0, columnIndex, this.grid.getDataLength() - 1, columnIndex)];
 				}
-				this.grid.setActiveCell(0, columnIndex);
+				this.grid.setActiveCell(this.grid.getViewport()?.top ?? 0, columnIndex);
 				this.setSelectedRanges(ranges);
 			}
 		}

--- a/src/sql/base/browser/ui/table/plugins/rowNumberColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/rowNumberColumn.plugin.ts
@@ -39,7 +39,7 @@ export class RowNumberColumn<T> implements Slick.Plugin<T> {
 
 	private handleHeaderClick(e: MouseEvent, args: Slick.OnHeaderClickEventArgs<T>): void {
 		if (args.column.id === 'rowNumber') {
-			this.grid.setActiveCell(0, 1);
+			this.grid.setActiveCell(this.grid.getViewport()?.top ?? 0, 1);
 			let selectionModel = this.grid.getSelectionModel();
 			if (selectionModel) {
 				selectionModel.setSelectedRanges([new Slick.Range(0, 0, this.grid.getDataLength() - 1, this.grid.getColumns().length - 1)]);

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -358,7 +358,6 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 
 	private _state: GridTableState;
 
-	private scrolled = false;
 	private visible = false;
 
 	private rowHeight: number;
@@ -450,8 +449,6 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		);
 		this.dataProvider.dataRows = collection;
 		this.table.updateRowCount();
-		// when we are removed slickgrid acts badly so we need to account for that
-		this.scrolled = false;
 	}
 
 	// actionsOrientation controls the orientation (horizontal or vertical) of the actionBar
@@ -520,8 +517,6 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		this._register(this.dataProvider.onFilterStateChange(() => { this.layout(); }));
 		this._register(this.table.onContextMenu(this.contextMenu, this));
 		this._register(this.table.onClick(this.onTableClick, this));
-		//This listener is used for correcting auto-scroling when clicking on the header for reszing.
-		this._register(this.table.onHeaderClick(this.onHeaderClick, this));
 		this._register(this.dataProvider.onFilterStateChange(() => {
 			const columns = this.table.columns as FilterableColumn<T>[];
 			this.state.columnFilters = columns.filter((column) => column.filterValues?.length > 0).map(column => {
@@ -581,10 +576,6 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 				// If the grid is not set up yet it can get scroll events resetting the top to 0px,
 				// so ignore those events
 				return;
-			}
-			if (!this.scrolled && (this.state.scrollPositionY || this.state.scrollPositionX) && isInDOM(this.container)) {
-				this.scrolled = true;
-				this.restoreScrollState();
 			}
 			if (this.state && isInDOM(this.container)) {
 				this.state.scrollPositionY = data.scrollTop;
@@ -662,11 +653,6 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 
 	public set state(val: GridTableState) {
 		this._state = val;
-	}
-
-	private onHeaderClick(event: ITableMouseEvent) {
-		//header clicks must be accounted for as they force the table to scroll to the top;
-		this.scrolled = false;
 	}
 
 	private async getRowData(start: number, length: number): Promise<ICellValue[][]> {


### PR DESCRIPTION
This PR fixes #19771

the issue is caused by a race-condition that happens when trying to set the active cell to the first cell of the column in response to the column header click, in the meanwhile, in the scroll handler it has some logic to restore the scroll position. there are couple issues:
1. doing scroll restore in the scroll handler seems wrong and I dug in to the history and it was a workaround for a issue that no longer exists, so I am removing the related code. the problem will go away with the code removal.
2. setting the active cell to the first cell of the column when the header is clicked is not user friendly, as a user, I would like to stay at where I am right now. (setting active cell is needed so that user can directly press ctrl+c to copy the selected cells)

as shown in the **After** gif, I also tested the following features that are related to the scroll feature:
1. row header click
1. editor switch 
1. auto-size column header

**before**
![grid-scroll](https://user-images.githubusercontent.com/13777222/181853915-4a954d09-9b5d-45da-9bf3-51a1528fac6e.gif)


**After**
![grid-scroll-after](https://user-images.githubusercontent.com/13777222/181853919-8031314a-d0b0-4a72-bafc-2c9eb4c317b5.gif)
