### PR TITLE
update STS to get fix for broken sql project build

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.2.0.16",
+	"version": "4.2.1.3",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
Bringing over fix for #20368. Also brings these commits into main - they've already been brought into the release/1.39 branch since STS was directly updated there to 4.2.1.2 yesterday.
![image](https://user-images.githubusercontent.com/31145923/185205187-514d23d2-da22-487c-9da8-1d1250d274ea.png)

