### PR TITLE
Fix null ref error in terminal service

### DIFF
--- a/src/vs/workbench/api/common/extHostTerminalService.ts
+++ b/src/vs/workbench/api/common/extHostTerminalService.ts
@@ -464,7 +464,7 @@ export abstract class BaseExtHostTerminalService extends Disposable implements I
 		if (id === null) {
 			this._activeTerminal = undefined;
 			if (original !== this._activeTerminal) {
-				this._onDidChangeActiveTerminal.fire(this._activeTerminal.value);
+				this._onDidChangeActiveTerminal.fire(undefined); // {{SQL CARBON EDIT}} This was set to undefined above so send that - this will be replaced with later refactorings that VS Code did
 			}
 			return;
 		}


### PR DESCRIPTION
Been seeing this error a lot when exiting ADS during development - and while I'm not sure exactly when it would come up that the ID would be set to null during normal runtime theoretically that seems to be possible so better to prevent the error. 

(VS Code is just sending _activeTerminal which is undefined at that point : https://github.com/microsoft/vscode/blob/release/1.62/src/vs/workbench/api/common/extHostTerminalService.ts#L470. But our build won't let us do that since the types don't match so I'm just hardcoding it to undefined since this stuff is all going to be refactored away here in an upcoming merge)