### PR TITLE
fix the zoom reset issue

### DIFF
--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -72,12 +72,12 @@ export function hyperLinkFormatter(row: number | undefined, cell: any | undefine
 		if (!value.isNull) {
 			cellClasses += ' xmlLink';
 			valueToDisplay = escape(value.displayValue);
-			return `<a class="${cellClasses}" href="#" >${valueToDisplay}</a>`;
+			return `<a class="${cellClasses}">${valueToDisplay}</a>`;
 		} else {
 			cellClasses += ' missing-value';
 		}
 	} else if (isHyperlinkCellValue(value)) {
-		return `<a class="${cellClasses}" href="#" title="${escape(value.displayText)}">${escape(value.displayText)}</a>`;
+		return `<a class="${cellClasses}" title="${escape(value.displayText)}">${escape(value.displayText)}</a>`;
 	}
 	return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
 }


### PR DESCRIPTION
This PR fixes #20176

I was able to identify that the dead link as the root cause, but still not sure why electron decides to reset the zoom level.

before:
![zoom-before](https://user-images.githubusercontent.com/13777222/183148851-442b1d62-5949-49f9-8250-8a6523939a5f.gif)


after:
![zoom-after](https://user-images.githubusercontent.com/13777222/183148863-477b753d-db5a-48b0-b48f-ef94c280229b.gif)
