### PR TITLE
Reorganized Execution Plan Comparison Properties View

### DIFF
--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -111,6 +111,17 @@ export function textFormatter(row: number | undefined, cell: any | undefined, va
 		valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
 		titleValue = valueToDisplay;
 	}
+	else if (value && value.title) {
+		if (value.title) {
+			valueToDisplay = value.title;
+
+			if (value.style) {
+				cellStyle = value.style;
+			}
+		}
+		valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
+		titleValue = valueToDisplay;
+	}
 
 	return `<span title="${titleValue}" style="${cellStyle}" class="${cellClasses}">${valueToDisplay}</span>`;
 }

--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -129,7 +129,7 @@ export function textFormatter(row: number | undefined, cell: any | undefined, va
 
 export function iconCssFormatter(row: number | undefined, cell: any | undefined, value: any, columnDef: any | undefined, dataContext: any | undefined): string {
 	if (isCssIconCellValue(value)) {
-		return `<div role="image" title="${escape(value.title)}" aria-label="${escape(value.title)}" class="grid-cell-value-container icon codicon slick-icon-cell-content ${value.iconCssClass}"></div>`;
+		return `<div role="image" title="${escape(value.title ?? '')}" aria-label="${escape(value.title ?? '')}" class="grid-cell-value-container icon codicon slick-icon-cell-content ${value.iconCssClass}"></div>`;
 	}
 	return textFormatter(row, cell, value, columnDef, dataContext);
 }

--- a/src/sql/base/common/numbers.ts
+++ b/src/sql/base/common/numbers.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function isNumber(text: string): boolean {
+	return !isNaN(parseInt(text)) && !isNaN(parseFloat(text));
+}

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -308,17 +308,15 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		let equalProperties: Map<string, TablePropertiesMapEntry> = new Map();
 
 		[...props.entries()].forEach(prop => {
-			if (prop.length === 2) {
-				const [rowKey, rowEntry] = prop;
-				const primaryProp = rowEntry.primaryProp;
-				const secondaryProp = rowEntry.secondaryProp;
+			const [rowKey, rowEntry] = prop;
+			const primaryProp = rowEntry.primaryProp;
+			const secondaryProp = rowEntry.secondaryProp;
 
-				if (primaryProp?.displayValue.localeCompare(secondaryProp?.displayValue) === 0) {
-					equalProperties.set(rowKey, rowEntry);
-				}
-				else {
-					unequalProperties.set(rowKey, rowEntry);
-				}
+			if (primaryProp?.displayValue.localeCompare(secondaryProp?.displayValue) === 0) {
+				equalProperties.set(rowKey, rowEntry);
+			}
+			else {
+				unequalProperties.set(rowKey, rowEntry);
 			}
 		});
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -60,7 +60,7 @@ function getRightPlanIsGreaterThanLeftPlanSummaryTextTemplate(rowName: string): 
 const notEqualTitle = localize('nodePropertyViewNameNotEqualTitle', 'Not equal to');
 const lessThanTitle = localize('nodePropertyViewNameLessThanTitle', 'Less than');
 const greaterThanTitle = localize('nodePropertyViewNameGreaterThanTitle', 'Greater than');
-const equalPropertiesRowHeader = localize('nodePropertyViewNameEqualPropertiesRowHeader', 'Equal Properties');
+const equivalentPropertiesRowHeader = localize('nodePropertyViewNameEquivalentPropertiesRowHeader', 'Equivalent Properties');
 const topTitleColumnHeader = localize('nodePropertyViewNameValueColumnTopHeader', "Value (Top Plan)");
 const leftTitleColumnHeader = localize('nodePropertyViewNameValueColumnLeftHeader', "Value (Left Plan)");
 const rightTitleColumnHeader = localize('nodePropertyViewNameValueColumnRightHeader', "Value (Right Plan)");
@@ -493,7 +493,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 		if (equalRows.length > 0) {
 			let equalRow = {};
-			equalRow['name'] = equalPropertiesRowHeader;
+			equalRow['name'] = equivalentPropertiesRowHeader;
 			equalRow['expanded'] = false;
 			equalRow['treeGridChildren'] = equalRows;
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -427,23 +427,23 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		});
 
 		let formattedRows: { [key: string]: string }[] = [];
-		let commonRows: { [key: string]: string }[] = [];
+		let equalRows: { [key: string]: string }[] = [];
 		for (const [_, row] of Object.entries(rows)) {
 			if (row.primary && row.secondary && row.primary['text'] === row.secondary['title']) {
-				commonRows.push(row);
+				equalRows.push(row);
 			}
 			else {
 				formattedRows.push(row);
 			}
 		}
 
-		if (commonRows.length > 0) {
-			let commonRow = {};
-			commonRow['name'] = '';
-			commonRow['expanded'] = false;
-			commonRow['treeGridChildren'] = commonRows;
+		if (equalRows.length > 0) {
+			let equalRow = {};
+			equalRow['name'] = '';
+			equalRow['expanded'] = false;
+			equalRow['treeGridChildren'] = equalRows;
 
-			formattedRows.push(commonRow);
+			formattedRows.push(equalRow);
 		}
 
 		return formattedRows;

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -13,11 +13,12 @@ import { isString } from 'vs/base/common/types';
 import { removeLineBreaks } from 'sql/base/common/strings';
 import * as DOM from 'vs/base/browser/dom';
 import { InternalExecutionPlanElement } from 'sql/workbench/contrib/executionPlan/browser/azdataGraphView';
-import { executionPlanComparisonPropertiesDifferent, executionPlanComparisonPropertiesUpArrow, executionPlanComparisonPropertiesDownArrow } from 'sql/workbench/contrib/executionPlan/browser/constants';
+import { executionPlanComparisonPropertiesDifferent } from 'sql/workbench/contrib/executionPlan/browser/constants';
 import * as sqlExtHostType from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
+import { Codicon } from 'vs/base/common/codicons';
 
 export enum ExecutionPlanCompareOrientation {
 	Horizontal = 'horizontal',
@@ -411,8 +412,8 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 							break;
 						case sqlExtHostType.executionPlan.ExecutionPlanGraphElementPropertyDataType.Number:
 							diffIcon = (parseFloat(v.primaryProp.displayValue) > parseFloat(v.secondaryProp.displayValue))
-								? { iconClass: executionPlanComparisonPropertiesDownArrow, title: greaterThanTitle }
-								: { iconClass: executionPlanComparisonPropertiesUpArrow, title: lessThanTitle };
+								? { iconClass: Codicon.chevronRight.classNames, title: greaterThanTitle }
+								: { iconClass: Codicon.chevronLeft.classNames, title: lessThanTitle };
 
 							break;
 						case sqlExtHostType.executionPlan.ExecutionPlanGraphElementPropertyDataType.String:

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -428,12 +428,12 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 		let formattedRows: { [key: string]: string }[] = [];
 		let commonRows: { [key: string]: string }[] = [];
-		for (const [key, value] of Object.entries(rows)) {
-			if (value.primary && value.secondary && value.primary['text'] === value.secondary['title']) {
-				commonRows.push(value);
+		for (const [_, row] of Object.entries(rows)) {
+			if (row.primary && row.secondary && row.primary['text'] === row.secondary['title']) {
+				commonRows.push(row);
 			}
 			else {
-				formattedRows.push(value);
+				formattedRows.push(row);
 			}
 		}
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -285,6 +285,23 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		}));
 	}
 
+	public sortPropertiesByImportance(props: Map<string, TablePropertiesMapEntry>): Map<string, TablePropertiesMapEntry> {
+		return new Map([...props.entries()].sort((a, b) => {
+			if (!a[1]?.displayOrder && !b[1]?.displayOrder) {
+				return 0;
+			}
+			else if (!a[1]?.displayOrder) {
+				return -1;
+			}
+			else if (!b[1]?.displayOrder) {
+				return 1;
+			}
+			else {
+				return a[1].displayOrder - b[1].displayOrder;
+			}
+		}));
+	}
+
 	/**
 	 * This method will sort properties by having those with different values appear at the top,
 	 * and similar values appearing at the bottom of the table.
@@ -303,7 +320,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 	 * @param props Map of properties that will be organized.
 	 * @returns A new map with different values appearing at the top and similar values appearing at the bottom.
 	 */
-	public sortPropertiesByDisplayValueEquivalency(props: Map<string, TablePropertiesMapEntry>): Map<string, TablePropertiesMapEntry> {
+	public sortPropertiesByDisplayValueEquivalency(props: Map<string, TablePropertiesMapEntry>, sortProperties: (props: Map<string, TablePropertiesMapEntry>) => Map<string, TablePropertiesMapEntry>): Map<string, TablePropertiesMapEntry> {
 		let unequalProperties: Map<string, TablePropertiesMapEntry> = new Map();
 		let equalProperties: Map<string, TablePropertiesMapEntry> = new Map();
 
@@ -319,6 +336,9 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 				unequalProperties.set(rowKey, rowEntry);
 			}
 		});
