### PR TITLE
bump pipeline image to Ubuntu 20.04

### DIFF
--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'Ubuntu-18.04'
+  vmImage: 'Ubuntu-20.04'
 
 trigger:
   branches:

--- a/build/azure-pipelines/linux/Dockerfile
+++ b/build/azure-pipelines/linux/Dockerfile
@@ -1,5 +1,5 @@
-#Download base image ubuntu 18.04
-FROM mcr.microsoft.com/mirror/docker/library/ubuntu:18.04
+#Download base image ubuntu 20.04
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04
 
 #Adding apt repos for g++-4.9
 RUN echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -7,7 +7,7 @@ resources:
 jobs:
 - job: Compile
   pool:
-    vmImage: 'Ubuntu-18.04'
+    vmImage: 'Ubuntu-20.04'
   container: linux-x64
   steps:
   - script: |
@@ -40,7 +40,7 @@ jobs:
 - job: Linux
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_LINUX'], 'true'))
   pool:
-    vmImage: 'Ubuntu-18.04'
+    vmImage: 'Ubuntu-20.04'
   container: linux-x64
   dependsOn:
   - Compile
@@ -75,7 +75,7 @@ jobs:
 - job: Release
   condition: and(succeeded(), or(eq(variables['VSCODE_RELEASE'], 'true'), and(eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['Build.Reason'], 'Schedule'))))
   pool:
-    vmImage: 'Ubuntu-18.04'
+    vmImage: 'Ubuntu-20.04'
   dependsOn:
   - macOS
   - Linux

--- a/build/azure-pipelines/sql-web-build.yml
+++ b/build/azure-pipelines/sql-web-build.yml
@@ -7,7 +7,7 @@ resources:
 jobs:
 - job: LinuxWeb
   pool:
-    vmImage: 'Ubuntu-18.04'
+    vmImage: 'Ubuntu-20.04'
   container: linux-x64
   variables:
     VSCODE_ARCH: x64
@@ -17,7 +17,7 @@ jobs:
 
 - job: Docker
   pool:
-    vmImage: 'Ubuntu-18.04'
+    vmImage: 'Ubuntu-20.04'
   container: linux-x64
   dependsOn:
   - LinuxWeb


### PR DESCRIPTION
This PR bumps pipeline image to Ubuntu 20.04
Product build and web build are passing with this change.
I've done basic sanity testing with the build drop on Windows, Mac and Ubuntu 18.04, no outstanding issues.

![image](https://user-images.githubusercontent.com/21186993/185515915-c7666210-fe6d-45ee-a77d-06de908b1f69.png)
