### PR TITLE
Clear invalid taskbar actions when changing notebook providers.

### DIFF
--- a/src/sql/base/browser/ui/taskbar/taskbar.ts
+++ b/src/sql/base/browser/ui/taskbar/taskbar.ts
@@ -162,4 +162,7 @@ export class Taskbar {
 		this.actionBar.dispose();
 	}
 
+	public clear(): void {
+		this.actionBar.clear();
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/20086

Following on from an offline design discussion, we should be removing invalid taskbar actions when changing notebook providers, rather than keeping them and marking them as disabled. For example, the Manage Packages button will get cleared when changing kernels from Python 3 to SQL.

![ActionBar](https://user-images.githubusercontent.com/12820011/186494713-8ab601d9-68b7-4f0f-abb9-b850bc5efc87.gif)