### PR TITLE
AzureAccountProvider & AzureAccountProviderService strict nulls

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -699,7 +699,7 @@ export interface RefreshToken extends AccountKey {
 }
 
 export interface MultiTenantTokenResponse {
-	[tenantId: string]: Token
+	[tenantId: string]: Token | undefined;
 }
 
 export interface Token extends AccountKey {

--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -25,7 +25,7 @@ const localize = nls.loadMessageBundle();
 export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disposable {
 	private static readonly CONFIGURATION_SECTION = 'accounts.azure.auth';
 	private readonly authMappings = new Map<AzureAuthType, AzureAuth>();
-	private initComplete: Deferred<void, Error>;
+	private initComplete!: Deferred<void, Error>;
 	private initCompletePromise: Promise<void> = new Promise<void>((resolve, reject) => this.initComplete = { resolve, reject });
 
 	constructor(
@@ -58,14 +58,15 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 		this.authMappings.clear();
 		const configuration = vscode.workspace.getConfiguration(AzureAccountProvider.CONFIGURATION_SECTION);
 
-		const codeGrantMethod: boolean = configuration.get('codeGrant');
-		const deviceCodeMethod: boolean = configuration.get('deviceCode');
+		const codeGrantMethod: boolean = configuration.get<boolean>('codeGrant', false);
+		const deviceCodeMethod: boolean = configuration.get<boolean>('deviceCode', false);
 
 		if (codeGrantMethod === true && !this.forceDeviceCode) {
 			this.authMappings.set(AzureAuthType.AuthCodeGrant, new AzureAuthCodeGrant(metadata, tokenCache, context, uriEventHandler));
-		}
-		if (deviceCodeMethod === true || this.forceDeviceCode) {
+		} else if (deviceCodeMethod === true || this.forceDeviceCode) {
 			this.authMappings.set(AzureAuthType.DeviceCode, new AzureDeviceCode(metadata, tokenCache, context, uriEventHandler));
+		} else {
+			console.error('No authentication methods selected');
 		}
 	}
 
@@ -74,12 +75,17 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 			return this.authMappings.values().next().value;
 		}
 
-		const authType: AzureAuthType = account?.properties?.azureAuthType;
+		const authType: AzureAuthType | undefined = account?.properties?.azureAuthType;
 		if (authType) {
-			return this.authMappings.get(authType);
-		} else {
-			return this.authMappings.values().next().value;
+			const authMapping = this.authMappings.get(authType);
+			if (authMapping) {
+				return authMapping;
+			}
 		}
+		if (this.authMappings.size === 0) {
+			throw new Error('No authentication mappings selected');
+		}
+		return this.authMappings.values().next().value;
 	}
 
 	initialize(storedAccounts: AzureAccount[]): Thenable<AzureAccount[]> {


### PR DESCRIPTION
Mostly just initializing stuff but I did add a few new errors/warnings that I thought were better to have.

1. If the user doesn't have an auth method chosen. It would be good to go over the auth method selection in the settings at some point - since right now a user can uncheck all auth methods which will break everything anyways. 
2. If for some reason we aren't able to find the expected auth method - right now it would just return undefined which isn't something we handle anywhere else so we'd end up with a very unhelpful error. This will at least make it clear what the problem is (and tying into one, this isn't something we should generally be allowing anyways since I expect that we should require at least one auth method to be chosen at any given time regardless)