### PR TITLE
Use a "Text Size" label for markdown heading dropdown.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -78,7 +78,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 	public insertOrderedList = localize('insertOrderedList', "Insert ordered list");
 	public insertImage = localize('insertImage', "Insert image");
 	public buttonPreview = localize('buttonPreview', "Markdown preview toggle - off");
-	public dropdownHeading = localize('dropdownHeading', "Heading");
+	public headingDropdownLabel = localize('headingDropdownLabel', "Text Size");
 	public optionHeading1 = localize('optionHeading1', "Heading 1");
 	public optionHeading2 = localize('optionHeading2', "Heading 2");
 	public optionHeading3 = localize('optionHeading3', "Heading 3");
@@ -148,7 +148,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 		let codeButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.codeText', '', 'code masked-icon', this.insertCode, this.cellModel, MarkdownButtonType.CODE);
 		let listButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.listText', '', 'list masked-icon', this.insertList, this.cellModel, MarkdownButtonType.UNORDERED_LIST);
 		let orderedListButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.orderedText', '', 'ordered-list masked-icon', this.insertOrderedList, this.cellModel, MarkdownButtonType.ORDERED_LIST);
-		let headingDropdown = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading', '', 'heading', this.dropdownHeading, this.cellModel, null);
+		let headingDropdown = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading', '', 'heading', this.headingDropdownLabel, this.cellModel, null);
 		let heading1 = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading1', this.optionHeading1, 'heading 1', this.optionHeading1, this.cellModel, MarkdownButtonType.HEADING1);
 		let heading2 = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading2', this.optionHeading2, 'heading 2', this.optionHeading2, this.cellModel, MarkdownButtonType.HEADING2);
 		let heading3 = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading3', this.optionHeading3, 'heading 3', this.optionHeading3, this.cellModel, MarkdownButtonType.HEADING3);
@@ -172,7 +172,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			this._actionBar.actionRunner,
 			undefined,
 			'masked-pseudo-after dropdown-arrow heading-dropdown',
-			this.optionParagraph,
+			this.headingDropdownLabel,
 			undefined
 		);
 		dropdownMenuActionViewItem.render(buttonDropdownContainer);


### PR DESCRIPTION
Currently the toolbar dropdown that changes the markdown text size always says "Paragraph" for the label, regardless of which size option is selected. I've changed that label to "Text Size" here for better clarity.

![TextSizeDropdown](https://user-images.githubusercontent.com/12820011/184262146-badb9212-0687-4e7c-840a-90336269df87.PNG)