### PR TITLE
Fix Query Token Expiration

### DIFF
--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -17,6 +17,7 @@ import { PublicClientApplication } from '@azure/msal-node';
 import { DataProtectionScope, PersistenceCreator, PersistenceCachePlugin } from '@azure/msal-node-extensions';
 import * as path from 'path';
 import { Logger } from '../utils/Logger';
+import { AuthLibrary } from './auths/azureAuth';
 
 let localize = nls.loadMessageBundle();
 
@@ -42,7 +43,7 @@ export class AzureAccountProviderService implements vscode.Disposable {
 	private _event: events.EventEmitter = new events.EventEmitter();
 	private readonly _uriEventHandler: UriEventHandler = new UriEventHandler();
 	public clientApplication!: PublicClientApplication;
-	public authLibrary: string | undefined;
+	public authLibrary: AuthLibrary;
 
 	constructor(private _context: vscode.ExtensionContext, private _userStoragePath: string) {
 		this.authLibrary = vscode.workspace.getConfiguration('azure').get('authenticationLibrary');

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -27,7 +27,6 @@ import { AzureResource, ConnectionOptionSpecialType } from 'sql/workbench/api/co
 import { IAccountManagementService } from 'sql/platform/accounts/common/interfaces';
 
 import * as azdata from 'azdata';
-
 import * as nls from 'vs/nls';
 import * as errors from 'vs/base/common/errors';
 import { Disposable } from 'vs/base/common/lifecycle';
@@ -954,7 +953,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				this._logService.info(`Previous pending reconnect promise for uri ${uri} is rejected with error ${err}, will attempt to reconnect if necessary.`);
 			}
 		}
-
+		// TODO: need way to check auth library
+		// if msal: this.fillInOrClearToken
 		const expiry = profile.options.expiresOn;
 		if (typeof expiry === 'number' && !Number.isNaN(expiry)) {
 			const currentTime = new Date().getTime() / 1000;


### PR DESCRIPTION
Right now, after a token has expired (1.5 hours after being issued) you are not able to run any more queries.

After this change, the token gets refreshed automatically. 

I also fixed the typing of the authLibrary