### PR TITLE
Set target platform for database project from the server metadata

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -593,6 +593,15 @@ export const targetPlatformToVersion: Map<string, string> = new Map<string, stri
 	[SqlTargetPlatform.sqlDW, 'Dw']
 ]);
 
+export const serverVersionToTargetPlatform: Map<number, SqlTargetPlatform> = new Map<number, SqlTargetPlatform>([
+	[11, SqlTargetPlatform.sqlServer2012],
+	[12, SqlTargetPlatform.sqlServer2014],
+	[13, SqlTargetPlatform.sqlServer2016],
+	[14, SqlTargetPlatform.sqlServer2017],
+	[15, SqlTargetPlatform.sqlServer2019],
+	[16, SqlTargetPlatform.sqlServer2022]
+]);
+
 // DW is special since the system dacpac folder has a different name from the target platform
 export const AzureDwFolder = 'AzureDw';
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -593,7 +593,7 @@ export const targetPlatformToVersion: Map<string, string> = new Map<string, stri
 	[SqlTargetPlatform.sqlDW, 'Dw']
 ]);
 
-export const serverVersionToTargetPlatform: Map<number, SqlTargetPlatform> = new Map<number, SqlTargetPlatform>([
+export const onPremServerVersionToTargetPlatform: Map<number, SqlTargetPlatform> = new Map<number, SqlTargetPlatform>([
 	[11, SqlTargetPlatform.sqlServer2012],
 	[12, SqlTargetPlatform.sqlServer2014],
 	[13, SqlTargetPlatform.sqlServer2016],

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as azdataType from 'azdata';
+import type * as azdataType from 'azdata';
 import * as vscode from 'vscode';
 import * as os from 'os';
 import * as constants from './constants';
@@ -714,20 +714,20 @@ export async function fileContainsCreateTableStatement(fullPath: string, project
 
 /**
  * Gets target platform based on the server edition/version
- * @param profile server connection profile
+ * @param connectionId server connection profile id
  * @returns target platform for the database project
  */
-export async function getTargetPlatformFromServerVersion(profile: azdataType.IConnectionProfile): Promise<SqlTargetPlatform | undefined> {
-	const serverInfo = await azdataType.connection.getServerInfo(profile.id);
+export async function getTargetPlatformFromServerVersion(connectionId: string): Promise<SqlTargetPlatform | undefined> {
+	const serverInfo = await getAzdataApi()!.connection.getServerInfo(connectionId);
 	const isCloud = serverInfo.isCloud;
 
 	let targetPlatform;
 	if (isCloud) {
 		const engineEdition = serverInfo.engineEditionId;
-		targetPlatform = engineEdition === azdataType.DatabaseEngineEdition.SqlDataWarehouse ? SqlTargetPlatform.sqlDW : (engineEdition === azdataType.DatabaseEngineEdition.SqlDatabase ? SqlTargetPlatform.sqlAzure : undefined);
+		targetPlatform = engineEdition === getAzdataApi()!.DatabaseEngineEdition.SqlDataWarehouse ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;
 	} else {
 		const serverMajorVersion = serverInfo.serverMajorVersion;
-		targetPlatform = serverMajorVersion ? constants.serverVersionToTargetPlatform.get(serverMajorVersion) : undefined;
+		targetPlatform = serverMajorVersion ? constants.onPremServerVersionToTargetPlatform.get(serverMajorVersion) : undefined;
 	}
 
 	return targetPlatform;

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1399,7 +1399,7 @@ export class ProjectsController {
 		if (utils.getAzdataApi()) {
 			let createProjectFromDatabaseDialog = this.getCreateProjectFromDatabaseDialog(profile as azdataType.IConnectionProfile);
 
-			createProjectFromDatabaseDialog.createProjectFromDatabaseCallback = async (model) => await this.createProjectFromDatabaseCallback(model, profile as azdataType.IConnectionProfile);
+			createProjectFromDatabaseDialog.createProjectFromDatabaseCallback = async (model, connectionId) => await this.createProjectFromDatabaseCallback(model, connectionId);
 
 			await createProjectFromDatabaseDialog.openDialog();
 
@@ -1426,13 +1426,13 @@ export class ProjectsController {
 		return new CreateProjectFromDatabaseDialog(profile);
 	}
 
-	public async createProjectFromDatabaseCallback(model: ImportDataModel, profile?: azdataType.IConnectionProfile) {
+	public async createProjectFromDatabaseCallback(model: ImportDataModel, connectionId?: string) {
 		try {
 
 			const newProjFolderUri = model.filePath;
 			let targetPlatform: SqlTargetPlatform | undefined;
-			if (profile) {
-				targetPlatform = await utils.getTargetPlatformFromServerVersion(profile);
+			if (connectionId) {
+				targetPlatform = await utils.getTargetPlatformFromServerVersion(connectionId);
 			}
 
 			const newProjFilePath = await this.createNewProject({

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1399,7 +1399,7 @@ export class ProjectsController {
 		if (utils.getAzdataApi()) {
 			let createProjectFromDatabaseDialog = this.getCreateProjectFromDatabaseDialog(profile as azdataType.IConnectionProfile);
 
-			createProjectFromDatabaseDialog.createProjectFromDatabaseCallback = async (model) => await this.createProjectFromDatabaseCallback(model);
+			createProjectFromDatabaseDialog.createProjectFromDatabaseCallback = async (model) => await this.createProjectFromDatabaseCallback(model, profile as azdataType.IConnectionProfile);
 
 			await createProjectFromDatabaseDialog.openDialog();
 
@@ -1426,16 +1426,21 @@ export class ProjectsController {
 		return new CreateProjectFromDatabaseDialog(profile);
 	}
 
-	public async createProjectFromDatabaseCallback(model: ImportDataModel) {
+	public async createProjectFromDatabaseCallback(model: ImportDataModel, profile?: azdataType.IConnectionProfile) {
 		try {
 
 			const newProjFolderUri = model.filePath;
+			let targetPlatform: SqlTargetPlatform | undefined;
+			if (profile) {
+				targetPlatform = await utils.getTargetPlatformFromServerVersion(profile);
+			}
 
 			const newProjFilePath = await this.createNewProject({
 				newProjName: model.projName,
 				folderUri: vscode.Uri.file(newProjFolderUri),
 				projectTypeId: model.sdkStyle ? constants.emptySqlDatabaseSdkProjectTypeId : constants.emptySqlDatabaseProjectTypeId,
-				sdkStyle: model.sdkStyle
+				sdkStyle: model.sdkStyle,
+				targetPlatform: targetPlatform
 			});
 
 			model.filePath = path.dirname(newProjFilePath);

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -32,7 +32,7 @@ export class CreateProjectFromDatabaseDialog {
 	private toDispose: vscode.Disposable[] = [];
 	private initDialogComplete: Deferred = new Deferred();
 
-	public createProjectFromDatabaseCallback: ((model: ImportDataModel) => any) | undefined;
+	public createProjectFromDatabaseCallback: ((model: ImportDataModel, connectionId?: string) => any) | undefined;
 
 	constructor(private profile: azdataType.IConnectionProfile | undefined) {
 		this.dialog = getAzdataApi()!.window.createModelViewDialog(constants.createProjectFromDatabaseDialogName, 'createProjectFromDatabaseDialog');
@@ -411,7 +411,7 @@ export class CreateProjectFromDatabaseDialog {
 		};
 
 		azdataApi!.window.closeDialog(this.dialog);
-		await this.createProjectFromDatabaseCallback!(model);
+		await this.createProjectFromDatabaseCallback!(model, this.connectionId!);
 
 		this.dispose();
 	}


### PR DESCRIPTION
This PR fixes #20363.
Currently, all the database projects created from the databases are assigned DSP (target platform) as "Sql Server 2019". instead of its current version. The changes in PR reads the server metadata to determine its version and maps & assigns it appropriately to the target platform for the database project.
Steps to repro:
1. Connect to DW server with a user db.
2. Create project from this user db.
-- The project should now be created with appropriate target platform.

This PR doesn't handle the VSCode version of Projects.
