### PR TITLE
Fix to not prompt user when token acquisition fails for stale user accounts.

### DIFF
--- a/extensions/azurecore/src/azureResource/services/subscriptionService.ts
+++ b/extensions/azurecore/src/azureResource/services/subscriptionService.ts
@@ -31,18 +31,25 @@ export class AzureResourceSubscriptionService implements IAzureResourceSubscript
 		for (const tenantId of tenantIds ?? account.properties.tenants.map(t => t.id)) {
 			try {
 				const token = await azdata.accounts.getAccountSecurityToken(account, tenantId, azdata.AzureResource.ResourceManagement);
-				const subClient = new SubscriptionClient(new TokenCredentials(token.token, token.tokenType), { baseUri: account.properties.providerSettings.settings.armResource.endpoint });
-				const newSubs = await subClient.subscriptions.list();
-				subscriptions.push(...newSubs.map(newSub => {
-					return {
-						id: newSub.subscriptionId,
-						name: newSub.displayName,
-						tenant: tenantId
-					};
-				}));
-				gotSubscriptions = true;
+				if (token !== undefined) {
+					const subClient = new SubscriptionClient(new TokenCredentials(token.token, token.tokenType), { baseUri: account.properties.providerSettings.settings.armResource.endpoint });
+					const newSubs = await subClient.subscriptions.list();
+					subscriptions.push(...newSubs.map(newSub => {
+						return {
+							id: newSub.subscriptionId,
+							name: newSub.displayName,
+							tenant: tenantId
+						};
+					}));
+					gotSubscriptions = true;
+				}
+				else if (!account.isStale) {
+					const errorMsg = localize('azure.resource.tenantTokenError', "Failed to acquire Access Token for account '{0}' (tenant '{1}').", account.displayInfo.displayName, tenantId);
+					console.warn(errorMsg);
+					void vscode.window.showWarningMessage(errorMsg);
+				}
 			} catch (error) {
-				const errorMsg = localize('azure.resource.tenantSubscriptionsError', "Failed to get subscriptions for account {0} (tenant '{1}'). {2}", account.key.accountId, tenantId, AzureResourceErrorMessageUtil.getErrorMessage(error));
+				const errorMsg = localize('azure.resource.tenantSubscriptionsError', "Failed to get subscriptions for account {0} (tenant '{1}'). {2}", account.displayInfo.displayName, tenantId, AzureResourceErrorMessageUtil.getErrorMessage(error));
 				console.warn(errorMsg);
 				errors.push(error);
 				void vscode.window.showWarningMessage(errorMsg);


### PR DESCRIPTION
This PR fixes #20505 by disabling subscription error messages for "stale" accounts.

New behavior with fix:

https://user-images.githubusercontent.com/13396919/187599924-441a0e5d-535a-4ac7-931a-72fd9439d4b1.mp4

To reproduce the same, below steps can be followed:
1. Sign in to Azure and when logged in, clear token cache.
2. Restart Azure Studio

ADS should mark the account as "Stale" as it cannot find credentials in cache, and will prompt user for new credentials as shown in video, instead of showing subscription failures.

The PR also adds below changes:
- Includes account name in error message for a more meaningful message.
- Check for "undefined" token and prompts accordingly.