### PR TITLE
dashboard refresh fix

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable.ts
@@ -11,6 +11,7 @@ import { TextWithIconColumn } from 'sql/base/browser/ui/table/plugins/textWithIc
 import { Table } from 'sql/base/browser/ui/table/table';
 import { TableDataView } from 'sql/base/browser/ui/table/tableDataView';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
+import { IDashboardService } from 'sql/platform/dashboard/browser/dashboardService';
 import { attachTableStyler } from 'sql/platform/theme/common/styler';
 import { BaseActionContext, ManageActionContext } from 'sql/workbench/browser/actions';
 import { getFlavor, ObjectListViewProperty } from 'sql/workbench/contrib/dashboard/browser/dashboardRegistry';
@@ -60,7 +61,8 @@ export class ExplorerTable extends Disposable {
 		private readonly menuService: IMenuService,
 		private readonly contextKeyService: IContextKeyService,
 		private readonly progressService: IEditorProgressService,
-		private readonly logService: ILogService) {
+		private readonly logService: ILogService,
+		private readonly dashboardService: IDashboardService) {
 		super();
 		this._explorerView = new ExplorerView(this.context);
 		const connectionInfo = this.bootStrapService.connectionManagementService.connectionInfo;
@@ -99,6 +101,10 @@ export class ExplorerTable extends Disposable {
 			this._table.updateRowCount();
 		}));
 		this._register(this._view.onFilterStateChange(() => {
+			this._table.grid.invalidateAllRows();
+			this._table.updateRowCount();
+		}));
+		this._register(this.dashboardService.onLayout(() => {
 			this._table.grid.invalidateAllRows();
 			this._table.updateRowCount();
 		}));

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
@@ -30,6 +30,7 @@ import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { getFlavor } from 'sql/workbench/contrib/dashboard/browser/dashboardRegistry';
+import { IDashboardService } from 'sql/platform/dashboard/browser/dashboardService';
 
 @Component({
 	selector: 'explorer-widget',
@@ -57,6 +58,7 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 		@Inject(IEditorProgressService) private readonly progressService: IEditorProgressService,
 		@Inject(IConnectionManagementService) private readonly connectionManagementService: IConnectionManagementService,
 		@Inject(ICapabilitiesService) private readonly capabilitiesService: ICapabilitiesService,
+		@Inject(IDashboardService) private readonly dashboardService: IDashboardService,
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef
 	) {
 		super(changeRef);
@@ -87,7 +89,8 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 			this.menuService,
 			this.contextKeyService,
 			this.progressService,
-			this.logService);
+			this.logService,
+			this.dashboardService);
 		this._register(this._input);
 		this._register(attachInputBoxStyler(this._input, this.themeService));
 		this._register(this._table);


### PR DESCRIPTION
This PR fixes #20564

fix: refresh the grid on re-layout to make sure it is displayed properly.

![dashboard](https://user-images.githubusercontent.com/13777222/189772133-098be52a-ef3a-45db-b3d7-b14416ee25bd.gif)
