### PR TITLE
Remove irrelevant context menu options from ledger objects in OE

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -511,7 +511,7 @@
         },
         {
           "command": "mssql.designTable",
-          "when": "connectionProvider == MSSQL && nodeType == Table && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Table && nodeSubType != LedgerDropped && config.workbench.enablePreviewFeatures",
           "group": "0_query@3"
         },
         {

--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -152,9 +152,11 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		ContextKeyExpr.and(
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
-			TreeNodeContextKey.SubType.notEqualsTo('LedgerDropped'),
 			ContextKeyExpr.or(
-				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+				ContextKeyExpr.and(
+					TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+					TreeNodeContextKey.SubType.notEqualsTo('LedgerDropped')
+				),
 				ContextKeyExpr.and(
 					TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
 					TreeNodeContextKey.SubType.notEqualsTo('Ledger'),
@@ -237,9 +239,11 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		ContextKeyExpr.and(
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
-			TreeNodeContextKey.SubType.notEqualsTo('LedgerDropped'),
 			ContextKeyExpr.or(
-				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+				ContextKeyExpr.and(
+					TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+					TreeNodeContextKey.SubType.notEqualsTo('LedgerDropped')
+				),
 				ContextKeyExpr.and(
 					TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
 					TreeNodeContextKey.SubType.notEqualsTo('Ledger'),

--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -132,6 +132,8 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	when:
 		ContextKeyExpr.and(
 			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+			TreeNodeContextKey.SubType.notEqualsTo('LedgerAppendOnly'),
+			TreeNodeContextKey.SubType.notEqualsTo('LedgerDropped'),
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
 			ServerInfoContextKey.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
@@ -150,9 +152,13 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		ContextKeyExpr.and(
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
+			TreeNodeContextKey.SubType.notEqualsTo('LedgerDropped'),
 			ContextKeyExpr.or(
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
-				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
+				ContextKeyExpr.and(
+					TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
+					TreeNodeContextKey.SubType.notEqualsTo('Ledger'),
+				),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Schema),
 				ContextKeyExpr.and(TreeNodeContextKey.NodeType.isEqualTo(NodeType.User), ServerInfoContextKey.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString())),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.User),
@@ -199,7 +205,8 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.StoredProcedure)),
 			ContextKeyExpr.and(
 				ConnectionContextKey.Provider.isEqualTo('MSSQL'),
-				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View)),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
+				TreeNodeContextKey.SubType.notEqualsTo('Ledger')),
 			ContextKeyExpr.and(
 				ConnectionContextKey.Provider.isEqualTo('MSSQL'),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.AggregateFunction)),
@@ -230,9 +237,13 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		ContextKeyExpr.and(
 			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 			ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
+			TreeNodeContextKey.SubType.notEqualsTo('LedgerDropped'),
 			ContextKeyExpr.or(
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
-				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
+				ContextKeyExpr.and(
+					TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
+					TreeNodeContextKey.SubType.notEqualsTo('Ledger'),
+				),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Schema),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.User),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.UserDefinedTableType),

--- a/src/sql/workbench/services/objectExplorer/browser/media/objectTypes/objecttypes.css
+++ b/src/sql/workbench/services/objectExplorer/browser/media/objectTypes/objecttypes.css
@@ -579,9 +579,15 @@
 	background: url("TableValuedFunctionParameter_Return.svg") center center no-repeat;
 }
 
-.vs .icon.table_ledger,
-.vs-dark .icon.table_ledger,
-.hc-black .icon.table_ledger {
+.vs .icon.table_ledgerappendonly,
+.vs-dark .icon.table_ledgerappendonly,
+.hc-black .icon.table_ledgerappendonly,
+.vs .icon.table_ledgerupdatable,
+.vs-dark .icon.table_ledgerupdatable,
+.hc-black .icon.table_ledgerupdatable,
+.vs .icon.table_ledgerdropped,
+.vs-dark .icon.table_ledgerdropped,
+.hc-black .icon.table_ledgerdropped  {
 	background: url("Table_Ledger.svg") center center no-repeat;
 }
 
@@ -608,7 +614,6 @@
 .hc-black .icon.historytable_ledgerhistory {
 	background: url("Table_LedgerHistory.svg") center center no-repeat;
 }
-
 
 .vs .icon.trigger,
 .vs-dark .icon.trigger,


### PR DESCRIPTION
This PR fixes #20570 by removing invalid context menu options from ledger objects.
This PR also fixes the broken ledger icon references from changing the ledger SubTypes in STS.

Manual Verification of context menus:

- Append-Only Ledger Table:
  'Edit Data' option is removed
  ![image](https://user-images.githubusercontent.com/58005768/189207889-b126ad43-5644-49ab-9b6b-1878768a2b9f.png)

- Dropped Ledger Tables:
  All options but 'Select Top 1000' and 'Refresh' are removed
  - Append-Only dropped table
    ![image](https://user-images.githubusercontent.com/58005768/189207988-8e2fca67-fea6-44e1-9b70-724a14a8d191.png)
  - Updatable dropped table
    ![image](https://user-images.githubusercontent.com/58005768/189207208-dc23d820-79ee-4e70-bf38-8521c05c598d.png)

- Ledger View:
  All options but 'Select Top 1000' and 'Refresh' are removed
  ![image](https://user-images.githubusercontent.com/58005768/189207659-0cc972d9-ef1f-496f-84e6-a5dd7e89bfa2.png)

- Dropped Ledger View:
  All options but 'Select Top 1000' and 'Refresh' are removed (same as for active ledger views)
  ![image](https://user-images.githubusercontent.com/58005768/189208079-c819e21b-dc91-4d6b-8da2-e79ee89468dd.png)

- Updatable Ledger Table Context Menu (no change):
  ![image](https://user-images.githubusercontent.com/58005768/189207372-9cadb5c8-d6d8-4c0e-ab74-a48a8aaf6a93.png)
