### PR TITLE
Add image tag matching target platform for publish to docker

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -160,6 +160,7 @@ export function OptionNotFoundWarningMessage(label: string) { return localize('o
 export const SqlServerName = 'SQL server';
 export const AzureSqlServerName = 'Azure SQL server';
 export const SqlServerDockerImageName = 'Microsoft SQL Server';
+export const SqlServerDocker2022ImageName = 'Microsoft SQL Server 2022 (preview)';
 export const AzureSqlDbFullDockerImageName = 'Azure SQL Database emulator Full';
 export const AzureSqlDbLiteDockerImageName = 'Azure SQL Database emulator Lite';
 export const AzureSqlLogicalServerName = 'Azure SQL logical server';

--- a/extensions/sql-database-projects/src/dialogs/utils.ts
+++ b/extensions/sql-database-projects/src/dialogs/utils.ts
@@ -155,3 +155,32 @@ export function getDockerBaseImages(target: string): DockerImageInfo[] {
 		];
 	}
 }
+
+/**
+ * This adds the tag matching the target platform to make sure the correct image is used for the project's target platform when the docker base image is SQL Server.
+ * If the image is Edge, then no tag is appended
+ * @param projectTargetVersion target version of the project
+ * @param dockerImage selected base docker image without tag
+ * @param imageInfo docker image info of the selected docker image
+ * @returns dockerBaseImage with the appropriate image tag appended if there is one
+ */
+export function getDefaultDockerImageWithTag(projectTargetVersion: string, dockerImage: string, imageInfo?: DockerImageInfo,): string {
+	if (imageInfo?.displayName === constants.SqlServerDockerImageName) {
+		switch (projectTargetVersion) {
+			case constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlServer2022):
+				dockerImage = `${dockerImage}:2022-latest`;
+				break;
+			case constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlServer2019):
+				dockerImage = `${dockerImage}:2019-latest`;
+				break;
+			case constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlServer2017):
+				dockerImage = `${dockerImage}:2017-latest`;
+				break;
+			default:
+				// nothing - let it be the default image defined as default in the container registry
+				break;
+		}
+	}
+
+	return dockerImage;
+}

--- a/extensions/sql-database-projects/src/test/dialogs/utils.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/utils.test.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as should from 'should';
+import { SqlTargetPlatform } from 'sqldbproj';
+import * as constants from '../../common/constants';
+import { getDefaultDockerImageWithTag, getDockerBaseImages } from '../../dialogs/utils';
+
+describe('Tests to verify dialog utils functions', function (): void {
+	it('getDefaultDockerImageWithTag should return correct image', () => {
+		const baseImages = getDockerBaseImages(constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlServer2022)!);
+		const sqlServerImageInfo = baseImages.find(image => image.displayName === constants.SqlServerDockerImageName);
+		const edgeImageInfo = baseImages.find(image => image.displayName === SqlTargetPlatform.sqlEdge);
+
+		should(getDefaultDockerImageWithTag('160', 'mcr.microsoft.com/mssql/server', sqlServerImageInfo)).equals(`${sqlServerImageInfo?.name}:2022-latest`, 'Unexpected docker image returned for target platform SQL Server 2022 and SQL Server base image');
+		should(getDefaultDockerImageWithTag('150', 'mcr.microsoft.com/mssql/server', sqlServerImageInfo)).equals(`${sqlServerImageInfo?.name}:2019-latest`, 'Unexpected docker image returned for target platform SQL Server 2019 and SQL Server base image');
+		should(getDefaultDockerImageWithTag('140', 'mcr.microsoft.com/mssql/server', sqlServerImageInfo)).equals(`${sqlServerImageInfo?.name}:2017-latest`, 'Unexpected docker image returned for target platform SQL Server 2017 and SQL Server base image');
+		should(getDefaultDockerImageWithTag('130', 'mcr.microsoft.com/mssql/server', sqlServerImageInfo)).equals(`${sqlServerImageInfo?.name}`, 'Unexpected docker image returned for target platform SQL Server 2016 and SQL Server base image');
+		should(getDefaultDockerImageWithTag('150', 'mcr.microsoft.com/azure-sql-edge', edgeImageInfo)).equals(`${edgeImageInfo?.name}`, 'Unexpected docker image returned for target platform SQL Server 2019 and Edge base image');
+
+		// different display names are returned when a project's target platform is Azure, but currently the Azure full image points to mcr.microsoft.com/mssql/server
+		const azureBaseImages = getDockerBaseImages(constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlAzure)!);
+		const azureFullImageInfo = azureBaseImages.find(image => image.displayName === constants.AzureSqlDbFullDockerImageName);
+		const azureLiteImageInfo = azureBaseImages.find(image => image.displayName === constants.AzureSqlDbLiteDockerImageName);
+
+		should(getDefaultDockerImageWithTag('AzureV12', 'mcr.microsoft.com/mssql/server', azureFullImageInfo)).equals(`${azureFullImageInfo?.name}`, 'Unexpected docker image returned for target platform Azure and Azure full base image');
+		should(getDefaultDockerImageWithTag('AzureV12', 'mcr.microsoft.com/azure-sql-edge', azureLiteImageInfo)).equals(`${azureLiteImageInfo?.name}`, 'Unexpected docker image returned for target platform Azure Azure lite base image');
+	});
+});
+

--- a/extensions/sql-database-projects/src/test/dialogs/utils.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/utils.test.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as should from 'should';
-import { SqlTargetPlatform } from 'sqldbproj';
 import * as constants from '../../common/constants';
+import { SqlTargetPlatform } from 'sqldbproj';
 import { getDefaultDockerImageWithTag, getDockerBaseImages } from '../../dialogs/utils';
 
 describe('Tests to verify dialog utils functions', function (): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #20142. Since we now allow projects to target SQL Server 2022, this makes it so that the default SQL Server container will be SQL Server 2022 for project's targeting 2022 so that the new features can be used.

There currently isn't a way to choose the image tag in ADS, only the base docker image can be selected. Previously, the default image is used for SQL Server, which strangely points to the 2017 docker image. As letting the user select the image tag isn't currently exposed, this PR adds logic to choose the appropriate latest image tag behind the scenes for the project's target platform for SQL Server.

Preview is added in the base docker image display name for project's targeting SQL Server 2022:
![image](https://user-images.githubusercontent.com/31145923/183993689-6a718d55-9636-4072-9421-a18f43de59ec.png)

Project's targeting other versions only have "Microsoft SQL Server", same as before:
![image](https://user-images.githubusercontent.com/31145923/183993702-025686e5-033e-42cf-8336-4e4ce0698ada.png)

