### PR TITLE
handle unsupported connection provider

### DIFF
--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -321,6 +321,13 @@ export interface IConnectionManagementService {
 	 * @returns array of connections
 	 */
 	getConnections(activeConnectionsOnly?: boolean): ConnectionProfile[];
+
+	/**
+	 * Handle the unsupported provider scenario.
+	 * @param providerName The provider name.
+	 * @returns Promise with a boolean value indicating whether the user has accepted the suggestion.
+	 */
+	handleUnsupportedProvider(providerName: string): Promise<boolean>;
 }
 
 export enum RunQueryOnConnectionMode {

--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -322,4 +322,8 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 	refreshAzureAccountTokenIfNecessary(uri: string): Promise<boolean> {
 		return undefined;
 	}
+
+	async handleUnsupportedProvider(providerName: string): Promise<boolean> {
+		return true;
+	}
 }

--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -141,6 +141,11 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 	}
 
 	public async $openConnectionDialog(providers: string[], initialConnectionProfile?: IConnectionProfile, connectionCompletionOptions?: azdata.IConnectionCompletionOptions): Promise<azdata.connection.Connection | undefined> {
+		if (initialConnectionProfile?.providerName && this._capabilitiesService.providers[initialConnectionProfile.providerName] === undefined) {
+			await this._connectionManagementService.handleUnsupportedProvider(initialConnectionProfile.providerName);
+			return undefined;
+		}
+
 		// Here we default to ConnectionType.editor which saves the connecton in the connection store by default
 		let connectionType = ConnectionType.editor;
 

--- a/src/sql/workbench/contrib/dashboard/browser/dashboardActions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboardActions.ts
@@ -25,20 +25,25 @@ export const DE_MANAGE_COMMAND_ID = 'dataExplorer.manage';
 // Manage
 CommandsRegistry.registerCommand({
 	id: DE_MANAGE_COMMAND_ID,
-	handler: (accessor, args: TreeViewItemHandleArg) => {
+	handler: async (accessor, args: TreeViewItemHandleArg) => {
 		if (args.$treeItem) {
 			const connectionService = accessor.get(IConnectionManagementService);
 			const capabilitiesService = accessor.get(ICapabilitiesService);
-			let options = {
-				showDashboard: true,
-				saveTheConnection: false,
-				params: undefined,
-				showConnectionDialogOnError: true,
-				showFirewallRuleOnError: true
-			};
-			let profile = new ConnectionProfile(capabilitiesService, args.$treeItem.payload);
-			let uri = generateUri(profile, 'dashboard');
-			return connectionService.connect(new ConnectionProfile(capabilitiesService, args.$treeItem.payload), uri, options);
+			const providerName = args.$treeItem?.payload?.providerName;
+			if (providerName && capabilitiesService.providers[providerName] === undefined) {
+				await connectionService.handleUnsupportedProvider(providerName);
+			} else {
+				let options = {
+					showDashboard: true,
+					saveTheConnection: false,
+					params: undefined,
+					showConnectionDialogOnError: true,
+					showFirewallRuleOnError: true
+				};
+				let profile = new ConnectionProfile(capabilitiesService, args.$treeItem.payload);
+				let uri = generateUri(profile, 'dashboard');
+				return connectionService.connect(new ConnectionProfile(capabilitiesService, args.$treeItem.payload), uri, options);
+			}
 		}
 		return Promise.resolve(true);
 	}

--- a/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
@@ -44,6 +44,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { ConnectionBrowseTab } from 'sql/workbench/services/connection/browser/connectionBrowseTab';
 import { ElementSizeObserver } from 'vs/editor/browser/config/elementSizeObserver';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
+import { onUnexpectedError } from 'vs/base/common/errors';
 
 export interface OnShowUIResponse {
 	selectedProviderDisplayName: string;
@@ -219,7 +220,7 @@ export class ConnectionDialogWidget extends Modal {
 
 		this._register(this.browsePanel.view.onSelectedConnectionChanged(e => {
 			this._connectionSource = e.source;
-			this.onConnectionClick(e.connectionProfile, e.connect);
+			this.onConnectionClick(e.connectionProfile, e.connect).catch(onUnexpectedError);
 		}));
 
 		this._panel.pushTab(this.browsePanel);
@@ -347,7 +348,7 @@ export class ConnectionDialogWidget extends Modal {
 			if (element instanceof ConnectionProfile) {
 				const isDoubleClick = origin === 'mouse' && (eventish as MouseEvent).detail === 2;
 				this._connectionSource = 'recent';
-				this.onConnectionClick(element, isDoubleClick);
+				this.onConnectionClick(element, isDoubleClick).catch(onUnexpectedError);
 			}
 		};
 		const actionProvider = this.instantiationService.createInstance(RecentConnectionActionsProvider);
@@ -369,13 +370,13 @@ export class ConnectionDialogWidget extends Modal {
 			this._recentConnectionTree.onMouseClick(e => {
 				if (e.element instanceof ConnectionProfile) {
 					this._connectionSource = 'recent';
-					this.onConnectionClick(e.element, false);
+					this.onConnectionClick(e.element, false).catch(onUnexpectedError);
 				}
 			});
 			this._recentConnectionTree.onMouseDblClick(e => {
 				if (e.element instanceof ConnectionProfile) {
 					this._connectionSource = 'recent';
-					this.onConnectionClick(e.element, true);
+					this.onConnectionClick(e.element, true).catch(onUnexpectedError);
 				}
 			});
 		}

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -14,7 +14,7 @@ import { ConnectionStore } from 'sql/platform/connection/common/connectionStore'
 import { ConnectionManagementInfo } from 'sql/platform/connection/common/connectionManagementInfo';
 import * as Utils from 'sql/platform/connection/common/utils';
 import * as Constants from 'sql/platform/connection/common/constants';
-import { ICapabilitiesService, ConnectionProviderProperties, ProviderFeatures } from 'sql/platform/capabilities/common/capabilitiesService';
+import { ICapabilitiesService, ConnectionProviderProperties, ProviderFeatures, ConnectionProviderAndExtensionMap } from 'sql/platform/capabilities/common/capabilitiesService';
 import * as ConnectionContracts from 'sql/workbench/services/connection/browser/connection';
 import { ConnectionStatusManager } from 'sql/platform/connection/common/connectionStatusManager';
 import { DashboardInput } from 'sql/workbench/browser/editor/profiler/dashboardInput';
@@ -51,6 +51,11 @@ import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
 import { URI } from 'vs/base/common/uri';
 import { QueryEditorInput } from 'sql/workbench/common/editor/query/queryEditorInput';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
+import { ViewContainerLocation } from 'vs/workbench/common/views';
+import { VIEWLET_ID as ExtensionsViewletID } from 'vs/workbench/contrib/extensions/common/extensions';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 
 export class ConnectionManagementService extends Disposable implements IConnectionManagementService {
 
@@ -94,7 +99,10 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		@IAccountManagementService private _accountManagementService: IAccountManagementService,
 		@ILogService private _logService: ILogService,
 		@IStorageService private _storageService: IStorageService,
-		@IExtensionService private readonly extensionService: IExtensionService
+		@IExtensionService private readonly _extensionService: IExtensionService,
+		@ICommandService private readonly _commandService: ICommandService,
+		@IPaneCompositePartService private readonly _paneCompositePartService: IPaneCompositePartService,
+		@IDialogService private readonly _dialogService: IDialogService
 	) {
 		super();
 
@@ -981,7 +989,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			options: connection.options
 		});
 
-		await this.extensionService.activateByEvent(`onConnect:${connection.providerName}`);
+		await this._extensionService.activateByEvent(`onConnect:${connection.providerName}`);
 
 		return this._providers.get(connection.providerName).onReady.then((provider) => {
 			provider.connect(uri, connectionInfo);
@@ -1648,5 +1656,23 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			}
 		}
 		return connections;
+	}
+
+	async handleUnsupportedProvider(providerName: string): Promise<boolean> {
+		const extensionId = ConnectionProviderAndExtensionMap.get(providerName);
+		const message = extensionId ? nls.localize('connection.extensionNotInstalled', "The extension '{0}' is required in order to connect to this resource. Do you want to install it?", extensionId) :
+			nls.localize('connectionDialog.connectionProviderNotSupported', "The extension that supports provider type '{0}' is not currently installed. Do you want to view the extensions?", providerName);
+		const result = await this._dialogService.confirm({
+			message: message,
+			type: 'question'
+		});
+		if (result.confirmed) {
+			if (extensionId) {
+				await this._commandService.executeCommand('extension.open', extensionId);
+			} else {
+				await this._paneCompositePartService.openPaneComposite(ExtensionsViewletID, ViewContainerLocation.Sidebar);
+			}
+		}
+		return result.confirmed;
 	}
 }

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -123,7 +123,7 @@ suite('ConnectionDialogService tests', () => {
 				}
 			};
 		});
-		testConnectionDialog = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, testInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService), new TestConfigurationService(), new TestCapabilitiesService(), undefined, undefined, undefined);
+		testConnectionDialog = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, testInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService), new TestConfigurationService(), new TestCapabilitiesService());
 		testConnectionDialog.render();
 		testConnectionDialog['renderBody'](DOM.createStyleSheet());
 		(connectionDialogService as any)._connectionDialog = testConnectionDialog;

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
@@ -65,7 +65,7 @@ suite('ConnectionDialogWidget tests', () => {
 			new TestCapabilitiesService());
 		let providerDisplayNames = ['Mock SQL Server'];
 		let providerNameToDisplayMap = { 'MSSQL': 'Mock SQL Server' };
-		connectionDialogWidget = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, cmInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService()), new TestConfigurationService(), new TestCapabilitiesService(), undefined, undefined, undefined);
+		connectionDialogWidget = new TestConnectionDialogWidget(providerDisplayNames, providerNameToDisplayMap['MSSQL'], providerNameToDisplayMap, cmInstantiationService, mockConnectionManagementService.object, undefined, undefined, viewDescriptorService, new TestThemeService(), new TestLayoutService(), new NullAdsTelemetryService(), new MockContextKeyService(), undefined, new NullLogService(), new TestTextResourcePropertiesService(new TestConfigurationService()), new TestConfigurationService(), new TestCapabilitiesService());
 		element = DOM.createStyleSheet();
 		connectionDialogWidget.render();
 		connectionDialogWidget['renderBody'](element);

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -185,7 +185,10 @@ suite('SQL ConnectionManagementService tests', () => {
 			accountManagementService.object,
 			testLogService, // ILogService
 			undefined, // IStorageService
-			getBasicExtensionService()
+			getBasicExtensionService(),
+			undefined,
+			undefined,
+			undefined
 		);
 		return connectionManagementService;
 	}
