### PR TITLE
Fix unpin notebook 

### DIFF
--- a/extensions/notebook/src/book/bookModel.ts
+++ b/extensions/notebook/src/book/bookModel.ts
@@ -117,7 +117,8 @@ export class BookModel {
 	}
 
 	public getNotebook(uri: string): BookTreeItem | undefined {
-		return this._allNotebooks.get(this.openAsUntitled ? path.basename(uri) : uri);
+		const notebookUri = vscode.Uri.file(uri).fsPath;
+		return this._allNotebooks.get(this.openAsUntitled ? path.basename(notebookUri) : notebookUri);
 	}
 
 	public async loadTableOfContentFiles(): Promise<void> {

--- a/extensions/notebook/src/book/bookModel.ts
+++ b/extensions/notebook/src/book/bookModel.ts
@@ -117,8 +117,7 @@ export class BookModel {
 	}
 
 	public getNotebook(uri: string): BookTreeItem | undefined {
-		const notebookUri = vscode.Uri.file(uri).fsPath;
-		return this._allNotebooks.get(this.openAsUntitled ? path.basename(notebookUri) : notebookUri);
+		return this._allNotebooks.get(this.openAsUntitled ? path.basename(uri) : uri);
 	}
 
 	public async loadTableOfContentFiles(): Promise<void> {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -151,8 +151,10 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			if (pinStatusChanged) {
 				// reset to original context value
 				bookTreeItem.contextValue = bookTreeItem.book.type === BookTreeItemType.Markdown ? BookTreeItemType.Markdown : getNotebookType(bookTreeItem.book);
+				// to search for notebook in allNotebooks dictionary we need to format uri
+				const notebookUri = vscode.Uri.file(bookTreeItem.book.contentPath).fsPath;
 				// if notebook is not in current book then it is a standalone notebook
-				let itemOpenedInBookTreeView = this.currentBook?.getNotebook(bookTreeItem.book.contentPath) ?? this.books.find(book => book.bookPath === bookTreeItem.book.contentPath)?.getNotebook(bookTreeItem.book.contentPath);
+				let itemOpenedInBookTreeView = this.currentBook?.getNotebook(notebookUri) ?? this.books.find(book => book.bookPath === bookTreeItem.book.contentPath)?.getNotebook(notebookUri);
 				if (itemOpenedInBookTreeView) {
 					itemOpenedInBookTreeView.contextValue = bookTreeItem.contextValue;
 					this._onDidChangeTreeData.fire(itemOpenedInBookTreeView.parent);


### PR DESCRIPTION
We looking for the notebook tree item in the book model, we need to convert the uri to vscode Uri format, otherwise the notebook is not found in windows since we are trying to match` c://path/to/notebook` to `c:\\path\\to\\notebook`

This PR addresses #20392
