### PR TITLE
Update SQL Agent extension in gallery to 0.49.0

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -14,14 +14,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.48.0",
-							"lastUpdated": "4/16/2020",
+							"version": "0.49.0",
+							"lastUpdated": "8/24/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/agent/agent-0.48.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/agent/agent-0.49.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -14,14 +14,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.48.0",
-							"lastUpdated": "11/05/2020",
+							"version": "0.49.0",
+							"lastUpdated": "8/24/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/agent/agent-0.48.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/agent/agent-0.49.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Update SQL Agent extension to 0.49.0 to pickup bug fix for Add Step dialog OK button not enabling.

The latest extension is available in the Aug release build https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=168186&view=results.
