### PR TITLE
Save db project information when saved in scmp file

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -1126,6 +1126,20 @@ export class SchemaCompareMainWindow {
 		if (ownerUri) {
 			endpointInfo = endpoint;
 			endpointInfo.ownerUri = ownerUri;
+		} else if (endpoint.endpointType === mssql.SchemaCompareEndpointType.Project) {
+			endpointInfo = {
+				endpointType: endpoint.endpointType,
+				packageFilePath: '',
+				serverDisplayName: '',
+				serverName: '',
+				databaseName: '',
+				ownerUri: '',
+				connectionDetails: undefined,
+				projectFilePath: endpoint.projectFilePath,
+				targetScripts: [],
+				dataSchemaProvider: '',
+				folderStructure: 'Schema/Object Type'			// TODO: Pick this automatically from the scmp file, after issue #20332 is resolved (check dsp as well)
+			};
 		} else {
 			// need to do this instead of just setting it to the endpoint because some fields are null which will cause an error when sending the compare request
 			endpointInfo = {
@@ -1135,7 +1149,11 @@ export class SchemaCompareMainWindow {
 				databaseName: '',
 				ownerUri: '',
 				packageFilePath: endpoint.packageFilePath,
-				connectionDetails: undefined
+				connectionDetails: undefined,
+				projectFilePath: '',
+				targetScripts: [],
+				dataSchemaProvider: '',
+				folderStructure: ''
 			};
 		}
 		return endpointInfo;

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -1138,7 +1138,7 @@ export class SchemaCompareMainWindow {
 				projectFilePath: endpoint.projectFilePath,
 				targetScripts: [],
 				dataSchemaProvider: '',
-				folderStructure: 'Schema/Object Type'			// TODO: Pick this automatically from the scmp file, after issue #20332 is resolved (check dsp as well)
+				folderStructure: loc.schemaObjectType			// TODO: Pick this automatically from the scmp file, after issue #20332 is resolved (check dsp as well)
 			};
 		} else {
 			// need to do this instead of just setting it to the endpoint because some fields are null which will cause an error when sending the compare request
@@ -1149,11 +1149,7 @@ export class SchemaCompareMainWindow {
 				databaseName: '',
 				ownerUri: '',
 				packageFilePath: endpoint.packageFilePath,
-				connectionDetails: undefined,
-				projectFilePath: '',
-				targetScripts: [],
-				dataSchemaProvider: '',
-				folderStructure: ''
+				connectionDetails: undefined
 			};
 		}
 		return endpointInfo;


### PR DESCRIPTION
This PR fixes #19228.

After the changes that went in for publishing changes to database projects from remote database, a small functionality was missed where schema compare file when opened didn't understand how to read and use database projects information stored in the scmp file. This PR fixes that scenario.
While working on this, this issue was found: https://github.com/microsoft/azuredatastudio/issues/20332 . For better testing: https://github.com/microsoft/azuredatastudio/issues/20334
