### PR TITLE
no-op is the object is disposed

### DIFF
--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -344,6 +344,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	private currentHeight: number;
 	private dataProvider: HybridDataProvider<T>;
 	private filterPlugin: HeaderFilter<T>;
+	private isDisposed: boolean = false;
 
 	private columns: Slick.Column<T>[];
 
@@ -420,6 +421,9 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	}
 
 	public async onDidInsert() {
+		if (this.isDisposed) {
+			return;
+		}
 		if (!this.table) {
 			this.build();
 		}
@@ -853,6 +857,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	}
 
 	public override dispose() {
+		this.isDisposed = true;
 		this.container.remove();
 		if (this.table) {
 			this.table.dispose();


### PR DESCRIPTION
This PR fixes #20013

during the document switch, when the view is not results view, it will still be created and then disposed in the onHide event handler, but the scrollable view will call the onDidInsert in a timer function and will cause the error of adding disposable to an already disposed disposableStore.

the fix it to mark it as disposed and no-op if it is disposed.
