### PR TITLE
handle default auth type

### DIFF
--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -221,7 +221,7 @@ export interface IConnectionManagementService {
 	/**
 	 * Gets the default authentication type from the configuration service
 	 */
-	getDefaultAuthenticationTypeId(): string;
+	getDefaultAuthenticationTypeId(providerName: string): string;
 
 	/**
 	 * Cancels the connection

--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -306,7 +306,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 		return undefined!;
 	}
 
-	getDefaultAuthenticationTypeId(): string {
+	getDefaultAuthenticationTypeId(providerName: string): string {
 		return undefined!;
 	}
 

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -798,6 +798,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	}
 
 	public getDefaultAuthenticationTypeId(providerName: string): string {
+		// only return the default authentication type if the provider supports the AuthType option.
+		// Other issues with the implementation is tracked here: https://github.com/microsoft/azuredatastudio/issues/20573
 		const authOption = this._capabilitiesService.getCapabilities(providerName)?.connection.connectionOptions?.find(option => option.specialValueType === ConnectionOptionSpecialType.authType);
 		const defaultAuthenticationType = authOption ? WorkbenchUtils.getSqlConfigValue<string>(this._configurationService, Constants.defaultAuthenticationType) : undefined;
 		return defaultAuthenticationType;

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -312,7 +312,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 			// If there is no authentication type set, set it using configuration
 			if (!newConnection.authenticationType || newConnection.authenticationType === '') {
-				newConnection.authenticationType = this.getDefaultAuthenticationTypeId();
+				newConnection.authenticationType = this.getDefaultAuthenticationTypeId(newConnection.providerName);
 			}
 
 			// If the password is required and still not loaded show the dialog
@@ -797,8 +797,9 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		return defaultProvider && this._providers.has(defaultProvider) ? defaultProvider : undefined;
 	}
 
-	public getDefaultAuthenticationTypeId(): string {
-		let defaultAuthenticationType = WorkbenchUtils.getSqlConfigValue<string>(this._configurationService, Constants.defaultAuthenticationType);
+	public getDefaultAuthenticationTypeId(providerName: string): string {
+		const authOption = this._capabilitiesService.getCapabilities(providerName)?.connection.connectionOptions?.find(option => option.specialValueType === ConnectionOptionSpecialType.authType);
+		const defaultAuthenticationType = authOption ? WorkbenchUtils.getSqlConfigValue<string>(this._configurationService, Constants.defaultAuthenticationType) : undefined;
 		return defaultAuthenticationType;
 	}
 


### PR DESCRIPTION
this PR fixes https://github.com/microsoft/azuredatastudio-mysql/issues/46
I wanted to transfer it to ads repo but couldn't.

the issue happened because we are assigning the AzureMFA as the default auth type and it fails the check for AzureMFA authentication type. 

fix: do not set authentication type if the auth type option is not specified by the connection provider.