### PR TITLE
Simplify IAzureResourceTreeDataProvider

### DIFF
--- a/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider.ts
@@ -60,21 +60,16 @@ export class AzureMonitorTreeDataProvider extends ResourceTreeDataProviderBase<a
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: AzureMonitorTreeDataProvider.containerId,
-				label: AzureMonitorTreeDataProvider.containerLabel,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: AzureMonitorTreeDataProvider.containerId,
+			label: AzureMonitorTreeDataProvider.containerLabel,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/cosmosdb/mongo/cosmosDbMongoTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/cosmosdb/mongo/cosmosDbMongoTreeDataProvider.ts
@@ -59,21 +59,16 @@ export class CosmosDbMongoTreeDataProvider extends ResourceTreeDataProviderBase<
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: CosmosDbMongoTreeDataProvider.CONTAINER_ID,
-				label: CosmosDbMongoTreeDataProvider.CONTAINER_LABEL,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<azdata.TreeItem[]> {
+		return [{
+			id: CosmosDbMongoTreeDataProvider.CONTAINER_ID,
+			label: CosmosDbMongoTreeDataProvider.CONTAINER_LABEL,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/database/databaseTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/database/databaseTreeDataProvider.ts
@@ -59,21 +59,16 @@ export class AzureResourceDatabaseTreeDataProvider extends ResourceTreeDataProvi
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: AzureResourceDatabaseTreeDataProvider.containerId,
-				label: AzureResourceDatabaseTreeDataProvider.containerLabel,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: AzureResourceDatabaseTreeDataProvider.containerId,
+			label: AzureResourceDatabaseTreeDataProvider.containerLabel,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
@@ -60,21 +60,16 @@ export class AzureResourceDatabaseServerTreeDataProvider extends ResourceTreeDat
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: AzureResourceDatabaseServerTreeDataProvider.containerId,
-				label: AzureResourceDatabaseServerTreeDataProvider.containerLabel,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: AzureResourceDatabaseServerTreeDataProvider.containerId,
+			label: AzureResourceDatabaseServerTreeDataProvider.containerLabel,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/kusto/kustoTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/kusto/kustoTreeDataProvider.ts
@@ -60,21 +60,16 @@ export class KustoTreeDataProvider extends ResourceTreeDataProviderBase<azureRes
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: KustoTreeDataProvider.containerId,
-				label: KustoTreeDataProvider.containerLabel,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: KustoTreeDataProvider.containerId,
+			label: KustoTreeDataProvider.containerLabel,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/mysqlFlexibleServer/mysqlFlexibleServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/mysqlFlexibleServer/mysqlFlexibleServerTreeDataProvider.ts
@@ -61,21 +61,16 @@ export class MysqlFlexibleServerTreeDataProvider extends ResourceTreeDataProvide
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: MysqlFlexibleServerTreeDataProvider.CONTAINER_ID,
-				label: MysqlFlexibleServerTreeDataProvider.CONTAINER_LABEL,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: MysqlFlexibleServerTreeDataProvider.CONTAINER_ID,
+			label: MysqlFlexibleServerTreeDataProvider.CONTAINER_LABEL,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
@@ -63,21 +63,16 @@ export class PostgresServerArcTreeDataProvider extends ResourceTreeDataProviderB
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: PostgresServerArcTreeDataProvider.containerId,
-				label: PostgresServerArcTreeDataProvider.containerLabel,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: PostgresServerArcTreeDataProvider.containerId,
+			label: PostgresServerArcTreeDataProvider.containerLabel,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
@@ -63,21 +63,16 @@ export class PostgresServerTreeDataProvider extends ResourceTreeDataProviderBase
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: PostgresServerTreeDataProvider.containerId,
-				label: PostgresServerTreeDataProvider.containerLabel,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: PostgresServerTreeDataProvider.containerId,
+			label: PostgresServerTreeDataProvider.containerLabel,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/resourceTreeDataProviderBase.ts
+++ b/extensions/azurecore/src/azureResource/providers/resourceTreeDataProviderBase.ts
@@ -17,16 +17,12 @@ export abstract class ResourceTreeDataProviderBase<T extends azureResource.Azure
 	public constructor(protected _resourceService: IAzureResourceService<T>) {
 	}
 
-	public getTreeItem(element: azureResource.IAzureResourceNode): azdata.TreeItem | Thenable<azdata.TreeItem> {
+	public async getResourceTreeItem(element: azureResource.IAzureResourceNode): Promise<azdata.TreeItem> {
 		return element.treeItem;
 	}
 
-	public async getChildren(element?: azureResource.IAzureResourceNode): Promise<azureResource.IAzureResourceNode[]> {
+	public async getChildren(element: azureResource.IAzureResourceNode): Promise<azureResource.IAzureResourceNode[]> {
 		try {
-			if (!element) {
-				return [this.createContainerNode()];
-			}
-
 			let resources: T[] = await this.getResources(element);
 
 			return resources.map((resource) => <azureResource.IAzureResourceNode>{
@@ -51,7 +47,7 @@ export abstract class ResourceTreeDataProviderBase<T extends azureResource.Azure
 
 	protected abstract getTreeItemForResource(resource: T, account: AzureAccount): azdata.TreeItem;
 
-	protected abstract createContainerNode(): azureResource.IAzureResourceNode;
+	public abstract getRootChildren(): Promise<azdata.TreeItem[]>;
 }
 
 export interface GraphData {

--- a/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceTreeDataProvider.ts
@@ -60,21 +60,16 @@ export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<az
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: SqlInstanceTreeDataProvider.containerId,
-				label: SqlInstanceTreeDataProvider.containerLabel,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: SqlInstanceTreeDataProvider.containerId,
+			label: SqlInstanceTreeDataProvider.containerLabel,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcTreeDataProvider.ts
@@ -60,21 +60,16 @@ export class SqlInstanceArcTreeDataProvider extends ResourceTreeDataProviderBase
 		};
 	}
 
-	protected createContainerNode(): azureResource.IAzureResourceNode {
-		return {
-			account: undefined,
-			subscription: undefined,
-			tenantId: undefined,
-			treeItem: {
-				id: SqlInstanceArcTreeDataProvider.containerId,
-				label: SqlInstanceArcTreeDataProvider.containerLabel,
-				iconPath: {
-					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
-					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
-				},
-				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
-			}
-		};
+	public async getRootChildren(): Promise<TreeItem[]> {
+		return [{
+			id: SqlInstanceArcTreeDataProvider.containerId,
+			label: SqlInstanceArcTreeDataProvider.containerLabel,
+			iconPath: {
+				dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
+			},
+			collapsibleState: TreeItemCollapsibleState.Collapsed,
+			contextValue: AzureResourceItemType.databaseServerContainer
+		}];
 	}
 }

--- a/extensions/azurecore/src/azureResource/resourceService.ts
+++ b/extensions/azurecore/src/azureResource/resourceService.ts
@@ -32,7 +32,7 @@ export class AzureResourceService {
 		this._areResourceProvidersLoaded = false;
 	}
 
-	public async getRootChildren(resourceProviderId: string, account: AzureAccount, subscription: azureResource.AzureResourceSubscription, tenatId: string): Promise<IAzureResourceNodeWithProviderId[]> {
+	public async getRootChildren(resourceProviderId: string, account: AzureAccount, subscription: azureResource.AzureResourceSubscription, tenantId: string): Promise<IAzureResourceNodeWithProviderId[]> {
 		await this.ensureResourceProvidersRegistered();
 
 		if (!(resourceProviderId in this._resourceProviders)) {
@@ -40,16 +40,18 @@ export class AzureResourceService {
 		}
 
 		const treeDataProvider = this._treeDataProviders[resourceProviderId];
-		const children = await treeDataProvider.getChildren();
+		const rootChildren = await treeDataProvider.getRootChildren();
 
-		return children.map((child) => <IAzureResourceNodeWithProviderId>{
-			resourceProviderId: resourceProviderId,
-			resourceNode: <azureResource.IAzureResourceNode>{
-				account: account,
-				subscription: subscription,
-				tenantId: tenatId,
-				treeItem: child.treeItem
-			}
+		return rootChildren.map(rootChild => {
+			return {
+				resourceProviderId,
+				resourceNode: {
+					account,
+					subscription,
+					tenantId,
+					treeItem: rootChild
+				}
+			};
 		});
 	}
 
@@ -70,7 +72,7 @@ export class AzureResourceService {
 		});
 	}
 
-	public async getTreeItem(resourceProviderId: string, element?: azureResource.IAzureResourceNode): Promise<TreeItem> {
+	public async getTreeItem(resourceProviderId: string, element: azureResource.IAzureResourceNode): Promise<TreeItem> {
 		await this.ensureResourceProvidersRegistered();
 
 		if (!(resourceProviderId in this._resourceProviders)) {
@@ -78,7 +80,7 @@ export class AzureResourceService {
 		}
 
 		const treeDataProvider = this._treeDataProviders[resourceProviderId];
-		return treeDataProvider.getTreeItem(element);
+		return treeDataProvider.getResourceTreeItem(element);
 	}
 
 	public get areResourceProvidersLoaded(): boolean {

--- a/extensions/azurecore/src/azureResource/tree/subscriptionTreeNode.ts
+++ b/extensions/azurecore/src/azureResource/tree/subscriptionTreeNode.ts
@@ -24,14 +24,14 @@ export class AzureResourceSubscriptionTreeNode extends AzureResourceContainerTre
 	public constructor(
 		public readonly account: AzureAccount,
 		public readonly subscription: azureResource.AzureResourceSubscription,
-		public readonly tenatId: string,
+		public readonly tenantId: string,
 		appContext: AppContext,
 		treeChangeHandler: IAzureResourceTreeChangeHandler,
 		parent: TreeNode
 	) {
 		super(appContext, treeChangeHandler, parent);
 
-		this._id = `account_${this.account.key.accountId}.subscription_${this.subscription.id}.tenant_${this.tenatId}`;
+		this._id = `account_${this.account.key.accountId}.subscription_${this.subscription.id}.tenant_${this.tenantId}`;
 		this.setCacheKey(`${this._id}.resources`);
 	}
 
@@ -42,7 +42,7 @@ export class AzureResourceSubscriptionTreeNode extends AzureResourceContainerTre
 			const children: IAzureResourceNodeWithProviderId[] = [];
 
 			for (const resourceProviderId of await resourceService.listResourceProviderIds()) {
-				children.push(...await resourceService.getRootChildren(resourceProviderId, this.account, this.subscription, this.tenatId));
+				children.push(...await resourceService.getRootChildren(resourceProviderId, this.account, this.subscription, this.tenantId));
 			}
 
 			if (children.length === 0) {

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -355,7 +355,22 @@ declare module 'azurecore' {
 			getTreeDataProvider(): IAzureResourceTreeDataProvider;
 		}
 
-		export interface IAzureResourceTreeDataProvider extends TreeDataProvider<IAzureResourceNode> {
+		export interface IAzureResourceTreeDataProvider {
+			 /**
+			  * Gets the root tree item nodes for this provider - these will be used as
+			  * direct children of the Account node in the Azure tree view.
+			  */
+			getRootChildren(): Promise<azdata.TreeItem[]>;
+			/**
+			 * Gets the children for a given {@link IAzureResourceNode}
+			 * @param element The parent node to get the children for
+			 */
+			getChildren(element: IAzureResourceNode): Promise<IAzureResourceNode[]>;
+			/**
+			 * Gets the tree item to display for a given {@link IAzureResourceNode}
+			 * @param element The resource node to get the TreeItem for
+			 */
+			getResourceTreeItem(element: IAzureResourceNode): Promise<azdata.TreeItem>;
 			browseConnectionMode: boolean;
 		}
 

--- a/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
@@ -104,7 +104,7 @@ describe('AzureResourceDatabaseTreeDataProvider.info', function (): void {
 	it('Should be correct when created.', async function (): Promise<void> {
 		const treeDataProvider = new AzureResourceDatabaseTreeDataProvider(mockDatabaseService.object, mockExtensionContext.object);
 
-		const treeItem = await treeDataProvider.getTreeItem(mockResourceRootNode);
+		const treeItem = await treeDataProvider.getResourceTreeItem(mockResourceRootNode);
 		should(treeItem.id).equal(mockResourceRootNode.treeItem.id);
 		should(treeItem.label).equal(mockResourceRootNode.treeItem.label);
 		should(treeItem.collapsibleState).equal(mockResourceRootNode.treeItem.collapsibleState);
@@ -129,19 +129,16 @@ describe('AzureResourceDatabaseTreeDataProvider.getChildren', function (): void 
 	it('Should return container node when element is undefined.', async function (): Promise<void> {
 		const treeDataProvider = new AzureResourceDatabaseTreeDataProvider(mockDatabaseService.object, mockExtensionContext.object);
 
-		const children = await treeDataProvider.getChildren();
+		const children = await treeDataProvider.getRootChildren();
 
 		should(children).Array();
 		should(children.length).equal(1);
 
 		const child = children[0];
-		should(child.account).undefined();
-		should(child.subscription).undefined();
-		should(child.tenantId).undefined();
-		should(child.treeItem.id).equal('azure.resource.providers.database.treeDataProvider.databaseContainer');
-		should(child.treeItem.label).equal('SQL database');
-		should(child.treeItem.collapsibleState).equal(vscode.TreeItemCollapsibleState.Collapsed);
-		should(child.treeItem.contextValue).equal('azure.resource.itemType.databaseContainer');
+		should(child.id).equal('azure.resource.providers.database.treeDataProvider.databaseContainer');
+		should(child.label).equal('SQL database');
+		should(child.collapsibleState).equal(vscode.TreeItemCollapsibleState.Collapsed);
+		should(child.contextValue).equal('azure.resource.itemType.databaseContainer');
 	});
 
 	it('Should return resource nodes when it is container node.', async function (): Promise<void> {

--- a/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
@@ -103,7 +103,7 @@ describe('AzureResourceDatabaseServerTreeDataProvider.info', function (): void {
 	it('Should be correct when created.', async function (): Promise<void> {
 		const treeDataProvider = new AzureResourceDatabaseServerTreeDataProvider(mockDatabaseServerService.object, mockExtensionContext.object);
 
-		const treeItem = await treeDataProvider.getTreeItem(mockResourceRootNode);
+		const treeItem = await treeDataProvider.getResourceTreeItem(mockResourceRootNode);
 		should(treeItem.id).equal(mockResourceRootNode.treeItem.id);
 		should(treeItem.label).equal(mockResourceRootNode.treeItem.label);
 		should(treeItem.collapsibleState).equal(mockResourceRootNode.treeItem.collapsibleState);
@@ -128,19 +128,16 @@ describe('AzureResourceDatabaseServerTreeDataProvider.getChildren', function ():
 	it('Should return container node when element is undefined.', async function (): Promise<void> {
 		const treeDataProvider = new AzureResourceDatabaseServerTreeDataProvider(mockDatabaseServerService.object, mockExtensionContext.object);
 
-		const children = await treeDataProvider.getChildren();
+		const children = await treeDataProvider.getRootChildren();
 
 		should(children).Array();
 		should(children.length).equal(1);
 
 		const child = children[0];
-		should(child.account).undefined();
-		should(child.subscription).undefined();
-		should(child.tenantId).undefined();
-		should(child.treeItem.id).equal('azure.resource.providers.databaseServer.treeDataProvider.databaseServerContainer');
-		should(child.treeItem.label).equal('SQL server');
-		should(child.treeItem.collapsibleState).equal(vscode.TreeItemCollapsibleState.Collapsed);
-		should(child.treeItem.contextValue).equal('azure.resource.itemType.databaseServerContainer');
+		should(child.id).equal('azure.resource.providers.databaseServer.treeDataProvider.databaseServerContainer');
+		should(child.label).equal('SQL server');
+		should(child.collapsibleState).equal(vscode.TreeItemCollapsibleState.Collapsed);
+		should(child.contextValue).equal('azure.resource.itemType.databaseServerContainer');
 	});
 
 	it('Should return resource nodes when it is container node.', async function (): Promise<void> {

--- a/extensions/azurecore/src/test/azureResource/resourceService.test.ts
+++ b/extensions/azurecore/src/test/azureResource/resourceService.test.ts
@@ -7,6 +7,7 @@ import * as should from 'should';
 import * as TypeMoq from 'typemoq';
 import 'mocha';
 import { fail } from 'assert';
+import * as azdata from 'azdata';
 
 import { AzureResourceService } from '../../azureResource/resourceService';
 import { AzureAccount, azureResource } from 'azurecore';
@@ -52,15 +53,15 @@ let resourceService: AzureResourceService;
 describe('AzureResourceService.listResourceProviderIds', function(): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider1.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider1.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
+		mockResourceTreeDataProvider1.setup((o) => o.getResourceTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
 		mockResourceProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider1.setup((o) => o.providerId).returns(() => 'mockResourceProvider1');
 		mockResourceProvider1.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider1.object);
 
 		mockResourceTreeDataProvider2 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider2.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider2.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider2.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
+		mockResourceTreeDataProvider2.setup((o) => o.getResourceTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
 		mockResourceProvider2 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider2.setup((o) => o.providerId).returns(() => 'mockResourceProvider2');
 		mockResourceProvider2.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider2.object);
@@ -89,8 +90,8 @@ describe('AzureResourceService.listResourceProviderIds', function(): void {
 describe('AzureResourceService.getRootChildren', function(): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider1.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider1.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
+		mockResourceTreeDataProvider1.setup((o) => o.getResourceTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
 		mockResourceProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider1.setup((o) => o.providerId).returns(() => 'mockResourceProvider1');
 		mockResourceProvider1.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider1.object);
@@ -122,9 +123,9 @@ describe('AzureResourceService.getRootChildren', function(): void {
 describe('AzureResourceService.getChildren', function(): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider1.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
+		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
 		mockResourceTreeDataProvider1.setup((o) => o.getChildren(TypeMoq.It.isAny())).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider1.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider1.setup((o) => o.getResourceTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
 		mockResourceProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider1.setup((o) => o.providerId).returns(() => 'mockResourceProvider1');
 		mockResourceProvider1.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider1.object);
@@ -155,9 +156,9 @@ describe('AzureResourceService.getChildren', function(): void {
 describe('AzureResourceService.getTreeItem', function(): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider1.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
+		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
 		mockResourceTreeDataProvider1.setup((o) => o.getChildren(TypeMoq.It.isAny())).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider1.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider1.setup((o) => o.getResourceTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
 		mockResourceProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider1.setup((o) => o.providerId).returns(() => 'mockResourceProvider1');
 		mockResourceProvider1.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider1.object);

--- a/extensions/azurecore/src/test/azureResource/resourceTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/resourceTreeNode.test.ts
@@ -96,7 +96,7 @@ let appContext: AppContext;
 describe('AzureResourceResourceTreeNode.info', function (): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider.setup((o) => o.getTreeItem(mockResourceRootNode)).returns(() => mockResourceRootNode.treeItem);
+		mockResourceTreeDataProvider.setup((o) => o.getResourceTreeItem(mockResourceRootNode)).returns(() => Promise.resolve(mockResourceRootNode.treeItem));
 		mockResourceTreeDataProvider.setup((o) => o.getChildren(mockResourceRootNode)).returns(() => Promise.resolve(mockResourceNodes));
 
 		mockResourceProvider = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
@@ -190,7 +190,7 @@ describe('AzureResourceResourceTreeNode.getChildren', function (): void {
 
 		const children = await resourceTreeNode.getChildren();
 
-		mockResourceTreeDataProvider.verify((o) => o.getChildren(), TypeMoq.Times.exactly(0));
+		mockResourceTreeDataProvider.verify((o) => o.getRootChildren(), TypeMoq.Times.exactly(0));
 
 		should(children).Array();
 		should(children.length).equal(0);

--- a/extensions/azurecore/src/test/azureResource/tree/subscriptionTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/tree/subscriptionTreeNode.test.ts
@@ -6,6 +6,7 @@
 import * as should from 'should';
 import * as TypeMoq from 'typemoq';
 import * as vscode from 'vscode';
+import * as azdata from 'azdata';
 import 'mocha';
 import { AppContext } from '../../../appContext';
 
@@ -69,15 +70,15 @@ describe('AzureResourceSubscriptionTreeNode.info', function(): void {
 		mockTreeChangeHandler = TypeMoq.Mock.ofType<IAzureResourceTreeChangeHandler>();
 
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider1.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider1.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
+		mockResourceTreeDataProvider1.setup((x: any) => x.then).returns(() => undefined);
 		mockResourceProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider1.setup((o) => o.providerId).returns(() => 'mockResourceProvider1');
 		mockResourceProvider1.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider1.object);
 
 		mockResourceTreeDataProvider2 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider2.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider2.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider2.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
+		mockResourceTreeDataProvider2.setup((x: any) => x.then).returns(() => undefined);
 		mockResourceProvider2 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider2.setup((o) => o.providerId).returns(() => 'mockResourceProvider2');
 		mockResourceProvider2.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider2.object);
@@ -121,15 +122,16 @@ describe('AzureResourceSubscriptionTreeNode.getChildren', function(): void {
 		mockTreeChangeHandler = TypeMoq.Mock.ofType<IAzureResourceTreeChangeHandler>();
 
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider1.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider1.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([{ label: 'Item1'}] as azdata.TreeItem[]));
+		mockResourceTreeDataProvider1.setup((o) => o.getResourceTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+
 		mockResourceProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider1.setup((o) => o.providerId).returns(() => 'mockResourceProvider1');
 		mockResourceProvider1.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider1.object);
 
 		mockResourceTreeDataProvider2 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
-		mockResourceTreeDataProvider2.setup((o) => o.getChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azureResource.IAzureResourceNode>().object]));
-		mockResourceTreeDataProvider2.setup((o) => o.getTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+		mockResourceTreeDataProvider2.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([{ label: 'Item2' }] as azdata.TreeItem[]));
+		mockResourceTreeDataProvider2.setup((o) => o.getResourceTreeItem(TypeMoq.It.isAny())).returns(() => Promise.resolve(TypeMoq.It.isAny()));
 		mockResourceProvider2 = TypeMoq.Mock.ofType<azureResource.IAzureResourceProvider>();
 		mockResourceProvider2.setup((o) => o.providerId).returns(() => 'mockResourceProvider2');
 		mockResourceProvider2.setup((o) => o.getTreeDataProvider()).returns(() => mockResourceTreeDataProvider2.object);
@@ -149,14 +151,14 @@ describe('AzureResourceSubscriptionTreeNode.getChildren', function(): void {
 		const subscriptionTreeNode = new AzureResourceSubscriptionTreeNode(mockAccount, mockSubscription, mockTenantId, appContext, mockTreeChangeHandler.object, undefined);
 		const children = await subscriptionTreeNode.getChildren();
 
-		mockResourceTreeDataProvider1.verify((o) => o.getChildren(), TypeMoq.Times.once());
+		mockResourceTreeDataProvider1.verify((o) => o.getRootChildren(), TypeMoq.Times.once());
 
-		mockResourceTreeDataProvider2.verify((o) => o.getChildren(), TypeMoq.Times.once());
+		mockResourceTreeDataProvider2.verify((o) => o.getRootChildren(), TypeMoq.Times.once());
 
-		const expectedChildren = await resourceService.listResourceProviderIds();
+		const expectedResourceProviderIds = await resourceService.listResourceProviderIds();
 
 		should(children).Array();
-		should(children.length).equal(expectedChildren.length);
+		should(children.length).equal(expectedResourceProviderIds.length, 'There should be one child for each resource provider');
 		for (const child of children) {
 			should(child).instanceOf(AzureResourceResourceTreeNode);
 		}


### PR DESCRIPTION
This started off as just fixing more strict nulls - in this case the ones in the `*TreeDataProvider` classes with `createContainerNode` since we were passing undefined for account/subscription/tenantId. This whole thing seemed very weird so I dug into it and tried to untangle this mess. 

The root problem here is that this stuff was loosely based off of the VS Code TreeDataProvider logic - but with a bunch of custom stuff thrown in. 

At a rough glance here's how it currently works : 

- Custom resource providers are registered. This is done by extensions in a [package.json contribution](https://github.com/Microsoft/azuredatastudio/blob/87391555c30f3288f2c0707faf9cebc0d40c8ea5/extensions/azurecore/src/azureResource/resourceService.ts#L109) (which the azurecore extension does itself as well)
- For each account node the direct children were gotten by calling getChildren with undefined (which is standard TreeDataProvider behavior)
- We were then setting the account/subscription/tenantId values from the returned object with the values from the account node itself (this is why the undefined in our resource providers was ok, it didn't matter what they were)
- For any subsequent children then getChildren was called on the resource nodes to get further children

I had a couple of issues with this : 

1. It's not intuitive - especially the overwriting of subscription values for just the root nodes
2. Extending TreeDataProvider gets us a lot of stuff that we don't want and just adds further confusion - for example the various event handlers which wouldn't even work if someone tried to use them. 

So I took this opportunity to slightly refactor this - by removing the TreeDataProvider extension from the interface and just directly adding the functions we want to use. This will give us better control over how this behaves and not needlessly tie us to the VS Code behavior.

I plan on coming back after I finish the strict null work and documenting all this behavior as well, since right now I don't believe we have any such documentation and it's mostly just a "guess and look at code" if anyone wants to add their own resources. (I want to wait in case there's other refactorings that I end up doing that change things even more)

With changes, just showing that behavior is unchanged.

![AzureTree](https://user-images.githubusercontent.com/28519865/189729987-39915b39-1445-43fc-a638-b93143ad62c6.gif)
