### PR TITLE
Opens graphical execution plan from DMV

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1417,11 +1417,11 @@ declare module 'azdata' {
 			/**
 			 * File contents
 			 */
-			graphFileContent: string;
+			graphFileContent: string | undefined;
 			/**
 			 * File type for execution plan. This will be the file type of the editor when the user opens the graph file
 			 */
-			graphFileType: string;
+			graphFileType: string | undefined;
 			/**
 			 * Index of the execution plan in the file content
 			 */

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
@@ -70,7 +70,7 @@ export class ExecutionPlanEditorOverrideContribution extends Disposable implemen
 			},
 			{},
 			(editorInput, group) => {
-				const executionPlanInput = this._instantiationService.createInstance(ExecutionPlanInput, editorInput.resource);
+				const executionPlanInput = this._instantiationService.createInstance(ExecutionPlanInput, editorInput.resource, undefined, undefined);
 				return { editor: executionPlanInput, options: editorInput.options, group: group };
 			}
 		);

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
@@ -70,8 +70,18 @@ export class ExecutionPlanEditorOverrideContribution extends Disposable implemen
 			},
 			{},
 			(editorInput, group) => {
-				const executionPlanInput = this._instantiationService.createInstance(ExecutionPlanInput, editorInput.resource, undefined, undefined);
-				return { editor: executionPlanInput, options: editorInput.options, group: group };
+				let executionPlanGraphInfo = {
+					graphFileContent: undefined,
+					graphFileType: undefined
+				};
+
+				const executionPlanInput = this._instantiationService.createInstance(ExecutionPlanInput, editorInput.resource, executionPlanGraphInfo);
+
+				return {
+					editor: executionPlanInput,
+					options: editorInput.options,
+					group: group
+				};
 			}
 		);
 	}

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -706,7 +706,12 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 			const value = subset[0][event.cell.cell - 1];
 			const isJson = isJsonCell(value);
 			if (column.isXml && value?.executionPlanFileExtension !== '') {
-				const executionPlanInput = this.instantiationService.createInstance(ExecutionPlanInput, undefined, value.displayValue, value?.executionPlanFileExtension);
+				let executionPlanGraphInfo = {
+					graphFileContent: value.displayValue,
+					graphFileType: value?.executionPlanFileExtension
+				};
+
+				const executionPlanInput = this.instantiationService.createInstance(ExecutionPlanInput, undefined, executionPlanGraphInfo);
 				await this.editorService.openEditor(executionPlanInput);
 			}
 			else if (column.isXml || isJson) {

--- a/src/sql/workbench/services/query/common/query.ts
+++ b/src/sql/workbench/services/query/common/query.ts
@@ -74,4 +74,5 @@ export interface ICellValue {
 	displayValue: string;
 	isNull?: boolean;
 	invariantCultureDisplayValue?: string;
+	executionPlanFileExtension?: string;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds functionality to open an execution plan from a DMV.

1. Query any table that stores execution plan XML: 
![image](https://user-images.githubusercontent.com/87730006/182726233-0819b1d4-2709-42fc-9282-c6ca725e9394.png)
2. Click on the XML hyper link will automatically launch the execution plan viewer when appropriate for the table cell data.
![image](https://user-images.githubusercontent.com/87730006/182726361-c556fe4f-c691-401e-81db-d2074808388e.png)