### PR TITLE
Add query history telemetry

### DIFF
--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -209,6 +209,7 @@
     }
   },
   "dependencies": {
+    "@microsoft/ads-extension-telemetry": "1.2.0",
     "vscode-nls": "^4.1.2"
   },
   "devDependencies": {

--- a/extensions/query-history/src/queryHistoryProvider.ts
+++ b/extensions/query-history/src/queryHistoryProvider.ts
@@ -150,7 +150,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 					const writeStorageFileAction = new TimedAction(TelemetryViews.QueryHistoryProvider, TelemetryActions.WriteStorageFile,
 						{},
 						{
-							NumItems: this._queryHistoryItems.length,
+							ItemCount: this._queryHistoryItems.length,
 							ItemLengthChars: stringifiedItems.length
 						});
 					// Use sync here so that we can write this out when the object is disposed

--- a/extensions/query-history/src/queryHistoryProvider.ts
+++ b/extensions/query-history/src/queryHistoryProvider.ts
@@ -150,7 +150,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 					// such as passwords (even in the query text itself)
 					const cipher = crypto.createCipheriv(STORAGE_ENCRYPTION_ALGORITHM, key!, iv!);
 					const stringifiedItems = JSON.stringify(this._queryHistoryItems);
-					writeStorageFileAction.additionalMeasures['ItemsLength'] = stringifiedItems.length;
+					writeStorageFileAction.additionalMeasures['ItemsLengthChars'] = stringifiedItems.length;
 					const encryptedText = Buffer.concat([cipher.update(Buffer.from(stringifiedItems)), cipher.final()]);
 					// Use sync here so that we can write this out when the object is disposed
 					fs.writeFileSync(this._historyStorageFile, encryptedText);

--- a/extensions/query-history/src/telemetry.ts
+++ b/extensions/query-history/src/telemetry.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import AdsTelemetryReporter, { TelemetryEventMeasures, TelemetryEventProperties } from '@microsoft/ads-extension-telemetry';
+
+export interface PackageInfo {
+	name: string;
+	version: string;
+	aiKey: string;
+}
+
+const packageInfo = require('../package.json') as PackageInfo;
+
+export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+
+/**
+ * A helper class to send an Action event with a duration, timer starts on construction and ends when send() is called.
+ */
+export class TimedAction {
+	/**
+	 * Additional properties to send along with the final message once send is called.
+	 */
+	public readonly additionalProperties: TelemetryEventProperties = {};
+	/**
+	 * Additional measures to send along with the final message once send is called.
+	 */
+	public readonly additionalMeasures: TelemetryEventMeasures = {};
+
+	private _start: number = Date.now();
+
+	/**
+	 * Creates a new TimedAction and sets the start time to Date.now().
+	 * @param _view The view this action originates from
+	 * @param _action The name of the action
+	 * @param properties Additional properties to send along with the final message once send is called
+	 * @param measures Additional measures to send along with the final message once send is called
+	 */
+	constructor(private _view: TelemetryViews, private _action: TelemetryActions, properties: TelemetryEventProperties = {}, measures: TelemetryEventMeasures = {}) {
+		Object.assign(this.additionalProperties, properties);
+		Object.assign(this.additionalMeasures, measures);
+	}
+
+	/**
+	 * Sends the event with the duration being the difference between when this TimedAction was created and now.
+	 * @param properties Additional properties to send along with the event
+	 * @param measures Additional measures to send along with the event
+	 */
+	public send(properties: TelemetryEventProperties = {}, measures: TelemetryEventMeasures = {}): void {
+		Object.assign(this.additionalProperties, properties);
+		Object.assign(this.additionalMeasures, measures);
+		TelemetryReporter.createActionEvent(this._view, this._action, undefined, undefined, Date.now() - this._start)
+			.withAdditionalProperties(this.additionalProperties)
+			.withAdditionalMeasurements(this.additionalMeasures)
+			.send();
+	}
+}
+
+/**
+ * Send an event indicating that a setting changed along with the new and old values. Core has a setting changed
+ * event already, but that doesn't capture the values so we make our own here.
+ * @param setting The name of the setting
+ * @param oldValue The original value
+ * @param newValue The new value
+ */
+export function sendSettingChangedEvent(setting: string, oldValue: string, newValue: string): void {
+	TelemetryReporter.createActionEvent(TelemetryViews.QueryHistoryProvider, TelemetryActions.SettingChanged, setting)
+		.withAdditionalProperties({
+			oldValue,
+			newValue
+		})
+		.send();
+}
+
+export enum TelemetryViews {
+	QueryHistory = 'QueryHistory',
+	QueryHistoryProvider = 'QueryHistoryProvider'
+}
+
+export enum TelemetryActions {
+	DoubleClick = 'DoubleClick',
+	Initialize = 'Initialize',
+	ReadStorageFile = 'ReadStorageFile',
+	SettingChanged = 'SettingChanged',
+	WriteStorageFile = 'WriteStorageFile'
+}

--- a/extensions/query-history/yarn.lock
+++ b/extensions/query-history/yarn.lock
@@ -228,6 +228,44 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@microsoft/1ds-core-js@3.2.6", "@microsoft/1ds-core-js@^3.2.3":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@microsoft/1ds-core-js/-/1ds-core-js-3.2.6.tgz#8a77909f89f991aa2f0b4ae8825c75042962e68e"
+  integrity sha512-6OpppYCEA+rXjcs2w0KnWji3Y6ZDx0wykY7ZL3QF68NS323C45GHSpkDpVRT/lDU6Xbau/PvQm2zTYAzLcperA==
+  dependencies:
+    "@microsoft/applicationinsights-core-js" "2.8.6"
+    "@microsoft/applicationinsights-shims" "^2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.6"
+
+"@microsoft/1ds-post-js@^3.2.3":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@microsoft/1ds-post-js/-/1ds-post-js-3.2.6.tgz#cdfa74acfc3205c0a5b79925284d6d166aa43901"
+  integrity sha512-Zdyl3FU6kU/a7TlVVSTBZg+hSECTT65iI99FsjMOx88HudyVyk9M/0lVbA+FVXvGaxzmtBW6Lw0qRHYp4tBMSA==
+  dependencies:
+    "@microsoft/1ds-core-js" "3.2.6"
+    "@microsoft/applicationinsights-shims" "^2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.6"
+
+"@microsoft/ads-extension-telemetry@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
+  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+  dependencies:
+    "@vscode/extension-telemetry" "^0.6.2"
+
+"@microsoft/applicationinsights-core-js@2.8.6":
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.6.tgz#4f0f9ad809aacfc96cb882139b69b3625519c51a"
+  integrity sha512-rL+ceda1Y6HaHBe1vIbNT/f5JGuHiD5Ydq+DoAfu56o13wyJu4sao3QKaabgaIM59pPO+3BMeGsK8NNUGYaT3w==
+  dependencies:
+    "@microsoft/applicationinsights-shims" "2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.6"
+
+"@microsoft/applicationinsights-shims@2.0.1", "@microsoft/applicationinsights-shims@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz#5d72fb7aaf4056c4fda54f9d7c93ccf8ca9bcbfd"
+  integrity sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ==
+
 "@microsoft/azdata-test@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@microsoft/azdata-test/-/azdata-test-3.0.0.tgz#5cc4f416e464e6127dc333afaf983ebe49a66f37"
@@ -239,6 +277,11 @@
     mocha-multi-reporters "^1.1.7"
     rimraf "^2.6.3"
     typemoq "^2.1.0"
+
+"@microsoft/dynamicproto-js@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.6.tgz#6fe03468862861f5f88ac4c3959a652b3797f1bc"
+  integrity sha512-D1Oivw1A4bIXhzBIy3/BBPn3p2On+kpO2NiYt9shICDK7L/w+cR6FFBUsBZ05l6iqzTeL+Jm8lAYn0g6G7DmDg==
 
 "@microsoft/vscodetestcover@^1.2.1":
   version "1.2.1"
@@ -264,6 +307,14 @@
   version "12.20.52"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.52.tgz#2fd2dc6bfa185601b15457398d4ba1ef27f81251"
   integrity sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==
+
+"@vscode/extension-telemetry@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@vscode/extension-telemetry/-/extension-telemetry-0.6.2.tgz#b86814ee680615730da94220c2b03ea9c3c14a8e"
+  integrity sha512-yb/wxLuaaCRcBAZtDCjNYSisAXz3FWsSqAha5nhHcYxx2ZPdQdWuZqVXGKq0ZpHVndBWWtK6XqtpCN2/HB4S1w==
+  dependencies:
+    "@microsoft/1ds-core-js" "^3.2.3"
+    "@microsoft/1ds-post-js" "^3.2.3"
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
Initial set of events : 

- Timing for important actions like reading/writing storage file
- Errors
- Settings changed

Actions executed are already captured by core telemetry so don't need to do anything more there. 