### PR TITLE
update container eula link

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -201,8 +201,8 @@ export const eulaAgreementTemplate = localize({ key: 'eulaAgreementTemplate', co
 export function eulaAgreementText(name: string) { return localize({ key: 'eulaAgreementText', comment: ['The placeholders are contents of the line and should not be translated.'] }, "I accept the {0}.", name); }
 export const eulaAgreementTitle = localize('eulaAgreementTitle', "Microsoft SQL Server License Agreement");
 export const edgeEulaAgreementTitle = localize('edgeEulaAgreementTitle', "Microsoft Azure SQL Edge License Agreement");
-export const sqlServerEulaLink = 'https://go.microsoft.com/fwlink/?linkid=857698';
-export const sqlServerEdgeEulaLink = 'https://go.microsoft.com/fwlink/?linkid=2139274';
+export const sqlServerEulaLink = 'https://aka.ms/mcr/osslegalnotice';
+export const sqlServerEdgeEulaLink = 'https://aka.ms/mcr/osslegalnotice';
 export const connectionNamePrefix = 'SQLDbProject';
 export const sqlServerDockerRegistry = 'mcr.microsoft.com';
 export const sqlServerDockerRepository = 'mssql/server';


### PR DESCRIPTION
The previous eula links were for specific versions: edge and 2017. This updated link, found under the dockerhub for SQL Server at the bottom at "license", will cover the various images being pulled down from MCR that have other SQL Server versions. 

I left the current text in dialog and quickpick as is - @dzsquared let me know if this should be updated too.
![image](https://user-images.githubusercontent.com/31145923/183724098-b80cf423-df61-4973-81b2-12a2e8beadf8.png)
![image](https://user-images.githubusercontent.com/31145923/183724156-4fafe776-a824-4818-9b7f-01711ced4838.png)

