### PR TITLE
Fix 'failed to load source map' warnings in console

### DIFF
--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -173,7 +173,7 @@ function rewriteSourceMappingURL(sourceMappingURLBase) {
         .pipe(es.mapSync(f => {
         const contents = f.contents.toString('utf8');
         const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
-        f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=((?!data:).*)$/gm, str));
+        f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=((?!data:).*)$/gm, str)); // {{SQL CARBON EDIT}} Don't rewrite embedded source maps - some of our dependencies have these (sanitize-html)
         return f;
     }));
     return es.duplex(input, output);

--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -171,9 +171,9 @@ function rewriteSourceMappingURL(sourceMappingURLBase) {
     const input = es.through();
     const output = input
         .pipe(es.mapSync(f => {
-        const contents = f.contents.toString('utf8');
-        const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
-        f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, str));
+        //const contents = (<Buffer>f.contents).toString('utf8');
+        //const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
+        //f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, str));
         return f;
     }));
     return es.duplex(input, output);

--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -171,9 +171,9 @@ function rewriteSourceMappingURL(sourceMappingURLBase) {
     const input = es.through();
     const output = input
         .pipe(es.mapSync(f => {
-        //const contents = (<Buffer>f.contents).toString('utf8');
-        //const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
-        //f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, str));
+        const contents = f.contents.toString('utf8');
+        const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
+        f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=((?!data:).*)$/gm, str));
         return f;
     }));
     return es.duplex(input, output);

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -225,9 +225,9 @@ export function rewriteSourceMappingURL(sourceMappingURLBase: string): NodeJS.Re
 
 	const output = input
 		.pipe(es.mapSync<VinylFile, VinylFile>(f => {
-			//const contents = (<Buffer>f.contents).toString('utf8');
-			//const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
-			//f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, str));
+			const contents = (<Buffer>f.contents).toString('utf8');
+			const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
+			f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=((?!data:).*)$/gm, str));
 			return f;
 		}));
 

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -227,7 +227,7 @@ export function rewriteSourceMappingURL(sourceMappingURLBase: string): NodeJS.Re
 		.pipe(es.mapSync<VinylFile, VinylFile>(f => {
 			const contents = (<Buffer>f.contents).toString('utf8');
 			const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
-			f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=((?!data:).*)$/gm, str));
+			f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=((?!data:).*)$/gm, str)); // {{SQL CARBON EDIT}} Don't rewrite embedded source maps - some of our dependencies have these (sanitize-html)
 			return f;
 		}));
 

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -225,9 +225,9 @@ export function rewriteSourceMappingURL(sourceMappingURLBase: string): NodeJS.Re
 
 	const output = input
 		.pipe(es.mapSync<VinylFile, VinylFile>(f => {
-			const contents = (<Buffer>f.contents).toString('utf8');
-			const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
-			f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, str));
+			//const contents = (<Buffer>f.contents).toString('utf8');
+			//const str = `//# sourceMappingURL=${sourceMappingURLBase}/${path.dirname(f.relative).replace(/\\/g, '/')}/$1`;
+			//f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, str));
 			return f;
 		}));
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28519865/186472501-7ee9671f-26c2-43de-b5d9-f959ebf84713.png)

The root cause here is that we have a package (sanitize-html) that contains embedded source maps. These were being blindly rewritten to append the source map URL, which resulted in an invalid URL. 

So fixing this by ignoring embedded source maps when rewriting the URLs. VS Code doesn't seem to have this problem (the package that was causing this isn't used by them and I didn't see any others that were like this) so they don't currently bother doing this kind of check. 

![image](https://user-images.githubusercontent.com/28519865/186484055-9a276fa4-24da-434e-b3b0-e41ce4638289.png)
