### PR TITLE
Update relative path to katex css

### DIFF
--- a/extensions/markdown-math/package.json
+++ b/extensions/markdown-math/package.json
@@ -35,7 +35,7 @@
     ],
     "markdown.markdownItPlugins": true,
     "markdown.previewStyles": [
-      "./node_modules/katex/dist/katex.min.css",
+      "./notebook-out/katex.min.css",
       "./preview-styles/index.css"
     ],
     "configuration": [


### PR DESCRIPTION
The extension was trying to find the css file in the wrong location, instead of the output folder.

Here's how it's done in vscode -> https://github.com/microsoft/vscode/blob/main/extensions/markdown-math/package.json#L71
This PR fixes #20091
