### PR TITLE
the fix open in designer menu item is not available after script is updated with newly added create table statements

### DIFF
--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -17,7 +17,7 @@ import { WorkspaceTreeItem } from 'dataworkspace';
 import * as constants from '../common/constants';
 import { SqlDatabaseProjectProvider } from '../projectProvider/projectProvider';
 import { EntryType, GenerateProjectFromOpenApiSpecOptions, ItemType } from 'sqldbproj';
-import { TableFileNode } from '../models/tree/fileFolderTreeItem';
+import { FileNode, TableFileNode } from '../models/tree/fileFolderTreeItem';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { getAzdataApi } from '../common/utils';
 
@@ -88,6 +88,7 @@ export default class MainController implements vscode.Disposable {
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.exclude', async (node: WorkspaceTreeItem) => { return this.projectsController.exclude(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.changeTargetPlatform', async (node: WorkspaceTreeItem) => { return this.projectsController.changeTargetPlatform(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.validateExternalStreamingJob', async (node: WorkspaceTreeItem) => { return this.projectsController.validateExternalStreamingJob(node); }));
+		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.openFileWithWatcher', async (fileSystemUri: vscode.Uri, node: FileNode) => { return this.projectsController.openFileWithWatcher(fileSystemUri, node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.openInDesigner', async (node: WorkspaceTreeItem) => {
 			if (node?.element instanceof TableFileNode) {
 				const tableFileNode = node.element as TableFileNode;

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -65,6 +65,11 @@ export enum TaskExecutionMode {
 
 export type AddDatabaseReferenceSettings = ISystemDatabaseReferenceSettings | IDacpacReferenceSettings | IProjectReferenceSettings;
 
+interface fileWatcherStatus {
+	fileWatcher: vscode.FileSystemWatcher;
+	containsCreateTableStatement: boolean;
+}
+
 /**
  * Controller for managing lifecycle of projects
  */
@@ -78,7 +83,8 @@ export class ProjectsController {
 	private azureSqlClient: AzureSqlClient;
 	private autorestHelper: AutorestHelper;
 
-	projFileWatchers = new Map<string, vscode.FileSystemWatcher>();
+	private projFileWatchers = new Map<string, vscode.FileSystemWatcher>();
+	private fileWatchers = new Map<string, fileWatcherStatus>();
 
 	constructor(private _outputChannel: vscode.OutputChannel) {
 		this.netCoreTool = new NetCoreTool(this._outputChannel);
@@ -886,6 +892,41 @@ export class ProjectsController {
 		} catch (err) {
 			void vscode.window.showErrorMessage(utils.getErrorMessage(err));
 		}
+	}
+
+	/**
+	 * Opens a file in the editor and adds a file watcher to check if a create table statement has been added
+	 * @param fileSystemUri uri of file
+	 * @param node node of file in the tree
+	 */
+	public async openFileWithWatcher(fileSystemUri: vscode.Uri, node: FileNode): Promise<void> {
+		await vscode.commands.executeCommand(constants.vscodeOpenCommand, fileSystemUri);
+		const projectTargetVersion = (node.root as ProjectRootTreeItem).project.getProjectTargetVersion();
+		const initiallyContainsCreateTableStatement = await utils.fileContainsCreateTableStatement(fileSystemUri.fsPath, projectTargetVersion);
+
+		const fileWatcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher(fileSystemUri.fsPath);
+		this.fileWatchers.set(fileSystemUri.fsPath, { fileWatcher: fileWatcher, containsCreateTableStatement: initiallyContainsCreateTableStatement });
+
+		fileWatcher.onDidChange(async (uri: vscode.Uri) => {
+			const afterContainsCreateTableStatement = await utils.fileContainsCreateTableStatement(fileSystemUri.fsPath, projectTargetVersion);
+			const previousStatus = this.fileWatchers.get(uri.fsPath)?.containsCreateTableStatement;
+
+			// if the contains create table statement status is different, reload the project so that the "Open in Designer" menu option
+			// on the file node is there if a create table statement has been added or removed if it's been removed
+			if (previousStatus !== afterContainsCreateTableStatement) {
+				utils.getDataWorkspaceExtensionApi().refreshProjectsTree();
+				this.fileWatchers.get(uri.fsPath)!.containsCreateTableStatement = afterContainsCreateTableStatement;
+			}
+		});
+
+		// stop watching for changes to the file after it's closed
+		const closeSqlproj = vscode.workspace.onDidCloseTextDocument((d) => {
+			if (this.fileWatchers.has(d.uri.fsPath)) {
+				this.fileWatchers.get(d.uri.fsPath)?.fileWatcher.dispose();
+				this.fileWatchers.delete(d.uri.fsPath);
+				closeSqlproj.dispose();
+			}
+		});
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -65,7 +65,7 @@ export enum TaskExecutionMode {
 
 export type AddDatabaseReferenceSettings = ISystemDatabaseReferenceSettings | IDacpacReferenceSettings | IProjectReferenceSettings;
 
-interface fileWatcherStatus {
+interface FileWatcherStatus {
 	fileWatcher: vscode.FileSystemWatcher;
 	containsCreateTableStatement: boolean;
 }
@@ -84,7 +84,7 @@ export class ProjectsController {
 	private autorestHelper: AutorestHelper;
 
 	private projFileWatchers = new Map<string, vscode.FileSystemWatcher>();
-	private fileWatchers = new Map<string, fileWatcherStatus>();
+	private fileWatchers = new Map<string, FileWatcherStatus>();
 
 	constructor(private _outputChannel: vscode.OutputChannel) {
 		this.netCoreTool = new NetCoreTool(this._outputChannel);

--- a/extensions/sql-database-projects/src/models/tree/fileFolderTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/fileFolderTreeItem.ts
@@ -60,9 +60,9 @@ export class FileNode extends BaseProjectTreeItem {
 		const treeItem = new vscode.TreeItem(this.fileSystemUri, vscode.TreeItemCollapsibleState.None);
 
 		treeItem.command = {
-			title: 'Open file',
-			command: 'vscode.open',
-			arguments: [this.fileSystemUri]
+			title: 'Open file with file watcher',
+			command: 'sqlDatabaseProjects.openFileWithWatcher',
+			arguments: [this.fileSystemUri, this]
 		};
 
 		treeItem.contextValue = DatabaseProjectItemType.file;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19788. This adds a file watcher when opening a script of sql project so that if a create table statement was added to the script and the file didn't contain one before, then the "Open in Designer" option is now available for that file in the project tree without needing to refresh the projects viewlet.

This only refreshes the projects viewlet if the "Open in Designer" option should be added or removed, so it doesn't happen for every change made to a file.

![showOpenInDesigner](https://user-images.githubusercontent.com/31145923/187748391-93f1f74e-7e4a-460d-bfb8-d8eee68f24f4.gif)
