### PR TITLE
upgrade service downloader

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@microsoft/ads-extension-telemetry": "^1.2.0",
-    "@microsoft/ads-service-downloader": "0.2.4",
+    "@microsoft/ads-service-downloader": "1.0.2",
     "vscode-nls": "^4.1.2"
   },
   "devDependencies": {

--- a/extensions/admin-tool-ext-win/yarn.lock
+++ b/extensions/admin-tool-ext-win/yarn.lock
@@ -207,10 +207,10 @@
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 
-"@microsoft/ads-service-downloader@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-0.2.4.tgz#905a11eb2da19673629852d9764fb9fb94ad81bd"
-  integrity sha512-3J0YjH29a5pP+5Yu0HF7itRBZpNOgUN34Gh/p0Py/TQr7qUzZSXwOM+fWD1nCea+q9t8mfHr0yuy0aeDX+33vQ==
+"@microsoft/ads-service-downloader@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-1.0.2.tgz#76cc9a44074525ac65a6ea15f8b5ee7eac87efbe"
+  integrity sha512-Qpc5HNLywVZbSxeUC4S7d+VRAUddrYjkIfDXl76UwCA0iuwzi71RtciEgWfCWAZMm9CbKTIbtFGh4pYw+h81nQ==
   dependencies:
     async-retry "^1.2.3"
     eventemitter2 "^5.0.1"

--- a/extensions/azuremonitor/config.json
+++ b/extensions/azuremonitor/config.json
@@ -5,14 +5,7 @@
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",
 		"OSX": "osx-x64-net5.0.tar.gz",
-		"CentOS_7": "rhel-x64-net5.0.tar.gz",
-		"Debian_8": "rhel-x64-net5.0.tar.gz",
-		"Fedora_23": "rhel-x64-net5.0.tar.gz",
-		"OpenSUSE_13_2": "rhel-x64-net5.0.tar.gz",
-		"RHEL_7": "rhel-x64-net5.0.tar.gz",
-		"SLES_12_2": "rhel-x64-net5.0.tar.gz",
-		"Ubuntu_14": "rhel-x64-net5.0.tar.gz",
-		"Ubuntu_16": "rhel-x64-net5.0.tar.gz"
+		"Linux": "rhel-x64-net5.0.tar.gz"
 	},
 	"installDirectory": "../sqltoolsservice/{#platform#}/{#version#}",
 	"executableFiles": [

--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -212,7 +212,7 @@
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.0",
     "figures": "^2.0.0",
     "find-remove": "1.2.1",
-    "@microsoft/ads-service-downloader": "0.2.4",
+    "@microsoft/ads-service-downloader": "1.0.2",
     "vscode-extension-telemetry": "0.4.2",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^4.0.0"

--- a/extensions/azuremonitor/src/azuremonitorServer.ts
+++ b/extensions/azuremonitor/src/azuremonitorServer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ServerProvider, IConfig, Events } from '@microsoft/ads-service-downloader';
+import { ServerProvider, IConfig, Events, LogLevel } from '@microsoft/ads-service-downloader';
 import { ServerOptions, TransportKind } from 'vscode-languageclient';
 import * as Constants from './constants';
 import * as vscode from 'vscode';
@@ -75,7 +75,7 @@ export class AzureMonitorServer {
 		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
 
 		const serverdownloader = new ServerProvider(this.config);
-		serverdownloader.eventEmitter.onAny(() => generateHandleServerProviderEvent());
+		serverdownloader.eventEmitter.onAny(generateHandleServerProviderEvent());
 		return serverdownloader.getOrDownloadServer();
 	}
 
