### PR TITLE
[SQL Migration] Add buttons to allow saving assessment/recommendation reports

### DIFF
--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -858,6 +858,7 @@ declare module 'mssql' {
 		assessmentResult: ServerAssessmentProperties;
 		rawAssessmentResult: any;
 		errors: ErrorModel[];
+		assessmentReportPath: string;
 	}
 
 	export interface ISqlMigrationService {

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -614,6 +614,7 @@ declare module 'mssql' {
 		sqlMiRecommendationResults: PaaSSkuRecommendationResultItem[];
 		sqlVmRecommendationResults: IaaSSkuRecommendationResultItem[];
 		instanceRequirements: SqlInstanceRequirements;
+		skuRecommendationReportPaths: string[];
 	}
 
 	// SKU recommendation enums, mirrored from Microsoft.SqlServer.Migration.SkuRecommendation

--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { window, Account, accounts, CategoryValue, DropDownComponent, IconPath } from 'azdata';
+import * as vscode from 'vscode';
 import { IconPathHelper } from '../constants/iconPathHelper';
 import { MigrationStatus, ProvisioningState } from '../models/migrationLocalStorage';
 import * as crypto from 'crypto';
@@ -864,4 +865,22 @@ export async function getBlobLastBackupFileNamesValues(lastFileNames: azureResou
 		];
 	}
 	return lastFileNamesValues;
+}
+
+export async function promptUserForFolder(): Promise<string> {
+	let path = '';
+
+	let options: vscode.OpenDialogOptions = {
+		defaultUri: vscode.Uri.file(getUserHome()!),
+		canSelectFiles: false,
+		canSelectFolders: true,
+		canSelectMany: false,
+	};
+
+	let fileUris = await vscode.window.showOpenDialog(options);
+	if (fileUris && fileUris?.length > 0 && fileUris[0]) {
+		path = fileUris[0].fsPath;
+	}
+
+	return path;
 }

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -94,6 +94,14 @@ export function CAN_BE_MIGRATED(eligibleDbs: number, totalDbs: number): string {
 export const ASSESSMENT_MIGRATION_WARNING = localize('sql.migration.assessment.migration.warning', "Databases that are not ready for migration to Azure SQL Managed Instance can be migrated to SQL Server on Azure Virtual Machines.");
 export const DATABASES_TABLE_TILE = localize('sql.migration.databases.table.title', "Databases");
 export const SQL_SERVER_INSTANCE = localize('sql.migration.sql.server.instance', "SQL Server instance");
+export const SAVE_ASSESSMENT_REPORT = localize('sql.migration.save.assessment.report', "Save assessment report");
+export const SAVE_RECOMMENDATION_REPORT = localize('sql.migration.save.recommendation.report', "Save recommendation report");
+export function SAVE_ASSESSMENT_REPORT_SUCCESS(filePath: string): string {
+	return localize('sql.migration.save.assessment.report.success', "Successfully saved assessment report to {0}.", filePath);
+}
+export function SAVE_RECOMMENDATION_REPORT_SUCCESS(filePath: string): string {
+	return localize('sql.migration.save.recommendation.report.success', "Successfully saved recommendation report to {0}.", filePath);
+}
 
 // SKU
 export const AZURE_RECOMMENDATION = localize('sql.migration.sku.recommendation', "Azure recommendation");

--- a/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
@@ -9,6 +9,10 @@ import { MigrationStateModel, MigrationTargetType } from '../../models/stateMach
 import { SqlDatabaseTree } from './sqlDatabasesTree';
 import { SqlMigrationImpactedObjectInfo } from 'mssql';
 import { SKURecommendationPage } from '../../wizard/skuRecommendationPage';
+import * as constants from '../../constants/strings';
+import * as utils from '../../api/utils';
+import * as fs from 'fs';
+import path = require('path');
 
 export type Issues = {
 	description: string,
@@ -24,6 +28,8 @@ export class AssessmentResultsDialog {
 	private _isOpen: boolean = false;
 	private dialog: azdata.window.Dialog | undefined;
 	private _model: MigrationStateModel;
+	private _saveButton!: azdata.window.Button;
+	private static readonly _assessmentReportName: string = 'SqlAssessmentReport.json';
 
 	// Dialog Name for Telemetry
 	public dialogName: string | undefined;
@@ -70,6 +76,27 @@ export class AssessmentResultsDialog {
 
 			this.dialog.cancelButton.label = AssessmentResultsDialog.CancelButtonText;
 			this._disposables.push(this.dialog.cancelButton.onClick(async () => await this.cancel()));
+
+			this._saveButton = azdata.window.createButton(
+				constants.SAVE_ASSESSMENT_REPORT,
+				'left');
+			this._disposables.push(
+				this._saveButton.onClick(async () => {
+					const folder = await utils.promptUserForFolder();
+					const destinationFilePath = path.join(folder, AssessmentResultsDialog._assessmentReportName);
+					if (this.model._assessmentReportFilePath) {
+						fs.copyFile(this.model._assessmentReportFilePath, destinationFilePath, (err) => {
+							if (err) {
+								console.log(err);
+							} else {
+								void vscode.window.showInformationMessage(constants.SAVE_ASSESSMENT_REPORT_SUCCESS(destinationFilePath));
+							}
+						});
+					} else {
+						console.log('assessment report not found');
+					}
+				}));
+			this.dialog.customButtons = [this._saveButton];
 
 			const dialogSetupPromises: Thenable<void>[] = [];
 

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/getAzureRecommendationDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/getAzureRecommendationDialog.ts
@@ -197,7 +197,7 @@ export class GetAzureRecommendationDialog {
 			}
 		}).component();
 		this._disposables.push(browseButton.onDidClick(async (e) => {
-			let folder = await this.handleBrowse();
+			let folder = await utils.promptUserForFolder();
 			this._collectDataFolderInput.value = folder;
 		}));
 
@@ -259,7 +259,7 @@ export class GetAzureRecommendationDialog {
 			}
 		}).component();
 		this._disposables.push(openButton.onDidClick(async (e) => {
-			let folder = await this.handleBrowse();
+			let folder = await utils.promptUserForFolder();
 			this._openExistingFolderInput.value = folder;
 		}));
 
