### PR TITLE
Support reordering columns in Primary Key

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.3.0.24",
+	"version": "4.3.0.26",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",

--- a/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
+++ b/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
@@ -678,7 +678,8 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 				removeRowConfirmationMessage: options.removeRowConfirmationMessage,
 				showRemoveRowConfirmation: options.showRemoveRowConfirmation,
 				showItemDetailInPropertiesView: false,
-				labelForAddNewButton: options.labelForAddNewButton ?? localize('tableDesigner.addNewColumnToPrimaryKey', "Add Column")
+				labelForAddNewButton: options.labelForAddNewButton ?? localize('tableDesigner.addNewColumnToPrimaryKey', "Add Column"),
+				canMoveRows: options.canMoveRows
 			}
 		});
 


### PR DESCRIPTION
This PR fixes #20422

Allow user to reorder the columns in primary key
before:
![image](https://user-images.githubusercontent.com/13777222/191146595-78a3a107-7827-4ba2-9da2-408918a949dc.png)

after:
![image](https://user-images.githubusercontent.com/13777222/191146499-9721c611-4c08-4bf1-87ea-f639a3963fc9.png)


changes in STS since current version:

![image](https://user-images.githubusercontent.com/13777222/191146655-d349e727-a6cf-4085-a620-e8be3acb416d.png)
