### PR TITLE
Give saveAsExcel its own config options

### DIFF
--- a/src/sql/platform/query/common/query.ts
+++ b/src/sql/platform/query/common/query.ts
@@ -12,6 +12,9 @@ export interface IQueryEditorConfiguration {
 			readonly textIdentifier: string,
 			readonly encoding: string
 		},
+		readonly saveAsExcel: {
+			readonly includeHeaders: boolean,
+		},
 		readonly saveAsXml: {
 			readonly formatted: boolean,
 			readonly encoding: string

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -374,6 +374,11 @@ const queryEditorConfiguration: IConfigurationNode = {
 			'description': localize('queryEditor.results.saveAsCsv.textIdentifier', "Character used for enclosing text fields when saving results as CSV"),
 			'default': '\"'
 		},
+		'queryEditor.results.saveAsExcel.includeHeaders': {
+			'type': 'boolean',
+			'description': localize('queryEditor.results.saveAsExcel.includeHeaders', "When true, column headers are included when saving results as an Excel file"),
+			'default': true
+		},
 		'queryEditor.results.saveAsCsv.encoding': {
 			'type': 'string',
 			'description': localize('queryEditor.results.saveAsCsv.encoding', "File encoding used when saving results as CSV"),

--- a/src/sql/workbench/services/query/common/resultSerializer.ts
+++ b/src/sql/workbench/services/query/common/resultSerializer.ts
@@ -191,6 +191,7 @@ export class ResultSerializer {
 
 		// get save results config from vscode config
 		let saveConfig = this._configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.saveAsCsv;
+
 		// if user entered config, set options
 		if (saveConfig) {
 			if (saveConfig.includeHeaders !== undefined) {
@@ -215,21 +216,23 @@ export class ResultSerializer {
 
 	private getConfigForJson(): SaveResultsRequestParams {
 		// JSON does not currently have special conditions
-		let saveResultsParams = <SaveResultsRequestParams>{ resultFormat: SaveFormat.JSON as string };
-		return saveResultsParams;
+		return <SaveResultsRequestParams>{ resultFormat: SaveFormat.JSON as string };
 	}
 
 	private getConfigForExcel(): SaveResultsRequestParams {
-		// get save results config from vscode config
-		// Note: we are currently using the configSaveAsCsv setting since it has the option mssql.saveAsCsv.includeHeaders
-		// and we want to have just 1 setting that lists this.
-		let config = this.getConfigForCsv();
-		config.resultFormat = SaveFormat.EXCEL;
-		config.delimiter = undefined;
-		config.lineSeperator = undefined;
-		config.textIdentifier = undefined;
-		config.encoding = undefined;
-		return config;
+		let saveResultsParams = <SaveResultsRequestParams>{ resultFormat: SaveFormat.EXCEL as string };
+
+		// Get save results config from vscode config
+		let saveConfig = this._configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.saveAsExcel;
+
+		// If user entered config, set options
+		if (saveConfig) {
+			if (saveConfig.includeHeaders !== undefined) {
+				saveResultsParams.includeHeaders = saveConfig.includeHeaders;
+			}
+		}
+
+		return saveResultsParams;
 	}
 
 	private getConfigForXml(): SaveResultsRequestParams {
@@ -237,6 +240,7 @@ export class ResultSerializer {
 
 		// get save results config from vscode config
 		let saveConfig = this._configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.saveAsXml;
+
 		// if user entered config, set options
 		if (saveConfig) {
 			if (saveConfig.formatted !== undefined) {
@@ -251,7 +255,14 @@ export class ResultSerializer {
 	}
 
 
-	private getParameters(uri: string, filePath: URI, batchIndex: number, resultSetNo: number, format: string, selection?: Slick.Range): SaveResultsRequestParams {
+	private getParameters(
+		uri: string,
+		filePath: URI,
+		batchIndex: number,
+		resultSetNo: number,
+		format: string,
+		selection?: Slick.Range
+	): SaveResultsRequestParams {
 		let saveResultsParams = this.getBasicSaveParameters(format);
 		saveResultsParams.filePath = filePath.fsPath;
 		saveResultsParams.ownerUri = uri;


### PR DESCRIPTION
**Description**: As a prerequisite to the hackathon project I'm working on to add support for exporting to Markdown, I propose giving saveAsExcel its own configuration section. This will be expanded later to give Markdown its own section, as well.

This fixes a (well, what I perceive as a) bug where the configuration for save as CSV (specifically, include headers) is used as the config for save as Excel. Thus, although the configuration states that `queryEditor.results.saveAsCSV.includeHeaders` the setting only impacts "saving results as CSV", it actually impacts saving to CSV *and* Excel. To resolve this, I have added a new configuration setting `queryEditor.results.saveAsExcel.includeHeaders` that controls header inclusion just for Excel. To facilitate this, the `getConfigForExcel` method in the `ResultsSerializer` has been updated to not call the `getConfigForCsv` method and instead read exclusively from the save as Excel settings.

**Testing**:
* My manual tests behave as expected
* Manual testing:
  a) Set Query Editor -> Results -> Save As Excel : Include Headers to false
  b) Run a query that selects something
  d) Right click on results, select Save As Excel, give it a place to save (alternatively, click the little button for it)
  e) Open file, validate headers are not included
  f) Repeat a - e with Include Headers set to true, checking for headers
  g) Repeat a - f while modifying Save As CSV : Include Headers