### PR TITLE
[SQL Migration] Revert dependency on new Azure Core API changes

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -38,8 +38,8 @@ export async function getLocations(account: azdata.Account, subscription: Subscr
 	const response = await api.getLocations(account, subscription, true);
 
 	const path = `/subscriptions/${subscription.id}/providers/Microsoft.DataMigration?api-version=${ARM_MGMT_API_VERSION}`;
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const dataMigrationResourceProvider = (await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host)).response.data;
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const dataMigrationResourceProvider = (await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true)).response.data;
 
 	const sqlMigratonResource = dataMigrationResourceProvider.resourceTypes.find((r: any) => r.resourceType === 'SqlMigrationServices');
 	const sqlMigrationResourceLocations = sqlMigratonResource.locations;
@@ -206,8 +206,8 @@ export type SqlVMServer = {
 export async function getAvailableSqlDatabaseServers(account: azdata.Account, subscription: Subscription): Promise<AzureSqlDatabaseServer[]> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/providers/Microsoft.Sql/servers?api-version=${SQL_SQLDB_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -218,8 +218,8 @@ export async function getAvailableSqlDatabaseServers(account: azdata.Account, su
 export async function getAvailableSqlDatabases(account: azdata.Account, subscription: Subscription, resourceGroupName: string, serverName: string): Promise<AzureSqlDatabase[]> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.Sql/servers/${serverName}/databases?api-version=${SQL_SQLDB_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -230,8 +230,8 @@ export async function getAvailableSqlDatabases(account: azdata.Account, subscrip
 export async function getAvailableSqlVMs(account: azdata.Account, subscription: Subscription): Promise<SqlVMServer[]> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines?api-version=${SQL_VM_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
@@ -280,8 +280,8 @@ export async function getSqlMigrationService(account: azdata.Account, subscripti
 export async function getSqlMigrationServiceById(account: azdata.Account, subscription: Subscription, sqlMigrationServiceId: string): Promise<SqlMigrationService> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`${sqlMigrationServiceId}?api-version=${DMSV2_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -292,8 +292,8 @@ export async function getSqlMigrationServiceById(account: azdata.Account, subscr
 export async function getSqlMigrationServicesByResourceGroup(account: azdata.Account, subscription: Subscription, resouceGroupName: string): Promise<SqlMigrationService[]> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resouceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=${DMSV2_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -307,8 +307,8 @@ export async function getSqlMigrationServicesByResourceGroup(account: azdata.Acc
 export async function getSqlMigrationServices(account: azdata.Account, subscription: Subscription): Promise<SqlMigrationService[]> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=${DMSV2_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -322,11 +322,11 @@ export async function getSqlMigrationServices(account: azdata.Account, subscript
 export async function createSqlMigrationService(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string, sessionId: string): Promise<SqlMigrationService> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}?api-version=${DMSV2_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const requestBody = {
 		'location': regionName
 	};
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.PUT, requestBody, true, host, getSessionIdHeader(sessionId));
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.PUT, requestBody, true, 'https://management.azure.com', getSessionIdHeader(sessionId));
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -336,7 +336,7 @@ export async function createSqlMigrationService(account: azdata.Account, subscri
 	const maxRetry = 24;
 	let i = 0;
 	for (i = 0; i < maxRetry; i++) {
-		const asyncResponse = await api.makeAzureRestRequest(account, subscription, asyncPath, azurecore.HttpRequestMethod.GET, undefined, true, host);
+		const asyncResponse = await api.makeAzureRestRequest(account, subscription, asyncPath, azurecore.HttpRequestMethod.GET, undefined, true);
 		const creationStatus = asyncResponse.response.data.status;
 		if (creationStatus === constants.ProvisioningState.Succeeded) {
 			break;
@@ -354,8 +354,8 @@ export async function createSqlMigrationService(account: azdata.Account, subscri
 export async function getSqlMigrationServiceAuthKeys(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string): Promise<SqlMigrationServiceAuthenticationKeys> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}/ListAuthKeys?api-version=${DMSV2_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -372,8 +372,8 @@ export async function regenerateSqlMigrationServiceAuthKey(account: azdata.Accou
 		'location': regionName,
 		'keyName': keyName,
 	};
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -398,8 +398,8 @@ export async function getStorageAccountAccessKeys(account: azdata.Account, subsc
 export async function getSqlMigrationServiceMonitoringData(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationService: string): Promise<IntegrationRuntimeMonitoringData> {
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationService}/listMonitoringData?api-version=${DMSV2_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -417,8 +417,8 @@ export async function startDatabaseMigration(
 
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`${targetServer.id}/providers/Microsoft.DataMigration/databaseMigrations/${targetDatabaseName}?api-version=${DMSV2_API_VERSION}`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.PUT, requestBody, true, host, getSessionIdHeader(sessionId));
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.PUT, requestBody, true, 'https://management.azure.com', getSessionIdHeader(sessionId));
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -437,8 +437,8 @@ export async function getMigrationDetails(account: azdata.Account, subscription:
 		: encodeURI(`${migrationId}?migrationOperationId=${migrationOperationId}&$expand=MigrationStatusDetails&api-version=${DMSV2_API_VERSION}`);
 
 	const api = await getAzureCoreAPI();
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host, undefined);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -449,8 +449,8 @@ export async function getMigrationDetails(account: azdata.Account, subscription:
 export async function getServiceMigrations(account: azdata.Account, subscription: Subscription, resourceId: string): Promise<DatabaseMigration[]> {
 	const path = encodeURI(`${resourceId}/listMigrations?&api-version=${DMSV2_API_VERSION}`);
 	const api = await getAzureCoreAPI();
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -462,8 +462,8 @@ export async function getMigrationTargetInstance(account: azdata.Account, subscr
 	const targetServerId = getMigrationTargetId(migration);
 	const path = encodeURI(`${targetServerId}?api-version=${SQL_MI_API_VERSION}`);
 	const api = await getAzureCoreAPI();
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -474,8 +474,8 @@ export async function getMigrationTargetInstance(account: azdata.Account, subscr
 export async function getMigrationAsyncOperationDetails(account: azdata.Account, subscription: Subscription, url: string): Promise<AzureAsyncOperationResource> {
 	const api = await getAzureCoreAPI();
 	const path = url.replace((new URL(url)).origin + '/', '');	// path is everything after the hostname, e.g. the 'test' part of 'https://management.azure.com/test'
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -486,8 +486,8 @@ export async function startMigrationCutover(account: azdata.Account, subscriptio
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`${migration.id}/cutover?api-version=${DMSV2_API_VERSION}`);
 	const requestBody = { migrationOperationId: migration.properties.migrationOperationId };
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true, host, undefined);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}
@@ -498,8 +498,8 @@ export async function stopMigration(account: azdata.Account, subscription: Subsc
 	const api = await getAzureCoreAPI();
 	const path = encodeURI(`${migration.id}/cancel?api-version=${DMSV2_API_VERSION}`);
 	const requestBody = { migrationOperationId: migration.properties.migrationOperationId };
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true, host, undefined);
+	// const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, requestBody, true);
 	if (response.errors.length > 0) {
 		throw new Error(response.errors.toString());
 	}

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -109,20 +109,20 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			// and came back, forcibly reload the location/resource group/resource values since they will now be different
 			this._migrationTargetPlatform = this.migrationStateModel._targetType;
 
-			await this._azureResourceTable.setDataValues([]);
-			this._targetPasswordInputBox.value = '';
-			this.migrationStateModel._sqlMigrationServices = undefined!;
-			this.migrationStateModel._targetServerInstance = undefined!;
-			this.migrationStateModel._resourceGroup = undefined!;
-			this.migrationStateModel._location = undefined!;
+			// await this._azureResourceTable.setDataValues([]);
+			// this._targetPasswordInputBox.value = '';
+			// this.migrationStateModel._sqlMigrationServices = undefined!;
+			// this.migrationStateModel._targetServerInstance = undefined!;
+			// this.migrationStateModel._resourceGroup = undefined!;
+			// this.migrationStateModel._location = undefined!;
 			await this.populateLocationDropdown();
 		}
 
-		if (this.migrationStateModel._didUpdateDatabasesForMigration) {
-			await this._azureResourceTable.setDataValues([]);
-			this._initializeSourceTargetDatabaseMap();
-			this._updateConnectionButtonState();
-		}
+		// if (this.migrationStateModel._didUpdateDatabasesForMigration) {
+		// 	await this._azureResourceTable.setDataValues([]);
+		// 	this._initializeSourceTargetDatabaseMap();
+		// 	this._updateConnectionButtonState();
+		// }
 
 		this.wizard.registerNavigationValidator((pageChangeInfo) => {
 			this.wizard.message = { text: '' };

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -108,8 +108,21 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			// if the user had previously selected values on this page, then went back to change the migration target platform
 			// and came back, forcibly reload the location/resource group/resource values since they will now be different
 			this._migrationTargetPlatform = this.migrationStateModel._targetType;
+
+			// await this._azureResourceTable.setDataValues([]);
+			// this._targetPasswordInputBox.value = '';
+			// this.migrationStateModel._sqlMigrationServices = undefined!;
+			// this.migrationStateModel._targetServerInstance = undefined!;
+			// this.migrationStateModel._resourceGroup = undefined!;
+			// this.migrationStateModel._location = undefined!;
 			await this.populateLocationDropdown();
 		}
+
+		// if (this.migrationStateModel._didUpdateDatabasesForMigration) {
+		// 	await this._azureResourceTable.setDataValues([]);
+		// 	this._initializeSourceTargetDatabaseMap();
+		// 	this._updateConnectionButtonState();
+		// }
 
 		this.wizard.registerNavigationValidator((pageChangeInfo) => {
 			this.wizard.message = { text: '' };

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -108,21 +108,8 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			// if the user had previously selected values on this page, then went back to change the migration target platform
 			// and came back, forcibly reload the location/resource group/resource values since they will now be different
 			this._migrationTargetPlatform = this.migrationStateModel._targetType;
-
-			// await this._azureResourceTable.setDataValues([]);
-			// this._targetPasswordInputBox.value = '';
-			// this.migrationStateModel._sqlMigrationServices = undefined!;
-			// this.migrationStateModel._targetServerInstance = undefined!;
-			// this.migrationStateModel._resourceGroup = undefined!;
-			// this.migrationStateModel._location = undefined!;
 			await this.populateLocationDropdown();
 		}
-
-		// if (this.migrationStateModel._didUpdateDatabasesForMigration) {
-		// 	await this._azureResourceTable.setDataValues([]);
-		// 	this._initializeSourceTargetDatabaseMap();
-		// 	this._updateConnectionButtonState();
-		// }
 
 		this.wizard.registerNavigationValidator((pageChangeInfo) => {
 			this.wizard.message = { text: '' };

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -109,20 +109,20 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			// and came back, forcibly reload the location/resource group/resource values since they will now be different
 			this._migrationTargetPlatform = this.migrationStateModel._targetType;
 
-			// await this._azureResourceTable.setDataValues([]);
-			// this._targetPasswordInputBox.value = '';
-			// this.migrationStateModel._sqlMigrationServices = undefined!;
-			// this.migrationStateModel._targetServerInstance = undefined!;
-			// this.migrationStateModel._resourceGroup = undefined!;
-			// this.migrationStateModel._location = undefined!;
+			await this._azureResourceTable.setDataValues([]);
+			this._targetPasswordInputBox.value = '';
+			this.migrationStateModel._sqlMigrationServices = undefined!;
+			this.migrationStateModel._targetServerInstance = undefined!;
+			this.migrationStateModel._resourceGroup = undefined!;
+			this.migrationStateModel._location = undefined!;
 			await this.populateLocationDropdown();
 		}
 
-		// if (this.migrationStateModel._didUpdateDatabasesForMigration) {
-		// 	await this._azureResourceTable.setDataValues([]);
-		// 	this._initializeSourceTargetDatabaseMap();
-		// 	this._updateConnectionButtonState();
-		// }
+		if (this.migrationStateModel._didUpdateDatabasesForMigration) {
+			await this._azureResourceTable.setDataValues([]);
+			this._initializeSourceTargetDatabaseMap();
+			this._updateConnectionButtonState();
+		}
 
 		this.wizard.registerNavigationValidator((pageChangeInfo) => {
 			this.wizard.message = { text: '' };


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Initially, we had an [issue](https://github.com/microsoft/azuredatastudio/issues/20275) reported where the SQL Migration extension did not work for customers in USGov. Upon further investigation, it was determined that this was due to a bug in the Azure Core API (which the SQL Migration extension relies on) which incorrectly assumed that all customers were in the public cloud.

So, in a previous PR (https://github.com/microsoft/azuredatastudio/pull/20304), we added a new `getProviderMetadataForAccount` function to the Azure Core API, which fixed the issue, and then we started consuming this new function all over the SQL Migration extension. 

In its current state, the extension works properly on insiders, as well as on local dev builds of ADS. However, it does not work properly (i.e. dropdowns don't load properly, etc) in any production version of ADS, past or present, including the v1.39 version which was just released recently, because the aforementioned changes to Azure Core did not actually end up making it into the product release on time. Therefore, this `getProviderMetadataForAccount` functionality that the SQL Migration extension now depends on is not actually available yet. 

This PR removes the dependency on this functionality in the SQL Migration extension, allowing the extension to work in production versions of ADS. Once ADS consumes the Azure Core changes, we can revert this PR.

This of course means we're back where we started in the sense that the extension will still not work for USGov/non-public cloud customers, which was the point of the fix to begin with, but this can still be worked around by directing customers to use insiders with a private build of the extension.

Issue was reproed by several team members and fix was also validated by several team members.