@@ -94,7 +94,7 @@ function generateServerOptions(logPath: string, executablePath: string): ServerO
 
 function generateHandleServerProviderEvent() {
 	let dots = 0;
-	return (e: string, ...args: any[]) => {
+	return (e: string | string[], ...args: any[]) => {
 		switch (e) {
 			case Events.INSTALL_START:
 				outputChannel.show(true);
@@ -121,6 +121,11 @@ function generateHandleServerProviderEvent() {
 				// Start a new line to end the dots from the DOWNLOAD_PROGRESS event.
 				outputChannel.appendLine('');
 				outputChannel.appendLine(localize('downloadServiceDoneChannelMsg', "Downloaded {0}", Constants.serviceName));
+				break;
+			case Events.LOG_EMITTED:
+				if (args[0] >= LogLevel.Warning) {
+					outputChannel.appendLine(args[1]);
+				}
 				break;
 			default:
 				console.error(`Unknown event from Server Provider ${e}`);

--- a/extensions/azuremonitor/yarn.lock
+++ b/extensions/azuremonitor/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-service-downloader@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-0.2.4.tgz#905a11eb2da19673629852d9764fb9fb94ad81bd"
-  integrity sha512-3J0YjH29a5pP+5Yu0HF7itRBZpNOgUN34Gh/p0Py/TQr7qUzZSXwOM+fWD1nCea+q9t8mfHr0yuy0aeDX+33vQ==
+"@microsoft/ads-service-downloader@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-1.0.2.tgz#76cc9a44074525ac65a6ea15f8b5ee7eac87efbe"
+  integrity sha512-Qpc5HNLywVZbSxeUC4S7d+VRAUddrYjkIfDXl76UwCA0iuwzi71RtciEgWfCWAZMm9CbKTIbtFGh4pYw+h81nQ==
   dependencies:
     async-retry "^1.2.3"
     eventemitter2 "^5.0.1"

--- a/extensions/import/config.json
+++ b/extensions/import/config.json
@@ -6,16 +6,7 @@
 		"Windows_64": "win-x64.zip",
 		"Windows_86": "win-x86.zip",
 		"OSX": "osx.tar.gz",
-		"Linux_64": "linux-x64.tar.gz",
-		"CentOS_7": "linux-x64.tar.gz",
-		"Debian_8": "linux-x64.tar.gz",
-		"Fedora_23": "linux-x64.tar.gz",
-		"OpenSUSE_13_2": "linux-x64.tar.gz",
-		"RHEL_7": "linux-x64.tar.gz",
-		"SLES_12_2": "linux-x64.tar.gz",
-		"Ubuntu_14": "linux-x64.tar.gz",
-		"Ubuntu_16": "linux-x64.tar.gz",
-		"Ubuntu_18": "linux-x64.tar.gz"
+		"Linux": "linux-x64.tar.gz"
 	},
 	"installDirectory": "flatfileimportservice/{#platform#}/{#version#}",
 	"executableFiles": [

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.3.0",
     "htmlparser2": "^3.10.1",
-    "@microsoft/ads-service-downloader": "0.2.4",
+    "@microsoft/ads-service-downloader": "1.0.2",
     "vscode-extension-telemetry": "0.4.2",
     "vscode-nls": "^3.2.1"
   },

--- a/extensions/import/src/services/serviceClient.ts
+++ b/extensions/import/src/services/serviceClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SqlOpsDataClient, ClientOptions } from 'dataprotocol-client';
-import { ServerProvider, Events } from '@microsoft/ads-service-downloader';
+import { ServerProvider, Events, LogLevel } from '@microsoft/ads-service-downloader';
 import { ServerOptions, TransportKind } from 'vscode-languageclient';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
@@ -136,6 +136,13 @@ export class ServiceClient {
 					break;
 				case Events.ENTRY_EXTRACTED:
 					this.outputChannel.appendLine(localize('entryExtractedChannelMsg', "Extracted {0} ({1}/{2})", args[0], args[1], args[2]));
+					break;
+				case Events.LOG_EMITTED:
+					if (args[0] >= LogLevel.Warning) {
+						this.outputChannel.appendLine(args[1]);
+					}
+					break;
+				default:
 					break;
 			}
 		};

--- a/extensions/import/yarn.lock
+++ b/extensions/import/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-service-downloader@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-0.2.4.tgz#905a11eb2da19673629852d9764fb9fb94ad81bd"
-  integrity sha512-3J0YjH29a5pP+5Yu0HF7itRBZpNOgUN34Gh/p0Py/TQr7qUzZSXwOM+fWD1nCea+q9t8mfHr0yuy0aeDX+33vQ==
+"@microsoft/ads-service-downloader@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-1.0.2.tgz#76cc9a44074525ac65a6ea15f8b5ee7eac87efbe"
+  integrity sha512-Qpc5HNLywVZbSxeUC4S7d+VRAUddrYjkIfDXl76UwCA0iuwzi71RtciEgWfCWAZMm9CbKTIbtFGh4pYw+h81nQ==
   dependencies:
     async-retry "^1.2.3"
     eventemitter2 "^5.0.1"

--- a/extensions/kusto/config.json
+++ b/extensions/kusto/config.json
@@ -5,14 +5,7 @@
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",
 		"OSX": "osx-x64-net5.0.tar.gz",
-		"CentOS_7": "rhel-x64-net5.0.tar.gz",
-		"Debian_8": "rhel-x64-net5.0.tar.gz",
-		"Fedora_23": "rhel-x64-net5.0.tar.gz",
-		"OpenSUSE_13_2": "rhel-x64-net5.0.tar.gz",
-		"RHEL_7": "rhel-x64-net5.0.tar.gz",
-		"SLES_12_2": "rhel-x64-net5.0.tar.gz",
-		"Ubuntu_14": "rhel-x64-net5.0.tar.gz",
-		"Ubuntu_16": "rhel-x64-net5.0.tar.gz"
+		"Linux": "rhel-x64-net5.0.tar.gz"
 	},
 	"installDirectory": "../sqltoolsservice/{#platform#}/{#version#}",
 	"executableFiles": [

--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -430,7 +430,7 @@
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.0",
     "figures": "^2.0.0",
     "find-remove": "1.2.1",
-    "@microsoft/ads-service-downloader": "0.2.4",
+    "@microsoft/ads-service-downloader": "1.0.2",
     "vscode-extension-telemetry": "0.4.2",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^4.0.0"

--- a/extensions/kusto/src/kustoServer.ts
+++ b/extensions/kusto/src/kustoServer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ServerProvider, IConfig, Events } from '@microsoft/ads-service-downloader';
+import { ServerProvider, IConfig, Events, LogLevel } from '@microsoft/ads-service-downloader';
 import { ServerOptions, TransportKind } from 'vscode-languageclient';
 import * as Constants from './constants';
 import * as vscode from 'vscode';
@@ -73,7 +73,7 @@ export class KustoServer {
 		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
 
 		const serverdownloader = new ServerProvider(this.config);
-		serverdownloader.eventEmitter.onAny(() => generateHandleServerProviderEvent());
+		serverdownloader.eventEmitter.onAny(generateHandleServerProviderEvent());
 		return serverdownloader.getOrDownloadServer();
 	}
 
@@ -92,7 +92,7 @@ function generateServerOptions(logPath: string, executablePath: string): ServerO
 
 function generateHandleServerProviderEvent() {
 	let dots = 0;
-	return (e: string, ...args: any[]) => {
+	return (e: string | string[], ...args: any[]) => {
 		switch (e) {
 			case Events.INSTALL_START:
 				outputChannel.show(true);
@@ -119,6 +119,11 @@ function generateHandleServerProviderEvent() {
 				// Start a new line to end the dots from the DOWNLOAD_PROGRESS event.
 				outputChannel.appendLine('');
 				outputChannel.appendLine(localize('downloadServiceDoneChannelMsg', "Downloaded {0}", Constants.serviceName));
+				break;
+			case Events.LOG_EMITTED:
+				if (args[0] >= LogLevel.Warning) {
+					outputChannel.appendLine(args[1]);
+				}
 				break;
 			default:
 				console.error(`Unknown event from Server Provider ${e}`);

--- a/extensions/kusto/yarn.lock
+++ b/extensions/kusto/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-service-downloader@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-0.2.4.tgz#905a11eb2da19673629852d9764fb9fb94ad81bd"
-  integrity sha512-3J0YjH29a5pP+5Yu0HF7itRBZpNOgUN34Gh/p0Py/TQr7qUzZSXwOM+fWD1nCea+q9t8mfHr0yuy0aeDX+33vQ==
+"@microsoft/ads-service-downloader@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-1.0.2.tgz#76cc9a44074525ac65a6ea15f8b5ee7eac87efbe"
+  integrity sha512-Qpc5HNLywVZbSxeUC4S7d+VRAUddrYjkIfDXl76UwCA0iuwzi71RtciEgWfCWAZMm9CbKTIbtFGh4pYw+h81nQ==
   dependencies:
     async-retry "^1.2.3"
     eventemitter2 "^5.0.1"

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -5,14 +5,7 @@
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",
 		"OSX": "osx-x64-net6.0.tar.gz",
-		"CentOS_7": "rhel-x64-net6.0.tar.gz",
-		"Debian_8": "rhel-x64-net6.0.tar.gz",
-		"Fedora_23": "rhel-x64-net6.0.tar.gz",
-		"OpenSUSE_13_2": "rhel-x64-net6.0.tar.gz",
-		"RHEL_7": "rhel-x64-net6.0.tar.gz",
-		"SLES_12_2": "rhel-x64-net6.0.tar.gz",
-		"Ubuntu_14": "rhel-x64-net6.0.tar.gz",
-		"Ubuntu_16": "rhel-x64-net6.0.tar.gz"
+		"Linux": "rhel-x64-net6.0.tar.gz"
 	},
 	"installDirectory": "./sqltoolsservice/{#platform#}/{#version#}",
 	"executableFiles": ["MicrosoftSqlToolsServiceLayer.exe", "MicrosoftSqlToolsServiceLayer"],

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1332,7 +1332,7 @@
     "find-remove": "1.2.1",
     "request": "^2.88.0",
     "request-light": "^0.3.0",
-    "@microsoft/ads-service-downloader": "1.0.0",
+    "@microsoft/ads-service-downloader": "1.0.2",
     "stream-meter": "^1.0.4",
     "through2": "^3.0.1",
     "tough-cookie": "^3.0.1",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1332,7 +1332,7 @@
     "find-remove": "1.2.1",
     "request": "^2.88.0",
     "request-light": "^0.3.0",
-    "@microsoft/ads-service-downloader": "0.2.4",
+    "@microsoft/ads-service-downloader": "1.0.0",
     "stream-meter": "^1.0.4",
     "through2": "^3.0.1",
     "tough-cookie": "^3.0.1",

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -32,6 +32,16 @@ const localize = nls.loadMessageBundle();
 const outputChannel = vscode.window.createOutputChannel(Constants.serviceName);
 const statusView = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 
+// The mapping between MSSQL log level and the service downloader log level.
+const LogLevelMapping: { [key: string]: number } = {
+	[TracingLevel.All]: LogLevel.Verbose,
+	[TracingLevel.Critical]: LogLevel.Critical,
+	[TracingLevel.Error]: LogLevel.Error,
+	[TracingLevel.Information]: LogLevel.Information,
+	[TracingLevel.Verbose]: LogLevel.Verbose,
+	[TracingLevel.Warning]: LogLevel.Warning
+};
+
 export class SqlToolsServer {
 
 	private client: SqlOpsDataClient;
@@ -146,15 +156,7 @@ function handleServerProviderEvent(e: string, ...args: any[]): void {
 			outputChannel.appendLine(localize('entryExtractedChannelMsg', "Extracted {0} ({1}/{2})", args[0], args[1], args[2]));
 			break;
 		case Events.LOG_EMITTED:
-			const levelMapping: { [key: string]: number } = {
-				[TracingLevel.All]: LogLevel.Verbose,
-				[TracingLevel.Critical]: LogLevel.Critical,
-				[TracingLevel.Error]: LogLevel.Error,
-				[TracingLevel.Information]: LogLevel.Information,
-				[TracingLevel.Verbose]: LogLevel.Verbose,
-				[TracingLevel.Warning]: LogLevel.Warning
-			};
-			const configuredLevel: number | undefined = levelMapping[getConfigTracingLevel()];
+			const configuredLevel: number | undefined = LogLevelMapping[getConfigTracingLevel()];
 			const logLevel = args[0] as LogLevel;
 			const message = args[1] as string;
 			if (configuredLevel !== undefined && logLevel >= configuredLevel) {

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -85,12 +85,25 @@ export function getConfigLogRetentionSeconds(): number {
 	}
 }
 
-export function getConfigTracingLevel(): string {
+/**
+ * The tracing level defined in the package.json
+ */
+export enum TracingLevel {
+	All = 'All',
+	Off = 'Off',
+	Critical = 'Critical',
+	Error = 'Error',
+	Warning = 'Warning',
+	Information = 'Information',
+	Verbose = 'Verbose'
+}
+
+export function getConfigTracingLevel(): TracingLevel {
 	let config = getConfiguration();
 	if (config) {
 		return config[configTracingLevel];
 	} else {
-		return undefined;
+		return TracingLevel.Critical;
 	}
 }
 

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -189,10 +189,10 @@
   dependencies:
     nan "^2.14.0"
 
-"@microsoft/ads-service-downloader@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-0.2.4.tgz#905a11eb2da19673629852d9764fb9fb94ad81bd"
-  integrity sha512-3J0YjH29a5pP+5Yu0HF7itRBZpNOgUN34Gh/p0Py/TQr7qUzZSXwOM+fWD1nCea+q9t8mfHr0yuy0aeDX+33vQ==
+"@microsoft/ads-service-downloader@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-1.0.0.tgz#dbdab7145c9554473fd7f60bb8beecdff27de971"
+  integrity sha512-yAw7yIueD67IBmuywxJ7LFFOCfqPKurtrz5X7oJm9zeYBBEW4JPK4tc4CQ3hvutSg0NAvvqOR4lp1J3ywMUu+Q==
   dependencies:
     async-retry "^1.2.3"
     eventemitter2 "^5.0.1"

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -189,10 +189,10 @@
   dependencies:
     nan "^2.14.0"
 
-"@microsoft/ads-service-downloader@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-1.0.0.tgz#dbdab7145c9554473fd7f60bb8beecdff27de971"
-  integrity sha512-yAw7yIueD67IBmuywxJ7LFFOCfqPKurtrz5X7oJm9zeYBBEW4JPK4tc4CQ3hvutSg0NAvvqOR4lp1J3ywMUu+Q==
+"@microsoft/ads-service-downloader@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-service-downloader/-/ads-service-downloader-1.0.2.tgz#76cc9a44074525ac65a6ea15f8b5ee7eac87efbe"
+  integrity sha512-Qpc5HNLywVZbSxeUC4S7d+VRAUddrYjkIfDXl76UwCA0iuwzi71RtciEgWfCWAZMm9CbKTIbtFGh4pYw+h81nQ==
   dependencies:
     async-retry "^1.2.3"
     eventemitter2 "^5.0.1"


### PR DESCRIPTION
1. Use new version of service downloader and simplify the runtime/file mapping section.
2. Fix the error in azuremonitor and kusto so that it can actually log messages into the output channel.