### PR TITLE
Replace Job Step retry placeholders with values

### DIFF
--- a/extensions/agent/src/dialogs/jobStepDialog.ts
+++ b/extensions/agent/src/dialogs/jobStepDialog.ts
@@ -403,7 +403,7 @@ export class JobStepDialog extends AgentDialog<JobStepData> {
 			.withProps({
 				inputType: 'number',
 				width: '100%',
-				placeHolder: '0'
+				value: '0'
 			})
 			.component();
 		this.retryIntervalBox = view.modelBuilder.inputBox()
@@ -411,7 +411,7 @@ export class JobStepDialog extends AgentDialog<JobStepData> {
 			.withProps({
 				inputType: 'number',
 				width: '100%',
-				placeHolder: '0'
+				value: '0'
 			}).component();
 
 		let retryAttemptsContainer = view.modelBuilder.formContainer()


### PR DESCRIPTION
This PR fixes #https://github.com/microsoft/azuredatastudio/issues/20171.  The controls custom validation is failing since the placeholder property doesn't set the component value.  This requires updating the retry controls to rerun the validation code.  This fix uses the component value properties instead so validation passes on these controls during dialog initialization.
