### PR TITLE
Don't use localized folder for azure tokens

### DIFF
--- a/extensions/azurecore/src/constants.ts
+++ b/extensions/azurecore/src/constants.ts
@@ -8,6 +8,8 @@ export const ViewType = 'view';
 
 export const dataGridProviderId = 'azure-resources';
 
+export const AzureTokenFolderName = 'Azure Accounts';
+
 export enum BuiltInCommands {
 	SetContext = 'setContext'
 }

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -233,7 +233,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 // Create the folder for storing the token caches
 async function findOrMakeStoragePath() {
 	let defaultLogLocation = getDefaultLogLocation();
-	let storagePath = path.join(defaultLogLocation, loc.extensionName);
+	let storagePath = path.join(defaultLogLocation, constants.AzureTokenFolderName);
 
 	try {
 		await fs.mkdir(defaultLogLocation, { recursive: true });


### PR DESCRIPTION
Currently we use a folder whose name is localized, which means if the user changes their display language they : 

1. Lose all existing tokens (since it'll be looking in a different folder)
2. End up with a new folder being created, e.g. `Cuentas de Azure` (one for each language)

So this is fixing that.

Note that currently this will just ignore any token caches in the old localized folder location - I considered adding logic to copy over the tokens but that got to be kind of annoying to consider all the edge cases (like a stale cache overwriting a newer one) and so instead of bothering with that I think it's fine to just keep it like this and for anyone who is using a localized version of ADS they'll just have to log in again to their account (which any errors should make clear). 