### PR TITLE
Allow Connection Profiles with different names

### DIFF
--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -215,7 +215,10 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		if (databaseDisplayName) {
 			id += ProviderConnectionInfo.idSeparator + 'databaseDisplayName' + ProviderConnectionInfo.nameValueSeparator + databaseDisplayName;
 		}
-
+		let connectionDisplayName: string = this.options['connectionName'];
+		if (connectionDisplayName) {
+			id += ProviderConnectionInfo.idSeparator + 'connectionName' + ProviderConnectionInfo.nameValueSeparator + connectionDisplayName;
+		}
 		return id + ProviderConnectionInfo.idSeparator + 'group' + ProviderConnectionInfo.nameValueSeparator + this.groupId;
 	}
 

--- a/src/sql/platform/connection/common/providerConnectionInfo.ts
+++ b/src/sql/platform/connection/common/providerConnectionInfo.ts
@@ -212,8 +212,7 @@ export class ProviderConnectionInfo extends Disposable implements azdata.Connect
 		if (this.serverCapabilities) {
 			idNames = this.serverCapabilities.connectionOptions.map(o => {
 				if ((o.specialValueType || o.isIdentity)
-					&& o.specialValueType !== ConnectionOptionSpecialType.password
-					&& o.specialValueType !== ConnectionOptionSpecialType.connectionName) {
+					&& o.specialValueType !== ConnectionOptionSpecialType.password) {
 					return o.name;
 				} else {
 					return undefined;

--- a/src/sql/platform/connection/test/common/providerConnectionInfo.test.ts
+++ b/src/sql/platform/connection/test/common/providerConnectionInfo.test.ts
@@ -215,7 +215,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 
 	test('getOptionsKey should create a valid unique id', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
-		let expectedId = 'providerName:MSSQL|authenticationType:|databaseName:database|serverName:new server|userName:user';
+		let expectedId = 'providerName:MSSQL|authenticationType:|connectionName:name|databaseName:database|serverName:new server|userName:user';
 		let id = conn.getOptionsKey();
 		assert.strictEqual(id, expectedId);
 	});
@@ -238,7 +238,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('getProviderFromOptionsKey should return the provider name from the options key successfully', () => {
-		let optionsKey = `providerName:${mssqlProviderName}|authenticationType:|databaseName:database|serverName:new server|userName:user`;
+		let optionsKey = `providerName:${mssqlProviderName}|authenticationType:|connectionName:new name|databaseName:database|serverName:new server|userName:user`;
 		let actual = ProviderConnectionInfo.getProviderFromOptionsKey(optionsKey);
 
 		assert.strictEqual(mssqlProviderName, actual);
@@ -253,7 +253,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('getProviderFromOptionsKey should return empty string give key without provider name', () => {
-		let optionsKey = 'providerName2:MSSQL|authenticationType:|databaseName:database|serverName:new server|userName:user';
+		let optionsKey = 'providerName2:MSSQL|authenticationType:|connectionName:new name|databaseName:database|serverName:new server|userName:user';
 		let expectedProviderId: string = '';
 		let actual = ProviderConnectionInfo.getProviderFromOptionsKey(optionsKey);
 


### PR DESCRIPTION
Allow connection profiles with the same server name and login name, but with unique connection names (test-name-1 and test-name-2 share the same login and server info). 
<img width="286" alt="Screen Shot 2022-09-01 at 2 43 04 PM" src="https://user-images.githubusercontent.com/18150417/188018219-cf49cc6b-bad9-42e3-bab0-c0a82a0f4658.png">
Previous behavior: after adding test-name-1, once I add test-name-2, it would overwrite test-name-1 because the servers share the same connection info (except for the connection names)

New behavior: test-name-1 and test-name-2 are able to be saved separately.

I did this by adding the connection name to the connection options key.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19307