@@ -1573,7 +1576,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		const testInstantiationService = new TestInstantiationService();
 		testInstantiationService.stub(IStorageService, new TestStorageService());
 		testInstantiationService.stubCreateInstance(ConnectionStore, connectionStoreMock.object);
-		const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService());
+		const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService(), undefined, undefined, undefined);
 		assert.strictEqual(profile.password, '', 'Profile should not have password initially');
 		assert.strictEqual(profile.options['password'], '', 'Profile options should not have password initially');
 		// Check for invalid profile id
@@ -1603,7 +1606,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		testInstantiationService.stub(IStorageService, new TestStorageService());
 		testInstantiationService.stubCreateInstance(ConnectionStore, connectionStoreMock.object);
 
-		const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService());
+		const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService(), undefined, undefined, undefined);
 		assert.strictEqual(profile.password, '', 'Profile should not have password initially');
 		assert.strictEqual(profile.options['password'], '', 'Profile options should not have password initially');
 		let credentials = await connectionManagementService.getConnectionCredentials(profile.id);
@@ -1848,7 +1851,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		createInstanceStub.withArgs(ConnectionStore).returns(connectionStoreMock.object);
 		createInstanceStub.withArgs(ConnectionStatusManager).returns(connectionStatusManagerMock.object);
 
