### PR TITLE
Set target platform for db projects from server metadata: mssql vscode extension

### DIFF
--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -58,6 +58,9 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 	createConnectionDetails(_: vscodeMssql.IConnectionInfo): vscodeMssql.ConnectionDetails {
 		throw new Error('Method not implemented.');
 	}
+	getServerInfo(_: vscodeMssql.IConnectionInfo): vscodeMssql.ServerInfo {
+		throw new Error('Method not implemented.');
+	}
 }
 
 export function createTestUtils(): TestUtils {

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -17,8 +17,6 @@ import * as which from 'which';
 import { promises as fs } from 'fs';
 import { ISqlProject, SqlTargetPlatform } from 'sqldbproj';
 
-const SqlDWEngineEdition = 6;
-
 export interface ValidationResult {
 	errorMessage: string;
 	validated: boolean
@@ -725,7 +723,7 @@ export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.
 	let targetPlatform;
 	if (isCloud) {
 		const engineEdition = serverInfo.engineEditionId;
-		targetPlatform = engineEdition === SqlDWEngineEdition ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;
+		targetPlatform = engineEdition === vscodeMssql.DatabaseEngineEdition.SqlDataWarehouse ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;
 	} else {
 		const serverMajorVersion = serverInfo.serverMajorVersion;
 		targetPlatform = serverMajorVersion ? constants.onPremServerVersionToTargetPlatform.get(serverMajorVersion) : undefined;

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -714,17 +714,16 @@ export async function fileContainsCreateTableStatement(fullPath: string, project
 
 /**
  * Gets target platform based on the server edition/version
- * @param connectionId server connection profile id
+ * @param serverInfo server information
  * @returns target platform for the database project
  */
-export async function getTargetPlatformFromServerVersion(connectionId: string): Promise<SqlTargetPlatform | undefined> {
-	const serverInfo = await getAzdataApi()!.connection.getServerInfo(connectionId);
+export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.ServerInfo | vscodeMssql.ServerInfo): Promise<SqlTargetPlatform | undefined> {
 	const isCloud = serverInfo.isCloud;
 
 	let targetPlatform;
 	if (isCloud) {
 		const engineEdition = serverInfo.engineEditionId;
-		targetPlatform = engineEdition === getAzdataApi()!.DatabaseEngineEdition.SqlDataWarehouse ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;
+		targetPlatform = engineEdition === 6 ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;		//DatabaseEngineEdition.SqlDataWarehouse = 6
 	} else {
 		const serverMajorVersion = serverInfo.serverMajorVersion;
 		targetPlatform = serverMajorVersion ? constants.onPremServerVersionToTargetPlatform.get(serverMajorVersion) : undefined;

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -17,6 +17,8 @@ import * as which from 'which';
 import { promises as fs } from 'fs';
 import { ISqlProject, SqlTargetPlatform } from 'sqldbproj';
 
+const SqlDWEngineEdition = 6;
+
 export interface ValidationResult {
 	errorMessage: string;
 	validated: boolean
@@ -723,7 +725,7 @@ export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.
 	let targetPlatform;
 	if (isCloud) {
 		const engineEdition = serverInfo.engineEditionId;
-		targetPlatform = engineEdition === 6 ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;		//DatabaseEngineEdition.SqlDataWarehouse = 6
+		targetPlatform = engineEdition === SqlDWEngineEdition ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;
 	} else {
 		const serverMajorVersion = serverInfo.serverMajorVersion;
 		targetPlatform = serverMajorVersion ? constants.onPremServerVersionToTargetPlatform.get(serverMajorVersion) : undefined;

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1420,7 +1420,7 @@ export class ProjectsController {
 			}
 			const model = await createNewProjectFromDatabaseWithQuickpick(profile as mssqlVscode.IConnectionInfo);
 			if (model) {
-				await this.createProjectFromDatabaseCallback(model);
+				await this.createProjectFromDatabaseCallback(model, profile as mssqlVscode.IConnectionInfo);
 			}
 			return undefined;
 		}
@@ -1431,13 +1431,22 @@ export class ProjectsController {
 		return new CreateProjectFromDatabaseDialog(profile);
 	}
 
-	public async createProjectFromDatabaseCallback(model: ImportDataModel, connectionId?: string) {
+	public async createProjectFromDatabaseCallback(model: ImportDataModel, connectionInfo: string | mssqlVscode.IConnectionInfo | undefined) {
 		try {
 
 			const newProjFolderUri = model.filePath;
 			let targetPlatform: SqlTargetPlatform | undefined;
-			if (connectionId) {
-				targetPlatform = await utils.getTargetPlatformFromServerVersion(connectionId);
+			let serverInfo;
+			if (connectionInfo) {
+				if (typeof connectionInfo === 'string') {
+					serverInfo = await utils.getAzdataApi()!.connection.getServerInfo(connectionInfo);
+				} else {
+					serverInfo = (await utils.getVscodeMssqlApi()).getServerInfo(connectionInfo);
+				}
+			}
+
+			if (serverInfo) {
+				targetPlatform = await utils.getTargetPlatformFromServerVersion(serverInfo);
 			}
 
 			const newProjFilePath = await this.createNewProject({

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1431,7 +1431,7 @@ export class ProjectsController {
 		return new CreateProjectFromDatabaseDialog(profile);
 	}
 
-	public async createProjectFromDatabaseCallback(model: ImportDataModel, connectionInfo: string | mssqlVscode.IConnectionInfo | undefined) {
+	public async createProjectFromDatabaseCallback(model: ImportDataModel, connectionInfo?: string | mssqlVscode.IConnectionInfo) {
 		try {
 
 			const newProjFolderUri = model.filePath;

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -509,7 +509,7 @@ describe('ProjectsController', function (): void {
 					version: '1.0.0.0',
 					extractTarget: mssql.ExtractTarget['schemaObjectType'],
 					sdkStyle: false
-				});
+				}, undefined);
 
 				return Promise.resolve(undefined);
 			});
@@ -517,7 +517,7 @@ describe('ProjectsController', function (): void {
 			const projController = TypeMoq.Mock.ofType(ProjectsController);
 			projController.callBase = true;
 			projController.setup(x => x.getCreateProjectFromDatabaseDialog(TypeMoq.It.isAny())).returns(() => createProjectFromDatabaseDialog.object);
-			projController.setup(x => x.createProjectFromDatabaseCallback(TypeMoq.It.isAny())).returns(() => {
+			projController.setup(x => x.createProjectFromDatabaseCallback(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
 				holler = createProjectFromDbHoller;
 				return Promise.resolve(undefined);
 			});

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -118,9 +118,27 @@ declare module 'vscode-mssql' {
 		/**
 		 * Get the server info for a connection
 		 * @param connectionInfo connection info of the connection
-	 	*/
-		 getServerInfo(connectionInfo: IConnectionInfo): ServerInfo
+		 */
+		getServerInfo(connectionInfo: IConnectionInfo): ServerInfo
 	}
+
+	/**
+	 * The possible values of the server engine edition
+	 * EngineEdition under https://docs.microsoft.com/sql/t-sql/functions/serverproperty-transact-sql is associated with these values
+	 */
+	 export const enum DatabaseEngineEdition {
+		Unknown = 0,
+		Personal = 1,
+		Standard = 2,
+		Enterprise = 3,
+		Express = 4,
+		SqlDatabase = 5,
+		SqlDataWarehouse = 6,
+		SqlStretchDatabase = 7,
+		SqlManagedInstance = 8,
+		SqlOnDemand = 11
+	}
+
 
 	/**
 	 * Information about a database connection
@@ -298,7 +316,7 @@ declare module 'vscode-mssql' {
 	/**
 	 * Information about a SQL Server instance.
 	 */
-	 export interface ServerInfo {
+	export interface ServerInfo {
 		/**
 		 * The major version of the SQL Server instance.
 		 */

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -114,6 +114,12 @@ declare module 'vscode-mssql' {
 		 * @returns A promise object for when the request receives a response
 		 */
 		sendRequest<P, R, E, R0>(requestType: RequestType<P, R, E, R0>, params?: P): Promise<R>;
+
+		/**
+		 * Get the server info for a connection
+		 * @param connectionInfo connection info of the connection
+	 	*/
+		 getServerInfo(connectionInfo: IConnectionInfo): ServerInfo
 	}
 
 	/**
@@ -287,6 +293,61 @@ declare module 'vscode-mssql' {
 		 * Gets or sets the connection string to use for this connection.
 		 */
 		connectionString: string | undefined;
+	}
+
+	/**
+	 * Information about a SQL Server instance.
+	 */
+	 export interface ServerInfo {
+		/**
+		 * The major version of the SQL Server instance.
+		 */
+		serverMajorVersion: number;
+
+		/**
+		 * The minor version of the SQL Server instance.
+		 */
+		serverMinorVersion: number;
+
+		/**
+		 * The build of the SQL Server instance.
+		 */
+		serverReleaseVersion: number;
+
+		/**
+		 * The ID of the engine edition of the SQL Server instance.
+		 */
+		engineEditionId: number;
+
+		/**
+		 * String containing the full server version text.
+		 */
+		serverVersion: string;
+
+		/**
+		 * String describing the product level of the server.
+		 */
+		serverLevel: string;
+
+		/**
+		 * The edition of the SQL Server instance.
+		 */
+		serverEdition: string;
+
+		/**
+		 * Whether the SQL Server instance is running in the cloud (Azure) or not.
+		 */
+		isCloud: boolean;
+
+		/**
+		 * The version of Azure that the SQL Server instance is running on, if applicable.
+		 */
+		azureVersion: number;
+
+		/**
+		 * The Operating System version string of the machine running the SQL Server instance.
+		 */
+		osVersion: string;
 	}
 
 	export const enum ExtractTarget {


### PR DESCRIPTION
This PR fixes #20576.
Read server metadata sent from mssql-vscode extension to set target platform automatically when creating project from database.
