### PR TITLE
Added message for no username provided

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1231,6 +1231,10 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 						if (connectionMngInfo.serverInfo) {
 							connection.options.isCloud = connectionMngInfo.serverInfo.isCloud;
 						}
+						else if (connectionMngInfo.ownerUri.indexOf('|user:|') !== -1) {
+							this._logService.info(`Server info provided is missing the required username for ${uri}`);
+							errorMessage = nls.localize('connectionManagementService.noUsernameForString', "Connection string is missing the required \"User Id\" property.");
+						}
 						resolve({ connected: connectResult, errorMessage: errorMessage, errorCode: errorCode, callStack: callStack, connectionProfile: connection });
 					}
 				}

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1234,7 +1234,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 						else if (connection.userName.length === 0) {
 							let connectionDisplayName = this._capabilitiesService.getCapabilities(connectionInfo.providerId).connection.displayName;
 							this._logService.info(`Connection info provided is missing the required username for ` + connectionDisplayName);
-							errorMessage = nls.localize('connectionManagementService.noUsername', "Required username is missing.");
+							errorMessage = nls.localize('connectionManagementService.noUsername', "Required username is missing for the \"{0}\" connection.", connectionDisplayName);
 						}
 						resolve({ connected: connectResult, errorMessage: errorMessage, errorCode: errorCode, callStack: callStack, connectionProfile: connection });
 					}

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1231,9 +1231,10 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 						if (connectionMngInfo.serverInfo) {
 							connection.options.isCloud = connectionMngInfo.serverInfo.isCloud;
 						}
-						else if (connectionMngInfo.ownerUri.indexOf('|user:|') !== -1) {
-							this._logService.info(`Server info provided is missing the required username for ${uri}`);
-							errorMessage = nls.localize('connectionManagementService.noUsernameForString', "Connection string is missing the required \"User Id\" property.");
+						else if (connection.userName.length === 0) {
+							let connectionDisplayName = this._capabilitiesService.getCapabilities(connectionInfo.providerId).connection.displayName;
+							this._logService.info(`Connection info provided is missing the required username for ` + connectionDisplayName);
+							errorMessage = nls.localize('connectionManagementService.noUsername', "Required username is missing.");
 						}
 						resolve({ connected: connectResult, errorMessage: errorMessage, errorCode: errorCode, callStack: callStack, connectionProfile: connection });
 					}

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1228,13 +1228,16 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 						this._connectionStatusManager.deleteConnection(uri);
 						resolve({ connected: connectResult, errorMessage: errorMessage, errorCode: errorCode, callStack: callStack, connectionProfile: connection });
 					} else {
+						let connectionOptions = this._capabilitiesService.getCapabilities(connection.providerName).connection.connectionOptions;
+						let authTypeRequired = connectionOptions.find(option => option.specialValueType === ConnectionOptionSpecialType.authType)?.isRequired;
 						if (connectionMngInfo.serverInfo) {
 							connection.options.isCloud = connectionMngInfo.serverInfo.isCloud;
 						}
-						else if (connection.userName.length === 0) {
-							let connectionDisplayName = this._capabilitiesService.getCapabilities(connectionInfo.providerId).connection.displayName;
-							this._logService.info(`Connection info provided is missing the required username for ` + connectionDisplayName);
-							errorMessage = nls.localize('connectionManagementService.noUsername', "Required username is missing for the \"{0}\" connection.", connectionDisplayName);
+						else if (connection.authenticationType === 'SqlLogin' && authTypeRequired && connection.userName.length === 0) {
+							let userNameDisplayName = this._capabilitiesService.getCapabilities(connection.providerName).connection.connectionOptions.find(
+								option => option.specialValueType === ConnectionOptionSpecialType.userName).displayName;
+							errorMessage = nls.localize('connectionManagementService.noUsername', "Required {0} is missing for the connection.", userNameDisplayName);
+							this._logService.info(errorMessage);
 						}
 						resolve({ connected: connectResult, errorMessage: errorMessage, errorCode: errorCode, callStack: callStack, connectionProfile: connection });
 					}


### PR DESCRIPTION
It turns out that when no username is provided for a regular Sql Login connection string, it does not return an error message (from STS), also the returned ServerInfo is null as well. In order to handle this, I added an edge case in ConnectionManagementService's createNewConnection function to account for this, adding an appropriate error message. 

This PR fixes #20111
