### PR TITLE
Adding a loader spinner before the options load

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -27,6 +27,7 @@ export class PublishOptionsDialog {
 	private excludeObjectTypesOptionsTab: azdataType.window.DialogTab | undefined;
 	private excludeObjectTypesOptionsTable: azdataType.TableComponent | undefined;
 	private excludeObjectTypesOptionsFlexBuilder: azdataType.FlexContainer | undefined;
+	private loader: azdataType.LoadingComponent | undefined;
 
 	constructor(defaultOptions: mssql.DeploymentOptions, private publish: PublishDatabaseDialog) {
 		this.optionsModel = new DeployOptionsModel(defaultOptions);
@@ -62,6 +63,15 @@ export class PublishOptionsDialog {
 
 	private initializeDeploymentOptionsDialogTab(): void {
 		this.optionsTab?.registerContent(async view => {
+			// creating loader component
+			this.loader = view.modelBuilder.loadingComponent()
+				.withProps({
+					CSSStyles: {
+						'margin-top': '350px'
+					}
+				})
+				.component();
+
 			this.descriptionHeading = view.modelBuilder.table().withProps({
 				data: [],
 				columns: [
@@ -108,6 +118,13 @@ export class PublishOptionsDialog {
 				.withLayout({
 					flexFlow: 'column'
 				}).component();
+
+			// adding loader to the flexcontainer
+			this.optionsFlexBuilder.addItem(this.loader);
+			await view.initializeModel(this.optionsFlexBuilder);
+			if (this.loader) {
+				this.loader.loading = false;
+			}
 
 			this.optionsFlexBuilder.addItem(this.optionsTable, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh', 'padding-top': '2px' } });
 			this.optionsFlexBuilder.addItem(this.descriptionHeading, { CSSStyles: { 'font-weight': 'bold', 'height': '30px' } });

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -66,10 +66,19 @@ export class PublishOptionsDialog {
 			const loader = view.modelBuilder.loadingComponent()
 				.withProps({
 					CSSStyles: {
-						'margin-top': '350px'
+						'margin-top': '50%'
 					}
 				})
 				.component();
+
+			this.optionsFlexBuilder = view.modelBuilder.flexContainer()
+				.withLayout({
+					flexFlow: 'column'
+				}).component();
+
+			// adding loading component to the flexcontainer
+			this.optionsFlexBuilder.addItem(loader);
+			await view.initializeModel(this.optionsFlexBuilder);
 
 			this.descriptionHeading = view.modelBuilder.table().withProps({
 				data: [],
@@ -113,19 +122,10 @@ export class PublishOptionsDialog {
 				}
 			}));
 
-			this.optionsFlexBuilder = view.modelBuilder.flexContainer()
-				.withLayout({
-					flexFlow: 'column'
-				}).component();
-
-			// adding loading component to the flexcontainer
-			this.optionsFlexBuilder.addItem(loader);
-			await view.initializeModel(this.optionsFlexBuilder);
-			loader.loading = false;
-
 			this.optionsFlexBuilder.addItem(this.optionsTable, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh', 'padding-top': '2px' } });
 			this.optionsFlexBuilder.addItem(this.descriptionHeading, { CSSStyles: { 'font-weight': 'bold', 'height': '30px' } });
 			this.optionsFlexBuilder.addItem(this.descriptionText, { CSSStyles: { 'padding': '4px', 'margin-right': '10px', 'overflow': 'scroll', 'height': '10vh' } });
+			loader.loading = false;
 			await view.initializeModel(this.optionsFlexBuilder);
 			// focus the first option
 			await this.optionsTable.focus();

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -27,7 +27,6 @@ export class PublishOptionsDialog {
 	private excludeObjectTypesOptionsTab: azdataType.window.DialogTab | undefined;
 	private excludeObjectTypesOptionsTable: azdataType.TableComponent | undefined;
 	private excludeObjectTypesOptionsFlexBuilder: azdataType.FlexContainer | undefined;
-	private loader: azdataType.LoadingComponent | undefined;
 
 	constructor(defaultOptions: mssql.DeploymentOptions, private publish: PublishDatabaseDialog) {
 		this.optionsModel = new DeployOptionsModel(defaultOptions);
@@ -63,8 +62,8 @@ export class PublishOptionsDialog {
 
 	private initializeDeploymentOptionsDialogTab(): void {
 		this.optionsTab?.registerContent(async view => {
-			// creating loader component
-			this.loader = view.modelBuilder.loadingComponent()
+			// create loading component
+			const loader = view.modelBuilder.loadingComponent()
 				.withProps({
 					CSSStyles: {
 						'margin-top': '350px'
@@ -119,12 +118,10 @@ export class PublishOptionsDialog {
 					flexFlow: 'column'
 				}).component();
 
-			// adding loader to the flexcontainer
-			this.optionsFlexBuilder.addItem(this.loader);
+			// adding loading component to the flexcontainer
+			this.optionsFlexBuilder.addItem(loader);
 			await view.initializeModel(this.optionsFlexBuilder);
-			if (this.loader) {
-				this.loader.loading = false;
-			}
+			loader.loading = false;
 
 			this.optionsFlexBuilder.addItem(this.optionsTable, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh', 'padding-top': '2px' } });
 			this.optionsFlexBuilder.addItem(this.descriptionHeading, { CSSStyles: { 'font-weight': 'bold', 'height': '30px' } });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/20282

There is a fraction of seconds delay on initializing the Deployment options component and better to have a loading spinner in place.

Updated:
https://user-images.githubusercontent.com/74571829/184442605-5a480807-a201-4eeb-af80-e29b453055b2.mp4

Old:
https://user-images.githubusercontent.com/74571829/184214799-c5945c12-54eb-4c12-83af-b3a7660c9288.mp4
