### PR TITLE
Update ads-extension-telemetry to 1.3.1

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -107,7 +107,7 @@
     ]
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "@microsoft/ads-service-downloader": "1.0.4",
     "vscode-nls": "^4.1.2"
   },

--- a/extensions/admin-tool-ext-win/src/telemetry.ts
+++ b/extensions/admin-tool-ext-win/src/telemetry.ts
@@ -11,7 +11,7 @@ const packageJson = require('../package.json');
 
 let packageInfo = Utils.getPackageInfo(packageJson);
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews>(packageInfo.name, packageInfo.version, packageInfo.aiKey);
 
 export enum TelemetryViews {
 	SsmsMinProperties = 'SsmsMinProperties',

--- a/extensions/admin-tool-ext-win/yarn.lock
+++ b/extensions/admin-tool-ext-win/yarn.lock
@@ -200,10 +200,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -92,7 +92,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "htmlparser2": "^3.10.1",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/dacpac/src/telemetry.ts
+++ b/extensions/dacpac/src/telemetry.ts
@@ -11,7 +11,7 @@ const packageJson = require('../package.json');
 
 let packageInfo = Utils.getPackageInfo(packageJson);
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews, TelemetryAction>(packageInfo.name, packageInfo.version, packageInfo.aiKey);
 
 export enum TelemetryViews {
 	DataTierApplicationWizard = 'DataTierApplicationWizard'
@@ -23,5 +23,7 @@ export enum TelemetryAction {
 	GenerateDeployPlan = 'GenerateDeployPlan',
 	ExtractDacpac = 'ExtractDacpacOperation',
 	ExportBacpac = 'ExportBacpacOperation',
-	ImportBacpac = 'ImportBacpacOperation'
+	ImportBacpac = 'ImportBacpacOperation',
+	ConnectionDialogCancelled = 'ConnectionDialogCancelled',
+	WizardCanceled = 'WizardCanceled'
 }

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -115,7 +115,7 @@ export class DataTierApplicationWizard {
 			// don't open the wizard if connection dialog is cancelled
 			if (!this.connection) {
 				//Reporting Dacpac wizard cancelled event to Telemetry
-				TelemetryReporter.sendActionEvent(TelemetryViews.DataTierApplicationWizard, 'ConnectionDialogCancelled');
+				TelemetryReporter.sendActionEvent(TelemetryViews.DataTierApplicationWizard, TelemetryAction.ConnectionDialogCancelled);
 				return false;
 			}
 		}
@@ -305,7 +305,7 @@ export class DataTierApplicationWizard {
 
 	// Cancel button on click event is using to send the data loss information to telemetry
 	private cancelDataTierApplicationWizard(): void {
-		TelemetryReporter.createActionEvent(TelemetryViews.DataTierApplicationWizard, 'WizardCanceled')
+		TelemetryReporter.createActionEvent(TelemetryViews.DataTierApplicationWizard, TelemetryAction.WizardCanceled)
 			.withAdditionalProperties({
 				isPotentialDataLoss: this.model.potentialDataLoss?.toString(),
 				page: this.wizard.currentPage.toString(),
@@ -477,7 +477,7 @@ export class DataTierApplicationWizard {
 		return this.dacfxService;
 	}
 
-	private sendDacFxOperationTelemetryEvent(result: azdata.ResultStatus, telemetryAction: string, additionalProps: TelemetryEventProperties, additionalMeasurements: TelemetryEventMeasures): void {
+	private sendDacFxOperationTelemetryEvent(result: azdata.ResultStatus, telemetryAction: TelemetryAction, additionalProps: TelemetryEventProperties, additionalMeasurements: TelemetryEventMeasures): void {
 		if (result?.success) {
 			TelemetryReporter.createActionEvent(TelemetryViews.DataTierApplicationWizard, telemetryAction)
 				.withAdditionalProperties(additionalProps)

--- a/extensions/dacpac/yarn.lock
+++ b/extensions/dacpac/yarn.lock
@@ -200,10 +200,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -178,7 +178,7 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.7",
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "vscode-nls": "^4.0.0"
   },
   "devDependencies": {

--- a/extensions/data-workspace/src/common/telemetry.ts
+++ b/extensions/data-workspace/src/common/telemetry.ts
@@ -10,7 +10,7 @@ const packageJson = require('../../package.json');
 
 let packageInfo = utils.getPackageInfo(packageJson)!;
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews, TelemetryActions>(packageInfo.name, packageInfo.version, packageInfo.aiKey);
 
 
 export enum TelemetryViews {

--- a/extensions/data-workspace/yarn.lock
+++ b/extensions/data-workspace/yarn.lock
@@ -200,10 +200,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -761,7 +761,7 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^3.2.1",
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "adm-zip": "^0.4.14",
     "error-ex": "^1.3.1",
     "fast-glob": "^3.1.0",

--- a/extensions/notebook/src/telemetry.ts
+++ b/extensions/notebook/src/telemetry.ts
@@ -6,7 +6,7 @@
 import AdsTelemetryReporter, { TelemetryEventMeasures, TelemetryEventProperties } from '@microsoft/ads-extension-telemetry';
 
 const packageJson = require('../package.json');
-export const TelemetryReporter = new AdsTelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<NbTelemetryView, NbTelemetryAction>(packageJson.name, packageJson.version, packageJson.aiKey);
 
 export enum NbTelemetryView {
 	Book = 'Book',

--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -239,10 +239,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -209,7 +209,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "vscode-nls": "^4.1.2"
   },
   "devDependencies": {

--- a/extensions/query-history/src/telemetry.ts
+++ b/extensions/query-history/src/telemetry.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
+import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 
 export interface PackageInfo {
 	name: string;

--- a/extensions/query-history/src/telemetry.ts
+++ b/extensions/query-history/src/telemetry.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import AdsTelemetryReporter, { TelemetryEventMeasures, TelemetryEventProperties } from '@microsoft/ads-extension-telemetry';
+import * as AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 
 export interface PackageInfo {
 	name: string;
@@ -13,49 +13,7 @@ export interface PackageInfo {
 
 const packageInfo = require('../package.json') as PackageInfo;
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
-
-/**
- * A helper class to send an Action event with a duration, timer starts on construction and ends when send() is called.
- */
-export class TimedAction {
-	/**
-	 * Additional properties to send along with the final message once send is called.
-	 */
-	public readonly additionalProperties: TelemetryEventProperties = {};
-	/**
-	 * Additional measures to send along with the final message once send is called.
-	 */
-	public readonly additionalMeasures: TelemetryEventMeasures = {};
-
-	private _start: number = Date.now();
-
-	/**
-	 * Creates a new TimedAction and sets the start time to Date.now().
-	 * @param _view The view this action originates from
-	 * @param _action The name of the action
-	 * @param properties Additional properties to send along with the final message once send is called
-	 * @param measures Additional measures to send along with the final message once send is called
-	 */
-	constructor(private _view: TelemetryViews, private _action: TelemetryActions, properties: TelemetryEventProperties = {}, measures: TelemetryEventMeasures = {}) {
-		Object.assign(this.additionalProperties, properties);
-		Object.assign(this.additionalMeasures, measures);
-	}
-
-	/**
-	 * Sends the event with the duration being the difference between when this TimedAction was created and now.
-	 * @param properties Additional properties to send along with the event
-	 * @param measures Additional measures to send along with the event
-	 */
-	public send(properties: TelemetryEventProperties = {}, measures: TelemetryEventMeasures = {}): void {
-		Object.assign(this.additionalProperties, properties);
-		Object.assign(this.additionalMeasures, measures);
-		TelemetryReporter.createActionEvent(this._view, this._action, undefined, undefined, Date.now() - this._start)
-			.withAdditionalProperties(this.additionalProperties)
-			.withAdditionalMeasurements(this.additionalMeasures)
-			.send();
-	}
-}
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews, TelemetryActions>(packageInfo.name, packageInfo.version, packageInfo.aiKey);
 
 /**
  * Send an event indicating that a setting changed along with the new and old values. Core has a setting changed

--- a/extensions/query-history/yarn.lock
+++ b/extensions/query-history/yarn.lock
@@ -246,10 +246,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -524,7 +524,7 @@
     ]
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "axios": "^0.27.2",
     "linux-release-info": "^2.0.0",
     "promisify-child-process": "^3.1.1",

--- a/extensions/resource-deployment/src/services/telemetryService.ts
+++ b/extensions/resource-deployment/src/services/telemetryService.ts
@@ -8,7 +8,7 @@ import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 
 const packageJson = vscode.extensions.getExtension('Microsoft.resource-deployment')!.packageJSON;
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryView, TelemetryAction>(packageJson.name, packageJson.version, packageJson.aiKey);
 
 export enum TelemetryView {
 	ResourceTypeWizard = 'ResourceTypeWizard'

--- a/extensions/resource-deployment/yarn.lock
+++ b/extensions/resource-deployment/yarn.lock
@@ -207,10 +207,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -111,7 +111,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "vscode-nls": "^4.0.0"
   },
   "devDependencies": {

--- a/extensions/schema-compare/src/telemetry.ts
+++ b/extensions/schema-compare/src/telemetry.ts
@@ -11,7 +11,7 @@ const packageJson = require('../package.json');
 
 let packageInfo = Utils.getPackageInfo(packageJson);
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews>(packageInfo.name, packageInfo.version, packageInfo.aiKey);
 
 export enum TelemetryViews {
 	SchemaCompareMainWindow = 'SchemaCompareMainWindow',

--- a/extensions/schema-compare/yarn.lock
+++ b/extensions/schema-compare/yarn.lock
@@ -200,10 +200,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/sql-assessment/package.json
+++ b/extensions/sql-assessment/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "vscode-nls": "^4.1.2",
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "vscode-languageclient": "^5.3.0-next.1"
   },
   "__metadata": {

--- a/extensions/sql-assessment/src/telemetry.ts
+++ b/extensions/sql-assessment/src/telemetry.ts
@@ -6,7 +6,7 @@
 import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 
 const packageJson = require('../package.json');
-export const TelemetryReporter = new AdsTelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<string, SqlTelemetryActions>(packageJson.name, packageJson.version, packageJson.aiKey);
 
 export const SqlAssessmentTelemetryView = 'SqlAssessmentTab';
 

--- a/extensions/sql-assessment/yarn.lock
+++ b/extensions/sql-assessment/yarn.lock
@@ -20,10 +20,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -63,7 +63,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "@microsoft/vscode-azext-utils": "^0.1.1",
     "fast-glob": "^3.2.7",
     "promisify-child-process": "^3.1.1",

--- a/extensions/sql-bindings/src/common/telemetry.ts
+++ b/extensions/sql-bindings/src/common/telemetry.ts
@@ -7,7 +7,7 @@ import { getPackageInfo } from './utils';
 
 const packageInfo = getPackageInfo()!;
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews, TelemetryActions | CreateAzureFunctionStep>(packageInfo.name, packageInfo.version, packageInfo.aiKey);
 
 export enum TelemetryViews {
 	SqlBindingsQuickPick = 'SqlBindingsQuickPick',
@@ -51,6 +51,8 @@ export enum CreateAzureFunctionStep {
 	getTemplateId = 'getTemplateId',
 	getConnectionStringSettingName = 'getConnectionStringSettingName',
 	promptForIncludePassword = 'promptForIncludePassword',
+	createFunctionAPI = 'createFunctionAPI',
+	finishCreateFunction = 'finishCreateFunction'
 }
 
 export enum ExitReason {

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -21,7 +21,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 	// telemetry properties for create azure function
 	let sessionId: string = uuid.v4();
 	let propertyBag: { [key: string]: string } = { sessionId: sessionId };
-	let telemetryStep: string = '';
+	let telemetryStep: CreateAzureFunctionStep | undefined = undefined;
 	let exitReason: string = ExitReason.cancelled;
 	TelemetryReporter.sendActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.startCreateAzureFunctionWithSqlBinding);
 	let connectionInfo: IConnectionInfo | undefined;
@@ -239,7 +239,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		let connectionStringExecuteStep = createAddConnectionStringStep(projectFolder, connectionInfo, connectionStringInfo.connectionStringSettingName);
 
 		// create C# Azure Function with SQL Binding
-		telemetryStep = 'createFunctionAPI';
+		telemetryStep = CreateAzureFunctionStep.createFunctionAPI;
 		await azureFunctionApi.createFunction({
 			language: 'C#',
 			targetFramework: 'netcoreapp3.1',
@@ -263,7 +263,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			.withAdditionalProperties(propertyBag)
 			.withConnectionInfo(connectionInfo).send();
 
-		telemetryStep = 'finishCreateFunction';
+		telemetryStep = CreateAzureFunctionStep.finishCreateFunction;
 		propertyBag.telemetryStep = telemetryStep;
 		exitReason = ExitReason.finishCreate;
 		TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.finishCreateAzureFunctionWithSqlBinding)
@@ -271,7 +271,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			.withConnectionInfo(connectionInfo).send();
 	} catch (error) {
 		let errorType = utils.getErrorType(error);
-		propertyBag.telemetryStep = telemetryStep;
+		propertyBag.telemetryStep = telemetryStep ?? '';
 		// an error occurred during createFunction
 		exitReason = ExitReason.error;
 		void vscode.window.showErrorMessage(constants.errorNewAzureFunction(error));
@@ -279,7 +279,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			.withAdditionalProperties(propertyBag).send();
 		return;
 	} finally {
-		propertyBag.telemetryStep = telemetryStep;
+		propertyBag.telemetryStep = telemetryStep ?? '';
 		propertyBag.exitReason = exitReason;
 		TelemetryReporter.createActionEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick)
 			.withAdditionalProperties(propertyBag).send();

--- a/extensions/sql-bindings/yarn.lock
+++ b/extensions/sql-bindings/yarn.lock
@@ -240,10 +240,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -478,7 +478,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "@xmldom/xmldom": "^0.8.2",
     "axios": "^0.27.2",
     "extract-zip": "^2.0.1",

--- a/extensions/sql-database-projects/src/common/telemetry.ts
+++ b/extensions/sql-database-projects/src/common/telemetry.ts
@@ -9,7 +9,7 @@ import { getPackageInfo } from './utils';
 
 const packageInfo = getPackageInfo()!;
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews, TelemetryActions>(packageInfo.name, packageInfo.version, packageInfo.aiKey);
 
 
 export enum TelemetryViews {
@@ -45,5 +45,7 @@ export enum TelemetryActions {
 	publishOptionsOpened = 'publishOptionsOpened',
 	resetOptions = 'resetOptions',
 	optionsChanged = 'optionsChanged',
-	profileLoaded = 'profileLoaded'
+	profileLoaded = 'profileLoaded',
+	SchemaComparisonFinished = 'SchemaComparisonFinished',
+	SchemaComparisonStarted = 'SchemaComparisonStarted'
 }

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1602,7 +1602,7 @@ export class ProjectsController {
 		target.targetScripts = await this.getProjectScriptFiles(target.projectFilePath);
 		target.dataSchemaProvider = await this.getProjectDatabaseSchemaProvider(target.projectFilePath);
 
-		TelemetryReporter.sendActionEvent(TelemetryViews.ProjectController, 'SchemaComparisonStarted');
+		TelemetryReporter.sendActionEvent(TelemetryViews.ProjectController, TelemetryActions.SchemaComparisonStarted);
 
 		// Perform schema comparison.  Results are cached in SqlToolsService under the operationId
 		const comparisonResult: mssql.SchemaCompareResult = await service.schemaCompare(
@@ -1618,7 +1618,7 @@ export class ProjectsController {
 			return;
 		}
 
-		TelemetryReporter.createActionEvent(TelemetryViews.ProjectController, 'SchemaComparisonFinished')
+		TelemetryReporter.createActionEvent(TelemetryViews.ProjectController, TelemetryActions.SchemaComparisonFinished)
 			.withAdditionalProperties({
 				'endTime': Date.now().toString(),
 				'operationId': comparisonResult.operationId

--- a/extensions/sql-database-projects/yarn.lock
+++ b/extensions/sql-database-projects/yarn.lock
@@ -240,10 +240,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -153,7 +153,7 @@
     ]
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.2.0",
+    "@microsoft/ads-extension-telemetry": "^1.3.1",
     "uuid": "^8.3.2",
     "vscode-nls": "^4.1.2"
   },

--- a/extensions/sql-migration/src/telemtery.ts
+++ b/extensions/sql-migration/src/telemtery.ts
@@ -11,7 +11,7 @@ let packageInfo = {
 	aiKey: packageJson.aiKey
 };
 
-export const TelemetryReporter = new AdsTelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews, TelemetryAction>(packageInfo.name, packageInfo.version, packageInfo.aiKey);
 
 export enum TelemetryViews {
 	SqlServerDashboard = 'SqlServerDashboard',

--- a/extensions/sql-migration/yarn.lock
+++ b/extensions/sql-migration/yarn.lock
@@ -20,10 +20,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 


### PR DESCRIPTION
Added support for specifying view/action types so that usage of the enums can be enforced. Fixed up the few places where that wasn't being done. 

(I didn't add enums were ones weren't previously - it just defaults to string i.e. the previous behavior. Owners can come in and add the enums later if they want)

Also moved query-history over to using the new functionality I added for creating timed action events. 