### PR TITLE
Add output channel for SQL Bindings extension

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -25,6 +25,8 @@ export interface ILocalSettingsJson {
 	ConnectionStrings?: { [key: string]: string };
 }
 
+export const outputChannel = vscode.window.createOutputChannel(constants.serviceName);
+
 /**
  * copied and modified from vscode-azurefunctions extension
  * https://github.com/microsoft/vscode-azurefunctions/blob/main/src/funcConfig/local.settings.ts
@@ -198,7 +200,8 @@ export async function getSettingsFile(projectFolder: string): Promise<string | u
  * @param selectedProjectFile is the users selected project file path
  */
 export async function addSqlNugetReferenceToProjectFile(selectedProjectFile: string): Promise<void> {
-	await utils.executeCommand(`dotnet add "${selectedProjectFile}" package ${constants.sqlExtensionPackageName} --prerelease`);
+	let addNugetCommmand = await utils.executeCommand(`dotnet add "${selectedProjectFile}" package ${constants.sqlExtensionPackageName} --prerelease`);
+	outputChannel.appendLine(constants.dotnetResult(addNugetCommmand));
 	TelemetryReporter.sendActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.addSQLNugetPackage);
 }
 

--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -200,8 +200,11 @@ export async function getSettingsFile(projectFolder: string): Promise<string | u
  * @param selectedProjectFile is the users selected project file path
  */
 export async function addSqlNugetReferenceToProjectFile(selectedProjectFile: string): Promise<void> {
+	// clear the output channel prior to adding the nuget reference
+	outputChannel.clear();
 	let addNugetCommmand = await utils.executeCommand(`dotnet add "${selectedProjectFile}" package ${constants.sqlExtensionPackageName} --prerelease`);
 	outputChannel.appendLine(constants.dotnetResult(addNugetCommmand));
+	outputChannel.show(true);
 	TelemetryReporter.sendActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.addSQLNugetPackage);
 }
 

--- a/extensions/sql-bindings/src/common/constants.ts
+++ b/extensions/sql-bindings/src/common/constants.ts
@@ -22,6 +22,7 @@ export const sqlBindingsHelpLink = 'https://github.com/Azure/azure-functions-sql
 export const passwordPlaceholder = '******';
 export const azureFunctionLocalSettingsFileName = 'local.settings.json';
 export const vscodeOpenCommand = 'vscode.open';
+export const serviceName = 'SQL Bindings';
 
 // localized constants
 export const functionNameTitle = localize('functionNameTitle', 'Function Name');
@@ -90,6 +91,7 @@ export function failedToParse(filename: string, error: any): string { return loc
 export function addSqlBinding(functionName: string): string { return localize('addSqlBinding', 'Adding SQL Binding to function "{0}"...'), functionName; }
 export function errorNewAzureFunction(error: any): string { return localize('errorNewAzureFunction', 'Error creating new Azure Function: {0}', utils.getErrorMessage(error)); }
 export function manuallyEnterObjectName(userObjectName: string): string { return `$(pencil) ${userObjectName}`; }
+export function dotnetResult(output: string): string { return localize('dotnetResult', 'Adding SQL nuget package:\n{0}', output); }
 
 // Known Azure settings reference for Azure Functions
 // https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19470.

I added the `SQL Bindings` output channel which will output the sql NuGet dotnet add command which would allow for further understanding of errors.
We will open the channel once we get the result from the `dotnet add package` command scenarios where the user is adding a new Azure function to an existing azure function project.
<img width="628" alt="image" src="https://user-images.githubusercontent.com/23587151/184456100-ba94ec4a-df7e-4409-b43b-abe25884c583.png">

The one thing that had issues would be to edit the warning shown in the issue as that is coming from core command failure logic rather than executing command found [here](https://github.com/microsoft/azuredatastudio/blob/main/extensions/sql-bindings/src/common/utils.ts#L43) where we can add a button to open the channel.
