### PR TITLE
[Port request] Vbump sqltoolsservice in release/1.39

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.2.0.16",
+	"version": "4.2.1.1",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


This PR bumps the version of sqltoolsservice in mssql from 4.2.0.16 to 4.2.1.1, which includes the latest changes from SQL Migration.

See https://github.com/microsoft/sqltoolsservice/pull/1638 and https://github.com/microsoft/azuredatastudio/issues/20370 for more details.
