### PR TITLE
Add AuthenticationType enum to typings

### DIFF
--- a/extensions/admin-tool-ext-win/src/main.ts
+++ b/extensions/admin-tool-ext-win/src/main.ts
@@ -129,7 +129,7 @@ async function launchSsmsDialog(action: string, connectionContext: azdata.Object
 		server: connectionContext.connectionProfile.serverName,
 		database: connectionContext.connectionProfile.databaseName,
 		user: connectionContext.connectionProfile.userName,
-		useAad: connectionContext.connectionProfile.authenticationType === 'AzureMFA',
+		useAad: connectionContext.connectionProfile.authenticationType === azdata.connection.AuthenticationType.AzureMFA,
 		urn: urn
 	};
 

--- a/extensions/arc/src/models/miaaModel.ts
+++ b/extensions/arc/src/models/miaaModel.ts
@@ -209,7 +209,7 @@ export class MiaaModel extends ResourceModel {
 		return {
 			serverName: `${ipAndPort.ip},${ipAndPort.port}`,
 			databaseName: '',
-			authenticationType: 'SqlLogin',
+			authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 			providerName: loc.miaaProviderName,
 			connectionName: '',
 			userName: this._miaaInfo.userName || '',

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -192,7 +192,7 @@ export class PostgresModel extends ResourceModel {
 		return {
 			serverName: `${ipAndPort.ip},${ipAndPort.port}`,
 			databaseName: '',
-			authenticationType: 'SqlLogin',
+			authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 			providerName: loc.postgresProviderName,
 			connectionName: '',
 			userName: this._pgInfo.userName || '',

--- a/extensions/arc/src/ui/dialogs/connectSqlDialog.ts
+++ b/extensions/arc/src/ui/dialogs/connectSqlDialog.ts
@@ -97,7 +97,7 @@ export abstract class ConnectToSqlDialog extends InitializingComponent {
 		const connectionProfile: azdata.IConnectionProfile = {
 			serverName: this.serverNameInputBox.value,
 			databaseName: '',
-			authenticationType: 'SqlLogin',
+			authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 			providerName: this.providerName,
 			connectionName: '',
 			userName: this.usernameInputBox.value,

--- a/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem } from 'azdata';
+import { ExtensionNodeType, TreeItem, connection } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -43,7 +43,7 @@ export class AzureMonitorTreeDataProvider extends ResourceTreeDataProviderBase<a
 				databaseName: databaseServer.defaultDatabaseName,
 				userName: databaseServer.loginName,
 				password: '',
-				authenticationType: 'AzureMFA',
+				authenticationType: connection.AuthenticationType.AzureMFA,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/azurecore/src/azureResource/providers/cosmosdb/mongo/cosmosDbMongoTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/cosmosdb/mongo/cosmosDbMongoTreeDataProvider.ts
@@ -42,7 +42,7 @@ export class CosmosDbMongoTreeDataProvider extends ResourceTreeDataProviderBase<
 				serverName: databaseServer.name,
 				userName: databaseServer.loginName,
 				password: '',
-				authenticationType: 'AzureMFA',
+				authenticationType: azdata.connection.AuthenticationType.AzureMFA,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem } from 'azdata';
+import { ExtensionNodeType, TreeItem, connection } from 'azdata';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -43,7 +43,7 @@ export class AzureResourceDatabaseServerTreeDataProvider extends ResourceTreeDat
 				databaseName: databaseServer.defaultDatabaseName,
 				userName: databaseServer.loginName,
 				password: '',
-				authenticationType: 'SqlLogin',
+				authenticationType: connection.AuthenticationType.SqlLogin,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem, connection } from 'azdata';
+import { ExtensionNodeType, TreeItem } from 'azdata';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();

--- a/extensions/azurecore/src/azureResource/providers/kusto/kustoTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/kusto/kustoTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem } from 'azdata';
+import { connection, ExtensionNodeType, TreeItem } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -43,7 +43,7 @@ export class KustoTreeDataProvider extends ResourceTreeDataProviderBase<azureRes
 				databaseName: databaseServer.defaultDatabaseName,
 				userName: databaseServer.loginName,
 				password: '',
-				authenticationType: 'AzureMFA',
+				authenticationType: connection.AuthenticationType.AzureMFA,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/azurecore/src/azureResource/providers/mysqlFlexibleServer/mysqlFlexibleServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/mysqlFlexibleServer/mysqlFlexibleServerTreeDataProvider.ts
@@ -12,7 +12,7 @@ import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from 'azurecore';
-import { Account, ExtensionNodeType, TreeItem } from 'azdata';
+import { Account, ExtensionNodeType, TreeItem, connection } from 'azdata';
 
 export class MysqlFlexibleServerTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly MYSQL_FLEXIBLE_SERVER_PROVIDER_ID = 'MySQL';
@@ -43,7 +43,7 @@ export class MysqlFlexibleServerTreeDataProvider extends ResourceTreeDataProvide
 				databaseName: databaseServer.defaultDatabaseName,
 				userName: databaseServer.loginName,
 				password: '',
-				authenticationType: 'SqlLogin',
+				authenticationType: connection.AuthenticationType.SqlLogin,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem } from 'azdata';
+import { ExtensionNodeType, TreeItem, connection } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -43,7 +43,7 @@ export class PostgresServerArcTreeDataProvider extends ResourceTreeDataProviderB
 				databaseName: databaseServer.defaultDatabaseName,
 				userName: `${databaseServer.loginName}@${databaseServer.fullName}`,
 				password: '',
-				authenticationType: 'SqlLogin',
+				authenticationType: connection.AuthenticationType.SqlLogin,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem } from 'azdata';
+import { ExtensionNodeType, TreeItem, connection } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -43,7 +43,7 @@ export class PostgresServerTreeDataProvider extends ResourceTreeDataProviderBase
 				databaseName: databaseServer.defaultDatabaseName,
 				userName: `${databaseServer.loginName}@${databaseServer.fullName}`,
 				password: '',
-				authenticationType: 'SqlLogin',
+				authenticationType: connection.AuthenticationType.SqlLogin,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem } from 'azdata';
+import { ExtensionNodeType, TreeItem, connection } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -43,7 +43,7 @@ export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<az
 				databaseName: databaseServer.defaultDatabaseName,
 				userName: databaseServer.loginName,
 				password: '',
-				authenticationType: 'SqlLogin',
+				authenticationType: connection.AuthenticationType.SqlLogin,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem } from 'azdata';
+import { ExtensionNodeType, TreeItem, connection } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -43,7 +43,7 @@ export class SqlInstanceArcTreeDataProvider extends ResourceTreeDataProviderBase
 				databaseName: databaseServer.defaultDatabaseName,
 				userName: databaseServer.loginName,
 				password: '',
-				authenticationType: 'SqlLogin',
+				authenticationType: connection.AuthenticationType.SqlLogin,
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',

