### PR TITLE
add current open folder to new project quickpick

### DIFF
--- a/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
@@ -49,13 +49,15 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 
 	const defaultProjectSaveLoc = defaultProjectSaveLocation();
 	const browseProjectLocationOptions = [constants.BrowseEllipsisWithIcon];
-	if (defaultProjectSaveLoc) {
-		browseProjectLocationOptions.unshift(defaultProjectSaveLoc.fsPath);
-	}
 
 	// if there's an open folder, add it for easier access. If there are multiple folders in the workspace, default to the first one
 	if (vscode.workspace.workspaceFolders) {
 		browseProjectLocationOptions.unshift(vscode.workspace.workspaceFolders[0].uri.fsPath);
+	}
+
+	// add default project save location if it's been set
+	if (defaultProjectSaveLoc) {
+		browseProjectLocationOptions.unshift(defaultProjectSaveLoc.fsPath);
 	}
 
 	// 3. Prompt for Project location

--- a/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
@@ -52,6 +52,12 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 	if (defaultProjectSaveLoc) {
 		browseProjectLocationOptions.unshift(defaultProjectSaveLoc.fsPath);
 	}
+
+	// if there's an open folder, add it for easier access. If there are multiple folders in the workspace, default to the first one
+	if (vscode.workspace.workspaceFolders) {
+		browseProjectLocationOptions.unshift(vscode.workspace.workspaceFolders[0].uri.fsPath);
+	}
+
 	// 3. Prompt for Project location
 	// We validate that the folder doesn't already exist, and if it does keep prompting them to pick a new one
 	let projectLocation = '';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes the vscode part of #19272. This adds the current open folder, or the first workspace folder if there are multiple, as options to speed up the create new project flow.

New project dialog with one open folder:
![image](https://user-images.githubusercontent.com/31145923/185513655-0bb87d1b-1559-4cb6-a92f-4b40f86db2f4.png)

when one or more folders in the workspace and the user also has the `Default Project Save Location` setting, both are added in the quickpick
![image](https://user-images.githubusercontent.com/31145923/185702928-fbbf6874-5654-4edd-991e-601f7d2e2e74.png)

no workspace/no folder open
![image](https://user-images.githubusercontent.com/31145923/185513930-8cf79d28-0f0e-45ab-acaf-0e321eeab6cf.png)


