### PR TITLE
Update extension galleries for Arc and Azure CLI

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.1",
-							"lastUpdated": "8/10/2022",
+							"version": "1.6.0",
+							"lastUpdated": "9/13/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.5.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.6.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4211,14 +4211,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.1",
-							"lastUpdated": "8/10/2022",
+							"version": "1.6.0",
+							"lastUpdated": "9/13/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.5.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.6.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.1",
-							"lastUpdated": "8/10/2022",
+							"version": "1.6.0",
+							"lastUpdated": "9/13/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.5.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.6.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4211,14 +4211,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.1",
-							"lastUpdated": "8/10/2022",
+							"version": "1.6.0",
+							"lastUpdated": "9/13/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.5.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.6.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Bump arc and azcli to version 1.6.0 in extension gallery for stable and insiders.
