### PR TITLE
Add max entries to query history

### DIFF
--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -55,6 +55,12 @@
             "type": "boolean",
             "default": true,
             "description": "%queryHistory.persistHistory%"
+          },
+          "queryHistory.maxEntries": {
+            "type": "integer",
+            "default": 100,
+            "minimum": 0,
+            "description": "%queryHistory.maxEntries%"
           }
         }
       }

--- a/extensions/query-history/package.nls.json
+++ b/extensions/query-history/package.nls.json
@@ -12,5 +12,6 @@
 	"queryHistory.clear": "Clear All History",
 	"queryHistory.disableCapture": "Pause Query History Capture",
 	"queryHistory.enableCapture": "Start Query History Capture",
-	"queryHistory.noEntries": "No queries to display"
+	"queryHistory.noEntries": "No queries to display",
+	"queryHistory.maxEntries": "Maximum number of entries to store. 0 means unlimited entries are stored. Increasing this limit may impact performance, especially if persistence is enabled."
 }

--- a/extensions/query-history/src/constants.ts
+++ b/extensions/query-history/src/constants.ts
@@ -7,6 +7,7 @@ export const QUERY_HISTORY_CONFIG_SECTION = 'queryHistory';
 export const CAPTURE_ENABLED_CONFIG_SECTION = 'captureEnabled';
 export const DOUBLE_CLICK_ACTION_CONFIG_SECTION = 'doubleClickAction';
 export const PERSIST_HISTORY_CONFIG_SECTION = 'persistHistory';
+export const MAX_ENTRIES_CONFIG_SECTION = 'maxEntries';
 
 export const ITEM_SELECTED_COMMAND_ID = 'queryHistory.itemSelected';
 


### PR DESCRIPTION
Closes https://github.com/microsoft/azuredatastudio/issues/7361

Default to 100 to start with since that's a pretty large amount of queries - will be using telemetry to see if people change this value to determine if that should be increased. 