### PR TITLE
Fix query history context item

### DIFF
--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -157,7 +157,7 @@
         },
         {
           "command": "queryHistory.disableCapture",
-          "when": "view == queryHistory && config.queryHistory.capatureEnabled",
+          "when": "view == queryHistory && config.queryHistory.captureEnabled",
           "group": "QueryHistory@5"
         },
         {


### PR DESCRIPTION
Typo - meant this didn't show up in the context menu