-		const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService());
+		const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService(), undefined, undefined, undefined);
 
 		// dupe connections have been seeded the numbers below already reflected the de-duped results
 
@@ -1881,7 +1884,7 @@ test('isRecent should evaluate whether a profile was recently connected or not',
 	});
 	let profile1 = createConnectionProfile('1');
 	let profile2 = createConnectionProfile('2');
-	const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService());
+	const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService(), undefined, undefined, undefined);
 	assert(connectionManagementService.isRecent(profile1));
 	assert(!connectionManagementService.isRecent(profile2));
 });
@@ -1899,7 +1902,7 @@ test('clearRecentConnection and ConnectionsList should call connectionStore func
 	testInstantiationService.stub(IStorageService, new TestStorageService());
 	sinon.stub(testInstantiationService, 'createInstance').withArgs(ConnectionStore).returns(connectionStoreMock.object);
 	let profile1 = createConnectionProfile('1');
-	const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService());
+	const connectionManagementService = new ConnectionManagementService(undefined, testInstantiationService, undefined, undefined, undefined, new TestCapabilitiesService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined, getBasicExtensionService(), undefined, undefined, undefined);
 	connectionManagementService.clearRecentConnection(profile1);
 	assert(called);
 	called = false;

--- a/src/sql/workbench/services/connection/test/browser/testConnectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/test/browser/testConnectionDialogWidget.ts
@@ -17,9 +17,6 @@ import { ITextResourcePropertiesService } from 'vs/editor/common/services/textRe
 import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
