### PR TITLE
Update account dropdown content to include tenant Id

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
@@ -284,7 +284,7 @@ export class AccountPicker extends Disposable {
 			const label = DOM.append(row, DOM.$('div.label'));
 
 			// TODO: Pick between the light and dark logo
-			label.innerText = tenant.displayName;
+			label.innerText = tenant.displayName.concat(' (', tenant.id, ')');
 		}
 		return null;
 	}

--- a/src/sql/workbench/services/accountManagement/browser/tenantListRenderer.ts
+++ b/src/sql/workbench/services/accountManagement/browser/tenantListRenderer.ts
@@ -47,7 +47,7 @@ export class TenantPickerListRenderer implements IListRenderer<Tenant, TenantPic
 	}
 
 	public renderElement(tenant: Tenant, index: number, templateData: PickerListTemplate): void {
-		templateData.displayName.innerText = tenant.displayName;
+		templateData.displayName.innerText = tenant.displayName.concat(' (', tenant.id, ')');
 	}
 
 	public disposeTemplate(template: PickerListTemplate): void {


### PR DESCRIPTION
This PR fixes #17162 by including tenant Id in Account display information.

Before: (as shared in original issue)

After:

![image](https://user-images.githubusercontent.com/13396919/187596742-0c9fe650-9c52-46d2-9b7c-b934ce756bce.png)

