### PR TITLE
[SQL-bindings] remove watcher for files

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -25,11 +25,6 @@ export interface ILocalSettingsJson {
 	ConnectionStrings?: { [key: string]: string };
 }
 
-export interface IFileFunctionObject {
-	filePromise: Promise<string>;
-	watcherDisposable: vscode.Disposable;
-}
-
 /**
  * copied and modified from vscode-azurefunctions extension
  * https://github.com/microsoft/vscode-azurefunctions/blob/main/src/funcConfig/local.settings.ts
@@ -196,42 +191,6 @@ export async function getHostFiles(): Promise<string[] | undefined> {
  */
 export async function getSettingsFile(projectFolder: string): Promise<string | undefined> {
 	return path.join(projectFolder, 'local.settings.json');
-}
-
-/**
- * New azure function file watcher and watcher disposable to be used to watch for changes to the azure function project
- * @param projectFolder is the parent directory to the project file
- * @returns the function file path once created and the watcher disposable
- */
-export function waitForNewFunctionFile(projectFolder: string): IFileFunctionObject {
-	const watcher = vscode.workspace.createFileSystemWatcher((
-		new vscode.RelativePattern(projectFolder, '**/*.cs')), false, true, true);
-	const filePromise = new Promise<string>((resolve, _) => {
-		watcher.onDidCreate((e) => {
-			resolve(e.fsPath);
-		});
-	});
-	return {
-		filePromise,
-		watcherDisposable: watcher
-	};
-}
-
-/**
- * Retrieves the new host project file once it has created and the watcher disposable
- * @returns the host file path once created and the watcher disposable
- */
-export function waitForNewHostFile(): IFileFunctionObject {
-	const watcher = vscode.workspace.createFileSystemWatcher('**/host.json', false, true, true);
-	const filePromise = new Promise<string>((resolve, _) => {
-		watcher.onDidCreate((e) => {
-			resolve(e.fsPath);
-		});
-	});
-	return {
-		filePromise,
-		watcherDisposable: watcher
-	};
 }
 
 /**

--- a/extensions/sql-bindings/src/common/utils.ts
+++ b/extensions/sql-bindings/src/common/utils.ts
@@ -84,20 +84,6 @@ export function generateQuotedFullName(schema: string, objectName: string): stri
 }
 
 /**
- * Returns a promise that will reject after the specified timeout
- * @param errorMessage error message to be returned in the rejection
- * @param ms timeout in milliseconds. Default is 10 seconds
- * @returns a promise that rejects after the specified timeout
- */
-export function timeoutPromise(errorMessage: string, ms: number = 10000): Promise<string> {
-	return new Promise((_, reject) => {
-		setTimeout(() => {
-			reject(new TimeoutError(errorMessage));
-		}, ms);
-	});
-}
-
-/**
  * Gets a unique file name
  * Increment the file name by adding 1 to function name if the file already exists
  * Undefined if the filename suffix count becomes greater than 1024

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -268,7 +268,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 	} catch (error) {
 		let errorType = utils.getErrorType(error);
 		propertyBag.telemetryStep = telemetryStep;
-		// else an error would occur during the createFunction
+		// an error occurred during createFunction
 		exitReason = ExitReason.error;
 		void vscode.window.showErrorMessage(constants.errorNewAzureFunction(error));
 		TelemetryReporter.createErrorEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick, undefined, errorType)

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -26,7 +26,6 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 	TelemetryReporter.sendActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.startCreateAzureFunctionWithSqlBinding);
 	let connectionInfo: IConnectionInfo | undefined;
 	let isCreateNewProject: boolean = false;
-	let newFunctionFileObject: azureFunctionsUtils.IFileFunctionObject | undefined;
 
 	try {
 		// check to see if Azure Functions Extension is installed
@@ -101,9 +100,6 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			// user has an azure function project open
 			projectFolder = path.dirname(projectFile);
 		}
-		// create a system file watcher for the project folder
-		newFunctionFileObject = azureFunctionsUtils.waitForNewFunctionFile(projectFolder);
-
 		// Get connection string parameters and construct object name from prompt or connectionInfo given
 		let objectName: string | undefined;
 		let selectedBindingType: BindingType | undefined;
@@ -263,9 +259,6 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			.withAdditionalProperties(propertyBag)
 			.withConnectionInfo(connectionInfo).send();
 
-		// check for the new function file to be created and dispose of the file system watcher
-		const timeoutForFunctionFile = utils.timeoutPromise(constants.timeoutAzureFunctionFileError);
-		await Promise.race([newFunctionFileObject.filePromise, timeoutForFunctionFile]);
 		telemetryStep = 'finishCreateFunction';
 		propertyBag.telemetryStep = telemetryStep;
 		exitReason = ExitReason.finishCreate;
@@ -275,15 +268,9 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 	} catch (error) {
 		let errorType = utils.getErrorType(error);
 		propertyBag.telemetryStep = telemetryStep;
-		if (errorType === 'TimeoutError') {
-			// this error can be cause by many different scenarios including timeout or error occurred during createFunction
-			exitReason = ExitReason.timeout;
-			console.log('Timed out waiting for Azure Function project to be created. This may not necessarily be an error, for example if the user canceled out of the create flow.');
-		} else {
-			// else an error would occur during the createFunction
-			exitReason = ExitReason.error;
-			void vscode.window.showErrorMessage(constants.errorNewAzureFunction(error));
-		}
+		// else an error would occur during the createFunction
+		exitReason = ExitReason.error;
+		void vscode.window.showErrorMessage(constants.errorNewAzureFunction(error));
 		TelemetryReporter.createErrorEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick, undefined, errorType)
 			.withAdditionalProperties(propertyBag).send();
 		return;
@@ -292,7 +279,6 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		propertyBag.exitReason = exitReason;
 		TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick)
 			.withAdditionalProperties(propertyBag).send();
-		newFunctionFileObject?.watcherDisposable.dispose();
 	}
 }
 

--- a/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
+++ b/extensions/sql-bindings/src/test/service/azureFunctionsService.test.ts
@@ -7,7 +7,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as should from 'should';
 import * as sinon from 'sinon';
-import * as TypeMoq from 'typemoq';
 import * as vscode from 'vscode';
 import * as azureFunctionUtils from '../../common/azureFunctionsUtils';
 import * as constants from '../../common/constants';
@@ -90,9 +89,6 @@ describe('AzureFunctionsService', () => {
 			sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').resolves((true));
 			sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
 
-			const testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
-			sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
-
 			should(connectionInfo.database).equal('my_db', 'Initial ConnectionInfo database should be my_db');
 			await azureFunctionService.createAzureFunction(tableTestNode);
 
@@ -126,9 +122,6 @@ describe('AzureFunctionsService', () => {
 				sinon.stub(fs.promises, 'writeFile').resolves();
 				sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').resolves((true));
 				sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
-
-				const testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
-				sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 				showErrorMessageSpy = sinon.spy(vscode.window, 'showErrorMessage'); // error message spy to be used for checking tests
 			});
@@ -220,9 +213,6 @@ describe('AzureFunctionsService', () => {
 				sinon.stub(fs.promises, 'writeFile').resolves();
 				sinon.stub(azureFunctionUtils, 'setLocalAppSetting').withArgs(sinon.match.any, 'SqlConnectionString', 'testConnectionString').resolves((true));
 				sinon.stub(utils, 'executeCommand').resolves('downloaded nuget package');
-
-				const testWatcher = TypeMoq.Mock.ofType<vscode.FileSystemWatcher>().object;
-				sinon.stub(azureFunctionUtils, 'waitForNewFunctionFile').withArgs(sinon.match.any).returns({ filePromise: Promise.resolve('TestFileCreated'), watcherDisposable: testWatcher });
 
 				showErrorMessageSpy = sinon.spy(vscode.window, 'showErrorMessage'); // error message spy to be used for checking tests
 			});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR removes the need to watch for the completion of the createFunction file due to upgrades ([here](https://github.com/microsoft/vscode-azurefunctions/pull/3268)) with vscode-azurefunctions as well as past changes.

The main thing I will work on is that we get proper error handling from vscode-azurefunctions createFunction API call when a user cancels out of the quickpick options.
