### PR TITLE
Improve the tenant logging

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -371,6 +371,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 			if (tenantResponse.status !== 200) {
 				Logger.error(`Error with tenant response, status: ${tenantResponse.status} | status text: ${tenantResponse.statusText}`);
 				Logger.error(`Headers: ${JSON.stringify(tenantResponse.headers)}`);
+				throw new Error('Error with tenant response');
 			}
 			const tenants: Tenant[] = tenantResponse.data.value.map((tenantInfo: TenantResponse) => {
 				Logger.verbose(`Tenant: ${tenantInfo.displayName}`);

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -368,6 +368,9 @@ export abstract class AzureAuth implements vscode.Disposable {
 		try {
 			Logger.verbose('Fetching tenants', tenantUri);
 			const tenantResponse = await this.makeGetRequest(tenantUri, token.token);
+			if (tenantResponse.status !== 200) {
+				Logger.error(`Error with tenant response, status: ${tenantResponse.status} | status text: ${tenantResponse.statusText}`);
+			}
 			const tenants: Tenant[] = tenantResponse.data.value.map((tenantInfo: TenantResponse) => {
 				Logger.verbose(`Tenant: ${tenantInfo.displayName}`);
 				return {

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -370,6 +370,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 			const tenantResponse = await this.makeGetRequest(tenantUri, token.token);
 			if (tenantResponse.status !== 200) {
 				Logger.error(`Error with tenant response, status: ${tenantResponse.status} | status text: ${tenantResponse.statusText}`);
+				Logger.error(`Headers: ${JSON.stringify(tenantResponse.headers)}`);
 			}
 			const tenants: Tenant[] = tenantResponse.data.value.map((tenantInfo: TenantResponse) => {
 				Logger.verbose(`Tenant: ${tenantInfo.displayName}`);


### PR DESCRIPTION
Improves the error logging for the get tenants call, before this we did not capture the response code/message returned from the tenantResponse, if it fails this will get put into the logs along with the headers which sometimes contain more useful information for debugging issues.  Will also throw an error after we detect the tenantResponse failure.

before: 
```
[Error]: Error fetching tenants :TypeError: Cannot read property 'map' of undefined - []
[Error]: Login failed - []
[Error]: Error: Error retrieving tenant information - []
```
after:
```
[Verbose]: Fetching tenants - ["https://management.azure.com/tenants?api-version=2019-11-01"]
[Pii]: GET request  response={"error":{"code":"AuthenticationFailed","message":"Authentication failed."}} - ["https://management.azure.com/tenants?api-version=2019-11-01"]
[Error]: Error with tenant response, status: 401 | status text: Unauthorized - []
[Error]: Headers: {"cache-control":"no-cache","pragma":"no-cache","content-type":"application/json; charset=utf-8","expires":"-1","www-authenticate":"Bearer authorization_uri=\"https://login.windows.net/\", error=\"invalid_token\", error_description=\"Could not find identity for access token.\"","x-ms-failure-cause":"gateway","x-ms-request-id":"958468ae-8b70-4b35-b4b5-dcbd7c2839d8","x-ms-correlation-request-id":"958468ae-8b70-4b35-b4b5-dcbd7c2839d8","x-ms-routing-request-id":"WESTUS:20220929T021827Z:958468ae-8b70-4b35-b4b5-dcbd7c2839d8","strict-transport-security":"max-age=31536000; includeSubDomains","x-content-type-options":"nosniff","date":"Thu, 29 Sep 2022 02:18:27 GMT","connection":"close","content-length":"76"} - []
[Error]: Error fetching tenants :TypeError: Cannot read property 'map' of undefined - []
[Error]: Login failed - []
[Error]: Error: Error retrieving tenant information - []
```
