### PR TITLE
Temporarily disable cell toolbar smoke tests

### DIFF
--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -273,7 +273,7 @@ export function setup(opts: minimist.ParsedArgs) {
 			});
 		});
 
-		describe('Cell Toolbar Actions', function () {
+		describe.skip('Cell Toolbar Actions', function () {
 			async function verifyCellToolbarBehavior(app: Application, toolbarAction: () => Promise<void>, selector: string, checkIfGone: boolean = false): Promise<void> {
 				// Run the test for each of the default text editor modes
 				for (let editMode of ['Markdown', 'Split View']) {


### PR DESCRIPTION
These smoke tests have been failing a lot in the CI, so disabling them for now while I investigate.