### PR TITLE
[Azure Core, SQL Migration] Fix wrong endpoints being used for non-public clouds 

### DIFF
--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -7,7 +7,7 @@ import { ResourceGraphClient } from '@azure/arm-resourcegraph';
 import { TokenCredentials } from '@azure/ms-rest-js';
 import axios, { AxiosRequestConfig } from 'axios';
 import * as azdata from 'azdata';
-import { AzureRestResponse, GetResourceGroupsResult, GetSubscriptionsResult, ResourceQueryResult, GetBlobContainersResult, GetFileSharesResult, HttpRequestMethod, GetLocationsResult, GetManagedDatabasesResult, CreateResourceGroupResult, GetBlobsResult, GetStorageAccountAccessKeyResult, AzureAccount, azureResource } from 'azurecore';
+import { AzureRestResponse, GetResourceGroupsResult, GetSubscriptionsResult, ResourceQueryResult, GetBlobContainersResult, GetFileSharesResult, HttpRequestMethod, GetLocationsResult, GetManagedDatabasesResult, CreateResourceGroupResult, GetBlobsResult, GetStorageAccountAccessKeyResult, AzureAccount, azureResource, AzureAccountProviderMetadata } from 'azurecore';
 import { EOL } from 'os';
 import * as nls from 'vscode-nls';
 import { AppContext } from '../appContext';
