### PR TITLE
Fix broken 'Create new' DMS dialog

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -531,7 +531,7 @@ export const TABLE_SELECTION_HASROWS_COLUMN = localize('sql.migratino.table.sele
 // integration runtime page
 export const SELECT_RESOURCE_GROUP = localize('sql.migration.blob.resourceGroup.select', "Select a resource group.");
 export const IR_PAGE_TITLE = localize('sql.migration.ir.page.title', "Azure Database Migration Service");
-export const IR_PAGE_DESCRIPTION = localize('sql.migration.ir.page.description', "Azure Database Migration Service orchestrates database migration activities and tracks their progress. You can select an existing Database Migration Service as an Azure SQL target if you have created one previously, or create a new one below.");
+export const IR_PAGE_DESCRIPTION = localize('sql.migration.ir.page.description', "Azure Database Migration Service orchestrates database migration activities and tracks their progress. You can select an existing Database Migration Service if you have created one previously, or create a new one below.");
 export const SQL_MIGRATION_SERVICE_NOT_FOUND_ERROR = localize('sql.migration.ir.page.sql.migration.service.not.found', "No Database Migration Service found. Create a new one.");
 export const CREATE_NEW = localize('sql.migration.create.new', "Create new");
 export const CREATE_NEW_MIGRATION_SERVICE = localize('sql.migration.create.new.migration.service', "Create new migration service");

--- a/extensions/sql-migration/src/wizard/integrationRuntimePage.ts
+++ b/extensions/sql-migration/src/wizard/integrationRuntimePage.ts
@@ -227,7 +227,9 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 					const dialog = new CreateSqlMigrationServiceDialog();
 					const createdDmsResult = await dialog.createNewDms(
 						this.migrationStateModel,
-						(<azdata.CategoryValue>this._resourceGroupDropdown.value).displayName);
+						this._resourceGroupDropdown.value
+							? (<azdata.CategoryValue>this._resourceGroupDropdown.value).displayName
+							: '');
 
 					this.migrationStateModel._sqlMigrationServiceResourceGroup = createdDmsResult.resourceGroup;
 					this.migrationStateModel._sqlMigrationService = createdDmsResult.service;

--- a/extensions/sql-migration/src/wizard/summaryPage.ts
+++ b/extensions/sql-migration/src/wizard/summaryPage.ts
@@ -111,8 +111,7 @@ export class SummaryPage extends MigrationWizardPage {
 						: (isSqlMiTarget)
 							? constants.SUMMARY_MI_TYPE
 							: constants.SUMMARY_SQLDB_TYPE,
-					await this.migrationStateModel.getLocationDisplayName(
-						this.migrationStateModel._targetServerInstance.name!)),
+					this.migrationStateModel._targetServerInstance.name),
 				await createHeadingTextComponent(
 					this._view,
 					constants.DATABASE_BACKUP_MIGRATION_MODE_LABEL),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

After the changes in https://github.com/microsoft/azuredatastudio/pull/20403, a bug was introduced that would cause the "Create new" button on Step 6 of the migration wizard to not do anything if there isn't a resource group selected: 

![image](https://user-images.githubusercontent.com/11844501/187536671-36f5666a-669b-4723-9a14-373973240079.png)

Of course the problem is that the behavior of these dropdowns is such that only resource groups containing a DMS service are shown, so any new user that doesn't have any DMS services yet won't have any resource groups to choose from, which in turn blocks them from creating a new one. The only way to fix this issue would have been to deploy a DMS service through other means, and then return to the extension.

This issue wasn't caught earlier since all of our test subscriptions already have a bunch of DMS services lying around, so the only way to repro this issue is to pick a subscription that doesn't have any DMS services, which is the experience that most first-time users would have. 