### PR TITLE
Fixes incorrect operation label when plans are oriented vertically and node selection changes.

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
@@ -208,7 +208,7 @@ export class ExecutionPlanComparisonEditorView {
 				c.style.display = 'none';
 			});
 			this._topPlanDiagramContainers[e.index].style.display = '';
-			this._propertiesView.setTopElement(this._topPlanDiagramModels[e.index].root);
+			this._propertiesView.setPrimaryElement(this._topPlanDiagramModels[e.index].root);
 			this._topPlanRecommendations.recommendations = this._topPlanDiagramModels[e.index].recommendations;
 			this._activeTopPlanIndex = e.index;
 
@@ -233,7 +233,7 @@ export class ExecutionPlanComparisonEditorView {
 				c.style.display = 'none';
 			});
 			this._bottomPlanDiagramContainers[e.index].style.display = '';
-			this._propertiesView.setTopElement(this._bottomPlanDiagramModels[e.index].root);
+			this._propertiesView.setPrimaryElement(this._bottomPlanDiagramModels[e.index].root);
 			this._bottomPlanRecommendations.recommendations = this._bottomPlanDiagramModels[e.index].recommendations;
 			this._activeBottomPlanIndex = e.index;
 
@@ -345,7 +345,7 @@ export class ExecutionPlanComparisonEditorView {
 				this._topPlanContainer.appendChild(graphContainer);
 				const diagram = this._instantiationService.createInstance(AzdataGraphView, graphContainer, e);
 				diagram.onElementSelected(e => {
-					this._propertiesView.setTopElement(e);
+					this._propertiesView.setPrimaryElement(e);
 					const id = e.id.replace(`element-`, '');
 					if (this._topSimilarNode.has(id)) {
 						const similarNode = this._topSimilarNode.get(id);
@@ -364,7 +364,7 @@ export class ExecutionPlanComparisonEditorView {
 				graphContainer.style.display = 'none';
 			});
 			this._topPlanDropdown.select(preSelectIndex);
-			this._propertiesView.setTopElement(executionPlanGraphs[0].root);
+			this._propertiesView.setPrimaryElement(executionPlanGraphs[0].root);
 			this._propertiesAction.enabled = true;
 			this._zoomInAction.enabled = true;
 			this._zoomOutAction.enabled = true;
@@ -385,7 +385,7 @@ export class ExecutionPlanComparisonEditorView {
 				this._bottomPlanContainer.appendChild(graphContainer);
 				const diagram = this._instantiationService.createInstance(AzdataGraphView, graphContainer, e);
 				diagram.onElementSelected(e => {
-					this._propertiesView.setBottomElement(e);
+					this._propertiesView.setSecondaryElement(e);
 					const id = e.id.replace(`element-`, '');
 					if (this._bottomSimilarNode.has(id)) {
 						const similarNode = this._bottomSimilarNode.get(id);
@@ -404,7 +404,7 @@ export class ExecutionPlanComparisonEditorView {
 				graphContainer.style.display = 'none';
 			});
 			this._bottomPlanDropdown.select(preSelectIndex);
-			this._propertiesView.setBottomElement(executionPlanGraphs[0].root);
+			this._propertiesView.setSecondaryElement(executionPlanGraphs[0].root);
 			this._addExecutionPlanAction.enabled = false;
 			this._searchNodeActionForAddedPlan.enabled = true;
 		}

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -23,6 +23,10 @@ export enum ExecutionPlanCompareOrientation {
 	Vertical = 'vertical'
 }
 
+const topOperationLabel = localize('nodePropertyViewTopOperation', 'Top operation');
+const bottomOperationLabel = localize('nodePropertyViewBottomOperation', 'Bottom operation');
+const leftOperationLabel = localize('nodePropertyViewLeftOperation', 'Left operation');
+const rightOperationLabel = localize('nodePropertyViewRightOperation', 'Right operation');
 const topTitleColumnHeader = localize('nodePropertyViewNameValueColumnTopHeader', "Value (Top Plan)");
 const leftTitleColumnHeader = localize('nodePropertyViewNameValueColumnLeftHeader', "Value (Left Plan)");
 const rightTitleColumnHeader = localize('nodePropertyViewNameValueColumnRightHeader', "Value (Right Plan)");
@@ -61,7 +65,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			this._primaryTarget = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		const operationOrientation = this._orientation === ExecutionPlanCompareOrientation.Horizontal ? 'Top operation' : 'Left operation';
+		const operationOrientation = this._orientation === ExecutionPlanCompareOrientation.Horizontal ? topOperationLabel : leftOperationLabel;
 		let topTitleText = localize('executionPlanComparisonPropertiesTopOperation', "{0}: {1}", operationOrientation, this._primaryTarget);
 		this._primaryContainer.innerText = topTitleText;
 		this._primaryContainer.title = topTitleText;
@@ -76,7 +80,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			this._secondaryTarget = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		const operationOrientation = this._orientation === ExecutionPlanCompareOrientation.Horizontal ? 'Bottom operation' : 'Right operation';
+		const operationOrientation = this._orientation === ExecutionPlanCompareOrientation.Horizontal ? bottomOperationLabel : rightOperationLabel;
 		let bottomTitleText = localize('executionPlanComparisonPropertiesBottomOperation', "{0}: {1}", operationOrientation, this._secondaryTarget);
 		this._secondaryContainer.innerText = bottomTitleText;
 		this._secondaryContainer.title = bottomTitleText;
@@ -88,8 +92,8 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		let secondaryTitleText = '';
 
 		const [primaryOperationOrientation, secondaryOperationOrientation] = this._orientation === ExecutionPlanCompareOrientation.Horizontal
-			? ['Top operation', 'Bottom operation']
-			: ['Left operation', 'Right operation'];
+			? [topOperationLabel, bottomOperationLabel]
+			: [leftOperationLabel, rightOperationLabel];
 
 		primaryTitleText = localize('executionPlanComparisonPropertiesPrimaryOperation', "{0}: {1}", primaryOperationOrientation, this._primaryTarget);
 		secondaryTitleText = localize('executionPlanComparisonPropertiesSecondaryOperation', "{0}: {1}", secondaryOperationOrientation, this._secondaryTarget);

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -23,6 +23,22 @@ export enum ExecutionPlanCompareOrientation {
 	Vertical = 'vertical'
 }
 
+function getTopOperationLabel(target: string): string {
+	return localize('nodePropertyViewTopOperation', 'Top operation: {0}', target);
+}
+
+function getBottomOperationLabel(target: string): string {
+	return localize('nodePropertyViewBottomOperation', 'Bottom operation: {0}', target);
+}
+
+function getLeftOperationLabel(target: string): string {
+	return localize('nodePropertyViewLeftOperation', 'Left operation: {0}', target);
+}
+
+function getRightOperationLabel(target: string): string {
+	return localize('nodePropertyViewRightOperation', 'Right operation: {0}', target);
+}
+
 const topTitleColumnHeader = localize('nodePropertyViewNameValueColumnTopHeader', "Value (Top Plan)");
 const leftTitleColumnHeader = localize('nodePropertyViewNameValueColumnLeftHeader', "Value (Left Plan)");
 const rightTitleColumnHeader = localize('nodePropertyViewNameValueColumnRightHeader', "Value (Right Plan)");
@@ -62,8 +78,8 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		}
 
 		const topTitleText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
-			? ExecutionPlanComparisonPropertiesView.getTopOperationLabel(this._primaryTarget)
-			: ExecutionPlanComparisonPropertiesView.getLeftOperationLabel(this._primaryTarget);
+			? getTopOperationLabel(this._primaryTarget)
+			: getLeftOperationLabel(this._primaryTarget);
 
 		this._primaryContainer.innerText = topTitleText;
 		this._primaryContainer.title = topTitleText;
@@ -79,8 +95,8 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		}
 
 		const bottomTitleText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
-			? ExecutionPlanComparisonPropertiesView.getBottomOperationLabel(this._secondaryTarget)
-			: ExecutionPlanComparisonPropertiesView.getRightOperationLabel(this._secondaryTarget);
+			? getBottomOperationLabel(this._secondaryTarget)
+			: getRightOperationLabel(this._secondaryTarget);
 
 		this._secondaryContainer.innerText = bottomTitleText;
 		this._secondaryContainer.title = bottomTitleText;
@@ -89,8 +105,8 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 	private updatePropertyContainerTitles(): void {
 		const [primaryTitleText, secondaryTitleText] = this._orientation === ExecutionPlanCompareOrientation.Horizontal
-			? [ExecutionPlanComparisonPropertiesView.getTopOperationLabel(this._primaryTarget), ExecutionPlanComparisonPropertiesView.getBottomOperationLabel(this._secondaryTarget)]
-			: [ExecutionPlanComparisonPropertiesView.getLeftOperationLabel(this._primaryTarget), ExecutionPlanComparisonPropertiesView.getRightOperationLabel(this._secondaryTarget)];
+			? [getTopOperationLabel(this._primaryTarget), getBottomOperationLabel(this._secondaryTarget)]
+			: [getLeftOperationLabel(this._primaryTarget), getRightOperationLabel(this._secondaryTarget)];
 
 		this._primaryContainer.innerText = primaryTitleText;
 		this._primaryContainer.title = primaryTitleText;
@@ -98,22 +114,6 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		this._secondaryContainer.title = secondaryTitleText;
 
 		this.updatePropertiesTableColumnHeaders();
-	}
-
-	private static getTopOperationLabel(target: string): string {
-		return localize('nodePropertyViewTopOperation', 'Top operation: {0}', target);
-	}
-
-	private static getBottomOperationLabel(target: string): string {
-		return localize('nodePropertyViewBottomOperation', 'Bottom operation: {0}', target);
-	}
-
-	private static getLeftOperationLabel(target: string): string {
-		return localize('nodePropertyViewLeftOperation', 'Left operation: {0}', target);
-	}
-
-	private static getRightOperationLabel(target: string): string {
-		return localize('nodePropertyViewRightOperation', 'Right operation: {0}', target);
 	}
 
 	public updatePropertiesTableColumnHeaders() {

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -69,37 +69,37 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		this.setHeader(header);
 	}
 
-	public setTopElement(e: InternalExecutionPlanElement): void {
-		this._model.topElement = e;
+	public setPrimaryElement(e: InternalExecutionPlanElement): void {
+		this._model.primaryElement = e;
 		if ((<azdata.executionPlan.ExecutionPlanNode>e).name) {
 			this._primaryTarget = removeLineBreaks((<azdata.executionPlan.ExecutionPlanNode>e).name);
 		} else {
 			this._primaryTarget = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		const topTitleText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
+		const primaryTitleText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
 			? getTopOperationLabel(this._primaryTarget)
 			: getLeftOperationLabel(this._primaryTarget);
 
-		this._primaryContainer.innerText = topTitleText;
-		this._primaryContainer.title = topTitleText;
+		this._primaryContainer.innerText = primaryTitleText;
+		this._primaryContainer.title = primaryTitleText;
 		this.refreshPropertiesTable();
 	}
 
-	public setBottomElement(e: InternalExecutionPlanElement): void {
-		this._model.bottomElement = e;
+	public setSecondaryElement(e: InternalExecutionPlanElement): void {
+		this._model.secondaryElement = e;
 		if ((<azdata.executionPlan.ExecutionPlanNode>e)?.name) {
 			this._secondaryTarget = removeLineBreaks((<azdata.executionPlan.ExecutionPlanNode>e).name);
 		} else {
 			this._secondaryTarget = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		const bottomTitleText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
+		const secondaryTitleText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
 			? getBottomOperationLabel(this._secondaryTarget)
 			: getRightOperationLabel(this._secondaryTarget);
 
-		this._secondaryContainer.innerText = bottomTitleText;
-		this._secondaryContainer.title = bottomTitleText;
+		this._secondaryContainer.innerText = secondaryTitleText;
+		this._secondaryContainer.title = secondaryTitleText;
 		this.refreshPropertiesTable();
 	}
 
@@ -125,22 +125,22 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 	public refreshPropertiesTable() {
 		const columns: Slick.Column<Slick.SlickData>[] = this.getPropertyTableColumns();
 
-		let topProps = [];
-		let bottomProps = [];
-		if (this._model.topElement?.properties) {
-			topProps = this._model.topElement.properties;
+		let primaryProps = [];
+		let secondaryProps = [];
+		if (this._model.primaryElement?.properties) {
+			primaryProps = this._model.primaryElement.properties;
 		}
-		if (this._model.bottomElement?.properties) {
-			bottomProps = this._model.bottomElement.properties;
+		if (this._model.secondaryElement?.properties) {
+			secondaryProps = this._model.secondaryElement.properties;
 		}
 
-		this.populateTable(columns, this.convertPropertiesToTableRows(topProps, bottomProps, -1, 0));
+		this.populateTable(columns, this.convertPropertiesToTableRows(primaryProps, secondaryProps, -1, 0));
 	}
 
 	private getPropertyTableColumns() {
 		const columns: Slick.Column<Slick.SlickData>[] = [];
 
-		if (this._model.topElement) {
+		if (this._model.primaryElement) {
 			columns.push({
 				id: 'name',
 				name: localize('nodePropertyViewNameNameColumnHeader', "Name"),
@@ -158,7 +158,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 				formatter: textFormatter
 			});
 		}
-		if (this._model.bottomElement) {
+		if (this._model.secondaryElement) {
 			columns.push(new TextWithIconColumn({
 				id: 'value2',
 				name: getPropertyViewNameValueColumnBottomHeaderForOrientation(this._orientation),
@@ -212,28 +212,28 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		}));
 	}
 
-	private convertPropertiesToTableRows(topNode: azdata.executionPlan.ExecutionPlanGraphElementProperty[], bottomNode: azdata.executionPlan.ExecutionPlanGraphElementProperty[], parentIndex: number, indent: number, rows: { [key: string]: string }[] = []): { [key: string]: string }[] {
+	private convertPropertiesToTableRows(primaryNode: azdata.executionPlan.ExecutionPlanGraphElementProperty[], secondaryNode: azdata.executionPlan.ExecutionPlanGraphElementProperty[], parentIndex: number, indent: number, rows: { [key: string]: string }[] = []): { [key: string]: string }[] {
 		let propertiesMap: Map<string, TablePropertiesMapEntry> = new Map();
 
-		if (topNode) {
-			topNode.forEach(p => {
+		if (primaryNode) {
+			primaryNode.forEach(p => {
 				propertiesMap.set(p.name, {
-					topProp: p,
-					bottomProp: undefined,
+					primaryProp: p,
+					secondaryProp: undefined,
 					displayOrder: p.displayOrder,
 					name: p.name
 				});
 			});
 		}
 
-		if (bottomNode) {
-			bottomNode.forEach(p => {
+		if (secondaryNode) {
+			secondaryNode.forEach(p => {
 				if (propertiesMap.has(p.name)) {
-					propertiesMap.get(p.name).bottomProp = p;
+					propertiesMap.get(p.name).secondaryProp = p;
 				} else {
 					propertiesMap.set(p.name, {
-						topProp: undefined,
-						bottomProp: p,
+						primaryProp: undefined,
+						secondaryProp: p,
 						displayOrder: p.displayOrder,
 						name: p.name
 					});
@@ -260,18 +260,18 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			};
 			row['parent'] = parentIndex;
 
-			const topProp = v.topProp;
-			const bottomProp = v.bottomProp;
+			const primaryProp = v.primaryProp;
+			const secondaryProp = v.secondaryProp;
 			let diffIconClass = '';
-			if (topProp && bottomProp) {
-				row['displayOrder'] = v.topProp.displayOrder;
-				if (v.topProp.displayValue !== v.bottomProp.displayValue) {
-					switch (v.topProp.dataType) {
+			if (primaryProp && secondaryProp) {
+				row['displayOrder'] = v.primaryProp.displayOrder;
+				if (v.primaryProp.displayValue !== v.secondaryProp.displayValue) {
+					switch (v.primaryProp.dataType) {
 						case sqlExtHostType.executionPlan.ExecutionPlanGraphElementPropertyDataType.Boolean:
 							diffIconClass = executionPlanComparisonPropertiesDifferent;
 							break;
 						case sqlExtHostType.executionPlan.ExecutionPlanGraphElementPropertyDataType.Number:
-							diffIconClass = (parseFloat(v.topProp.displayValue) > parseFloat(v.bottomProp.displayValue)) ? executionPlanComparisonPropertiesDownArrow : executionPlanComparisonPropertiesUpArrow;
+							diffIconClass = (parseFloat(v.primaryProp.displayValue) > parseFloat(v.secondaryProp.displayValue)) ? executionPlanComparisonPropertiesDownArrow : executionPlanComparisonPropertiesUpArrow;
 							break;
 						case sqlExtHostType.executionPlan.ExecutionPlanGraphElementPropertyDataType.String:
 							diffIconClass = executionPlanComparisonPropertiesDifferent;
@@ -282,47 +282,47 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 					}
 				}
 				row['primary'] = {
-					text: removeLineBreaks(v.topProp.displayValue, ' ')
+					text: removeLineBreaks(v.primaryProp.displayValue, ' ')
 				};
 				row['secondary'] = {
 					iconCssClass: diffIconClass,
-					title: removeLineBreaks(v.bottomProp.displayValue, ' ')
+					title: removeLineBreaks(v.secondaryProp.displayValue, ' ')
 				};
-				if ((topProp && !isString(topProp.value)) || (bottomProp && !isString(bottomProp.value))) {
+				if ((primaryProp && !isString(primaryProp.value)) || (secondaryProp && !isString(secondaryProp.value))) {
 					row['name'].iconCssClass += ` parent-row-styling`;
 					row['primary'].iconCssClass += ` parent-row-styling`;
 					row['secondary'].iconCssClass += ` parent-row-styling`;
 				}
 				rows.push(row);
-				if (!isString(topProp.value) && !isString(bottomProp.value)) {
-					this.convertPropertiesToTableRows(topProp.value, bottomProp.value, rows.length - 1, indent + 2, rows);
-				} else if (isString(topProp?.value) && !isString(bottomProp.value)) {
-					this.convertPropertiesToTableRows(undefined, bottomProp.value, rows.length - 1, indent + 2, rows);
-				} else if (!isString(topProp.value) && !isString(bottomProp.value)) {
-					this.convertPropertiesToTableRows(topProp.value, undefined, rows.length - 1, indent + 2, rows);
+				if (!isString(primaryProp.value) && !isString(secondaryProp.value)) {
+					this.convertPropertiesToTableRows(primaryProp.value, secondaryProp.value, rows.length - 1, indent + 2, rows);
+				} else if (isString(primaryProp?.value) && !isString(secondaryProp.value)) {
+					this.convertPropertiesToTableRows(undefined, secondaryProp.value, rows.length - 1, indent + 2, rows);
+				} else if (!isString(primaryProp.value) && !isString(secondaryProp.value)) {
+					this.convertPropertiesToTableRows(primaryProp.value, undefined, rows.length - 1, indent + 2, rows);
 				}
-			} else if (topProp && !bottomProp) {
-				row['displayOrder'] = v.topProp.displayOrder;
+			} else if (primaryProp && !secondaryProp) {
+				row['displayOrder'] = v.primaryProp.displayOrder;
 				row['primary'] = {
-					text: v.topProp.displayValue
+					text: v.primaryProp.displayValue
 				};
 				rows.push(row);
-				if (!isString(topProp.value)) {
+				if (!isString(primaryProp.value)) {
 					row['name'].iconCssClass += ` parent-row-styling`;
 					row['primary'].iconCssClass += ` parent-row-styling`;
-					this.convertPropertiesToTableRows(topProp.value, undefined, rows.length - 1, indent + 2, rows);
+					this.convertPropertiesToTableRows(primaryProp.value, undefined, rows.length - 1, indent + 2, rows);
 				}
-			} else if (!topProp && bottomProp) {
-				row['displayOrder'] = v.bottomProp.displayOrder;
+			} else if (!primaryProp && secondaryProp) {
+				row['displayOrder'] = v.secondaryProp.displayOrder;
 				row['secondary'] = {
-					title: v.bottomProp.displayValue,
+					title: v.secondaryProp.displayValue,
 					iconCssClass: diffIconClass
 				};
 				rows.push(row);
-				if (!isString(bottomProp.value)) {
+				if (!isString(secondaryProp.value)) {
 					row['name'].iconCssClass += ` parent-row-styling`;
 					row['secondary'].iconCssClass += ` parent-row-styling`;
-					this.convertPropertiesToTableRows(undefined, bottomProp.value, rows.length - 1, indent + 2, rows);
+					this.convertPropertiesToTableRows(undefined, secondaryProp.value, rows.length - 1, indent + 2, rows);
 				}
 			}
 
@@ -359,13 +359,13 @@ function getPropertyViewNameValueColumnBottomHeaderForOrientation(orientation: E
 }
 
 export interface ExecutionPlanComparisonPropertiesViewModel {
-	topElement: InternalExecutionPlanElement,
-	bottomElement: InternalExecutionPlanElement
+	primaryElement: InternalExecutionPlanElement,
+	secondaryElement: InternalExecutionPlanElement
 }
 
 interface TablePropertiesMapEntry {
-	topProp: azdata.executionPlan.ExecutionPlanGraphElementProperty,
-	bottomProp: azdata.executionPlan.ExecutionPlanGraphElementProperty,
+	primaryProp: azdata.executionPlan.ExecutionPlanGraphElementProperty,
+	secondaryProp: azdata.executionPlan.ExecutionPlanGraphElementProperty,
 	displayOrder: number,
 	name: string
 }

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -23,10 +23,6 @@ export enum ExecutionPlanCompareOrientation {
 	Vertical = 'vertical'
 }
 
-const topOperationLabel = localize('nodePropertyViewTopOperation', 'Top operation');
-const bottomOperationLabel = localize('nodePropertyViewBottomOperation', 'Bottom operation');
-const leftOperationLabel = localize('nodePropertyViewLeftOperation', 'Left operation');
-const rightOperationLabel = localize('nodePropertyViewRightOperation', 'Right operation');
 const topTitleColumnHeader = localize('nodePropertyViewNameValueColumnTopHeader', "Value (Top Plan)");
 const leftTitleColumnHeader = localize('nodePropertyViewNameValueColumnLeftHeader', "Value (Left Plan)");
 const rightTitleColumnHeader = localize('nodePropertyViewNameValueColumnRightHeader', "Value (Right Plan)");
@@ -65,8 +61,10 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			this._primaryTarget = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		const operationOrientation = this._orientation === ExecutionPlanCompareOrientation.Horizontal ? topOperationLabel : leftOperationLabel;
-		let topTitleText = localize('executionPlanComparisonPropertiesTopOperation', "{0}: {1}", operationOrientation, this._primaryTarget);
+		const topTitleText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
+			? ExecutionPlanComparisonPropertiesView.getTopOperationLabel(this._primaryTarget)
+			: ExecutionPlanComparisonPropertiesView.getLeftOperationLabel(this._primaryTarget);
+
 		this._primaryContainer.innerText = topTitleText;
 		this._primaryContainer.title = topTitleText;
 		this.refreshPropertiesTable();
@@ -80,23 +78,19 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			this._secondaryTarget = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		const operationOrientation = this._orientation === ExecutionPlanCompareOrientation.Horizontal ? bottomOperationLabel : rightOperationLabel;
-		let bottomTitleText = localize('executionPlanComparisonPropertiesBottomOperation', "{0}: {1}", operationOrientation, this._secondaryTarget);
+		const bottomTitleText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
+			? ExecutionPlanComparisonPropertiesView.getBottomOperationLabel(this._secondaryTarget)
+			: ExecutionPlanComparisonPropertiesView.getRightOperationLabel(this._secondaryTarget);
+
 		this._secondaryContainer.innerText = bottomTitleText;
 		this._secondaryContainer.title = bottomTitleText;
 		this.refreshPropertiesTable();
 	}
 
 	private updatePropertyContainerTitles(): void {
-		let primaryTitleText = '';
-		let secondaryTitleText = '';
-
-		const [primaryOperationOrientation, secondaryOperationOrientation] = this._orientation === ExecutionPlanCompareOrientation.Horizontal
-			? [topOperationLabel, bottomOperationLabel]
-			: [leftOperationLabel, rightOperationLabel];
-
-		primaryTitleText = localize('executionPlanComparisonPropertiesPrimaryOperation', "{0}: {1}", primaryOperationOrientation, this._primaryTarget);
-		secondaryTitleText = localize('executionPlanComparisonPropertiesSecondaryOperation', "{0}: {1}", secondaryOperationOrientation, this._secondaryTarget);
+		const [primaryTitleText, secondaryTitleText] = this._orientation === ExecutionPlanCompareOrientation.Horizontal
+			? [ExecutionPlanComparisonPropertiesView.getTopOperationLabel(this._primaryTarget), ExecutionPlanComparisonPropertiesView.getBottomOperationLabel(this._secondaryTarget)]
+			: [ExecutionPlanComparisonPropertiesView.getLeftOperationLabel(this._primaryTarget), ExecutionPlanComparisonPropertiesView.getRightOperationLabel(this._secondaryTarget)];
 
 		this._primaryContainer.innerText = primaryTitleText;
 		this._primaryContainer.title = primaryTitleText;
@@ -104,6 +98,22 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		this._secondaryContainer.title = secondaryTitleText;
 
 		this.updatePropertiesTableColumnHeaders();
+	}
+
+	private static getTopOperationLabel(target: string): string {
+		return localize('nodePropertyViewTopOperation', 'Top operation: {0}', target);
+	}
+
+	private static getBottomOperationLabel(target: string): string {
+		return localize('nodePropertyViewBottomOperation', 'Bottom operation: {0}', target);
+	}
+
+	private static getLeftOperationLabel(target: string): string {
+		return localize('nodePropertyViewLeftOperation', 'Left operation: {0}', target);
+	}
+
+	private static getRightOperationLabel(target: string): string {
+		return localize('nodePropertyViewRightOperation', 'Right operation: {0}', target);
 	}
 
 	public updatePropertiesTableColumnHeaders() {

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -61,7 +61,8 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			this._primaryTarget = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		let topTitleText = localize('executionPlanComparisonPropertiesTopOperation', "Top operation: {0}", this._primaryTarget);
+		const operationOrientation = this._orientation === ExecutionPlanCompareOrientation.Horizontal ? 'Top operation' : 'Left operation';
+		let topTitleText = localize('executionPlanComparisonPropertiesTopOperation', "{0}: {1}", operationOrientation, this._primaryTarget);
 		this._primaryContainer.innerText = topTitleText;
 		this._primaryContainer.title = topTitleText;
 		this.refreshPropertiesTable();
@@ -75,7 +76,8 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 			this._secondaryTarget = localize('executionPlanPropertiesEdgeOperationName', "Edge");
 		}
 
-		let bottomTitleText = localize('executionPlanComparisonPropertiesBottomOperation', "Bottom operation: {0}", this._secondaryTarget);
+		const operationOrientation = this._orientation === ExecutionPlanCompareOrientation.Horizontal ? 'Bottom operation' : 'Right operation';
+		let bottomTitleText = localize('executionPlanComparisonPropertiesBottomOperation', "{0}: {1}", operationOrientation, this._secondaryTarget);
 		this._secondaryContainer.innerText = bottomTitleText;
 		this._secondaryContainer.title = bottomTitleText;
 		this.refreshPropertiesTable();
@@ -85,14 +87,12 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		let primaryTitleText = '';
 		let secondaryTitleText = '';
 
-		if (this._orientation === ExecutionPlanCompareOrientation.Horizontal) {
-			primaryTitleText = localize('executionPlanComparisonPropertiesTopOperation', "Top operation: {0}", this._primaryTarget);
-			secondaryTitleText = localize('executionPlanComparisonPropertiesBottomOperation', "Bottom operation: {0}", this._secondaryTarget);
-		}
-		else {
-			primaryTitleText = localize('executionPlanComparisonPropertiesLeftOperation', "Left operation: {0}", this._primaryTarget);
-			secondaryTitleText = localize('executionPlanComparisonPropertiesRightOperation', "Right operation: {0}", this._secondaryTarget);
-		}
+		const [primaryOperationOrientation, secondaryOperationOrientation] = this._orientation === ExecutionPlanCompareOrientation.Horizontal
+			? ['Top operation', 'Bottom operation']
+			: ['Left operation', 'Right operation'];
+
+		primaryTitleText = localize('executionPlanComparisonPropertiesPrimaryOperation', "{0}: {1}", primaryOperationOrientation, this._primaryTarget);
+		secondaryTitleText = localize('executionPlanComparisonPropertiesSecondaryOperation', "{0}: {1}", secondaryOperationOrientation, this._secondaryTarget);
 
 		this._primaryContainer.innerText = primaryTitleText;
 		this._primaryContainer.title = primaryTitleText;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes an issue around the "Left operation" and "Right operation" labels changing back to "Top operation and "Right operation" when plans are vertically oriented and a different node is selected.

Before:
![Vertical Operation Label Bug](https://user-images.githubusercontent.com/87730006/191341517-dc701fa7-46dc-4345-81d5-dec151e91073.gif)

After: 
![Vertical Operation Label Fix](https://user-images.githubusercontent.com/87730006/191341501-a71337f5-7009-42f1-9686-495b9400abca.gif)

