### PR TITLE
use default folder or open folder as initial location in new project dialog

### DIFF
--- a/extensions/data-workspace/src/dialogs/newProjectDialog.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectDialog.ts
@@ -193,14 +193,10 @@ export class NewProjectDialog extends DialogBase {
 			width: constants.DefaultInputWidth
 		}).component();
 
+		// use the default save location if it's there
+		// otherwise, if there's an open folder, set the initial location to that. If there are multiple folders in the workspace, default to the first one
 		const defaultSaveLocation = defaultProjectSaveLocation();
-		if (defaultSaveLocation) {
-			// use the default save location if it's there
-			locationTextBox.value = defaultSaveLocation.fsPath;
-		} else if (vscode.workspace.workspaceFolders) {
-			// otherwise, if there's an open folder, set the initial location to that. If there are multiple folders in the workspace, default to the first one
-			locationTextBox.value = vscode.workspace.workspaceFolders[0].uri.fsPath;
-		}
+		locationTextBox.value = defaultSaveLocation?.fsPath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
 		this.register(locationTextBox.onTextChanged(() => {
 			this.model.location = locationTextBox.value!;

--- a/extensions/data-workspace/src/dialogs/newProjectDialog.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectDialog.ts
@@ -193,6 +193,15 @@ export class NewProjectDialog extends DialogBase {
 			width: constants.DefaultInputWidth
 		}).component();
 
+		const defaultSaveLocation = defaultProjectSaveLocation();
+		if (defaultSaveLocation) {
+			// use the default save location if it's there
+			locationTextBox.value = defaultSaveLocation.fsPath;
+		} else if (vscode.workspace.workspaceFolders) {
+			// otherwise, if there's an open folder, set the initial location to that. If there are multiple folders in the workspace, default to the first one
+			locationTextBox.value = vscode.workspace.workspaceFolders[0].uri.fsPath;
+		}
+
 		this.register(locationTextBox.onTextChanged(() => {
 			this.model.location = locationTextBox.value!;
 			return locationTextBox.updateProperty('title', locationTextBox.value);
@@ -209,7 +218,7 @@ export class NewProjectDialog extends DialogBase {
 				canSelectFiles: false,
 				canSelectFolders: true,
 				canSelectMany: false,
-				defaultUri: defaultProjectSaveLocation()
+				defaultUri: locationTextBox.value ? vscode.Uri.file(locationTextBox.value) : undefined
 			});
 			if (!folderUris || folderUris.length === 0) {
 				return;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19272. Previously, the location text box started as empty. To help speed up the create project flow, this changes populates that with an initial location in a couple cases. Similar to the change in https://github.com/microsoft/azuredatastudio/pull/20414

With this change, if the `Default Project Save Location` setting has a location set, the location text box will be initially populated with that value. Otherwise if there is an open folder, that folder, or the first workspace folder if there are multiple, is the initial value in the location text box.
