### PR TITLE
fix query results view issue

### DIFF
--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -86,6 +86,7 @@ class ResultsView extends Disposable implements IPanelView {
 
 	public clear() {
 		this.gridPanel.clear();
+		this._runner = undefined;
 	}
 
 	remove(): void {


### PR DESCRIPTION
This PR fixes #20233

The issue is because when we reset the input, the query runner variable for the results view is not cleared.