### PR TITLE
Further update to ConnectionInfoSummary typings

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -424,17 +424,17 @@ declare module 'azdata' {
 		connectionId: string;
 
 		/**
-		 * Full stack trace from the engine and service host.
+		 * Additional optional detailed error messages from the engine or service host, if an error occurred.
 		 */
-		messages: string;
+		messages?: string;
 
 		/**
-		 * Main error message(s) returned from the engine and service host, if any.
+		 * Error message returned from the engine or service host, if an error occurred.
 		 */
-		errorMessage: string;
+		errorMessage?: string;
 
 		/**
-		 * Error number returned from the engine, if any.
+		 * Error number returned from the engine or server host, if an error occurred.
 		 */
 		errorNumber: number;
 		/**

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -419,40 +419,42 @@ declare module 'azdata' {
 		ownerUri: string;
 
 		/**
-		 * connection id returned from service host.
+		 * Connection id returned from service host, if the connection was successful.
 		 */
-		connectionId: string;
+		connectionId?: string | undefined;
 
 		/**
 		 * Additional optional detailed error messages from the engine or service host, if an error occurred.
 		 */
-		messages?: string;
+		messages?: string | undefined;
 
 		/**
 		 * Error message returned from the engine or service host, if an error occurred.
 		 */
-		errorMessage?: string;
+		errorMessage?: string | undefined;
 
 		/**
 		 * Error number returned from the engine or server host, if an error occurred.
 		 */
-		errorNumber: number;
+		errorNumber?: number | undefined;
 		/**
-		 * Information about the connected server.
+		 * Information about the connected server, if the connection was successful.
 		 */
-		serverInfo: ServerInfo;
+		serverInfo?: ServerInfo | undefined;
 		/**
-		 * information about the actual connection established
+		 * Information about the actual connection established, if the connection was successful.
 		 */
-		connectionSummary: ConnectionSummary;
+		connectionSummary?: ConnectionSummary | undefined;
 		/**
-		 * Indicates whether the server version is supported by ADS. The default value is true. If the value is false, ADS will show a warning message.
+		 * Whether the server version is supported by the provider. Default is to assume true. If the value is false, Azure Data Studio
+		 * will show a warning message.
 		 */
-		isSupportedVersion?: boolean;
+		isSupportedVersion?: boolean | undefined;
 		/**
-		 * The messages that will be appended to the Azure Data Studio's warning message about unsupported versions.
+		 * Additional optional message with details about why the version isn't supported. This will be appended to the warning message Azure Data Studio
+		 * displays about unsupported versions.
 		 */
-		unsupportedVersionMessage?: string;
+		unsupportedVersionMessage?: string | undefined;
 	}
 
 	/**


### PR DESCRIPTION
Original PR : https://github.com/microsoft/azuredatastudio/pull/20511

Companion PRs:

https://github.com/microsoft/sqlops-dataprotocolclient/pull/66
https://github.com/microsoft/sqltoolsservice/pull/1665

I'm further updating this to : 

1. Fix the actual types to be correct - most of the properties here can be null based on whether the connection was successful or not so making that explicit to help avoid errors with not properly checking them. This is technically a breaking change for anyone who might be compiling in strict mode - but given that this is just fixing the typings to be correct (we're currently sending null for those values) it's better to have it be correct so that consumers can fix it themselves when they update their typings. This doesn't affect anything at runtime. 
2. Update the descriptions to be more accurate/generic