+
+		unequalProperties = sortProperties(unequalProperties);
+		equalProperties = sortProperties(equalProperties);
 
 		let map: Map<string, TablePropertiesMapEntry> = new Map();
 		unequalProperties.forEach((v, k) => {
@@ -378,13 +398,13 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 		switch (this.sortType) {
 			case PropertiesSortType.DisplayOrder:
-				propertiesMap = this.sortPropertiesByDisplayValueEquivalency(propertiesMap);
+				propertiesMap = this.sortPropertiesByDisplayValueEquivalency(propertiesMap, this.sortPropertiesByImportance);
 				break;
 			case PropertiesSortType.Alphabetical:
-				propertiesMap = this.sortPropertiesAlphabetically(propertiesMap);
+				propertiesMap = this.sortPropertiesByDisplayValueEquivalency(propertiesMap, this.sortPropertiesAlphabetically);
 				break;
 			case PropertiesSortType.ReverseAlphabetical:
-				propertiesMap = this.sortPropertiesReverseAlphabetically(propertiesMap);
+				propertiesMap = this.sortPropertiesByDisplayValueEquivalency(propertiesMap, this.sortPropertiesReverseAlphabetically);
 				break;
 		}
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -56,6 +56,7 @@ function getRightPlanIsGreaterThanLeftPlanSummaryPointTemplate(rowName: string):
 	return localize('nodePropertyViewRightPlanGreaterThanLeftPlan', '{0} is greater for the right plan than it is for the left plan.', rowName);
 }
 
+const equalPropertiesRowHeader = localize('nodePropertyViewNameEqualPropertiesRowHeader', 'Equal Properties');
 const topTitleColumnHeader = localize('nodePropertyViewNameValueColumnTopHeader', "Value (Top Plan)");
 const leftTitleColumnHeader = localize('nodePropertyViewNameValueColumnLeftHeader', "Value (Left Plan)");
 const rightTitleColumnHeader = localize('nodePropertyViewNameValueColumnRightHeader', "Value (Right Plan)");
@@ -439,7 +440,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 		if (equalRows.length > 0) {
 			let equalRow = {};
-			equalRow['name'] = '';
+			equalRow['name'] = equalPropertiesRowHeader;
 			equalRow['expanded'] = false;
 			equalRow['treeGridChildren'] = equalRows;
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -14,7 +14,6 @@ import * as DOM from 'vs/base/browser/dom';
 import { InternalExecutionPlanElement } from 'sql/workbench/contrib/executionPlan/browser/azdataGraphView';
 import { executionPlanComparisonPropertiesDifferent, executionPlanComparisonPropertiesUpArrow, executionPlanComparisonPropertiesDownArrow } from 'sql/workbench/contrib/executionPlan/browser/constants';
 import * as sqlExtHostType from 'sql/workbench/api/common/sqlExtHostTypes';
-import { TextWithIconColumn } from 'sql/base/browser/ui/table/plugins/textWithIconColumn';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -43,6 +43,9 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	// Header container
 	private _headerContainer: HTMLElement;
 
+	// Summary container
+	private _summaryContainer: HTMLElement;
+
 	// Properties actions
 	private _headerActionsContainer!: HTMLElement;
 	private _headerActions: ActionBar;
@@ -109,6 +112,9 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 
 		this._headerContainer = DOM.$('.header');
 		propertiesContent.appendChild(this._headerContainer);
+
+		this._summaryContainer = DOM.$('.summary');
+		propertiesContent.appendChild(this._summaryContainer);
 
 		this._searchAndActionBarContainer = DOM.$('.search-action-bar-container');
 		propertiesContent.appendChild(this._searchAndActionBarContainer);
@@ -222,6 +228,10 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 		this._headerContainer.appendChild(c);
 	}
 
+	public setSummary(c: HTMLElement): void {
+		this._summaryContainer.appendChild(c);
+	}
+
 	public set tableHeight(value: number) {
 		if (this.tableHeight !== value) {
 			this._tableHeight = value;
@@ -264,6 +274,7 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	private resizeTable(): void {
 		const spaceOccupied = (this._titleBarContainer.getBoundingClientRect().height
 			+ this._headerContainer.getBoundingClientRect().height
+			+ this._summaryContainer.getBoundingClientRect().height
 			+ this._headerActionsContainer.getBoundingClientRect().height);
 
 		this.tableHeight = (this._parentContainer.getBoundingClientRect().height - spaceOccupied - 15);

--- a/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
+++ b/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
@@ -610,6 +610,15 @@ However we always want it to be the width of the container it is resizing.
 	height: 16px;
 }
 
+.eps-container .comparison-editor .plan-comparison-container .properties .properties-content .table-container .table .monaco-table .ui-widget .slick-viewport .grid-canvas .ui-widget-content.slick-row .slick-cell .grid-cell-value-container.icon.codicon.slick-icon-cell-content.codicon-chevron-left,
+.eps-container .comparison-editor .plan-comparison-container .properties .properties-content .table-container .table .monaco-table .ui-widget .slick-viewport .grid-canvas .ui-widget-content.slick-row .slick-cell .grid-cell-value-container.icon.codicon.slick-icon-cell-content.codicon-chevron-right {
+	background-size: 16px 16px;
+	background-position: center;
+	background-repeat: no-repeat;
+	width: 16px;
+	height: 16px;
+	margin-left: -28px;
+}
 
 .eps-container .ep-properties-down-arrow {
 	background-image: url(../images/actionIcons/downArrow.svg);

--- a/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
+++ b/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
@@ -597,7 +597,7 @@ However we always want it to be the width of the container it is resizing.
 	background-position: center;
 	background-repeat: no-repeat;
 	width: 16px;
-	height: auto;
+	height: 16px;
 }
 
 .vs-dark .eps-container .ep-properties-different,
@@ -607,7 +607,7 @@ However we always want it to be the width of the container it is resizing.
 	background-position: center;
 	background-repeat: no-repeat;
 	width: 16px;
-	height: auto;
+	height: 16px;
 }
 
 
@@ -617,7 +617,7 @@ However we always want it to be the width of the container it is resizing.
 	background-position: center;
 	background-repeat: no-repeat;
 	width: 16px;
-	height: auto;
+	height: 16px;
 }
 
 .vs-dark .eps-container .ep-properties-down-arrow,
@@ -627,7 +627,7 @@ However we always want it to be the width of the container it is resizing.
 	background-position: center;
 	background-repeat: no-repeat;
 	width: 16px;
-	height: auto;
+	height: 16px;
 }
 
 .eps-container .ep-properties-up-arrow {
@@ -636,7 +636,7 @@ However we always want it to be the width of the container it is resizing.
 	background-position: center;
 	background-repeat: no-repeat;
 	width: 16px;
-	height: auto;
+	height: 16px;
 }
 
 .vs-dark .eps-container .ep-properties-up-arrow,
@@ -646,7 +646,7 @@ However we always want it to be the width of the container it is resizing.
 	background-position: center;
 	background-repeat: no-repeat;
 	width: 16px;
-	height: auto;
+	height: 16px;
 }
 
 .eps-container .ep-top-operations {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR isn't associated with any issue, and is an enhancement to the execution plan comparison properties view. The enhancement changes the following things:
1. Adds a summary section to the properties view that includes 3 different items
2. Reorganizes the properties table, so that differences appear first and equivalent properties are collapsed at the bottom.

Equivalent properties collapsed:
![image](https://user-images.githubusercontent.com/87730006/193102844-f68e420f-0836-4c00-9a4a-e2733b3aa855.png)

Equivalent properties expanded:
![image](https://user-images.githubusercontent.com/87730006/193102911-bf205d6e-7ad5-4982-8006-f0e2467a20ba.png)