### PR TITLE
Type out query text one letter at a time in autocompletion test.

### DIFF
--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -40,9 +40,10 @@ export function setup(opts: minimist.ParsedArgs) {
 			await app.workbench.sqlNotebook.addCellFromPlaceholder('Code');
 			await app.workbench.sqlNotebook.waitForPlaceholderGone();
 
-			const text1: string = 'SEL';
-			await app.workbench.sqlNotebook.waitForTypeInEditor(text1);
-			await app.code.dispatchKeybinding('ctrl+space bar');
+			await app.workbench.sqlNotebook.waitForTypeInEditor('S');
+			await app.workbench.sqlNotebook.waitForTypeInEditor('E');
+			await app.workbench.sqlNotebook.waitForTypeInEditor('L');
+			await app.code.dispatchKeybinding('ctrl+space');
 
 			// check for completion suggestions
 			await app.workbench.sqlNotebook.waitForSuggestionWidget();


### PR DESCRIPTION
I noticed we've been having a lot of failures in the basic code cell behavior smoke test. The autocomplete test has been failing because "SELECT" doesn't show up at the top of the autocomplete list when typing "SEL". I can't tell why typing in "SEL" all at once isn't working in the smoke tests, since it never repros manually; however, I found out that typing each letter individually before checking the autocomplete is a good workaround for the test.