### PR TITLE
Ensure SQL Nuget package reference is always updating to latest

### DIFF
--- a/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
+++ b/extensions/sql-bindings/src/common/azureFunctionsUtils.ts
@@ -196,13 +196,13 @@ export async function getSettingsFile(projectFolder: string): Promise<string | u
 }
 
 /**
- * Adds the required nuget package to the project
- * @param selectedProjectFile is the users selected project file path
+ * Adds the latest SQL nuget package to the project
+ * @param projectFolder is the folder containing the project file
  */
-export async function addSqlNugetReferenceToProjectFile(selectedProjectFile: string): Promise<void> {
+export async function addSqlNugetReferenceToProjectFile(projectFolder: string): Promise<void> {
 	// clear the output channel prior to adding the nuget reference
 	outputChannel.clear();
-	let addNugetCommmand = await utils.executeCommand(`dotnet add "${selectedProjectFile}" package ${constants.sqlExtensionPackageName} --prerelease`);
+	let addNugetCommmand = await utils.executeCommand(`dotnet add "${projectFolder}" package ${constants.sqlExtensionPackageName} --prerelease`);
 	outputChannel.appendLine(constants.dotnetResult(addNugetCommmand));
 	outputChannel.show(true);
 	TelemetryReporter.sendActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.addSQLNugetPackage);
@@ -477,8 +477,6 @@ export async function promptAndUpdateConnectionStringSetting(projectUri: vscode.
 				connectionStringSettingName = selectedSetting?.label;
 			}
 		}
-		// Add sql extension package reference to project. If the reference is already there, it doesn't get added again
-		await addSqlNugetReferenceToProjectFile(projectUri.fsPath);
 	} else {
 		// if no AF project was found or there's more than one AF functions project in the workspace,
 		// ask for the user to input the setting name

--- a/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as uuid from 'uuid';
 import * as constants from '../common/constants';
 import * as utils from '../common/utils';
+import * as path from 'path';
 import * as azureFunctionsUtils from '../common/azureFunctionsUtils';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
 import { addSqlBinding, getAzureFunctions } from '../services/azureFunctionsService';
@@ -113,6 +114,13 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined):
 					.withAdditionalProperties(propertyBag).send();
 				return;
 			}
+
+			// Update sql extension package reference to latest SQL binding nuget package
+			// only add if AF project (.csproj) is found
+			if (projectUri?.fsPath) {
+				await azureFunctionsUtils.addSqlNugetReferenceToProjectFile(path.dirname(projectUri?.fsPath));
+			}
+
 			exitReason = 'done';
 			TelemetryReporter.createActionEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding)
 				.withAdditionalProperties(propertyBag).send();

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -255,6 +255,10 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			suppressCreateProjectPrompt: true,
 			...(isCreateNewProject && { executeStep: connectionStringExecuteStep })
 		});
+
+		// Update sql extension package reference to latest SQL binding nuget package
+		await azureFunctionsUtils.addSqlNugetReferenceToProjectFile(projectFolder);
+
 		TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, telemetryStep)
 			.withAdditionalProperties(propertyBag)
 			.withConnectionInfo(connectionInfo).send();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #20353.

When a user uses **_Create Azure Function with SQL binding_** the `addSqlNugetReferenceToProjectFile` function happens before the creation of the cs file (via the createFunction API) call which generates the templates and subsequently updates the .csproj (AF project file) back to the latest released version on the azure functions side.

Instead, I made sure we do this at the end after the azure function project is created and therefore executed after to ensure we always use the latest SQL Bindings NuGet package.

Subsequent change was needed for **_Add SQL binding_** as well so that it can also have the same change. 