@@ -156,7 +156,7 @@ export async function getLocations(appContext: AppContext, account?: AzureAccoun
 
 	try {
 		const path = `/subscriptions/${subscription.id}/locations?api-version=2020-01-01`;
-		const host = getCorrectArmEndpointForAccount(account);
+		const host = getProviderMetadataForAccount(account).settings.armResource.endpoint;
 		const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors, host);
 		result.locations.push(...response.response.data.value);
 		result.errors.push(...response.errors);
@@ -433,7 +433,7 @@ export async function makeHttpRequest(account: AzureAccount, subscription: azure
 
 export async function getManagedDatabases(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, managedInstance: azureResource.AzureSqlManagedInstance, ignoreErrors: boolean): Promise<GetManagedDatabasesResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${managedInstance.resourceGroup}/providers/Microsoft.Sql/managedInstances/${managedInstance.name}/databases?api-version=2020-02-02-preview`;
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = getProviderMetadataForAccount(account).settings.armResource.endpoint;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors, host);
 	return {
 		databases: response?.response?.data?.value ?? [],
@@ -443,7 +443,7 @@ export async function getManagedDatabases(account: AzureAccount, subscription: a
 
 export async function getBlobContainers(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetBlobContainersResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/blobServices/default/containers?api-version=2019-06-01`;
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = getProviderMetadataForAccount(account).settings.armResource.endpoint;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors, host);
 	return {
 		blobContainers: response?.response?.data?.value ?? [],
@@ -453,7 +453,7 @@ export async function getBlobContainers(account: AzureAccount, subscription: azu
 
 export async function getFileShares(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetFileSharesResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/fileServices/default/shares?api-version=2019-06-01`;
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = getProviderMetadataForAccount(account).settings.armResource.endpoint;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors, host);
 	return {
 		fileShares: response?.response?.data?.value ?? [],
@@ -466,7 +466,7 @@ export async function createResourceGroup(account: AzureAccount, subscription: a
 	const requestBody = {
 		location: location
 	};
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = getProviderMetadataForAccount(account).settings.armResource.endpoint;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.PUT, requestBody, ignoreErrors, host);
 	return {
 		resourceGroup: response?.response?.data,
@@ -476,7 +476,7 @@ export async function createResourceGroup(account: AzureAccount, subscription: a
 
 export async function getStorageAccountAccessKey(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetStorageAccountAccessKeyResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/listKeys?api-version=2019-06-01`;
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = getProviderMetadataForAccount(account).settings.armResource.endpoint;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.POST, undefined, ignoreErrors, host);
 	return {
 		keyName1: response?.response?.data?.keys[0].value ?? '',
@@ -513,11 +513,10 @@ export async function getBlobs(account: AzureAccount, subscription: azureResourc
 	return result;
 }
 
-function getCorrectArmEndpointForAccount(account: AzureAccount): string {
-	// Looks up the correct ARM endpoint for the given account, as defined in azurecore\src\account-provider\providerSettings.ts
+export function getProviderMetadataForAccount(account: AzureAccount): AzureAccountProviderMetadata {
 	const provider = providerSettings.find(provider => {
 		return account.properties.providerSettings.id === provider.metadata.id;
 	});
 
-	return provider.metadata.settings.armResource.endpoint;
+	return provider.metadata;
 }

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -514,6 +514,7 @@ export async function getBlobs(account: AzureAccount, subscription: azureResourc
 }
 
 function getCorrectArmEndpointForAccount(account: AzureAccount): string {
+	// Looks up the correct ARM endpoint for the given account, as defined in azurecore\src\account-provider\providerSettings.ts
 	const provider = providerSettings.find(provider => {
 		return account.properties.providerSettings.id === provider.metadata.id;
 	});

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -513,7 +513,7 @@ export async function getBlobs(account: AzureAccount, subscription: azureResourc
 	return result;
 }
 
-export function getCorrectArmEndpointForAccount(account: AzureAccount): string {
+function getCorrectArmEndpointForAccount(account: AzureAccount): string {
 	const provider = providerSettings.find(provider => {
 		return account.properties.providerSettings.id === provider.metadata.id;
 	});

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -16,6 +16,7 @@ import { AzureResourceServiceNames } from './constants';
 import { IAzureResourceSubscriptionFilterService, IAzureResourceSubscriptionService } from './interfaces';
 import { AzureResourceGroupService } from './providers/resourceGroup/resourceGroupService';
 import { BlobServiceClient, StorageSharedKeyCredential } from '@azure/storage-blob';
+import providerSettings from '../account-provider/providerSettings';
 
 const localize = nls.loadMessageBundle();
 
@@ -155,7 +156,8 @@ export async function getLocations(appContext: AppContext, account?: AzureAccoun
 
 	try {
 		const path = `/subscriptions/${subscription.id}/locations?api-version=2020-01-01`;
-		const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors);
+		const host = getCorrectArmEndpointForAccount(account);
+		const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors, host);
 		result.locations.push(...response.response.data.value);
 		result.errors.push(...response.errors);
 	} catch (err) {
@@ -431,7 +433,8 @@ export async function makeHttpRequest(account: AzureAccount, subscription: azure
 
 export async function getManagedDatabases(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, managedInstance: azureResource.AzureSqlManagedInstance, ignoreErrors: boolean): Promise<GetManagedDatabasesResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${managedInstance.resourceGroup}/providers/Microsoft.Sql/managedInstances/${managedInstance.name}/databases?api-version=2020-02-02-preview`;
-	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors);
+	const host = getCorrectArmEndpointForAccount(account);
+	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors, host);
 	return {
 		databases: response?.response?.data?.value ?? [],
 		errors: response.errors ? response.errors : []
@@ -440,7 +443,8 @@ export async function getManagedDatabases(account: AzureAccount, subscription: a
 
 export async function getBlobContainers(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetBlobContainersResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/blobServices/default/containers?api-version=2019-06-01`;
-	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors);
+	const host = getCorrectArmEndpointForAccount(account);
+	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors, host);
 	return {
 		blobContainers: response?.response?.data?.value ?? [],
 		errors: response.errors ? response.errors : []
@@ -449,7 +453,8 @@ export async function getBlobContainers(account: AzureAccount, subscription: azu
 
 export async function getFileShares(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetFileSharesResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/fileServices/default/shares?api-version=2019-06-01`;
-	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors);
+	const host = getCorrectArmEndpointForAccount(account);
+	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors, host);
 	return {
 		fileShares: response?.response?.data?.value ?? [],
 		errors: response.errors ? response.errors : []
@@ -461,7 +466,8 @@ export async function createResourceGroup(account: AzureAccount, subscription: a
 	const requestBody = {
 		location: location
 	};
-	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.PUT, requestBody, ignoreErrors);
+	const host = getCorrectArmEndpointForAccount(account);
+	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.PUT, requestBody, ignoreErrors, host);
 	return {
 		resourceGroup: response?.response?.data,
 		errors: response.errors ? response.errors : []
@@ -470,7 +476,8 @@ export async function createResourceGroup(account: AzureAccount, subscription: a
 
 export async function getStorageAccountAccessKey(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetStorageAccountAccessKeyResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/listKeys?api-version=2019-06-01`;
-	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.POST, undefined, ignoreErrors);
+	const host = getCorrectArmEndpointForAccount(account);
+	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.POST, undefined, ignoreErrors, host);
 	return {
 		keyName1: response?.response?.data?.keys[0].value ?? '',
 		keyName2: response?.response?.data?.keys[0].value ?? '',
@@ -504,4 +511,12 @@ export async function getBlobs(account: AzureAccount, subscription: azureResourc
 		}
 	}
 	return result;
+}
+
+export function getCorrectArmEndpointForAccount(account: AzureAccount): string {
+	const provider = providerSettings.find(provider => {
+		return account.properties.providerSettings.id === provider.metadata.id;
+	});
+
+	return provider.metadata.settings.armResource.endpoint;
 }

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -306,6 +306,7 @@ declare module 'azurecore' {
 		 * @param region The region value
 		 */
 		getRegionDisplayName(region?: string): string;
+		getProviderMetadataForAccount(account: AzureAccount): AzureAccountProviderMetadata;
 		provideResources(): azureResource.IAzureResourceProvider[];
 
 		runGraphQuery<T extends azureResource.AzureGraphResource>(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors: boolean, query: string): Promise<ResourceQueryResult<T>>;

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -215,6 +215,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 			return azureResourceUtils.makeHttpRequest(account, subscription, path, requestType, requestBody, ignoreErrors, host, requestHeaders);
 		},
 		getRegionDisplayName: utils.getRegionDisplayName,
+		getProviderMetadataForAccount(account: azurecore.AzureAccount) {
+			return azureResourceUtils.getProviderMetadataForAccount(account);
+		},
 		runGraphQuery<T extends azurecore.azureResource.AzureGraphResource>(account: azurecore.AzureAccount,
 			subscriptions: azurecore.azureResource.AzureResourceSubscription[],
 			ignoreErrors: boolean,

--- a/extensions/machine-learning/src/test/stubs.ts
+++ b/extensions/machine-learning/src/test/stubs.ts
@@ -55,6 +55,9 @@ export class AzurecoreApiStub implements azurecore.IExtension {
 	getRegionDisplayName(_region?: string | undefined): string {
 		throw new Error('Method not implemented.');
 	}
+	getProviderMetadataForAccount(_account: azurecore.AzureAccount): azurecore.AzureAccountProviderMetadata {
+		throw new Error('Method not implemented.');
+	}
 	provideResources(): azurecore.azureResource.IAzureResourceProvider[] {
 		throw new Error('Method not implemented.');
 	}

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -211,8 +211,7 @@ export async function createSqlMigrationService(account: azdata.Account, subscri
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
-	const asyncUrl = response.response.headers['azure-asyncoperation']
-		.replace('https://management.azure.com/', '');
+	const asyncUrl = response.response.headers['azure-asyncoperation'];
 	const asyncPath = asyncUrl.replace((new URL(asyncUrl)).origin + '/', '');	// path is everything after the hostname, e.g. the 'test' part of 'https://management.azure.com/test'
 
 	const maxRetry = 24;

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as azurecore from 'azurecore';
 import * as constants from '../constants/strings';
-import { getSessionIdHeader, getCorrectArmEndpointForAccount } from './utils';
+import { getSessionIdHeader } from './utils';
 import { ProvisioningState } from '../models/migrationLocalStorage';
 import { URL } from 'url';
 
@@ -38,7 +38,7 @@ export async function getLocations(account: azdata.Account, subscription: Subscr
 	const response = await api.getLocations(account, subscription, true);
 
 	const path = `/subscriptions/${subscription.id}/providers/Microsoft.DataMigration?api-version=${ARM_MGMT_API_VERSION}`;
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const dataMigrationResourceProvider = (await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host)).response.data;
 
 	const sqlMigratonResource = dataMigrationResourceProvider.resourceTypes.find((r: any) => r.resourceType === 'SqlMigrationServices');
@@ -111,7 +111,7 @@ export type SqlVMServer = {
 export async function getAvailableSqlVMs(account: azdata.Account, subscription: Subscription): Promise<SqlVMServer[]> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines?api-version=${SQL_VM_API_VERSION}`);
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 
 	if (response.errors.length > 0) {
@@ -161,7 +161,7 @@ export async function getSqlMigrationService(account: azdata.Account, subscripti
 export async function getSqlMigrationServiceById(account: azdata.Account, subscription: Subscription, sqlMigrationServiceId: string): Promise<SqlMigrationService> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`${sqlMigrationServiceId}?api-version=${DMSV2_API_VERSION}`);
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -173,7 +173,7 @@ export async function getSqlMigrationServiceById(account: azdata.Account, subscr
 export async function getSqlMigrationServicesByResourceGroup(account: azdata.Account, subscription: Subscription, resouceGroupName: string): Promise<SqlMigrationService[]> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resouceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=${DMSV2_API_VERSION}`);
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -188,7 +188,7 @@ export async function getSqlMigrationServicesByResourceGroup(account: azdata.Acc
 export async function getSqlMigrationServices(account: azdata.Account, subscription: Subscription): Promise<SqlMigrationService[]> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=${DMSV2_API_VERSION}`);
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -206,7 +206,7 @@ export async function createSqlMigrationService(account: azdata.Account, subscri
 	const requestBody = {
 		'location': regionName
 	};
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.PUT, requestBody, true, host, getSessionIdHeader(sessionId));
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -235,7 +235,7 @@ export async function createSqlMigrationService(account: azdata.Account, subscri
 export async function getSqlMigrationServiceAuthKeys(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string): Promise<SqlMigrationServiceAuthenticationKeys> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}/ListAuthKeys?api-version=${DMSV2_API_VERSION}`);
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, undefined, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -253,7 +253,7 @@ export async function regenerateSqlMigrationServiceAuthKey(account: azdata.Accou
 		'location': regionName,
 		'keyName': keyName,
 	};
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -279,7 +279,7 @@ export async function getStorageAccountAccessKeys(account: azdata.Account, subsc
 export async function getSqlMigrationServiceMonitoringData(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationService: string): Promise<IntegrationRuntimeMonitoringData> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationService}/listMonitoringData?api-version=${DMSV2_API_VERSION}`);
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, undefined, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -290,7 +290,7 @@ export async function getSqlMigrationServiceMonitoringData(account: azdata.Accou
 export async function startDatabaseMigration(account: azdata.Account, subscription: Subscription, regionName: string, targetServer: SqlManagedInstance | SqlVMServer, targetDatabaseName: string, requestBody: StartDatabaseMigrationRequest, sessionId: string): Promise<StartDatabaseMigrationResponse> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`${targetServer.id}/providers/Microsoft.DataMigration/databaseMigrations/${targetDatabaseName}?api-version=${DMSV2_API_VERSION}`);
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.PUT, requestBody, true, host, getSessionIdHeader(sessionId));
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -310,7 +310,7 @@ export async function getMigrationDetails(account: azdata.Account, subscription:
 		: encodeURI(`${migrationId}?migrationOperationId=${migrationOperationId}&$expand=MigrationStatusDetails&api-version=${DMSV2_API_VERSION}`);
 
 	const api = await getAzureCoreAPI();
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host, undefined);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -322,7 +322,7 @@ export async function getMigrationDetails(account: azdata.Account, subscription:
 export async function getServiceMigrations(account: azdata.Account, subscription: Subscription, resourceId: string): Promise<DatabaseMigration[]> {
 	const path = encodeURI(`${resourceId}/listMigrations?&api-version=${DMSV2_API_VERSION}`);
 	const api = await getAzureCoreAPI();
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -335,7 +335,7 @@ export async function getMigrationTargetInstance(account: azdata.Account, subscr
 	const targetServerId = getMigrationTargetId(migration);
 	const path = encodeURI(`${targetServerId}?api-version=${SQL_MI_API_VERSION}`);
 	const api = await getAzureCoreAPI();
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -347,7 +347,7 @@ export async function getMigrationTargetInstance(account: azdata.Account, subscr
 export async function getMigrationAsyncOperationDetails(account: azdata.Account, subscription: Subscription, url: string): Promise<AzureAsyncOperationResource> {
 	const api = await getAzureCoreAPI();
 	const path = url.replace((new URL(url)).origin + '/', '');	// path is everything after the hostname, e.g. the 'test' part of 'https://management.azure.com/test'
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -359,7 +359,7 @@ export async function startMigrationCutover(account: azdata.Account, subscriptio
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`${migration.id}/cutover?api-version=${DMSV2_API_VERSION}`);
 	const requestBody = { migrationOperationId: migration.properties.migrationOperationId };
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true, host, undefined);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -371,7 +371,7 @@ export async function stopMigration(account: azdata.Account, subscription: Subsc
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`${migration.id}/cancel?api-version=${DMSV2_API_VERSION}`);
 	const requestBody = { migrationOperationId: migration.properties.migrationOperationId };
-	const host = getCorrectArmEndpointForAccount(account);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true, host, undefined);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());

--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -867,6 +867,7 @@ export async function getBlobLastBackupFileNamesValues(lastFileNames: azureResou
 }
 
 export function getCorrectArmEndpointForAccount(account: AzureAccount): string {
+	// Looks up the correct ARM endpoint for the given account, as defined in extensions\azurecore\src\account-provider\providerSettings.ts
 	switch (account.properties.providerSettings.id) {
 		case 'azure_publicCloud':
 			return 'https://management.azure.com';

--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -8,8 +8,7 @@ import { IconPathHelper } from '../constants/iconPathHelper';
 import { MigrationStatus, ProvisioningState } from '../models/migrationLocalStorage';
 import * as crypto from 'crypto';
 import * as azure from './azure';
-import { AzureAccount, azureResource, AzureRestResponse, HttpRequestMethod, IExtension, Tenant, } from 'azurecore';
-// import providerSettings from '../../../azurecore/src/account-provider/providerSettings';
+import { AzureAccount, azureResource, Tenant } from 'azurecore';
 import * as constants from '../constants/strings';
 import { logError, TelemetryViews } from '../telemtery';
 import { AdsMigrationStatus } from '../dashboard/tabBase';
@@ -867,29 +866,19 @@ export async function getBlobLastBackupFileNamesValues(lastFileNames: azureResou
 	return lastFileNamesValues;
 }
 
-// a wrapper for IExtension.makeAzureRestRequest() which automatically populates the correct host depending on which cloud the account is in
-export async function makeAzureRestRequest(api: IExtension, account: AzureAccount, subscription: azureResource.AzureResourceSubscription, path: string, requestType: HttpRequestMethod, requestBody?: any, ignoreErrors?: boolean, zzzzzzz?: string, requestHeaders?: { [key: string]: string }): Promise<AzureRestResponse> {
-	let host;
+export function getCorrectArmEndpointForAccount(account: AzureAccount): string {
 	switch (account.properties.providerSettings.id) {
 		case 'azure_publicCloud':
-			host = 'https://management.azure.com';
-			break;
+			return 'https://management.azure.com';
 		case 'azure_usGovtCloud':
-			host = 'https://management.usgovcloudapi.net';
-			break;
+			return 'https://management.usgovcloudapi.net';
 		case 'azure_usNatCloud':
-			host = 'https://management.core.eaglex.ic.gov';
-			break;
+			return 'https://management.core.eaglex.ic.gov';
 		case 'azure_germanyCloud':
-			host = 'https://management.microsoftazure.de';
-			break;
+			return 'https://management.microsoftazure.de';
 		case 'azure_chinaCloud':
-			host = 'https://management.chinacloudapi.cn';
-			break;
+			return 'https://management.chinacloudapi.cn';
 		default:
-			host = 'https://management.azure.com';
-			break;
+			throw new Error('unknown cloud');
 	}
-
-	return await api.makeAzureRestRequest(account, subscription, path, requestType, requestBody, ignoreErrors, host);
 }

--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -8,7 +8,7 @@ import { IconPathHelper } from '../constants/iconPathHelper';
 import { MigrationStatus, ProvisioningState } from '../models/migrationLocalStorage';
 import * as crypto from 'crypto';
 import * as azure from './azure';
-import { AzureAccount, azureResource, Tenant } from 'azurecore';
+import { azureResource, Tenant } from 'azurecore';
 import * as constants from '../constants/strings';
 import { logError, TelemetryViews } from '../telemtery';
 import { AdsMigrationStatus } from '../dashboard/tabBase';
@@ -864,22 +864,4 @@ export async function getBlobLastBackupFileNamesValues(lastFileNames: azureResou
 		];
 	}
 	return lastFileNamesValues;
-}
-
-export function getCorrectArmEndpointForAccount(account: AzureAccount): string {
-	// Looks up the correct ARM endpoint for the given account, as defined in extensions\azurecore\src\account-provider\providerSettings.ts
-	switch (account.properties.providerSettings.id) {
-		case 'azure_publicCloud':
-			return 'https://management.azure.com';
-		case 'azure_usGovtCloud':
-			return 'https://management.usgovcloudapi.net';
-		case 'azure_usNatCloud':
-			return 'https://management.core.eaglex.ic.gov';
-		case 'azure_germanyCloud':
-			return 'https://management.microsoftazure.de';
-		case 'azure_chinaCloud':
-			return 'https://management.chinacloudapi.cn';
-		default:
-			throw new Error('unknown cloud');
-	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The SQL Migration extension makes use of several functions which interact with the ARM REST API, such as `getLocations`, `createResourceGroup`, `getSqlMigrationService`, `getAvailableSqlVMs`, and more. 

Some of the more common ones (such as `getLocations` and `createResourceGroup`) are provided via the Azure Core API, whereas the others that are more migration specific (such as `getSqlMigrationService` and `getAvailableSqlVMs`) are implemented by the SQL Migration extension API itself. 

An issue was reported (https://github.com/microsoft/azuredatastudio/issues/20275) which stated that non-public cloud users were unable to proceed in the SQL Migration wizard, due to the fact that these functions were trying to call the ARM REST API endpoint for the public cloud (`management.azure.com`) instead of the correct endpoint for the respective non-public clouds (the list of which can be found [here](https://github.com/microsoft/azuredatastudio/blob/main/extensions/azurecore/src/account-provider/providerSettings.ts)). Upon further investigation, both implementations -- both in Azure Core and in SQL Migration -- incorrectly default to the public cloud endpoint regardless of the account type.

In this PR, we modify the implementation of these functions to first examine the provider settings of the provided Azure account, and then make the HTTP request to the correct endpoint based on which cloud the account is a part of. This is done by exposing a new function `getProviderMetadataForAccount` in the Azure Core API. 

Tested and verified that wizard behavior now works as intended in the SQL Migration extension using a test account in USGov.
![image](https://user-images.githubusercontent.com/11844501/184248642-05a4a4dd-2b3e-4e85-af98-460029087b0a.png)

-- *still need to test end to end migration* --