### PR TITLE
Fix Scmp dialog not presenting Folder Structure option for Projects as Target

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -350,6 +350,7 @@ export class SchemaCompareDialog {
 					break;
 				case mssql.SchemaCompareEndpointType.Project:
 					targetComponents.push(this.targetProjectFilePathComponent);
+					targetComponents.push(this.targetProjectStructureComponent);
 					break;
 			}
 


### PR DESCRIPTION
This PR fixes #20395.
Project structure dropdown component was missed during the initial changes for Update project from db, to be added in the target component list. This PR adds it appropriately.
![image](https://user-images.githubusercontent.com/57200045/187806688-b6eda5f4-0c9a-44f6-b001-c1e5b56d4647.png)
