### PR TITLE
[SQL Migration] Release 1.0.5 to Insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.4",
-							"lastUpdated": "06/23/2022",
+							"version": "1.0.5",
+							"lastUpdated": "09/08/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.0.4.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.0.5.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4073,7 +4073,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.37.0"
+									"value": ">=1.39.0"
 								}
 							]
 						}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the Insiders extension gallery to the latest release candidate version of the SQL Migration extension. It also bumps the dependent version of ADS (`Microsoft.AzDataEngine`) to 1.39 to match what is defined in our [package.json](https://github.com/microsoft/azuredatastudio/blob/main/extensions/sql-migration/package.json#L13).

Link to `Azure Data Studio - Extensions` pipeline run containing vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=170305&view=results