@@ -379,24 +379,5 @@ export class GetAzureRecommendationDialog {
 
 	public get isOpen(): boolean {
 		return this._isOpen;
-	}
-
-	// TO-DO: add validation
-	private async handleBrowse(): Promise<string> {
-		let path = '';
-
-		let options: vscode.OpenDialogOptions = {
-			defaultUri: vscode.Uri.file(utils.getUserHome()!),
-			canSelectFiles: false,
-			canSelectFolders: true,
-			canSelectMany: false,
-		};
-
-		let fileUris = await vscode.window.showOpenDialog(options);
-		if (fileUris && fileUris?.length > 0 && fileUris[0]) {
-			path = fileUris[0].fsPath;
-		}
-
-		return path;
 	}
 }

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -199,6 +199,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 	public _assessedDatabaseList!: string[];
 	public _runAssessments: boolean = true;
 	private _assessmentApiResponse!: mssql.AssessmentResult;
+	public _assessmentReportFilePath: string;
 	public mementoString: string;
 
 	public _databasesForMigration: string[] = [];
@@ -263,6 +264,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 		this._databaseBackup.networkShares = [];
 		this._databaseBackup.blobs = [];
 		this._targetDatabaseNames = [];
+		this._assessmentReportFilePath = '';
 		this.mementoString = 'sqlMigration.assessmentResults';
 
 		this._skuScalingFactor = 100;
@@ -325,6 +327,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 					}) ?? [],
 					errors: this._assessmentApiResponse?.errors ?? []
 				};
+				this._assessmentReportFilePath = response.assessmentReportPath;
 			} else {
 				this._assessmentResults = {
 					issues: [],

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -211,6 +211,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 	public _skuRecommendationResults!: SkuRecommendation;
 	public _skuRecommendationPerformanceDataSource!: PerformanceDataSourceOptions;
 	private _skuRecommendationApiResponse!: mssql.SkuRecommendationResult;
+	public _skuRecommendationReportFilePaths: string[];
 	public _skuRecommendationPerformanceLocation!: string;
 	private _skuRecommendationRecommendedDatabaseList!: string[];
 	private _startPerfDataCollectionApiResponse!: mssql.StartPerfDataCollectionResult;
@@ -265,6 +266,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 		this._databaseBackup.blobs = [];
 		this._targetDatabaseNames = [];
 		this._assessmentReportFilePath = '';
+		this._skuRecommendationReportFilePaths = [];
 		this.mementoString = 'sqlMigration.assessmentResults';
 
 		this._skuScalingFactor = 100;
@@ -397,16 +399,19 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 						sqlDbRecommendationResults: response?.sqlDbRecommendationResults ?? [],
 						sqlMiRecommendationResults: response?.sqlMiRecommendationResults ?? [],
 						sqlVmRecommendationResults: response?.sqlVmRecommendationResults ?? [],
-						instanceRequirements: response?.instanceRequirements
+						instanceRequirements: response?.instanceRequirements,
+						skuRecommendationReportPaths: response?.skuRecommendationReportPaths
 					},
 				};
+				this._skuRecommendationReportFilePaths = response.skuRecommendationReportPaths;
 			} else {
 				this._skuRecommendationResults = {
 					recommendations: {
 						sqlDbRecommendationResults: [],
 						sqlMiRecommendationResults: [],
 						sqlVmRecommendationResults: [],
-						instanceRequirements: response?.instanceRequirements
+						instanceRequirements: response?.instanceRequirements,
+						skuRecommendationReportPaths: response?.skuRecommendationReportPaths
 					},
 				};
 			}
@@ -419,7 +424,8 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 					sqlDbRecommendationResults: this._skuRecommendationApiResponse?.sqlDbRecommendationResults ?? [],
 					sqlMiRecommendationResults: this._skuRecommendationApiResponse?.sqlMiRecommendationResults ?? [],
 					sqlVmRecommendationResults: this._skuRecommendationApiResponse?.sqlVmRecommendationResults ?? [],
-					instanceRequirements: this._skuRecommendationApiResponse?.instanceRequirements
+					instanceRequirements: this._skuRecommendationApiResponse?.instanceRequirements,
+					skuRecommendationReportPaths: this._skuRecommendationApiResponse?.skuRecommendationReportPaths
 				},
 				recommendationError: error
 			};


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In this PR, we:
- add a button to the assessment results dialog which allows the user to save the assessment report (in json format) to a directory of their choosing
  - ![image](https://user-images.githubusercontent.com/11844501/181862758-0c15cee7-1c5c-41c9-b318-0adf70a908aa.png)
  - this also fixes an issue where previously, running multiple assessments in a short time (e.g. by going backwards, changing the database list, and assessing again) would cause all subsequent assessments to fail
- add a button to the SKU recommendation results details dialog which allows the user to save the SKU recommendation reports (in HTML format) to a directory of their choosing
  - ![image](https://user-images.githubusercontent.com/11844501/181863070-39f520a7-f54d-4844-8355-809b6ae84030.png)

----------

See corresponding PR in sqltoolsservice: https://github.com/microsoft/sqltoolsservice/pull/1613