### PR TITLE
ServerInfoContextKey instead of MssqlNodeContextKey for OE items

### DIFF
--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -16,6 +16,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ItemContextKey } from 'sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerContext';
 import { EditDataAction } from 'sql/workbench/browser/scriptingActions';
 import { DatabaseEngineEdition } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { ServerInfoContextKey } from 'sql/workbench/services/connection/common/serverInfoContextKey';
 
 //#region -- Data Explorer
 // Script as Create
@@ -133,8 +134,8 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
-			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
-			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlDataWarehouse.toString())
+			ServerInfoContextKey.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
+			ServerInfoContextKey.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlDataWarehouse.toString())
 		)
 });
 
@@ -153,7 +154,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Schema),
-				ContextKeyExpr.and(TreeNodeContextKey.NodeType.isEqualTo(NodeType.User), MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString())),
+				ContextKeyExpr.and(TreeNodeContextKey.NodeType.isEqualTo(NodeType.User), ServerInfoContextKey.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString())),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.User),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.UserDefinedTableType),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.StoredProcedure),

--- a/src/sql/workbench/services/objectExplorer/browser/mssqlNodeContext.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/mssqlNodeContext.ts
@@ -20,6 +20,12 @@ export interface INodeContextValue {
 	viewId: string;
 }
 
+/**
+ * This context key is for Data Explorer nodes only - it is not used for Object Explorer nodes. For that use
+ * [treeNodeContextKey](https://github.com/Microsoft/azuredatastudio/blob/main/src/sql/workbench/services/objectExplorer/common/treeNodeContextKey.ts),
+ * [connectionContextKey](https://github.com/Microsoft/azuredatastudio/blob/main/src/sql/workbench/services/connection/common/connectionContextKey.ts) or
+ * [serverInfoContextKey](https://github.com/Microsoft/azuredatastudio/blob/main/src/sql/workbench/services/connection/common/serverInfoContextKey.ts)
+ */
 export class MssqlNodeContext extends Disposable {
 
 	static readonly canSelect = new Set([NodeType.Table, NodeType.View]);


### PR DESCRIPTION
Was writing up some documentation about menu item contributions and was greatly confused by this since nothing I saw was showing the MssqlNodeContextKey being bound for OE items. Dug into it and found out that it's actually https://github.com/Microsoft/azuredatastudio/blob/main/src/sql/workbench/services/connection/common/serverInfoContextKey.ts#L16 being bound - which just happens to share the EngineEdition field and so it seemed to work correctly. 

So I'm just fixing that and adding a comment to try and help avoid this in the future (in addition to the docs I'm writing in the wiki)