### PR TITLE
add config option for Microsoft.Build.Sql version used to build legacy sql projects

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -63,6 +63,10 @@
           "sqlDatabaseProjects.collapseProjectNodes": {
             "type": "boolean",
             "description": "%sqlDatabaseProjects.collapseProjectNodes%"
+          },
+          "sqlDatabaseProjects.microsoftBuildSqlVersion": {
+            "type": "string",
+            "description": "%sqlDatabaseProjects.microsoftBuildSqlVersion%"
           }
         }
       }

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -41,6 +41,6 @@
 	"sqlDatabaseProjects.nodejsDoNotAsk": "Whether to prompt the user to install Node.js when not detected.",
 	"sqlDatabaseProjects.autorestSqlVersion": "Which version of Autorest.Sql to use from NPM.  Latest will be used if not set.",
 	"sqlDatabaseProjects.collapseProjectNodes": "Whether project nodes start collapsed",
-	"sqlDatabaseProjects.microsoftBuildSqlVersion": "Which version of Microsoft.Build.Sql SDK to use for building legacy sql projects.",
+	"sqlDatabaseProjects.microsoftBuildSqlVersion": "Which version of Microsoft.Build.Sql SDK to use for building legacy sql projects. Example: 0.1.3-preview",
 	"sqlDatabaseProjects.welcome": "No database projects currently open.\n[New Project](command:sqlDatabaseProjects.new)\n[Open Project](command:sqlDatabaseProjects.open)\n[Create Project From Database](command:sqlDatabaseProjects.importDatabase)"
 }

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -41,5 +41,6 @@
 	"sqlDatabaseProjects.nodejsDoNotAsk": "Whether to prompt the user to install Node.js when not detected.",
 	"sqlDatabaseProjects.autorestSqlVersion": "Which version of Autorest.Sql to use from NPM.  Latest will be used if not set.",
 	"sqlDatabaseProjects.collapseProjectNodes": "Whether project nodes start collapsed",
+	"sqlDatabaseProjects.microsoftBuildSqlVersion": "Which version of Microsoft.Build.Sql SDK to use for building legacy sql projects.",
 	"sqlDatabaseProjects.welcome": "No database projects currently open.\n[New Project](command:sqlDatabaseProjects.new)\n[Open Project](command:sqlDatabaseProjects.open)\n[Create Project From Database](command:sqlDatabaseProjects.importDatabase)"
 }

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -354,6 +354,7 @@ export const parentTreeItemUnknown = localize('parentTreeItemUnknown', "Cannot a
 export const prePostDeployCount = localize('prePostDeployCount', "To successfully build, update the project to have one pre-deployment script and/or one post-deployment script");
 export const invalidProjectReload = localize('invalidProjectReload', "Cannot access provided database project. Only valid, open database projects can be reloaded.");
 export const externalStreamingJobValidationPassed = localize('externalStreamingJobValidationPassed', "Validation of external streaming job passed.");
+export const errorRetrievingBuildFiles = localize('errorRetrievingBuildFiles', "Could not build project. Error retrieving files needed to build.");
 export function projectAlreadyOpened(path: string) { return localize('projectAlreadyOpened', "Project '{0}' is already opened.", path); }
 export function projectAlreadyExists(name: string, path: string) { return localize('projectAlreadyExists', "A project named {0} already exists in {1}.", name, path); }
 export function noFileExist(fileName: string) { return localize('noFileExist', "File {0} doesn't exist", fileName); }

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -614,7 +614,9 @@ export enum PublishTargetType {
 	newAzureServer = 'newAzureServer'
 }
 
+// Configuration keys
 export const CollapseProjectNodesKey = 'collapseProjectNodes';
+export const microsoftBuildSqlVersionKey = 'microsoftBuildSqlVersion';
 
 // httpClient
 export const downloadError = localize('downloadError', "Download error");
@@ -623,6 +625,7 @@ export const downloading = localize('downloading', "Downloading");
 
 // buildHelper
 export const downloadingDacFxDlls = localize('downloadingDacFxDlls', "Downloading Microsoft.Build.Sql nuget to get build DLLs");
-export const extractingDacFxDlls = localize('extractingDacFxDlls', "Extracting DacFx build DLLs");
+export function downloadingFromTo(from: string, to: string) { return localize('downloadingFromTo', "Downloading from {0} to {1}", from, to); }
+export function extractingDacFxDlls(location: string) { return localize('extractingDacFxDlls', "Extracting DacFx build DLLs to {0}", location); }
 export function errorDownloading(url: string, error: string) { return localize('errorDownloading', "Error downloading {0}. Error: {1}", url, error); }
 export function errorExtracting(path: string, error: string) { return localize('errorExtracting', "Error extracting files from {0}. Error: {1}", path, error); }

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -232,7 +232,12 @@ export class ProjectsController {
 
 		// get dlls and targets file needed for building for legacy style projects
 		if (!project.isSdkStyleProject) {
-			await this.buildHelper.createBuildDirFolder(this._outputChannel);
+			const result = await this.buildHelper.createBuildDirFolder(this._outputChannel);
+
+			if (!result) {
+				void vscode.window.showErrorMessage('Could not build project. Error retrieving files needed to build');
+				return '';
+			}
 		}
 
 		const options: ShellCommandOptions = {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -235,7 +235,7 @@ export class ProjectsController {
 			const result = await this.buildHelper.createBuildDirFolder(this._outputChannel);
 
 			if (!result) {
-				void vscode.window.showErrorMessage('Could not build project. Error retrieving files needed to build');
+				void vscode.window.showErrorMessage(constants.errorRetrievingBuildFiles);
 				return '';
 			}
 		}


### PR DESCRIPTION
Fixes #20526. By adding this configuration option, users can change the version of Microsoft.Build.Sql used for building legacy style projects if they want to, which could be helpful for testing fixes without needing to release a whole new version of the extension. If not set, the default Microsoft.Build.Sql version specified in the extension will be used. 

![image](https://user-images.githubusercontent.com/31145923/187987810-0e8bba13-7a8d-4b92-bed6-a49c1bec87f4.png)

The version is output in the Output window so the user can see what's being downloaded: 
![image](https://user-images.githubusercontent.com/31145923/187978478-c97ead15-5595-4781-9e99-888fe82a053b.png)


When an invalid version is set, then these errors show and build is not continued.

![image](https://user-images.githubusercontent.com/31145923/187809588-9982f3b9-d184-49d0-a1b1-31c340b5fea4.png)
