### PR TITLE
use grep and invert option

### DIFF
--- a/test/smoke/test/index.js
+++ b/test/smoke/test/index.js
@@ -33,8 +33,6 @@ if (process.env.BUILD_ARTIFACTSTAGINGDIRECTORY) {
 	};
 }
 
-const mocha = new Mocha(options);
-
 // {{SQL CARBON EDIT}} - If grep option is specified, only run the matching test cases (local test case development/debug scenario),
 // otherwise the value of 'RUN_UNSTABLE_TESTS' environment variable will be used to determine whether to run the stable test cases or the whole test suite.
 // Unstable test cases have "@UNSTABLE@" in their full name (test suite name + test name).
@@ -43,12 +41,15 @@ if (!options.grep) {
 		console.info('running all test cases.');
 	} else {
 		console.info('running stable test cases.');
-		mocha.grep('@UNSTABLE@').invert();
+		options.grep= '@UNSTABLE@';
+		options.invert = true;
 	}
 } else {
 	console.info('running test cases match the grep option.');
 }
 // {{SQL CARBON EDIT}} - end of edit.
+
+const mocha = new Mocha(options);
 
 mocha.addFile('out/main.js');
 mocha.run(failures => process.exit(failures ? -1 : 0));


### PR DESCRIPTION
Use `invert` and `grep` properties instead of calling the methods.

In my previous PR: https://github.com/microsoft/azuredatastudio/pull/20639, I used the `grep()` and `invert()` methods directly because I don't see the `invert` option in `Mocha.Options` interface. Today, I looked at the mocha.js directly and noticed the `invert` property are actually supported, it is the typing file that do not have it included. 

I only find the `invert` property being included in the 9.x typing file which is different from our mocha's major version, so I am not going to update the typing file version.

tested with the following builds.

All Test Cases:
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=171977&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=05af1eac-c39c-5c75-1e3f-dd115ec8907d
![image](https://user-images.githubusercontent.com/13777222/191871898-a23376ba-40bc-4332-bb38-9ecd12b9d685.png)

Stable Test Cases:
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=172058&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=05af1eac-c39c-5c75-1e3f-dd115ec8907d

![image](https://user-images.githubusercontent.com/13777222/191871938-3987ddd1-5151-4d09-9a60-921f09497619.png)
