### PR TITLE
Set cell preview mode when toggling edit mode.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -436,6 +436,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			this.cellModel.showMarkdown = false;
 		} else {
 			this.markdownMode = this.cellModel.showMarkdown;
+			this.previewMode = this.cellModel.showPreview;
 		}
 		this.updatePreview();
 		this._changeRef.detectChanges();

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -294,6 +294,7 @@ export function setup(opts: minimist.ParsedArgs) {
 					}
 					await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 				}
+				await app.workbench.settingsEditor.clearUserSettings();
 			}
 
 			async function verifyToolbarKeyboardShortcut(app: Application, keyboardShortcut: string, selector: string) {
@@ -311,6 +312,7 @@ export function setup(opts: minimist.ParsedArgs) {
 					await app.workbench.sqlNotebook.waitForTextCellPreviewContent(testText, selector);
 					await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 				}
+				await app.workbench.settingsEditor.clearUserSettings();
 			}
 
 			it('can bold selected text', async function () {


### PR DESCRIPTION
This PR fixes #20093

We call toggleEditMode when first creating the text cell component, but we don't set the previewMode value when making the cell editable. This means the preview pane will always show when first creating the cell, even if the default is markdown only. Changing the cell view mode updates the preview mode correctly, which is why you only see this when first creating the cell.