### PR TITLE
Fix Scope, Azure Pane

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -24,7 +24,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { Logger } from '../../utils/Logger';
 import * as qs from 'qs';
 import { AzureAuthError } from './azureAuthError';
-import { AuthenticationResult, PublicClientApplication } from '@azure/msal-node';
+import { AuthenticationResult, InteractionRequiredAuthError, PublicClientApplication } from '@azure/msal-node';
 
 const localize = nls.loadMessageBundle();
 
@@ -325,8 +325,6 @@ export abstract class AzureAuth implements vscode.Disposable {
 	 * @param azureResource
 	 * @returns The authentication result, including the access token
 	 */
-	// TODO: Need to add resource we are getting the token for
-	// Can replace most refreshToken calls with getToken, it does the same thing
 	public async getTokenMsal(accountId: string, azureResource: azdata.AzureResource): Promise<AuthenticationResult | null> {
 		const cache = this.clientApplication.getTokenCache();
 		if (!cache) {
@@ -343,7 +341,9 @@ export abstract class AzureAuth implements vscode.Disposable {
 			Logger.error('Error: Could not fetch account when acquiring token');
 			return null;
 		}
-		let newScope = [`${resource?.endpoint}/User.Read`];
+
+		let newScope = [`${resource?.endpoint}.default`];
+
 		// construct request
 		const tokenRequest = {
 			account: account,
@@ -353,13 +353,19 @@ export abstract class AzureAuth implements vscode.Disposable {
 			return await this.clientApplication.acquireTokenSilent(tokenRequest);
 		} catch (e) {
 			Logger.error('Failed to acquireTokenSilent', e);
-			// need to create an auth url request
-			const tenant: Tenant = {
-				id: account.tenantId,
-				displayName: ''
-			};
-			const authResult = await this.loginMsal(tenant, resource);
-			return authResult.response;
+			if (e instanceof InteractionRequiredAuthError) {
+				// build refresh token request
+				const tenant: Tenant = {
+					id: account.tenantId,
+					displayName: ''
+				};
+				const authResult = await this.loginMsal(tenant, resource);
+				return authResult.response;
+			} else if (e.name === 'ClientAuthError') {
+				Logger.error(e.message);
+			}
+			Logger.error('Failed to silently acquire token, not InteractionRequiredAuthError');
+			return null;
 		}
 
 	}

--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -45,7 +45,7 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 			if (impactProvider === true) {
 				this.handleAuthMapping(metadata, tokenCache, context, uriEventHandler);
 			}
-			const impactLibrary = changeEvent.affectsConfiguration(AzureAccountProvider.CONFIGURATION_SECTION);
+			const impactLibrary = changeEvent.affectsConfiguration('authenticationLibrary');
 			if (impactLibrary === true) {
 				this.authLibrary = vscode.workspace.getConfiguration('azure').get('authenticationLibrary');
 			}
@@ -116,6 +116,7 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 			}
 			else {
 				//TODO: if msal: do this
+				account.isStale = false;
 				accounts.push(account);
 			}
 		}

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -49,7 +49,7 @@ const publicAzureSettings: ProviderSettings = {
 			},
 			armResource: {
 				id: SettingIds.arm,
-				endpoint: 'https://management.azure.com',
+				endpoint: 'https://management.azure.com/',
 				azureResourceId: AzureResource.ResourceManagement
 			},
 			sqlResource: {


### PR DESCRIPTION
Uses the default scope, this fixes the issue where it failed to open the Azure pane.

More on the default scope: https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#the-default-scope

Here's the important bit:
> Using scope={resource-identifier}/.default is functionally the same as resource={resource-identifier} on the v1.0 endpoint (where {resource-identifier}

Also fixes an issue where MSAL accounts would be marked as "stale" automatically upon generating the accounts pane