-import { INotificationService } from 'vs/platform/notification/common/notification';
-import { ICommandService } from 'vs/platform/commands/common/commands';
-import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 
 export class TestConnectionDialogWidget extends ConnectionDialogWidget {
 	constructor(
@@ -39,11 +36,8 @@ export class TestConnectionDialogWidget extends ConnectionDialogWidget {
 		@ILogService logService: ILogService,
 		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@ICapabilitiesService capabilitiesService: ICapabilitiesService,
-		@INotificationService notificationService: INotificationService,
-		@IPaneCompositePartService paneCompositeService: IPaneCompositePartService,
-		@ICommandService commandService: ICommandService
+		@ICapabilitiesService capabilitiesService: ICapabilitiesService
 	) {
-		super(providerDisplayNameOptions, selectedProviderType, providerNameToDisplayNameMap, _instantiationService, _connectionManagementService, _contextMenuService, _contextViewService, themeService, layoutService, telemetryService, contextKeyService, clipboardService, logService, textResourcePropertiesService, configurationService, capabilitiesService, notificationService, paneCompositeService, commandService);
+		super(providerDisplayNameOptions, selectedProviderType, providerNameToDisplayNameMap, _instantiationService, _connectionManagementService, _contextMenuService, _contextViewService, themeService, layoutService, telemetryService, contextKeyService, clipboardService, logService, textResourcePropertiesService, configurationService, capabilitiesService);
 	}
 }


### PR DESCRIPTION
This PR fixes #20533 

previously I added the provider check for the browse connection view, now also add it for the azure tree scenarios.

unknown provider - direct user to extensions view:
![provider-unknown](https://user-images.githubusercontent.com/13777222/189422277-11a7435e-30fc-4ad6-b2bf-60fdbb06bab8.gif)

known provider - open the extension page directly:
![provider-known](https://user-images.githubusercontent.com/13777222/189422320-fa14c36c-6c44-420f-9c52-16a69fb21fc1.gif)
