### PR TITLE
Don't run publish typings for hotfixes

### DIFF
--- a/build/azure-pipelines/publish-types/publish-types.yml
+++ b/build/azure-pipelines/publish-types/publish-types.yml
@@ -2,7 +2,7 @@
 
 trigger:
   branches:
-    include: ["refs/tags/*"]
+    include: ["refs/tags/*.0"] # {{SQL CARBON EDIT}} Only run on major version releases
 
 pr: none
 


### PR DESCRIPTION
Currently this pipeline fails when a hotfix tag (like 1.39.1) is made. There's no reason to run the pipeline at all though - we can just skip it for any non-0 tags and save the failed build notifcation. 