--- a/extensions/big-data-cluster/src/extension.ts
+++ b/extensions/big-data-cluster/src/extension.ts
@@ -139,7 +139,7 @@ async function getMountProps(explorerContext?: azdata.ObjectExplorerContext): Pr
 	let profile = explorerContext.connectionProfile;
 	let mountProps: MountHdfsProperties = {
 		url: endpoint,
-		auth: profile.authenticationType === 'SqlLogin' ? 'basic' : 'integrated',
+		auth: profile.authenticationType === azdata.connection.AuthenticationType.SqlLogin ? 'basic' : 'integrated',
 		username: profile.userName,
 		password: profile.password,
 		hdfsPath: getHdsfPath(explorerContext.nodeInfo.nodePath)

--- a/extensions/cms/src/cmsResource/tree/cmsResourceTreeNode.ts
+++ b/extensions/cms/src/cmsResource/tree/cmsResourceTreeNode.ts
@@ -38,7 +38,7 @@ export class CmsResourceTreeNode extends CmsResourceTreeNodeBase {
 			let nodes: CmsResourceTreeNodeBase[] = [];
 			if (!this.ownerUri) {
 				// Set back password to get ownerUri
-				if (this.connection.options.authenticationType === 'SqlLogin' && this.connection.options.savePassword === true) {
+				if (this.connection.options.authenticationType === azdata.connection.AuthenticationType.SqlLogin && this.connection.options.savePassword === true) {
 					this.connection.options.password = await this.appContext.cmsUtils.getPassword(this.connection.options.user);
 				}
 			}

--- a/extensions/cms/src/cmsResource/tree/registeredServerTreeNode.ts
+++ b/extensions/cms/src/cmsResource/tree/registeredServerTreeNode.ts
@@ -38,7 +38,7 @@ export class RegisteredServerTreeNode extends CmsResourceTreeNodeBase {
 			databaseName: '',
 			userName: undefined as string,
 			password: undefined as string,
-			authenticationType: 'Integrated',
+			authenticationType: azdata.connection.AuthenticationType.Integrated,
 			savePassword: false,
 			groupFullName: '',
 			groupId: '',

--- a/extensions/cms/src/cmsUtils.ts
+++ b/extensions/cms/src/cmsUtils.ts
@@ -14,7 +14,6 @@ const localize = nls.loadMessageBundle();
 const cmsProvider: string = 'MSSQL-CMS';
 const mssqlProvider: string = 'MSSQL';
 const CredentialNamespace = 'cmsCredentials';
-const sqlLoginAuthType: string = 'SqlLogin';
 
 interface CreateCmsResult {
 	listRegisteredServersResult: mssql.ListRegisteredServersResult;
@@ -121,7 +120,7 @@ export class CmsUtils {
 				return cachedServer.name !== cmsServerName;
 			});
 		}
-		if (connection.options.authenticationType === sqlLoginAuthType && connection.options.savePassword) {
+		if (connection.options.authenticationType === azdata.connection.AuthenticationType.SqlLogin && connection.options.savePassword) {
 			this._credentialProvider.deleteCredential(connection.options.user);
 		}
 	}

--- a/extensions/import/src/test/wizard/pages/summaryPage.test.ts
+++ b/extensions/import/src/test/wizard/pages/summaryPage.test.ts
@@ -163,7 +163,7 @@ describe('import extension summary page tests', function () {
 			options: {
 				azureAccount: getAzureAccounts()[1].key.accountId,
 				azureTenantId: 'azureAccount2Tenant',
-				authenticationType: 'AzureMFA'
+				authenticationType: azdata.connection.AuthenticationType.AzureMFA
 			}
 		};
 

--- a/extensions/import/src/wizard/pages/summaryPage.ts
+++ b/extensions/import/src/wizard/pages/summaryPage.ts
@@ -136,11 +136,11 @@ export class SummaryPage extends ImportPage {
 		let err;
 
 		const currentServer = this.model.server;
-		const includePasswordInConnectionString = (currentServer.options.authenticationType === 'Integrated') ? false : true;
+		const includePasswordInConnectionString = (currentServer.options.authenticationType === azdata.connection.AuthenticationType.Integrated) ? false : true;
 		const connectionString = await azdata.connection.getConnectionString(currentServer.connectionId, includePasswordInConnectionString);
 
 		let accessToken = undefined;
-		if (currentServer.options.authenticationType === 'AzureMFA') {
+		if (currentServer.options.authenticationType === azdata.connection.AuthenticationType.AzureMFA) {
 			const azureAccount = (await azdata.accounts.getAllAccounts()).filter(v => v.key.accountId === currentServer.options.azureAccount)[0];
 			accessToken = (await azdata.accounts.getAccountSecurityToken(azureAccount, currentServer.options.azureTenantId, azdata.AzureResource.Sql)).token;
 		}

--- a/extensions/integration-tests/src/test/testConfig.ts
+++ b/extensions/integration-tests/src/test/testConfig.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as azdata from 'azdata';
+
 /*
 	TODO: Due to a runtime error, I duplicated this file at these 2 locations:
 	$/extensions/integration-test/src/testConfig.ts
@@ -45,7 +47,7 @@ let connectionProviderMapping: { [key: string]: { name: string; displayName: str
 let authenticationTypeMapping: { [key: string]: { name: string; displayName: string } } = {};
 connectionProviderMapping[ConnectionProvider.SQLServer] = { name: 'MSSQL', displayName: 'Microsoft SQL Server' };
 
-authenticationTypeMapping[AuthenticationType.SqlLogin] = { name: 'SqlLogin', displayName: 'SQL Login' };
+authenticationTypeMapping[AuthenticationType.SqlLogin] = { name: azdata.connection.AuthenticationType.SqlLogin, displayName: 'SQL Login' };
 authenticationTypeMapping[AuthenticationType.Windows] = { name: 'Integrated', displayName: 'Windows Authentication' };
 
 export function getConfigValue(name: string): string {

--- a/extensions/notebook/src/test/model/sessionManager.test.ts
+++ b/extensions/notebook/src/test/model/sessionManager.test.ts
@@ -263,7 +263,7 @@ describe('Jupyter Session', function (): void {
 				id: 'id',
 				providerName: 'MSSQL',
 				options: {
-					authenticationType: 'SqlLogin',
+					authenticationType: connection.AuthenticationType.SqlLogin,
 				},
 				password: '',
 				savePassword: false,
@@ -340,7 +340,7 @@ describe('Jupyter Session', function (): void {
 			id: 'id',
 			providerName: 'MSSQL',
 			options: {
-				authenticationType: 'SqlLogin',
+				authenticationType: connection.AuthenticationType.SqlLogin,
 			},
 			password: '',
 			savePassword: false,
@@ -366,7 +366,7 @@ describe('Jupyter Session', function (): void {
 			id: 'id',
 			providerName: 'provider',
 			options: {
-				authenticationType: 'SqlLogin',
+				authenticationType: connection.AuthenticationType.SqlLogin,
 			},
 			password: '',
 			savePassword: false,

--- a/extensions/schema-compare/src/test/testUtils.ts
+++ b/extensions/schema-compare/src/test/testUtils.ts
@@ -15,7 +15,7 @@ export const mockIConnectionProfile: azdata.IConnectionProfile = {
 	databaseName: 'My Database',
 	userName: 'My User',
 	password: 'My Pwd',
-	authenticationType: 'SqlLogin',
+	authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 	savePassword: false,
 	groupFullName: 'My groupName',
 	groupId: 'My GroupId',
@@ -38,7 +38,7 @@ export const mockConnectionInfo = {
 	databaseName: 'My Database',
 	userName: 'My User',
 	password: 'My Pwd',
-	authenticationType: 'SqlLogin'
+	authenticationType: azdata.connection.AuthenticationType.SqlLogin
 };
 
 export const mockFilePath: string = 'test.dacpac';

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -120,7 +120,7 @@ export async function verifyConnectionAndGetOwnerUri(endpoint: mssql.SchemaCompa
 
 				let userConnection;
 				userConnection = connectionList.find(connection =>
-				(endpoint.connectionDetails['authenticationType'] === 'SqlLogin'
+				(endpoint.connectionDetails['authenticationType'] === azdata.connection.AuthenticationType.SqlLogin
 					&& endpoint.connectionDetails['serverName'] === connection.options.server
 					&& endpoint.connectionDetails['userName'] === connection.options.user
 					&& (endpoint.connectionDetails['databaseName'].toLowerCase() === connection.options.database.toLowerCase()

--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -88,7 +88,7 @@ export function createTestCredentials(): vscodeMssql.IConnectionInfo {
 		accountId: 'test-account-id',
 		tenantId: 'test-tenant-id',
 		port: 1234,
-		authenticationType: 'SqlLogin',
+		authenticationType: vscodeMssql.AuthenticationType.SqlLogin,
 		azureAccountToken: '',
 		expiresOn: 0,
 		encrypt: false,

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -535,11 +535,6 @@ export const activeDirectoryInteractive = 'active directory interactive';
 export const userIdSetting = 'User ID';
 export const passwordSetting = 'Password';
 
-// Authentication types
-export const integratedAuth = 'Integrated';
-export const azureMfaAuth = 'AzureMFA';
-export const sqlAuth = 'SqlAuth';
-
 export const azureAddAccount = localize('azureAddAccount', "Add an Account...");
 
 // Tree item types

--- a/extensions/sql-database-projects/src/models/dataSources/sqlConnectionStringSource.ts
+++ b/extensions/sql-database-projects/src/models/dataSources/sqlConnectionStringSource.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as azdataType from 'azdata';
+import * as vscodeMssql from 'vscode-mssql';
 import { DataSource } from './dataSources';
 import * as constants from '../../common/constants';
 
@@ -44,11 +45,11 @@ export class SqlConnectionDataSource extends DataSource {
 
 	public get authType(): string {
 		if (this.azureMFA) {
-			return constants.azureMfaAuth;
+			return vscodeMssql.AuthenticationType.AzureMFA;
 		} else if (this.integratedSecurity) {
-			return constants.integratedAuth;
+			return vscodeMssql.AuthenticationType.Integrated;
 		} else {
-			return constants.sqlAuth;
+			return 'SqlAuth';
 		}
 	}
 

--- a/extensions/sql-database-projects/src/test/testContext.ts
+++ b/extensions/sql-database-projects/src/test/testContext.ts
@@ -110,7 +110,7 @@ export const mockConnectionProfile: azdata.IConnectionProfile = {
 	databaseName: 'My Database',
 	userName: 'My User',
 	password: 'My Pwd',
-	authenticationType: 'SqlLogin',
+	authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 	savePassword: false,
 	groupFullName: 'My groupName',
 	groupId: 'My GroupId',
@@ -122,7 +122,7 @@ export const mockConnectionProfile: azdata.IConnectionProfile = {
 		database: 'My Database',
 		user: 'My User',
 		password: 'My Pwd',
-		authenticationType: 'SqlLogin',
+		authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 		connectionName: 'My Connection Name'
 	}
 };

--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -50,11 +50,6 @@ export const excludeDatabses: string[] = [
 	'model'
 ];
 
-export enum AuthenticationType {
-	Integrated = 'Integrated',
-	SqlLogin = 'SqlLogin'
-}
-
 export interface TableInfo {
 	databaseName: string;
 	tableName: string;
@@ -89,14 +84,14 @@ function getSqlDbConnectionProfile(
 		databaseName: databaseName,
 		userName: userName,
 		password: password,
-		authenticationType: AuthenticationType.SqlLogin,
+		authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 		savePassword: false,
 		saveProfile: false,
 		options: {
 			conectionName: '',
 			server: serverName,
 			database: databaseName,
-			authenticationType: AuthenticationType.SqlLogin,
+			authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 			user: userName,
 			password: password,
 			connectionTimeout: 60,
@@ -125,7 +120,7 @@ function getConnectionProfile(
 		azureResourceId: azureResourceId,
 		userName: userName,
 		password: password,
-		authenticationType: AuthenticationType.SqlLogin,
+		authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 		savePassword: false,
 		groupFullName: '',
 		groupId: '',
@@ -134,7 +129,7 @@ function getConnectionProfile(
 		options: {
 			conectionName: '',
 			server: serverName,
-			authenticationType: AuthenticationType.SqlLogin,
+			authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 			user: userName,
 			password: password,
 			connectionTimeout: 60,

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -16,7 +16,6 @@ import * as utils from '../api/utils';
 import { logError, TelemetryViews } from '../telemtery';
 import * as styles from '../constants/styles';
 import { TableMigrationSelectionDialog } from '../dialog/tableMigrationSelection/tableMigrationSelectionDialog';
-import { AuthenticationType } from '../api/sqlUtils';
 
 const WIZARD_TABLE_COLUMN_WIDTH = '200px';
 const WIZARD_TABLE_COLUMN_WIDTH_SMALL = '170px';
@@ -728,9 +727,9 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 						this.migrationStateModel.sourceConnectionId)), query);
 
 				const username = results.rows[0][0].displayValue;
-				this.migrationStateModel._authenticationType = connectionProfile.authenticationType === AuthenticationType.SqlLogin
+				this.migrationStateModel._authenticationType = connectionProfile.authenticationType === azdata.connection.AuthenticationType.SqlLogin
 					? MigrationSourceAuthenticationType.Sql
-					: connectionProfile.authenticationType === AuthenticationType.Integrated
+					: connectionProfile.authenticationType === azdata.connection.AuthenticationType.Integrated
 						? MigrationSourceAuthenticationType.Integrated
 						: undefined!;
 				this._sourceHelpText.value = constants.SQL_SOURCE_DETAILS(

--- a/extensions/sql-migration/src/wizard/sqlSourceConfigurationPage.ts
+++ b/extensions/sql-migration/src/wizard/sqlSourceConfigurationPage.ts
@@ -9,7 +9,6 @@ import { MigrationWizardPage } from '../models/migrationWizardPage';
 import { MigrationSourceAuthenticationType, MigrationStateModel, StateChangeEvent } from '../models/stateMachine';
 import * as constants from '../constants/strings';
 import { createLabelTextComponent, createHeadingTextComponent, WIZARD_INPUT_COMPONENT_WIDTH } from './wizardController';
-import { AuthenticationType } from '../api/sqlUtils';
 
 export class SqlSourceConfigurationPage extends MigrationWizardPage {
 	private _view!: azdata.ModelView;
@@ -60,9 +59,9 @@ export class SqlSourceConfigurationPage extends MigrationWizardPage {
 		const query = 'select SUSER_NAME()';
 		const results = await queryProvider.runQueryAndReturn(await (azdata.connection.getUriForConnection(this.migrationStateModel.sourceConnectionId)), query);
 		const username = results.rows[0][0].displayValue;
-		this.migrationStateModel._authenticationType = connectionProfile.authenticationType === AuthenticationType.SqlLogin
+		this.migrationStateModel._authenticationType = connectionProfile.authenticationType === azdata.connection.AuthenticationType.SqlLogin
 			? MigrationSourceAuthenticationType.Sql
-			: connectionProfile.authenticationType === AuthenticationType.Integrated
+			: connectionProfile.authenticationType === azdata.connection.AuthenticationType.Integrated
 				? MigrationSourceAuthenticationType.Integrated
 				: undefined!;
 

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -122,11 +122,41 @@ declare module 'vscode-mssql' {
 		getServerInfo(connectionInfo: IConnectionInfo): ServerInfo
 	}
 
+		/**
+		 * Well-known Authentication types.
+		 */
+		 export enum AuthenticationType {
+			/**
+			 * Username and password
+			 */
+			SqlLogin = 'SqlLogin',
+			/**
+			 * Windows Authentication
+			 */
+			Integrated = 'Integrated',
+			/**
+			 * Azure Active Directory - Universal with MFA support
+			 */
+			AzureMFA = 'AzureMFA',
+			/**
+			 * Azure Active Directory - Password
+			 */
+			AzureMFAAndUser = 'AzureMFAAndUser',
+			/**
+			 * Datacenter Security Token Service Authentication
+			 */
+			DSTSAuth = 'dstsAuth',
+			/**
+			 * No authentication required
+			 */
+			None = 'None'
+		}
+
 	/**
 	 * The possible values of the server engine edition
 	 * EngineEdition under https://docs.microsoft.com/sql/t-sql/functions/serverproperty-transact-sql is associated with these values
 	 */
-	 export const enum DatabaseEngineEdition {
+	export const enum DatabaseEngineEdition {
 		Unknown = 0,
 		Personal = 1,
 		Standard = 2,

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -125,7 +125,7 @@ declare module 'vscode-mssql' {
 		/**
 		 * Well-known Authentication types.
 		 */
-		 export enum AuthenticationType {
+		 export const enum AuthenticationType {
 			/**
 			 * Username and password
 			 */

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -92,6 +92,7 @@ declare module 'azdata' {
 	 * Namespace for connection management
 	 */
 	export namespace connection {
+
 		/**
 		 * Connection profile primary class
 		 */

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -92,7 +92,6 @@ declare module 'azdata' {
 	 * Namespace for connection management
 	 */
 	export namespace connection {
-
 		/**
 		 * Connection profile primary class
 		 */

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -5,6 +5,7 @@
 
 // This is the place for API experiments and proposal.
 
+import { AuthenticationType } from 'sql/platform/connection/common/constants';
 import * as vscode from 'vscode';
 
 declare module 'azdata' {
@@ -403,9 +404,42 @@ declare module 'azdata' {
 	 * Add optional azureAccount for connectionWidget.
 	 */
 	export interface IConnectionProfile extends ConnectionInfo {
+		authenticationType: string | AuthenticationType;
 		azureAccount?: string;
 		azureResourceId?: string;
 		azurePortalEndpoint?: string;
+	}
+
+	export namespace connection {
+		/**
+		 * Well-known Authentication types commonly supported by connection providers.
+		 */
+		export enum AuthenticationType {
+			/**
+			 * Username and password
+			 */
+			SqlLogin = 'SqlLogin',
+			/**
+			 * Windows Authentication
+			 */
+			Integrated = 'Integrated',
+			/**
+			 * Azure Active Directory - Universal with MFA support
+			 */
+			AzureMFA = 'AzureMFA',
+			/**
+			 * Azure Active Directory - Password
+			 */
+			AzureMFAAndUser = 'AzureMFAAndUser',
+			/**
+			 * Datacenter Security Token Service Authentication
+			 */
+			DSTSAuth = 'dstsAuth',
+			/**
+			 * No authentication required
+			 */
+			None = 'None'
+		}
 	}
 
 	/*

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -399,10 +399,10 @@ declare module 'azdata' {
 		title: string;
 	}
 
-	/*
-	 * Add optional azureAccount for connectionWidget.
-	 */
 	export interface IConnectionProfile extends ConnectionInfo {
+		/**
+		 * The type of authentication to use when connecting
+		 */
 		authenticationType: string | connection.AuthenticationType;
 		azureAccount?: string;
 		azureResourceId?: string;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -5,7 +5,6 @@
 
 // This is the place for API experiments and proposal.
 
-import { AuthenticationType } from 'sql/platform/connection/common/constants';
 import * as vscode from 'vscode';
 
 declare module 'azdata' {
@@ -404,7 +403,7 @@ declare module 'azdata' {
 	 * Add optional azureAccount for connectionWidget.
 	 */
 	export interface IConnectionProfile extends ConnectionInfo {
-		authenticationType: string | AuthenticationType;
+		authenticationType: string | connection.AuthenticationType;
 		azureAccount?: string;
 		azureResourceId?: string;
 		azurePortalEndpoint?: string;

--- a/src/sql/platform/connection/common/connectionStore.ts
+++ b/src/sql/platform/connection/common/connectionStore.ts
@@ -9,6 +9,7 @@ import { ConnectionConfig } from 'sql/platform/connection/common/connectionConfi
 import { fixupConnectionCredentials } from 'sql/platform/connection/common/connectionInfo';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { ConnectionProfileGroup, IConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
+import { AuthenticationType } from 'sql/platform/connection/common/constants';
 import { IConnectionProfile, ProfileMatcher } from 'sql/platform/connection/common/interfaces';
 import { ICredentialsService } from 'sql/platform/credentials/common/credentialsService';
 import { isDisposable } from 'vs/base/common/lifecycle';
@@ -90,9 +91,9 @@ export class ConnectionStore {
 					}
 					return { profile: credentialsItem, savedCred: !!savedCred };
 				});
-		} else if (credentialsItem.authenticationType === 'AzureMFA' || credentialsItem.authenticationType === 'dstsAuth' && credentialsItem.azureAccount) {
+		} else if (credentialsItem.authenticationType === AuthenticationType.AzureMFA || credentialsItem.authenticationType === AuthenticationType.DSTSAuth && credentialsItem.azureAccount) {
 			return Promise.resolve({ profile: credentialsItem, savedCred: true });
-		} else if (credentialsItem.authenticationType === 'None') {
+		} else if (credentialsItem.authenticationType === AuthenticationType.None) {
 			// Kusto supports no authentication
 			return Promise.resolve({ profile: credentialsItem, savedCred: true });
 		} else {

--- a/src/sql/platform/connection/common/constants.ts
+++ b/src/sql/platform/connection/common/constants.ts
@@ -24,12 +24,33 @@ export const passwordChars = '***************';
 /* default authentication type setting name*/
 export const defaultAuthenticationType = 'defaultAuthenticationType';
 
+/**
+ * Well-known Authentication types commonly supported by connection providers.
+ */
 export enum AuthenticationType {
+	/**
+	 * Username and password
+	 */
 	SqlLogin = 'SqlLogin',
+	/**
+	 * Windows Authentication
+	 */
 	Integrated = 'Integrated',
+	/**
+	 * Azure Active Directory - Universal with MFA support
+	 */
 	AzureMFA = 'AzureMFA',
+	/**
+	 * Azure Active Directory - Password
+	 */
 	AzureMFAAndUser = 'AzureMFAAndUser',
+	/**
+	 * Datacenter Security Token Service Authentication
+	 */
 	DSTSAuth = 'dstsAuth',
+	/**
+	 * No authentication required
+	 */
 	None = 'None'
 }
 

--- a/src/sql/platform/connection/common/constants.ts
+++ b/src/sql/platform/connection/common/constants.ts
@@ -24,12 +24,14 @@ export const passwordChars = '***************';
 /* default authentication type setting name*/
 export const defaultAuthenticationType = 'defaultAuthenticationType';
 
-/* authentication types */
-export const sqlLogin = 'SqlLogin';
-export const integrated = 'Integrated';
-export const azureMFA = 'AzureMFA';
-export const azureMFAAndUser = 'AzureMFAAndUser';
-export const dstsAuth = 'dstsAuth';
+export enum AuthenticationType {
+	SqlLogin = 'SqlLogin',
+	Integrated = 'Integrated',
+	AzureMFA = 'AzureMFA',
+	AzureMFAAndUser = 'AzureMFAAndUser',
+	DSTSAuth = 'dstsAuth',
+	None = 'None'
+}
 
 /* CMS constants */
 export const cmsProviderName = 'MSSQL-CMS';

--- a/src/sql/platform/connection/common/providerConnectionInfo.ts
+++ b/src/sql/platform/connection/common/providerConnectionInfo.ts
@@ -19,7 +19,6 @@ export class ProviderConnectionInfo extends Disposable implements azdata.Connect
 	options: { [name: string]: any } = {};
 
 	private _providerName?: string;
-	private static readonly SqlAuthentication = 'SqlLogin';
 	public static readonly ProviderPropertyName = 'providerName';
 
 	public constructor(
@@ -194,7 +193,7 @@ export class ProviderConnectionInfo extends Disposable implements azdata.Connect
 			option => option.specialValueType === ConnectionOptionSpecialType.password)!; // i guess we are going to assume there is a password field
 		let isPasswordRequired = optionMetadata.isRequired;
 		if (this.providerName === Constants.mssqlProviderName) {
-			isPasswordRequired = this.authenticationType === ProviderConnectionInfo.SqlAuthentication && optionMetadata.isRequired;
+			isPasswordRequired = this.authenticationType === Constants.AuthenticationType.SqlLogin && optionMetadata.isRequired;
 		}
 		return isPasswordRequired;
 	}

--- a/src/sql/platform/connection/test/common/connectionStore.test.ts
+++ b/src/sql/platform/connection/test/common/connectionStore.test.ts
@@ -15,7 +15,7 @@ import { TestCredentialsService } from 'sql/platform/credentials/test/common/tes
 import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
 import { deepClone, deepFreeze } from 'vs/base/common/objects';
 import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
-import { mssqlProviderName } from 'sql/platform/connection/common/constants';
+import { AuthenticationType, mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ConnectionProviderProperties } from 'sql/platform/capabilities/common/capabilitiesService';
 import { InMemoryStorageService } from 'vs/platform/storage/common/storage';
 import { generateUuid } from 'vs/base/common/uuid';
@@ -25,7 +25,7 @@ suite('ConnectionStore', () => {
 		connectionName: 'new name',
 		serverName: 'namedServer',
 		databaseName: 'bcd',
-		authenticationType: 'SqlLogin',
+		authenticationType: AuthenticationType.SqlLogin,
 		userName: 'cde', // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Mock value, never actually used to connect")]
 		password: generateUuid(),
 		savePassword: true,
@@ -214,7 +214,7 @@ suite('ConnectionStore', () => {
 			credentialsService, capabilitiesService);
 		const integratedCred = Object.assign({}, defaultNamedProfile, {
 			serverName: defaultNamedProfile.serverName + 'Integrated',
-			authenticationType: 'Integrated',
+			authenticationType: AuthenticationType.Integrated,
 			userName: '',
 			password: ''
 		});

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -40,6 +40,7 @@ import { ITelemetryEventProperties } from 'sql/platform/telemetry/common/telemet
 import { ExtHostAzureBlob } from 'sql/workbench/api/common/extHostAzureBlob';
 import { ExtHostAzureAccount } from 'sql/workbench/api/common/extHostAzureAccount';
 import { IExtHostExtensionService } from 'vs/workbench/api/common/extHostExtensionService';
+import { AuthenticationType } from 'sql/platform/connection/common/constants';
 
 export interface IAzdataExtensionApiFactory {
 	(extension: IExtensionDescription): typeof azdata;
@@ -106,6 +107,9 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 			// namespace: connection
 			const connection: typeof azdata.connection = {
 				// "azdata" API definition
+
+				AuthenticationType: AuthenticationType,
+
 				ConnectionProfile: sqlExtHostTypes.ConnectionProfile,
 
 				getCurrentConnection(): Thenable<azdata.connection.ConnectionProfile> {

--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -291,10 +291,10 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 		*/
 		profile.authenticationType =
 			args.authenticationType ? args.authenticationType :
-				args.integrated ? Constants.integrated :
-					args.aad ? Constants.azureMFA :
-						(args.user && args.user.length > 0) ? args.user.includes('@') ? Constants.azureMFA : Constants.sqlLogin :
-							Constants.integrated;
+				args.integrated ? Constants.AuthenticationType.Integrated :
+					args.aad ? Constants.AuthenticationType.AzureMFA :
+						(args.user && args.user.length > 0) ? args.user.includes('@') ? Constants.AuthenticationType.AzureMFA : Constants.AuthenticationType.SqlLogin :
+							Constants.AuthenticationType.Integrated;
 
 		profile.connectionName = '';
 		profile.setOptionValue('applicationName', Constants.applicationName);

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -195,13 +195,13 @@ suite('commandLineService tests', () => {
 		args.server = 'myserver';
 		args.database = 'mydatabase';
 		args.user = 'myuser';
-		args.authenticationType = Constants.sqlLogin;
+		args.authenticationType = Constants.AuthenticationType.SqlLogin;
 
 		connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
 		connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
 		let originalProfile: IConnectionProfile = undefined;
-		connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin), 'connection', true))
+		connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.AuthenticationType.SqlLogin), 'connection', true))
 			.returns((conn) => {
 				originalProfile = conn;
 				return Promise.resolve('unused');
@@ -308,7 +308,7 @@ suite('commandLineService tests', () => {
 		connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
 		let originalProfile: IConnectionProfile = undefined;
-		connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.integrated), 'connection', true))
+		connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.AuthenticationType.Integrated), 'connection', true))
 			.returns((conn) => {
 				originalProfile = conn;
 				return Promise.resolve('unused');
@@ -333,7 +333,7 @@ suite('commandLineService tests', () => {
 			groupFullName: 'testGroup',
 			serverName: 'myserver',
 			databaseName: 'mydatabase',
-			authenticationType: Constants.integrated,
+			authenticationType: Constants.AuthenticationType.Integrated,
 			password: undefined,
 			userName: '',
 			groupId: undefined,
@@ -351,7 +351,7 @@ suite('commandLineService tests', () => {
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
 		let originalProfile: IConnectionProfile = undefined;
 		connectionManagementService.setup(c => c.connectIfNotConnected(
-			TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.integrated && p.connectionName === 'Test' && p.id === 'testID'), 'connection', true))
+			TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.AuthenticationType.Integrated && p.connectionName === 'Test' && p.id === 'testID'), 'connection', true))
 			.returns((conn) => {
 				originalProfile = conn;
 				return Promise.resolve('unused');
@@ -373,13 +373,13 @@ suite('commandLineService tests', () => {
 		args.server = 'myserver';
 		args.database = 'mydatabase';
 		args.user = 'myuser';
-		args.authenticationType = Constants.sqlLogin;
+		args.authenticationType = Constants.AuthenticationType.SqlLogin;
 		args._ = ['c:\\dir\\file.sql'];
 		connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
 		connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
 		let originalProfile: IConnectionProfile = undefined;
-		connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin), 'connection', true))
+		connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.AuthenticationType.SqlLogin), 'connection', true))
 			.returns((conn) => {
 				originalProfile = conn;
 				return Promise.resolve('unused');
@@ -400,7 +400,7 @@ suite('commandLineService tests', () => {
 		const editorService: TypeMoq.Mock<IEditorService> = TypeMoq.Mock.ofType<IEditorService>(TestEditorService, TypeMoq.MockBehavior.Strict);
 		editorService.setup(e => e.editors).returns(() => [queryInput]);
 		connectionManagementService.setup(c =>
-			c.connect(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin),
+			c.connect(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.AuthenticationType.SqlLogin),
 				uri.toString(),
 				TypeMoq.It.is<IConnectionCompletionOptions>(i => i.params.input === queryInput && i.params.connectionType === ConnectionType.editor))
 		).verifiable(TypeMoq.Times.once());
@@ -447,7 +447,7 @@ suite('commandLineService tests', () => {
 			connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
 			connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
 			let originalProfile: IConnectionProfile = undefined;
-			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin), 'connection', true))
+			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.AuthenticationType.SqlLogin), 'connection', true))
 				.returns((conn) => {
 					originalProfile = conn;
 					return Promise.resolve('unused');
@@ -478,7 +478,7 @@ suite('commandLineService tests', () => {
 			connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
 			connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
 			let originalProfile: IConnectionProfile = undefined;
-			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin), 'connection', true))
+			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.AuthenticationType.SqlLogin), 'connection', true))
 				.returns((conn) => {
 					originalProfile = conn;
 					return Promise.resolve('unused');
@@ -538,7 +538,7 @@ suite('commandLineService tests', () => {
 			connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
 			connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
 			connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
-			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin), 'connection', true))
+			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.AuthenticationType.SqlLogin), 'connection', true))
 				.returns((conn) => {
 					return Promise.resolve('unused');
 				})

--- a/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
@@ -15,8 +15,6 @@ import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
-import { integrated, azureMFA } from 'sql/platform/connection/common/constants';
-import { AuthenticationType } from 'sql/workbench/services/connection/browser/connectionWidget';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { ConnectionViewletPanel } from 'sql/workbench/contrib/dataExplorer/browser/connectionViewletPanel';
@@ -31,6 +29,7 @@ workbenchRegistry.registerWorkbenchContribution(ConnectionStatusbarItem, Lifecyc
 
 import 'sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint';
 import { ServerTreeViewView } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
+import { AuthenticationType } from 'sql/platform/connection/common/constants';
 
 // Connection Dashboard registration
 
@@ -124,8 +123,8 @@ CommandsRegistry.registerCommand('azdata.connect',
 		const capabilitiesServices = accessor.get(ICapabilitiesService);
 		const connectionManagementService = accessor.get(IConnectionManagementService);
 		if (args && args.serverName && args.providerName
-			&& (args.authenticationType === integrated
-				|| args.authenticationType === azureMFA
+			&& (args.authenticationType === AuthenticationType.Integrated
+				|| args.authenticationType === AuthenticationType.AzureMFA
 				|| (args.userName && args.password))) {
 			const profile: azdata.IConnectionProfile = {
 				serverName: args.serverName,
@@ -178,7 +177,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'sql.defaultAuthenticationType': {
 			'type': 'string',
-			'enum': ['SqlLogin', 'AzureMFA', `AzureMFAAndUser`, 'Integrated'],
+			'enum': [AuthenticationType.SqlLogin, AuthenticationType.AzureMFA, AuthenticationType.AzureMFAAndUser, AuthenticationType.Integrated],
 			'description': localize('sql.defaultAuthenticationTypeDescription', "Default authentication type to use when connecting to Azure resources. "),
 			'enumDescriptions': [
 				localize('sql.defaultAuthenticationType.SqlLogin', "Sql Login"),
@@ -186,7 +185,7 @@ configurationRegistry.registerConfiguration({
 				localize('sql.defaultAuthenticationType.AzureMFAAndUser', "Azure Active Directory - Password"),
 				localize('sql.defaultAuthenticationType.Integrated', "Windows Authentication"),
 			],
-			'default': 'AzureMFA'
+			'default': AuthenticationType.AzureMFA
 		},
 		'sql.defaultEngine': {
 			'type': 'string',

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookContexts.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookContexts.test.ts
@@ -10,7 +10,7 @@ import { IConnectionManagementService } from 'sql/platform/connection/common/con
 import { TestConnectionManagementService } from 'sql/platform/connection/test/common/testConnectionManagementService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
-import { mssqlProviderName } from 'sql/platform/connection/common/constants';
+import { AuthenticationType, mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 suite('Notebook Contexts', function (): void {
 	const defaultContext = NotebookContexts.DefaultContext;
@@ -23,7 +23,7 @@ suite('Notebook Contexts', function (): void {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -33,7 +33,7 @@ import { TestConnectionManagementService } from 'sql/platform/connection/test/co
 import { isUndefinedOrNull } from 'vs/base/common/types';
 import { NotebookEditorContentLoader } from 'sql/workbench/contrib/notebook/browser/models/notebookInput';
 import { SessionManager } from 'sql/workbench/contrib/notebook/test/emptySessionClasses';
-import { mssqlProviderName } from 'sql/platform/connection/common/constants';
+import { AuthenticationType, mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { uriPrefixes } from 'sql/platform/connection/common/utils';
 import { NullAdsTelemetryService } from 'sql/platform/telemetry/common/adsTelemetryService';
@@ -1071,7 +1071,7 @@ suite('notebook model', function (): void {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
@@ -1091,7 +1091,7 @@ suite('notebook model', function (): void {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
@@ -25,7 +25,7 @@ import { ObjectExplorerActionsContext } from 'sql/workbench/services/objectExplo
 import { IConnectionResult, IConnectionParams } from 'sql/platform/connection/common/connectionManagement';
 import { TreeSelectionHandler } from 'sql/workbench/services/objectExplorer/browser/treeSelectionHandler';
 import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
-import { UNSAVED_GROUP_ID, mssqlProviderName } from 'sql/platform/connection/common/constants';
+import { UNSAVED_GROUP_ID, mssqlProviderName, AuthenticationType } from 'sql/platform/connection/common/constants';
 import { $ } from 'vs/base/browser/dom';
 import { OEManageConnectionAction } from 'sql/workbench/contrib/dashboard/browser/dashboardActions';
 import { IViewsService, IView, ViewContainerLocation, ViewContainer, IViewPaneContainer } from 'vs/workbench/common/views';
@@ -96,7 +96,7 @@ suite('SQL Connection Tree Action tests', () => {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
@@ -183,7 +183,7 @@ suite('SQL Connection Tree Action tests', () => {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
@@ -228,7 +228,7 @@ suite('SQL Connection Tree Action tests', () => {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
@@ -304,7 +304,7 @@ suite('SQL Connection Tree Action tests', () => {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
@@ -349,7 +349,7 @@ suite('SQL Connection Tree Action tests', () => {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
@@ -746,7 +746,7 @@ suite('SQL Connection Tree Action tests', () => {
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
 			databaseName: 'testDatabaseName',
-			authenticationType: 'integrated',
+			authenticationType: AuthenticationType.Integrated,
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,

--- a/src/sql/workbench/services/connection/browser/cmsConnectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/cmsConnectionWidget.ts
@@ -23,7 +23,7 @@ import * as DOM from 'vs/base/browser/dom';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { OS, OperatingSystem } from 'vs/base/common/platform';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
-import { ConnectionWidget, AuthenticationType } from 'sql/workbench/services/connection/browser/connectionWidget';
+import { ConnectionWidget } from 'sql/workbench/services/connection/browser/connectionWidget';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMessageService';
 
@@ -33,8 +33,8 @@ import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMess
 export class CmsConnectionWidget extends ConnectionWidget {
 
 	private _serverDescriptionInputBox: InputBox;
-	protected _authTypeMap: { [providerName: string]: AuthenticationType[] } = {
-		[Constants.cmsProviderName]: [AuthenticationType.SqlLogin, AuthenticationType.Integrated]
+	protected _authTypeMap: { [providerName: string]: Constants.AuthenticationType[] } = {
+		[Constants.cmsProviderName]: [Constants.AuthenticationType.SqlLogin, Constants.AuthenticationType.Integrated]
 	};
 
 	constructor(options: azdata.ConnectionOption[],
@@ -92,17 +92,17 @@ export class CmsConnectionWidget extends ConnectionWidget {
 		// True when opening a CMS dialog to add a registered server
 		if (authTypeChanged) {
 			// Registered Servers only support Integrated Auth
-			newAuthTypes = authTypeOption.categoryValues.filter((option) => option.name === AuthenticationType.Integrated);
+			newAuthTypes = authTypeOption.categoryValues.filter((option) => option.name === Constants.AuthenticationType.Integrated);
 			this._authTypeSelectBox.setOptions(newAuthTypes.map(c => c.displayName));
-			authTypeOption.defaultValue = AuthenticationType.Integrated;
+			authTypeOption.defaultValue = Constants.AuthenticationType.Integrated;
 		} else {
 			// CMS supports all auth types
 			newAuthTypes = authTypeOption.categoryValues;
 			this._authTypeSelectBox.setOptions(newAuthTypes.map(c => c.displayName));
 			if (OS === OperatingSystem.Windows) {
-				authTypeOption.defaultValue = this.getAuthTypeDisplayName(AuthenticationType.Integrated);
+				authTypeOption.defaultValue = this.getAuthTypeDisplayName(Constants.AuthenticationType.Integrated);
 			} else {
-				authTypeOption.defaultValue = this.getAuthTypeDisplayName(AuthenticationType.SqlLogin);
+				authTypeOption.defaultValue = this.getAuthTypeDisplayName(Constants.AuthenticationType.SqlLogin);
 			}
 		}
 		this._authTypeSelectBox.selectWithOptionName(authTypeOption.defaultValue);

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -158,7 +158,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			defaultAuthenticationType = WorkbenchUtils.getSqlConfigValue<string>(this._configurationService, Constants.defaultAuthenticationType);
 		}
 
-		return defaultAuthenticationType || Constants.sqlLogin;  // as a fallback, default to sql login if the value from settings is not available
+		return defaultAuthenticationType || Constants.AuthenticationType.SqlLogin;  // as a fallback, default to sql login if the value from settings is not available
 
 	}
 

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -865,9 +865,9 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 * @param connection The connection to fill in or update
 	 */
 	private async fillInOrClearToken(connection: interfaces.IConnectionProfile): Promise<boolean> {
-		if (connection.authenticationType !== Constants.azureMFA
-			&& connection.authenticationType !== Constants.azureMFAAndUser
-			&& connection.authenticationType !== Constants.dstsAuth) {
+		if (connection.authenticationType !== Constants.AuthenticationType.AzureMFA
+			&& connection.authenticationType !== Constants.AuthenticationType.AzureMFAAndUser
+			&& connection.authenticationType !== Constants.AuthenticationType.DSTSAuth) {
 			connection.options['azureAccountToken'] = undefined;
 			return true;
 		}
@@ -875,7 +875,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		let azureResource = this.getAzureResourceForConnection(connection);
 		const accounts = await this._accountManagementService.getAccounts();
 
-		if (connection.authenticationType === Constants.dstsAuth) {
+		if (connection.authenticationType === Constants.AuthenticationType.DSTSAuth) {
 			let dstsAccounts = accounts.filter(a => a.key.providerId.startsWith('dstsAuth'));
 			if (dstsAccounts.length <= 0) {
 				connection.options['azureAccountToken'] = undefined;
@@ -894,7 +894,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 		const azureAccounts = accounts.filter(a => a.key.providerId.startsWith('azure'));
 		if (azureAccounts && azureAccounts.length > 0) {
-			let accountId = (connection.authenticationType === Constants.azureMFA || connection.authenticationType === Constants.azureMFAAndUser) ? connection.azureAccount : connection.userName;
+			let accountId = (connection.authenticationType === Constants.AuthenticationType.AzureMFA || connection.authenticationType === Constants.AuthenticationType.AzureMFAAndUser) ? connection.azureAccount : connection.userName;
 			let account = azureAccounts.find(account => account.key.accountId === accountId);
 			if (account) {
 				this._logService.debug(`Getting security token for Azure account ${account.key.accountId}`);

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -35,15 +35,7 @@ import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMess
 import Severity from 'vs/base/common/severity';
 import { ConnectionStringOptions } from 'sql/platform/capabilities/common/capabilitiesService';
 import { isFalsyOrWhitespace } from 'vs/base/common/strings';
-
-export enum AuthenticationType {
-	SqlLogin = 'SqlLogin',
-	Integrated = 'Integrated',
-	AzureMFA = 'AzureMFA',
-	AzureMFAAndUser = 'AzureMFAAndUser',
-	dSTSAuth = 'dstsAuth',
-	None = 'None' // Kusto supports no authentication
-}
+import { AuthenticationType } from 'sql/platform/connection/common/constants';
 
 const ConnectionStringText = localize('connectionWidget.connectionString', "Connection string");
 
@@ -83,7 +75,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 	protected _databaseNameInputBox: Dropdown;
 	protected _advancedButton: Button;
 	private static readonly _authTypes: AuthenticationType[] =
-		[AuthenticationType.AzureMFA, AuthenticationType.AzureMFAAndUser, AuthenticationType.Integrated, AuthenticationType.SqlLogin, AuthenticationType.dSTSAuth, AuthenticationType.None];
+		[AuthenticationType.AzureMFA, AuthenticationType.AzureMFAAndUser, AuthenticationType.Integrated, AuthenticationType.SqlLogin, AuthenticationType.DSTSAuth, AuthenticationType.None];
 	private static readonly _osByName = {
 		Windows: OperatingSystem.Windows,
 		Macintosh: OperatingSystem.Macintosh,
@@ -528,7 +520,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 			// Immediately show/hide appropriate elements though so user gets immediate feedback while we load accounts
 			this._tableContainer.classList.remove('hide-username');
 			this._tableContainer.classList.remove('hide-azure-accounts');
-		} else if (currentAuthType === AuthenticationType.dSTSAuth) {
+		} else if (currentAuthType === AuthenticationType.DSTSAuth) {
 			this._accountManagementService.getAccountsForProvider('dstsAuth').then(accounts => {
 				if (accounts && accounts.length > 0) {
 					accounts[0].key.providerArgs = {
@@ -891,7 +883,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		if (this.authenticationType === AuthenticationType.AzureMFAAndUser || this.authenticationType === AuthenticationType.AzureMFA) {
 			return this._azureAccountDropdown.value;
 		}
-		if (this.authenticationType === AuthenticationType.dSTSAuth) {
+		if (this.authenticationType === AuthenticationType.DSTSAuth) {
 			return this._token;
 		}
 		return undefined;

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -61,7 +61,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		databaseName: 'database',
 		userName: 'user',
 		password: 'password',
-		authenticationType: 'integrated',
+		authenticationType: Constants.AuthenticationType.Integrated,
 		savePassword: true,
 		groupFullName: 'g2/g2-2',
 		groupId: 'group id',
@@ -121,7 +121,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			c => c.serverName === connectionProfileWithEmptyUnsavedPassword.serverName))).returns(
 				() => Promise.resolve({ profile: connectionProfileWithEmptyUnsavedPassword, savedCred: false }));
 		connectionStore.setup(x => x.isPasswordRequired(TypeMoq.It.isAny())).returns((profile) => {
-			if (profile.authenticationType === Constants.azureMFA) {
+			if (profile.authenticationType === Constants.AuthenticationType.AzureMFA) {
 				return false;
 			}
 			return true;
@@ -1649,7 +1649,7 @@ suite('SQL ConnectionManagementService tests', () => {
 	test('addSavedPassword fills in Azure access tokens for Azure accounts', async () => {
 		// Set up a connection profile that uses Azure
 		let azureConnectionProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesService, connectionProfile);
-		azureConnectionProfile.authenticationType = 'AzureMFA';
+		azureConnectionProfile.authenticationType = Constants.AuthenticationType.AzureMFA;
 		let username = 'testuser@microsoft.com';
 		azureConnectionProfile.azureAccount = username;
 		let servername = 'test-database.database.windows.net';
@@ -1688,7 +1688,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			token: testToken,
 			tokenType: 'Bearer'
 		}));
-		connectionStore.setup(x => x.addSavedPassword(TypeMoq.It.is(profile => profile.authenticationType === 'AzureMFA'))).returns(profile => Promise.resolve({
+		connectionStore.setup(x => x.addSavedPassword(TypeMoq.It.is(profile => profile.authenticationType === Constants.AuthenticationType.AzureMFA))).returns(profile => Promise.resolve({
 			profile: profile,
 			savedCred: false
 		}));
@@ -1705,7 +1705,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		const uri: string = 'Editor Uri';
 		// Set up a connection profile that uses Azure
 		const azureConnectionProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesService, connectionProfile);
-		azureConnectionProfile.authenticationType = 'AzureMFA';
+		azureConnectionProfile.authenticationType = Constants.AuthenticationType.AzureMFA;
 		const username = 'testuser@microsoft.com';
 		azureConnectionProfile.azureAccount = username;
 		const servername = 'test-database.database.windows.net';
@@ -1747,7 +1747,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			]);
 		});
 
-		connectionStore.setup(x => x.addSavedPassword(TypeMoq.It.is(profile => profile.authenticationType === 'AzureMFA'))).returns(profile => Promise.resolve({
+		connectionStore.setup(x => x.addSavedPassword(TypeMoq.It.is(profile => profile.authenticationType === Constants.AuthenticationType.AzureMFA))).returns(profile => Promise.resolve({
 			profile: profile,
 			savedCred: false
 		}));
@@ -1776,7 +1776,7 @@ suite('SQL ConnectionManagementService tests', () => {
 	test('addSavedPassword fills in Azure access token for selected tenant', async () => {
 		// Set up a connection profile that uses Azure
 		let azureConnectionProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesService, connectionProfile);
-		azureConnectionProfile.authenticationType = 'AzureMFA';
+		azureConnectionProfile.authenticationType = Constants.AuthenticationType.AzureMFA;
 		let username = 'testuser@microsoft.com';
 		azureConnectionProfile.azureAccount = username;
 		let servername = 'test-database.database.windows.net';
@@ -1814,7 +1814,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 		let returnedToken = { token: 'testToken', tokenType: 'Bearer' };
 		accountManagementService.setup(x => x.getAccountSecurityToken(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(returnedToken));
-		connectionStore.setup(x => x.addSavedPassword(TypeMoq.It.is(profile => profile.authenticationType === 'AzureMFA'))).returns(profile => Promise.resolve({
+		connectionStore.setup(x => x.addSavedPassword(TypeMoq.It.is(profile => profile.authenticationType === Constants.AuthenticationType.AzureMFA))).returns(profile => Promise.resolve({
 			profile: profile,
 			savedCred: false
 		}));
@@ -1918,7 +1918,7 @@ export function createConnectionProfile(id: string, password?: string): Connecti
 		groupFullName: 'testGroup',
 		serverName: 'testServerName',
 		databaseName: 'testDatabaseName',
-		authenticationType: Constants.integrated,
+		authenticationType: Constants.AuthenticationType.Integrated,
 		password: password ?? 'test',
 		userName: 'testUsername',
 		groupId: undefined,


### PR DESCRIPTION
Got annoyed at the various copies of AuthenticationType values being duplicated everywhere - and this is something that extensions would find very useful when creating or using connection infos (especially since the values aren't really documented anywhere).

Purposely keeping it pretty generic though as just a list of well-known auth types since we don't really have a good way of telling the user what auth types a specific provider may or may not support. If that was something that ended up being useful I think adding functionality to the providers to say what auth types they support would be good. 

This does mean we need to be extra careful when changing these values though - since they're runtime objects if we were to change the strings at all that could break a lot of stuff (but that's pretty much the same as what would happen now with changing the hardcoded string constants so it's not really that much different. The main difference here is that extensions using this would also then have their values changed which could be unexpected). 