### PR TITLE
Target provisioning experience in Azure SQL Migration extension

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -387,7 +387,7 @@
         "mssql.parallelMessageProcessing": {
           "type": "boolean",
           "description": "%mssql.parallelMessageProcessing%",
-          "default": false
+          "default": true
         }
       }
     },

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1128,7 +1128,7 @@ export interface SqlMigrationGenerateProvisioningScriptParams {
 }
 
 export namespace SqlMigrationGenerateProvisioningScriptRequest {
-	export const type = new RequestType<SqlMigrationGenerateProvisioningScriptParams, mssql.GenerateProvisioningScriptResult, void, void>('migration/generateprovisioningscript');
+	export const type = new RequestType<SqlMigrationGenerateProvisioningScriptParams, mssql.ProvisioningScriptResult, void, void>('migration/generateprovisioningscript');
 }
 
 export interface SqlMigrationStartPerfDataCollectionParams {

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1124,7 +1124,7 @@ export namespace GetSqlMigrationSkuRecommendationsRequest {
 }
 
 export interface SqlMigrationGenerateProvisioningScriptParams {
-	skuRecommendations: mssql.SkuRecommendationResult[];
+	skuRecommendations: mssql.SkuRecommendationResultItem[];
 }
 
 export namespace SqlMigrationGenerateProvisioningScriptRequest {

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1128,7 +1128,7 @@ export interface SqlMigrationGenerateProvisioningScriptParams {
 }
 
 export namespace SqlMigrationGenerateProvisioningScriptRequest {
-	export const type = new RequestType<SqlMigrationGenerateProvisioningScriptParams, void, void, void>('migration/generateprovisioningscript');
+	export const type = new RequestType<SqlMigrationGenerateProvisioningScriptParams, mssql.GenerateProvisioningScriptResult, void, void>('migration/generateprovisioningscript');
 }
 
 export interface SqlMigrationStartPerfDataCollectionParams {

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1123,6 +1123,14 @@ export namespace GetSqlMigrationSkuRecommendationsRequest {
 	export const type = new RequestType<SqlMigrationSkuRecommendationsParams, mssql.SkuRecommendationResult, void, void>('migration/getskurecommendations');
 }
 
+export interface SqlMigrationGenerateProvisioningScriptParams {
+	skuRecommendations: mssql.SkuRecommendationResult[];
+}
+
+export namespace SqlMigrationGenerateProvisioningScriptRequest {
+	export const type = new RequestType<SqlMigrationGenerateProvisioningScriptParams, void, void, void>('migration/generateprovisioningscript');
+}
+
 export interface SqlMigrationStartPerfDataCollectionParams {
 	ownerUri: string,
 	dataFolder: string,

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -789,7 +789,7 @@ declare module 'mssql' {
 	}
 
 	export interface ProvisioningScriptResult {
-		provisioningScript: string;
+		provisioningScriptFilePath: string;
 	}
 
 	export interface ISqlMigrationService {

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -788,6 +788,10 @@ declare module 'mssql' {
 		errors: ErrorModel[];
 	}
 
+	export interface GenerateProvisioningScriptResult {
+		provisioningScript: string;
+	}
+
 	export interface ISqlMigrationService {
 		getAssessments(ownerUri: string, databases: string[]): Promise<AssessmentResult | undefined>;
 	}

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -697,6 +697,7 @@ declare module 'mssql' {
 	export interface ISqlMigrationService {
 		getAssessments(ownerUri: string, databases: string[]): Promise<AssessmentResult | undefined>;
 		getSkuRecommendations(dataFolder: string, perfQueryIntervalInSec: number, targetPlatforms: string[], targetSqlInstance: string, targetPercentile: number, scalingFactor: number, startTime: string, endTime: string, includePreviewSkus: boolean, databaseAllowList: string[]): Promise<SkuRecommendationResult | undefined>;
+		generateProvisioningScript(skuRecommendations: SkuRecommendationResult[]): Promise<void | undefined>;
 		startPerfDataCollection(ownerUri: string, dataFolder: string, perfQueryIntervalInSec: number, staticQueryIntervalInSec: number, numberOfIterations: number): Promise<StartPerfDataCollectionResult | undefined>;
 		stopPerfDataCollection(): Promise<StopPerfDataCollectionResult | undefined>;
 		refreshPerfDataCollection(lastRefreshedTime: Date): Promise<RefreshPerfDataCollectionResult | undefined>;

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -789,7 +789,7 @@ declare module 'mssql' {
 	}
 
 	export interface ProvisioningScriptResult {
-		script: string;
+		provisioningScript: string;
 	}
 
 	export interface ISqlMigrationService {

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -697,7 +697,7 @@ declare module 'mssql' {
 	export interface ISqlMigrationService {
 		getAssessments(ownerUri: string, databases: string[]): Promise<AssessmentResult | undefined>;
 		getSkuRecommendations(dataFolder: string, perfQueryIntervalInSec: number, targetPlatforms: string[], targetSqlInstance: string, targetPercentile: number, scalingFactor: number, startTime: string, endTime: string, includePreviewSkus: boolean, databaseAllowList: string[]): Promise<SkuRecommendationResult | undefined>;
-		generateProvisioningScript(skuRecommendations: SkuRecommendationResult[]): Promise<void | undefined>;
+		generateProvisioningScript(skuRecommendations: SkuRecommendationResult[]): Promise<ProvisioningScriptResult | undefined>;
 		startPerfDataCollection(ownerUri: string, dataFolder: string, perfQueryIntervalInSec: number, staticQueryIntervalInSec: number, numberOfIterations: number): Promise<StartPerfDataCollectionResult | undefined>;
 		stopPerfDataCollection(): Promise<StopPerfDataCollectionResult | undefined>;
 		refreshPerfDataCollection(lastRefreshedTime: Date): Promise<RefreshPerfDataCollectionResult | undefined>;
@@ -788,7 +788,7 @@ declare module 'mssql' {
 		errors: ErrorModel[];
 	}
 
-	export interface GenerateProvisioningScriptResult {
+	export interface ProvisioningScriptResult {
 		provisioningScript: string;
 	}
 

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -697,7 +697,7 @@ declare module 'mssql' {
 	export interface ISqlMigrationService {
 		getAssessments(ownerUri: string, databases: string[]): Promise<AssessmentResult | undefined>;
 		getSkuRecommendations(dataFolder: string, perfQueryIntervalInSec: number, targetPlatforms: string[], targetSqlInstance: string, targetPercentile: number, scalingFactor: number, startTime: string, endTime: string, includePreviewSkus: boolean, databaseAllowList: string[]): Promise<SkuRecommendationResult | undefined>;
-		generateProvisioningScript(skuRecommendations: SkuRecommendationResult[]): Promise<ProvisioningScriptResult | undefined>;
+		generateProvisioningScript(skuRecommendations: SkuRecommendationResultItem[]): Promise<ProvisioningScriptResult | undefined>;
 		startPerfDataCollection(ownerUri: string, dataFolder: string, perfQueryIntervalInSec: number, staticQueryIntervalInSec: number, numberOfIterations: number): Promise<StartPerfDataCollectionResult | undefined>;
 		stopPerfDataCollection(): Promise<StopPerfDataCollectionResult | undefined>;
 		refreshPerfDataCollection(lastRefreshedTime: Date): Promise<RefreshPerfDataCollectionResult | undefined>;

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -789,7 +789,7 @@ declare module 'mssql' {
 	}
 
 	export interface ProvisioningScriptResult {
-		provisioningScript: string;
+		script: string;
 	}
 
 	export interface ISqlMigrationService {

--- a/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
+++ b/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
@@ -75,7 +75,7 @@ export class SqlMigrationService implements mssql.ISqlMigrationService {
 		return undefined;
 	}
 
-	async generateProvisioningScript(skuRecommendations: mssql.SkuRecommendationResult[]): Promise<void | undefined>
+	async generateProvisioningScript(skuRecommendations: mssql.SkuRecommendationResult[]): Promise<mssql.ProvisioningScriptResult | undefined>
 	{
 		let params: contracts.SqlMigrationGenerateProvisioningScriptParams = { skuRecommendations: skuRecommendations };
 

--- a/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
+++ b/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
@@ -75,6 +75,20 @@ export class SqlMigrationService implements mssql.ISqlMigrationService {
 		return undefined;
 	}
 
+	async generateProvisioningScript(skuRecommendations: mssql.SkuRecommendationResult[]): Promise<void | undefined>
+	{
+		let params: contracts.SqlMigrationGenerateProvisioningScriptParams = { skuRecommendations: skuRecommendations };
+
+		try {
+			return this.client.sendRequest(contracts.SqlMigrationGenerateProvisioningScriptRequest.type, params);
+		}
+		catch (e) {
+			this.client.logFailedRequest(contracts.SqlMigrationGenerateProvisioningScriptRequest.type, e);
+		}
+
+		return undefined;
+	}
+
 	async startPerfDataCollection(
 		ownerUri: string,
 		dataFolder: string,

--- a/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
+++ b/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
@@ -75,8 +75,7 @@ export class SqlMigrationService implements mssql.ISqlMigrationService {
 		return undefined;
 	}
 
-	async generateProvisioningScript(skuRecommendations: mssql.SkuRecommendationResultItem[]): Promise<mssql.ProvisioningScriptResult | undefined>
-	{
+	async generateProvisioningScript(skuRecommendations: mssql.SkuRecommendationResultItem[]): Promise<mssql.ProvisioningScriptResult | undefined> {
 		let params: contracts.SqlMigrationGenerateProvisioningScriptParams = { skuRecommendations: skuRecommendations };
 
 		try {

--- a/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
+++ b/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
@@ -75,7 +75,7 @@ export class SqlMigrationService implements mssql.ISqlMigrationService {
 		return undefined;
 	}
 
-	async generateProvisioningScript(skuRecommendations: mssql.SkuRecommendationResult[]): Promise<mssql.ProvisioningScriptResult | undefined>
+	async generateProvisioningScript(skuRecommendations: mssql.SkuRecommendationResultItem[]): Promise<mssql.ProvisioningScriptResult | undefined>
 	{
 		let params: contracts.SqlMigrationGenerateProvisioningScriptParams = { skuRecommendations: skuRecommendations };
 

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -145,6 +145,7 @@ export class PublishDatabaseDialog {
 			this.connectionRow = this.createConnectionRow(view);
 			this.databaseRow = this.createDatabaseRow(view);
 			const displayOptionsButton = this.createOptionsButton(view);
+			displayOptionsButton.enabled = false;
 
 			const horizontalFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
 			horizontalFormSection.addItems([profileRow, this.databaseRow]);
@@ -171,10 +172,12 @@ export class PublishDatabaseDialog {
 								title: constants.selectConnectionRadioButtonsTitle,
 								component: selectConnectionRadioButtons
 							},*/
+							/* TODO : Disabling deployment options for the July release
 							{
 								component: displayOptionsButton,
 								title: ''
 							}
+							*/
 						]
 					}
 				], {

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -110,6 +110,21 @@ export class GenerateArmTemplateDialog {
 				...styles.BODY_CSS,
 			}
 		}).component();
+
+		const armTemplateSaveInstructions = _view.modelBuilder.text().withProps({
+			// TODO: Update text
+			// Replace with localized string in the future
+			value: 'ARM template save instructions',
+			CSSStyles: {
+				...styles.BODY_CSS,
+				'margin-right': '20px'
+			}
+		}).component();
+
+		container.addItems([
+			armTemplateSaveInstructions,
+		]);
+
 		return container;
 	}
 

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -159,6 +159,14 @@ export class GenerateArmTemplateDialog {
 		return container;
 	}
 
+	private async updateArmTemplateStatus(succeeded: boolean): Promise<void> {
+		await this._generateArmTemplateContainer.updateCssStyles({ 'display': 'none' });
+
+		if (succeeded){
+			await this._saveArmTemplateContainer.updateCssStyles({ 'display': 'inline' });
+		}
+	}
+
 	public async openDialog(dialogName?: string, recommendations?: mssql.SkuRecommendationResult) {
 		if (!this._isOpen){
 			this._isOpen = true;

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -3,6 +3,76 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as azdata from 'azdata';
+import * as vscode from 'vscode';
+import { MigrationStateModel } from '../../models/stateMachine';
+import * as constants from '../../constants/strings';
+import * as styles from '../../constants/styles';
+import { selectDropDownIndex } from '../../api/utils';
+import { SKURecommendationPage } from '../../wizard/skuRecommendationPage';
+import * as mssql from 'mssql';
+
 export class GenerateArmTemplateDialog {
+	private dialog: azdata.window.Dialog | undefined;
+	private _isOpen: boolean = false;
+
+	private _disposables: vscode.Disposable[] = [];
+
+	private async initializeDialog(dialog: azdata.window.Dialog): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			dialog.registerContent(async (view) => {
+				try {
+					const flex = this.createContainer(view);
+
+					this._disposables.push(view.onClosed(e => {
+						this._disposables.forEach(
+							d => { try { d.dispose(); } catch { } });
+					}));
+
+					await view.initializeModel(flex);
+					resolve();
+				} catch (ex) {
+					reject(ex);
+				}
+			});
+		});
+	}
+
+	private createContainer(_view: azdata.ModelView): azdata.FlexContainer {
+		const container = _view.modelBuilder.flexContainer().withProps({
+			CSSStyles: {
+				'margin': '8px 16px',
+				'flex-direction': 'column',
+			}
+		}).component();
+		const description1 = _view.modelBuilder.text().withProps({
+			value: constants.AZURE_RECOMMENDATION_DESCRIPTION,
+			CSSStyles: {
+				...styles.BODY_CSS,
+			}
+		}).component();
+		const description2 = _view.modelBuilder.text().withProps({
+			value: constants.AZURE_RECOMMENDATION_DESCRIPTION2,
+			CSSStyles: {
+				...styles.BODY_CSS,
+				'margin-top': '8px',
+			}
+		}).component();
+		container.addItems([
+			description1,
+			description2,
+		]);
+		return container;
+	}
+
+	public async openDialog(dialogName?: string, recommendations?: mssql.SkuRecommendationResult) {
+		if (!this._isOpen){
+			this._isOpen = true;
+		}
+	}
+
+	public get isOpen(): boolean {
+		return this._isOpen;
+	}
 
 }

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -18,6 +18,9 @@ export class GenerateArmTemplateDialog {
 
 	private _disposables: vscode.Disposable[] = [];
 
+	private _generateArmTemplateContainer!: azdata.FlexContainer;
+	private _saveArmTemplateContainer!: azdata.FlexContainer;
+
 	private async initializeDialog(dialog: azdata.window.Dialog): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
 			dialog.registerContent(async (view) => {
@@ -45,23 +48,32 @@ export class GenerateArmTemplateDialog {
 				'flex-direction': 'column',
 			}
 		}).component();
-		const description1 = _view.modelBuilder.text().withProps({
-			value: constants.AZURE_RECOMMENDATION_DESCRIPTION,
-			CSSStyles: {
-				...styles.BODY_CSS,
-			}
-		}).component();
-		const description2 = _view.modelBuilder.text().withProps({
-			value: constants.AZURE_RECOMMENDATION_DESCRIPTION2,
-			CSSStyles: {
-				...styles.BODY_CSS,
-				'margin-top': '8px',
-			}
-		}).component();
+		this._generateArmTemplateContainer = this.CreateGenerateArmTemplateContainer(_view);
+		this._saveArmTemplateContainer = this.CreateSaveArmTemplateContainer(_view);
 		container.addItems([
-			description1,
-			description2,
+			this._generateArmTemplateContainer,
+			this._saveArmTemplateContainer,
 		]);
+		return container;
+	}
+
+	// TODO: Implement this
+	private CreateGenerateArmTemplateContainer(_view: azdata.ModelView): azdata.FlexContainer {
+		const container = _view.modelBuilder.flexContainer().withProps({
+			CSSStyles: {
+				...styles.BODY_CSS,
+			}
+		}).component();
+		return container;
+	}
+
+	// TODO: Implement this
+	private CreateSaveArmTemplateContainer(_view: azdata.ModelView): azdata.FlexContainer {
+		const container = _view.modelBuilder.flexContainer().withProps({
+			CSSStyles: {
+				...styles.BODY_CSS,
+			}
+		}).component();
 		return container;
 	}
 

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -81,6 +81,7 @@ export class GenerateArmTemplateDialog {
 		if (!this._isOpen){
 			this._isOpen = true;
 
+			// Replace 'Generate ARM template' with a localized string in the future
 			this.dialog = azdata.window.createModelViewDialog('Generate ARM template', 'GenerateArmTemplateDialog', 'narrow');
 
 			this.dialog.okButton.label = GenerateArmTemplateDialog.CloseButtonText;

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -119,9 +119,12 @@ export class GenerateArmTemplateDialog {
 			value: 'a\nb\nc\nd\ne',
 			rows: 20,
 			multiline: true,
+			// UNCOMMENT THIS AFTER TESTING
 			// readOnly: true,
 			CSSStyles: {
 				'font': '14px "Monaco", "Menlo", "Consolas", "Droid Sans Mono", "Inconsolata", "Courier New", monospace',
+				// 'overflow': 'scroll',
+				// 'white-space': 'nowrap',
 			}
 		}).component();
 

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -5,14 +5,14 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { MigrationStateModel } from '../../models/stateMachine';
 import * as constants from '../../constants/strings';
 import * as styles from '../../constants/styles';
-import { selectDropDownIndex } from '../../api/utils';
-import { SKURecommendationPage } from '../../wizard/skuRecommendationPage';
 import * as mssql from 'mssql';
 
 export class GenerateArmTemplateDialog {
+
+	private static readonly CloseButtonText: string = 'Close';
+
 	private dialog: azdata.window.Dialog | undefined;
 	private _isOpen: boolean = false;
 
@@ -68,7 +68,24 @@ export class GenerateArmTemplateDialog {
 	public async openDialog(dialogName?: string, recommendations?: mssql.SkuRecommendationResult) {
 		if (!this._isOpen){
 			this._isOpen = true;
+
+			this.dialog = azdata.window.createModelViewDialog('Generate ARM template', 'GenerateArmTemplateDialog', 'narrow');
+
+			this.dialog.okButton.label = GenerateArmTemplateDialog.CloseButtonText;
+			this._disposables.push(this.dialog.okButton.onClick(async () => await this.execute()));
+
+			this.dialog.cancelButton.hidden = true;
+
+			const dialogSetupPromises: Thenable<void>[] = [];
+			dialogSetupPromises.push(this.initializeDialog(this.dialog));
+			azdata.window.openDialog(this.dialog);
+			await Promise.all(dialogSetupPromises);
+
 		}
+	}
+
+	protected async execute() {
+		this._isOpen = false;
 	}
 
 	public get isOpen(): boolean {

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -57,7 +57,6 @@ export class GenerateArmTemplateDialog {
 		return container;
 	}
 
-	// TODO: Implement this
 	private CreateGenerateArmTemplateContainer(_view: azdata.ModelView): azdata.FlexContainer {
 
 		const armTemplateLoader = _view.modelBuilder.loadingComponent().component();
@@ -84,7 +83,6 @@ export class GenerateArmTemplateDialog {
 			value: 'We are generating an ARM template according to your recommended SKU. This may take some time.',
 			CSSStyles: {
 				...styles.BODY_CSS,
-				'margin-right': '20px'
 			}
 		}).component();
 

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export class GenerateArmTemplateDialog {
+
+}

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -105,25 +105,32 @@ export class GenerateArmTemplateDialog {
 
 	// TODO: Implement this
 	private CreateSaveArmTemplateContainer(_view: azdata.ModelView): azdata.FlexContainer {
-		const container = _view.modelBuilder.flexContainer().withProps({
-			CSSStyles: {
-				...styles.BODY_CSS,
-			}
-		}).component();
-
 		const armTemplateSaveInstructions = _view.modelBuilder.text().withProps({
 			// TODO: Update text
 			// Replace with localized string in the future
 			value: 'ARM template save instructions',
 			CSSStyles: {
 				...styles.BODY_CSS,
-				'margin-right': '20px'
+				'margin-bottom': '8px',
 			}
 		}).component();
 
-		container.addItems([
+		const armTemplateInputBox = _view.modelBuilder.inputBox().withProps({
+			value: 'a\nb\nc\nd\ne',
+			rows: 20,
+			multiline: true,
+			// readOnly: true,
+			CSSStyles: {
+				'font': '14px "Monaco", "Menlo", "Consolas", "Droid Sans Mono", "Inconsolata", "Courier New", monospace',
+			}
+		}).component();
+
+		const container = _view.modelBuilder.flexContainer().withLayout({
+			flexFlow: 'column'
+		}).withItems([
 			armTemplateSaveInstructions,
-		]);
+			armTemplateInputBox
+		]).component();
 
 		return container;
 	}

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -24,7 +24,8 @@ export class GenerateArmTemplateDialog {
 	private _generateArmTemplateContainer!: azdata.FlexContainer;
 	private _saveArmTemplateContainer!: azdata.FlexContainer;
 
-	private _armTemplate!: string;
+	// REMOVE AFTER TESTING
+	private _armTemplate: string = 'testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt';
 
 	private async initializeDialog(dialog: azdata.window.Dialog): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
@@ -113,46 +114,53 @@ export class GenerateArmTemplateDialog {
 		const armTemplateSaveInstructions = _view.modelBuilder.text().withProps({
 			// TODO: Update text
 			// Replace with localized string in the future
-			value: 'ARM template save instructions',
+			value: 'ARM template save instructions placeholder',
 			CSSStyles: {
 				...styles.BODY_CSS,
 				'margin-bottom': '8px',
 			}
 		}).component();
 
-		const armTemplateInputBox = _view.modelBuilder.inputBox().withProps({
-			value: 'a\nb\nc\nd\ne',
-			rows: 20,
-			multiline: true,
-			// UNCOMMENT THIS AFTER TESTING
-			// readOnly: true,
+		const armTemplateTextBox = _view.modelBuilder.text().withProps({
+			value: this._armTemplate,
+			width: '100%',
+			height: '100%',
 			CSSStyles: {
 				'font': '14px "Monaco", "Menlo", "Consolas", "Droid Sans Mono", "Inconsolata", "Courier New", monospace',
-				'margin-bottom': '8px',
-				// 'overflow': 'scroll',
-				// 'white-space': 'nowrap',
+				'margin': '0'
 			}
 		}).component();
 
 		const saveArmTemplateButton = _view.modelBuilder.button().withProps({
 			// Replace with localized string in the future
 			label: 'Save ARM template',
-			width: 150,
+			width: 120,
 			CSSStyles: {
 				'margin': '0'
 			}
 		}).component();
 		this._disposables.push(saveArmTemplateButton.onDidClick(async (e) => {
-			// REMOVE AFTER TESTING
-			this._armTemplate = 'TEST\nTEST\nTEST\nTEST';
 			await this.saveArmTemplate();
 		}));
 
+		const textContainer = _view.modelBuilder.flexContainer().withLayout({
+			flexFlow: 'column',
+			height: 500,
+		}).withProps({
+			CSSStyles: {
+				'overflow': 'auto',
+				'user-select': 'text',
+				'margin-bottom': '8px'
+			}
+		}).withItems([
+			armTemplateTextBox
+		]).component();
+
 		const container = _view.modelBuilder.flexContainer().withLayout({
-			flexFlow: 'column'
+			flexFlow: 'column',
 		}).withItems([
 			armTemplateSaveInstructions,
-			armTemplateInputBox,
+			textContainer,
 			saveArmTemplateButton
 		]).component();
 

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -59,11 +59,49 @@ export class GenerateArmTemplateDialog {
 
 	// TODO: Implement this
 	private CreateGenerateArmTemplateContainer(_view: azdata.ModelView): azdata.FlexContainer {
-		const container = _view.modelBuilder.flexContainer().withProps({
+
+		const armTemplateLoader = _view.modelBuilder.loadingComponent().component();
+
+		const armTemplateProgress = _view.modelBuilder.text().withProps({
+			// Replace with localized string in the future
+			value: 'ARM template generation in progress...',
 			CSSStyles: {
 				...styles.BODY_CSS,
+				'margin-right': '20px'
 			}
 		}).component();
+
+		const armTemplateLoadingContainer = _view.modelBuilder.flexContainer().withLayout({
+			height: '100%',
+			flexFlow: 'row',
+		}).component();
+
+		armTemplateLoadingContainer.addItem(armTemplateProgress, { flex: '0 0 auto' });
+		armTemplateLoadingContainer.addItem(armTemplateLoader, { flex: '0 0 auto' });
+
+		const armTemplateLoadingInfo = _view.modelBuilder.text().withProps({
+			// Replace with localized string in the future
+			value: 'We are generating an ARM template according to your recommended SKU. This may take some time.',
+			CSSStyles: {
+				...styles.BODY_CSS,
+				'margin-right': '20px'
+			}
+		}).component();
+
+		const armTemplateLoadingInfoCcontainer = _view.modelBuilder.flexContainer().withLayout({
+			height: '100%',
+			flexFlow: 'row',
+		}).component();
+
+		armTemplateLoadingInfoCcontainer.addItem(armTemplateLoadingInfo, { flex: '0 0 auto' });
+
+		const container = _view.modelBuilder.flexContainer().withLayout({
+			flexFlow: 'column'
+		}).withItems([
+			armTemplateLoadingContainer,
+			armTemplateLoadingInfoCcontainer
+		]).component();
+
 		return container;
 	}
 
@@ -82,7 +120,7 @@ export class GenerateArmTemplateDialog {
 			this._isOpen = true;
 
 			// Replace 'Generate ARM template' with a localized string in the future
-			this.dialog = azdata.window.createModelViewDialog('Generate ARM template', 'GenerateArmTemplateDialog', 'narrow');
+			this.dialog = azdata.window.createModelViewDialog('Generate ARM template', 'GenerateArmTemplateDialog', 'medium');
 
 			this.dialog.okButton.label = GenerateArmTemplateDialog.CloseButtonText;
 			this._disposables.push(this.dialog.okButton.onClick(async () => await this.execute()));

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -92,7 +92,6 @@ export class GenerateArmTemplateDialog {
 			dialogSetupPromises.push(this.initializeDialog(this.dialog));
 			azdata.window.openDialog(this.dialog);
 			await Promise.all(dialogSetupPromises);
-
 		}
 	}
 

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -11,7 +11,6 @@ import { join } from 'path';
 import * as styles from '../../constants/styles';
 import * as mssql from 'mssql';
 import * as utils from '../../api/utils';
-import { Console } from 'console';
 
 export class GenerateArmTemplateDialog {
 
@@ -202,9 +201,7 @@ export class GenerateArmTemplateDialog {
 			await Promise.all(dialogSetupPromises);
 
 			// Generate ARM template upon opening dialog
-			console.log('ARM template generation started');
 			await this.model.generateProvisioningScript(this._targetType);
-			console.log('ARM template generation complete');
 			const error = this.model._provisioningScriptResult.error;
 
 			if (error) {

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -240,7 +240,7 @@ export class GenerateArmTemplateDialog {
 			this._disposables.push(this.dialog.okButton.onClick(async () => await this.execute()));
 			this.dialog.cancelButton.hidden = true;
 
-			const armTemplateSaveButton = azdata.window.createButton('Download template', 'left');
+			const armTemplateSaveButton = azdata.window.createButton('Save template', 'left');
 			this._disposables.push(armTemplateSaveButton.onClick(async () => await this.saveArmTemplate()));
 
 			this.dialog.customButtons = [armTemplateSaveButton];

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 import * as styles from '../../constants/styles';
 import * as mssql from 'mssql';
 import * as utils from '../../api/utils';
+import { logError, TelemetryViews } from '../../telemtery';
 
 export class GenerateArmTemplateDialog {
 
@@ -113,7 +114,6 @@ export class GenerateArmTemplateDialog {
 		return container;
 	}
 
-	// TODO: Implement this
 	private CreateSaveArmTemplateContainer(_view: azdata.ModelView): azdata.FlexContainer {
 		const armTemplateSaveInstructions = _view.modelBuilder.text().withProps({
 			// TODO: Update text
@@ -206,6 +206,7 @@ export class GenerateArmTemplateDialog {
 			const error = this.model._provisioningScriptResult.error;
 
 			if (error) {
+				logError(TelemetryViews.ProvisioningScriptWizard, 'ProvisioningScriptGenerationUnexpectedError', error);
 				await this.updateArmTemplateStatus(false);
 			}
 			else {

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -6,6 +6,7 @@
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import { MigrationStateModel, MigrationTargetType } from '../../models/stateMachine';
 import * as constants from '../../constants/strings';
 import { join } from 'path';
 import * as styles from '../../constants/styles';
@@ -23,6 +24,10 @@ export class GenerateArmTemplateDialog {
 
 	private _generateArmTemplateContainer!: azdata.FlexContainer;
 	private _saveArmTemplateContainer!: azdata.FlexContainer;
+
+	constructor(public model: MigrationStateModel, public _targetType: MigrationTargetType) {
+
+	}
 
 	// REMOVE AFTER TESTING
 	private _armTemplate: string = 'testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt\nt';
@@ -189,7 +194,6 @@ export class GenerateArmTemplateDialog {
 
 			this.dialog.okButton.label = GenerateArmTemplateDialog.CloseButtonText;
 			this._disposables.push(this.dialog.okButton.onClick(async () => await this.execute()));
-
 			this.dialog.cancelButton.hidden = true;
 
 			const dialogSetupPromises: Thenable<void>[] = [];

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -14,7 +14,6 @@ import * as utils from '../../api/utils';
 import { logError, TelemetryViews } from '../../telemtery';
 import { IconPathHelper } from '../../constants/iconPathHelper';
 
-
 export class GenerateArmTemplateDialog {
 
 	private static readonly CloseButtonText: string = 'Close';
@@ -282,6 +281,7 @@ export class GenerateArmTemplateDialog {
 		});
 
 		fs.writeFileSync(filePath!.fsPath, this._armTemplateText);
+		void vscode.window.showInformationMessage('Successfully saved ARM template to ' + filePath + '.');
 	}
 
 }

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 import * as styles from '../../constants/styles';
 import * as mssql from 'mssql';
 import * as utils from '../../api/utils';
+import { Console } from 'console';
 
 export class GenerateArmTemplateDialog {
 
@@ -178,7 +179,7 @@ export class GenerateArmTemplateDialog {
 		await this._generateArmTemplateContainer.updateCssStyles({ 'display': 'none' });
 
 		if (succeeded){
-			this._armTemplateText = this.model._provisioningScriptResult.result.provisioningScript;
+			this._armTemplateText = fs.readFileSync(this.model._provisioningScriptResult.result.provisioningScriptFilePath).toString();
 			this._armTemplateTextBox.value = this._armTemplateText;
 			await this._saveArmTemplateContainer.updateCssStyles({ 'display': 'inline' });
 		}
@@ -201,7 +202,9 @@ export class GenerateArmTemplateDialog {
 			await Promise.all(dialogSetupPromises);
 
 			// Generate ARM template upon opening dialog
+			console.log('ARM template generation started');
 			await this.model.generateProvisioningScript(this._targetType);
+			console.log('ARM template generation complete');
 			const error = this.model._provisioningScriptResult.error;
 
 			if (error) {

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -120,12 +120,30 @@ export class GenerateArmTemplateDialog {
 	}
 
 	private CreateSaveArmTemplateContainer(_view: azdata.ModelView): azdata.FlexContainer {
-		const armTemplateSaveInstructions = _view.modelBuilder.text().withProps({
-			// TODO: Update text
+		const armTemplateDescription = _view.modelBuilder.text().withProps({
 			// Replace with localized string in the future
-			value: 'ARM template save instructions placeholder',
+			value: 'ARM templates enable you to define the infrastructure requirements for your deployments on Azure.',
 			CSSStyles: {
 				...styles.BODY_CSS,
+				'margin-bottom': '8px',
+			}
+		}).component();
+
+		const armTemplateLearnMoreLink = _view.modelBuilder.hyperlink().withProps({
+			// Replace with localized string in the future
+			position: 'absolute',
+			label: 'Learn more on how to deploy ARM templates',
+			url: 'https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/quickstart-create-templates-use-the-portal#edit-and-deploy-the-template',
+			CSSStyles: {
+				...styles.BODY_CSS,
+			}
+		}).component();
+
+		const armTemplateLearnMoreContainer = _view.modelBuilder.flexContainer().withItems([
+			armTemplateLearnMoreLink,
+		]).withProps({
+			height: 20,
+			CSSStyles: {
 				'margin-bottom': '8px',
 			}
 		}).component();
@@ -145,7 +163,7 @@ export class GenerateArmTemplateDialog {
 
 		const textContainer = _view.modelBuilder.flexContainer().withLayout({
 			flexFlow: 'column',
-			height: 750,
+			height: 600,
 		}).withProps({
 			CSSStyles: {
 				'overflow': 'auto',
@@ -158,10 +176,12 @@ export class GenerateArmTemplateDialog {
 
 		const container = _view.modelBuilder.flexContainer().withLayout({
 			flexFlow: 'column',
+			position: 'relative',
 		}).withProps({
 			display: 'none',
 		}).withItems([
-			armTemplateSaveInstructions,
+			armTemplateDescription,
+			armTemplateLearnMoreContainer,
 			textContainer
 		]).component();
 
@@ -214,13 +234,13 @@ export class GenerateArmTemplateDialog {
 		if (!this._isOpen){
 			this._isOpen = true;
 
-			this.dialog = azdata.window.createModelViewDialog('View ARM template', 'ViewArmTemplateDialog', 'medium');
+			this.dialog = azdata.window.createModelViewDialog('Generate ARM template', 'ViewArmTemplateDialog', 'medium');
 
 			this.dialog.okButton.label = GenerateArmTemplateDialog.CloseButtonText;
 			this._disposables.push(this.dialog.okButton.onClick(async () => await this.execute()));
 			this.dialog.cancelButton.hidden = true;
 
-			const armTemplateSaveButton = azdata.window.createButton('Save ARM template', 'left');
+			const armTemplateSaveButton = azdata.window.createButton('Download template', 'left');
 			this._disposables.push(armTemplateSaveButton.onClick(async () => await this.saveArmTemplate()));
 
 			this.dialog.customButtons = [armTemplateSaveButton];

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -275,7 +275,7 @@ export class GenerateArmTemplateDialog {
 
 	private async saveArmTemplate(): Promise<void> {
 		const filePath = await vscode.window.showSaveDialog({
-			defaultUri: vscode.Uri.file(join(utils.getUserHome()!, 'ARMTemplate-' + new Date().toISOString().split('T')[0] + '.json')),
+			defaultUri: vscode.Uri.file(join(utils.getUserHome()!, 'ARMTemplate-' + this._targetType + '-' + new Date().toISOString().split('T')[0] + '.json')),
 			filters: {
 				'JSON File': ['json']
 			}

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -131,7 +131,8 @@ export class GenerateArmTemplateDialog {
 			height: '100%',
 			CSSStyles: {
 				'font': '14px "Monaco", "Menlo", "Consolas", "Droid Sans Mono", "Inconsolata", "Courier New", monospace',
-				'margin': '0'
+				'margin': '0',
+				'white-space': 'pre',
 			}
 
 		}).component();

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -178,7 +178,7 @@ export class GenerateArmTemplateDialog {
 		await this._generateArmTemplateContainer.updateCssStyles({ 'display': 'none' });
 
 		if (succeeded){
-			this._armTemplateText = this.model._provisioningScriptResult.provisioningScriptResult.script;
+			this._armTemplateText = this.model._provisioningScriptResult.result.provisioningScript;
 			this._armTemplateTextBox.value = this._armTemplateText;
 			await this._saveArmTemplateContainer.updateCssStyles({ 'display': 'inline' });
 		}
@@ -202,7 +202,7 @@ export class GenerateArmTemplateDialog {
 
 			// Generate ARM template upon opening dialog
 			await this.model.generateProvisioningScript(this._targetType);
-			const error = this.model._provisioningScriptResult.provisioningScriptError;
+			const error = this.model._provisioningScriptResult.error;
 
 			if (error) {
 				await this.updateArmTemplateStatus(false);

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -209,7 +209,6 @@ export class GenerateArmTemplateDialog {
 			}
 			else {
 				await this.updateArmTemplateStatus(true);
-
 			}
 		}
 	}

--- a/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
+++ b/extensions/sql-migration/src/dialog/skuRecommendationResults/generateArmTemplateDialog.ts
@@ -219,7 +219,7 @@ export class GenerateArmTemplateDialog {
 	private async updateArmTemplateStatus(succeeded: boolean): Promise<void> {
 		await this._generateArmTemplateContainer.updateCssStyles({ 'display': 'none' });
 
-		if (succeeded){
+		if (succeeded) {
 			this._armTemplateText = fs.readFileSync(this.model._provisioningScriptResult.result.provisioningScriptFilePath).toString();
 			this._armTemplateTextBox.value = this._armTemplateText;
 			await this._saveArmTemplateContainer.updateCssStyles({ 'display': 'inline' });
@@ -230,7 +230,7 @@ export class GenerateArmTemplateDialog {
 	}
 
 	public async openDialog(dialogName?: string, recommendations?: mssql.SkuRecommendationResult) {
-		if (!this._isOpen){
+		if (!this._isOpen) {
 			this._isOpen = true;
 
 			this.dialog = azdata.window.createModelViewDialog('Generate ARM template', 'ViewArmTemplateDialog', 'medium');

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -550,7 +550,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			logError(TelemetryViews.ProvisioningScriptWizard, 'GenerateProvisioningScriptFailed', error);
 			this._provisioningScriptResult = {
 				result: {
-					provisioningScript: '',
+					provisioningScriptFilePath: '',
 				},
 				error: error,
 			};

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -1130,3 +1130,8 @@ export interface SkuRecommendation {
 	recommendations: mssql.SkuRecommendationResult;
 	recommendationError?: Error;
 }
+
+export interface ProvisioningScript {
+	provisioningScriptResult: mssql.ProvisioningScriptResult;
+	provisioningScriptError?: Error;
+}

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -541,7 +541,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			}
 
 			this._provisioningScriptResult = {
-				provisioningScriptResult: this._provisioningScriptApiResponse,
+				result: this._provisioningScriptApiResponse,
 			};
 
 			return this._provisioningScriptResult;
@@ -549,10 +549,10 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 		} catch (error) {
 			logError(TelemetryViews.ProvisioningScriptWizard, 'GenerateProvisioningScriptFailed', error);
 			this._provisioningScriptResult = {
-				provisioningScriptResult: {
-					script: '',
+				result: {
+					provisioningScript: '',
 				},
-				provisioningScriptError: error,
+				error: error,
 			};
 		}
 		return this._provisioningScriptResult;
@@ -1178,6 +1178,6 @@ export interface SkuRecommendation {
 }
 
 export interface ProvisioningScript {
-	provisioningScriptResult: mssql.ProvisioningScriptResult;
-	provisioningScriptError?: Error;
+	result: mssql.ProvisioningScriptResult;
+	error?: Error;
 }

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -550,7 +550,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			logError(TelemetryViews.ProvisioningScriptWizard, 'GenerateProvisioningScriptFailed', error);
 			this._provisioningScriptResult = {
 				provisioningScriptResult: {
-					provisioningScript: '',
+					script: '',
 				},
 				provisioningScriptError: error,
 			};

--- a/extensions/sql-migration/src/telemtery.ts
+++ b/extensions/sql-migration/src/telemtery.ts
@@ -34,6 +34,7 @@ export enum TelemetryViews {
 	MigrationLocalStorage = 'MigrationLocalStorage',
 	SkuRecommendationWizard = 'SkuRecommendationWizard',
 	DataCollectionWizard = 'GetAzureRecommendationDialog',
+	ProvisioningScriptWizard = 'GenerateArmTemplateDialog',
 	SelectMigrationServiceDialog = 'SelectMigrationServiceDialog',
 	Utils = 'Utils'
 }

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -335,6 +335,15 @@ export class SKURecommendationPage extends MigrationWizardPage {
 							'text-decoration': 'none',
 						}
 					},
+					{
+						// 8 - CardDescriptionIndex.GENERATE_ARM_TEMPLATE
+						textValue: '',
+						linkDisplayValue: '',
+						linkStyles: {
+							...styles.BODY_CSS,
+							'text-decoration': 'none',
+						}
+					},
 				]
 			});
 
@@ -635,12 +644,14 @@ export class SKURecommendationPage extends MigrationWizardPage {
 				// this._rbg.cards[index].descriptions[5].textValue = constants.ASSESSED_DBS(dbCount);
 				if (this.hasRecommendations()) {
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue = constants.VIEW_DETAILS;
+					this._rbg.cards[index].descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue = 'Generate ARM template';
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.SKU_RECOMMENDATION].textStyles = {
 						...styles.BODY_CSS,
 						'font-weight': '500',
 					};
 				} else {
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue = '';
+					this._rbg.cards[index].descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue = '';
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.SKU_RECOMMENDATION].textStyles = {
 						...styles.BODY_CSS,
 					};
@@ -1184,4 +1195,5 @@ export enum CardDescriptionIndex {
 	SKU_RECOMMENDATION = 5,
 	VM_CONFIGURATIONS = 6,
 	VIEW_SKU_DETAILS = 7,
+	GENERATE_ARM_TEMPLATE = 8,
 }

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -262,7 +262,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 			iconHeight: '35px',
 			iconWidth: '35px',
 			cardWidth: '250px',
-			cardHeight: '340px',
+			cardHeight: '380px',
 			iconPosition: 'left',
 			CSSStyles: {
 				'margin-top': '0px',
@@ -350,8 +350,13 @@ export class SKURecommendationPage extends MigrationWizardPage {
 			this._disposables.push(this._rbg.onLinkClick(async (e: azdata.RadioCardLinkClickEvent) => {
 				if (this.hasRecommendations()) {
 					const skuRecommendationResultsDialog = new SkuRecommendationResultsDialog(this.migrationStateModel, product.type);
-					if (e.cardId === skuRecommendationResultsDialog._targetType) {
-						await skuRecommendationResultsDialog.openDialog(e.cardId, this.migrationStateModel._skuRecommendationResults.recommendations);
+					if (e.description.linkDisplayValue === e.card.descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue) {
+						if (e.cardId === skuRecommendationResultsDialog._targetType) {
+							await skuRecommendationResultsDialog.openDialog(e.cardId, this.migrationStateModel._skuRecommendationResults.recommendations);
+						}
+					}
+					else if (e.description.linkDisplayValue === e.card.descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue) {
+
 					}
 				}
 			}));

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -17,7 +17,7 @@ import { IconPath, IconPathHelper } from '../constants/iconPathHelper';
 import { WIZARD_INPUT_COMPONENT_WIDTH } from './wizardController';
 import * as styles from '../constants/styles';
 import { SkuEditParametersDialog } from '../dialog/skuRecommendationResults/skuEditParametersDialog';
-import { GenerateArmTemplateDialog } from '../dialog/skuRecommendationResults/generateArmTemplateDialog';
+import { GenerateArmTemplateDialog } from '../dialog/skuRecommendationResults/viewArmTemplateDialog';
 import { logError, TelemetryViews } from '../telemtery';
 
 export interface Product {
@@ -653,8 +653,8 @@ export class SKURecommendationPage extends MigrationWizardPage {
 				// this._rbg.cards[index].descriptions[5].textValue = constants.ASSESSED_DBS(dbCount);
 				if (this.hasRecommendations()) {
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue = constants.VIEW_DETAILS;
-					// Replace 'Generate ARM template' with a localized string in the future
-					this._rbg.cards[index].descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue = 'Generate ARM template';
+					// Replace with a localized string in the future
+					this._rbg.cards[index].descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue = 'View ARM template';
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.SKU_RECOMMENDATION].textStyles = {
 						...styles.BODY_CSS,
 						'font-weight': '500',

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -351,7 +351,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 			this._disposables.push(this._rbg.onLinkClick(async (e: azdata.RadioCardLinkClickEvent) => {
 				if (this.hasRecommendations()) {
 					const skuRecommendationResultsDialog = new SkuRecommendationResultsDialog(this.migrationStateModel, product.type);
-					const generateArmTemplateDialog = new GenerateArmTemplateDialog();
+					const generateArmTemplateDialog = new GenerateArmTemplateDialog(this.migrationStateModel, product.type);
 					if (e.description.linkDisplayValue === e.card.descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue) {
 						if (e.cardId === skuRecommendationResultsDialog._targetType) {
 							await skuRecommendationResultsDialog.openDialog(e.cardId, this.migrationStateModel._skuRecommendationResults.recommendations);

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -17,7 +17,7 @@ import { IconPath, IconPathHelper } from '../constants/iconPathHelper';
 import { WIZARD_INPUT_COMPONENT_WIDTH } from './wizardController';
 import * as styles from '../constants/styles';
 import { SkuEditParametersDialog } from '../dialog/skuRecommendationResults/skuEditParametersDialog';
-import { GenerateArmTemplateDialog } from '../dialog/skuRecommendationResults/viewArmTemplateDialog';
+import { GenerateArmTemplateDialog } from '../dialog/skuRecommendationResults/generateArmTemplateDialog';
 import { logError, TelemetryViews } from '../telemtery';
 
 export interface Product {
@@ -337,7 +337,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 						}
 					},
 					{
-						// 8 - CardDescriptionIndex.GENERATE_ARM_TEMPLATE
+						// 8 - CardDescriptionIndex.VIEW_TEMPLATE
 						textValue: '',
 						linkDisplayValue: '',
 						linkStyles: {
@@ -357,7 +357,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 							await skuRecommendationResultsDialog.openDialog(e.cardId, this.migrationStateModel._skuRecommendationResults.recommendations);
 						}
 					}
-					else if (e.description.linkDisplayValue === e.card.descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue) {
+					else if (e.description.linkDisplayValue === e.card.descriptions[CardDescriptionIndex.VIEW_TEMPLATE].linkDisplayValue) {
 						if (e.cardId === skuRecommendationResultsDialog._targetType) {
 							await generateArmTemplateDialog.openDialog(e.cardId, this.migrationStateModel._skuRecommendationResults.recommendations);
 						}
@@ -654,14 +654,14 @@ export class SKURecommendationPage extends MigrationWizardPage {
 				if (this.hasRecommendations()) {
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue = constants.VIEW_DETAILS;
 					// Replace with a localized string in the future
-					this._rbg.cards[index].descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue = 'View ARM template';
+					this._rbg.cards[index].descriptions[CardDescriptionIndex.VIEW_TEMPLATE].linkDisplayValue = 'View template';
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.SKU_RECOMMENDATION].textStyles = {
 						...styles.BODY_CSS,
 						'font-weight': '500',
 					};
 				} else {
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue = '';
-					this._rbg.cards[index].descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue = '';
+					this._rbg.cards[index].descriptions[CardDescriptionIndex.VIEW_TEMPLATE].linkDisplayValue = '';
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.SKU_RECOMMENDATION].textStyles = {
 						...styles.BODY_CSS,
 					};
@@ -1205,5 +1205,5 @@ export enum CardDescriptionIndex {
 	SKU_RECOMMENDATION = 5,
 	VM_CONFIGURATIONS = 6,
 	VIEW_SKU_DETAILS = 7,
-	GENERATE_ARM_TEMPLATE = 8,
+	VIEW_TEMPLATE = 8,
 }

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -653,6 +653,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 				// this._rbg.cards[index].descriptions[5].textValue = constants.ASSESSED_DBS(dbCount);
 				if (this.hasRecommendations()) {
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue = constants.VIEW_DETAILS;
+					// Replace 'Generate ARM template' with a localized string in the future
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue = 'Generate ARM template';
 					this._rbg.cards[index].descriptions[CardDescriptionIndex.SKU_RECOMMENDATION].textStyles = {
 						...styles.BODY_CSS,

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -17,6 +17,7 @@ import { IconPath, IconPathHelper } from '../constants/iconPathHelper';
 import { WIZARD_INPUT_COMPONENT_WIDTH } from './wizardController';
 import * as styles from '../constants/styles';
 import { SkuEditParametersDialog } from '../dialog/skuRecommendationResults/skuEditParametersDialog';
+import { GenerateArmTemplateDialog } from '../dialog/skuRecommendationResults/generateArmTemplateDialog';
 import { logError, TelemetryViews } from '../telemtery';
 
 export interface Product {
@@ -350,13 +351,16 @@ export class SKURecommendationPage extends MigrationWizardPage {
 			this._disposables.push(this._rbg.onLinkClick(async (e: azdata.RadioCardLinkClickEvent) => {
 				if (this.hasRecommendations()) {
 					const skuRecommendationResultsDialog = new SkuRecommendationResultsDialog(this.migrationStateModel, product.type);
+					const generateArmTemplateDialog = new GenerateArmTemplateDialog();
 					if (e.description.linkDisplayValue === e.card.descriptions[CardDescriptionIndex.VIEW_SKU_DETAILS].linkDisplayValue) {
 						if (e.cardId === skuRecommendationResultsDialog._targetType) {
 							await skuRecommendationResultsDialog.openDialog(e.cardId, this.migrationStateModel._skuRecommendationResults.recommendations);
 						}
 					}
 					else if (e.description.linkDisplayValue === e.card.descriptions[CardDescriptionIndex.GENERATE_ARM_TEMPLATE].linkDisplayValue) {
-
+						if (e.cardId === skuRecommendationResultsDialog._targetType) {
+							await generateArmTemplateDialog.openDialog(e.cardId, this.migrationStateModel._skuRecommendationResults.recommendations);
+						}
 					}
 				}
 			}));


### PR DESCRIPTION
This PR adds target provisioning functionality to the Azure SQL Migration extension wizard on the assessment results and recommendation page. 

Currently, there is no easy way to provision recommended resources within migration tooling after the Azure recommendation is obtained. This PR adds a new "View Template" link on the Azure SQL target radio cards after generating the Azure recommendation. The link opens a dialog that displays an ARM template corresponding to the recommended target. The template text can be copied or saved, and the user can upload the template to Azure Portal to provision the target.

![image](https://user-images.githubusercontent.com/54997940/183515327-13306a54-f007-4c4c-93a2-7f588b6bcc08.png)

![image](https://user-images.githubusercontent.com/54997940/183515500-c5378672-95cf-4d82-9952-0c610bed6106.png)
