### PR TITLE
SQL MIAA list now accounts for new text output from Azure CLI

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,7 +2,7 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",

--- a/extensions/arc/src/common/utils.ts
+++ b/extensions/arc/src/common/utils.ts
@@ -371,3 +371,15 @@ export function getTimeStamp(dateTime: string | undefined): number {
 export function checkISOTimeString(dateTime: string): boolean {
 	return /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d.*Z/.test(dateTime);
 }
+
+/**
+ * Parses out the SQL MIAA list from the raw json output
+ * @param raw The raw version output from az sql mi-arc list
+ */
+export function parseMiaaList(raw: string): string | undefined {
+	// The output of az sql mi-arc list looks like:
+	// 'Found 1 Arc-enabled SQL Managed Instances in namespace testns1\r\n[\r\n  {\r\n    "name": "sqlinstance1",\r\n    "primaryEndpoint": "20.236.10.81,1422",\r\n    "replicas": "3/3",\r\n    "state": "Ready"\r\n  }\r\n]'
+	const lines = raw.split('\n');
+	lines.splice(0, 1);
+	return lines.join('\n');
+}

--- a/extensions/arc/src/models/controllerModel.ts
+++ b/extensions/arc/src/models/controllerModel.ts
@@ -6,6 +6,7 @@
 import { ControllerInfo, ResourceType } from 'arc';
 import * as azExt from 'az-ext';
 import * as vscode from 'vscode';
+import { parseMiaaList } from '../common/utils';
 import * as loc from '../localizedConstants';
 import { AzureArcTreeDataProvider } from '../ui/tree/azureArcTreeDataProvider';
 
@@ -110,14 +111,15 @@ export class ControllerModel {
 				}));
 			}),
 			this._azApi.az.sql.miarc.list({ resourceGroup: undefined, namespace: namespace }, this.azAdditionalEnvVars).then(result => {
-				newRegistrations.push(...result.stdout.map(r => {
+				let miaaList = parseMiaaList(result.stdout.toString());
+				let jsonList: azExt.SqlMiListResult[] = JSON.parse(<string>miaaList);
+				newRegistrations.push(...jsonList.map(r => {
 					return {
 						instanceName: r.name,
 						state: r.state,
 						instanceType: ResourceType.sqlManagedInstances
 					};
 				}));
-
 			})
 		]).then(() => {
 			this._registrations = newRegistrations;

--- a/extensions/azcli/package.json
+++ b/extensions/azcli/package.json
@@ -2,7 +2,7 @@
   "name": "azcli",
   "displayName": "%azcli.arc.displayName%",
   "description": "%azcli.arc.description%",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",

--- a/extensions/azcli/src/az.ts
+++ b/extensions/azcli/src/az.ts
@@ -207,7 +207,7 @@ export class AzTool implements azExt.IAzApi {
 					// Additional arguments
 				},
 				additionalEnvVars?: azExt.AdditionalEnvVars
-			): Promise<azExt.AzOutput<azExt.SqlMiListResult[]>> => {
+			): Promise<azExt.AzOutput<azExt.SqlMiListRawOutput>> => {
 				const argsArray = ['sql', 'mi-arc', 'list'];
 				if (args.resourceGroup) {
 					argsArray.push('--resource-group', args.resourceGroup);
@@ -216,7 +216,8 @@ export class AzTool implements azExt.IAzApi {
 					argsArray.push('--k8s-namespace', args.namespace);
 					argsArray.push('--use-k8s');
 				}
-				return this.executeCommand<azExt.SqlMiListResult[]>(argsArray, additionalEnvVars);
+				return this.executeCommand<azExt.SqlMiListRawOutput>(argsArray, additionalEnvVars);
+
 			},
 			show: (
 				name: string,

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -29,6 +29,11 @@ declare module 'az-ext' {
 		protocol: string // "https"
 	}
 
+	export interface SqlMiListRawOutput {
+		text: string,
+		miaaList: SqlMiListResult[]
+	}
+
 	export interface SqlMiListResult {
 		name: string, // "arc-miaa"
 		replicas: string, // "1/1"
@@ -592,7 +597,7 @@ declare module 'az-ext' {
 					},
 					// Additional arguments
 					additionalEnvVars?: AdditionalEnvVars
-				): Promise<AzOutput<SqlMiListResult[]>>,
+				): Promise<AzOutput<SqlMiListRawOutput>>,
 				show(
 					name: string,
 					args: {


### PR DESCRIPTION
Bug: Refresh not working because it calls az sql mi-arc list, which now outputs something different.

This fix enables ADS to work with new Azure CLI arcdata ext. The command 'az sql mi-arc list' now outputs this string before the array of objects:
'Found 1 Arc-enabled SQL Managed Instances in namespace ns1'

Changes:
- Added a function that splits the output of az sql mi-arc list into lines and removes the first one.
- After removing first line of text, turn the rest into a JSON output
- Changed the output of az sql mi-arc list in the ADS azcli extension to be SqlMiListRawOutput instead of SqlMiListResult[]