### PR TITLE
table designer perf improvement - add user setting for preload db model 

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.3.0.18",
+	"version": "4.3.0.23",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -393,6 +393,11 @@
           "type": "boolean",
           "description": "%mssql.parallelMessageProcessing%",
           "default": false
+        },
+        "mssql.tableDesigner.preloadDatabaseModel": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.tableDesigner.preloadDatabaseModel%"
         }
       }
     },

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -188,5 +188,6 @@
 
 	"title.newTable": "New Table",
 	"title.designTable": "Design",
-	"mssql.parallelMessageProcessing" : "[Experimental] Whether the requests to the SQL Tools Service should be handled in parallel. This is introduced to discover the issues there might be when handling all requests in parallel. The default value is false. Relaunch of ADS is required when the value is changed."
+	"mssql.parallelMessageProcessing" : "[Experimental] Whether the requests to the SQL Tools Service should be handled in parallel. This is introduced to discover the issues there might be when handling all requests in parallel. The default value is false. Relaunch of ADS is required when the value is changed.",
+	"mssql.tableDesigner.preloadDatabaseModel": "Whether to preload the database model when the database node in the object explorer is expanded. When enabled, the loading time of table designer can be reduced."
 }

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -189,5 +189,5 @@
 	"title.newTable": "New Table",
 	"title.designTable": "Design",
 	"mssql.parallelMessageProcessing" : "[Experimental] Whether the requests to the SQL Tools Service should be handled in parallel. This is introduced to discover the issues there might be when handling all requests in parallel. The default value is false. Relaunch of ADS is required when the value is changed.",
-	"mssql.tableDesigner.preloadDatabaseModel": "Whether to preload the database model when the database node in the object explorer is expanded. When enabled, the loading time of table designer can be reduced."
+	"mssql.tableDesigner.preloadDatabaseModel": "Whether to preload the database model when the database node in the object explorer is expanded. When enabled, the loading time of table designer can be reduced. Note: You might see higher than normal memory usage if you need to expand a lot of database nodes."
 }

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -21,6 +21,7 @@ const configLogFilesRemovalLimit = 'logFilesRemovalLimit';
 const extensionConfigSectionName = 'mssql';
 const configLogDebugInfo = 'logDebugInfo';
 const parallelMessageProcessingConfig = 'parallelMessageProcessing';
+const tableDesignerPreloadConfig = 'tableDesigner.preloadDatabaseModel';
 
 /**
  *
@@ -90,6 +91,22 @@ export function getConfigTracingLevel(): string {
 		return config[configTracingLevel];
 	} else {
 		return undefined;
+	}
+}
+
+export function getConfigPreloadDatabaseModel(): boolean {
+	let config = getConfiguration();
+	if (config) {
+		return config.get<boolean>(tableDesignerPreloadConfig);
+	} else {
+		return false;
+	}
+}
+
+export function setConfigPreloadDatabaseModel(enable: boolean): void {
+	let config = getConfiguration();
+	if (config) {
+		void config.update(tableDesignerPreloadConfig, enable, true);
 	}
 }
 


### PR DESCRIPTION
Currently, the initial launch of table designer takes more time than subsequent ones, introduce a user setting to let user decide whether preload of the database model should be performed to make the initial launch experience smoother.

when user opens table designer (for both new and existing tables) for the first time, we show the following prompt.
![image](https://user-images.githubusercontent.com/13777222/190311013-b35e5054-5ab8-4973-9d9f-347cb97604c3.png)

regardless of the choice, this prompt will not show again.


STS changes since current version:
![image](https://user-images.githubusercontent.com/13777222/190484405-2766835a-f958-4c67-866d-467a7e4b006d.png)