### PR TITLE
Add app quality to extension API

### DIFF
--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -128,11 +128,10 @@ export async function getParallelMessageProcessingConfig(): Promise<boolean> {
 	if (!config) {
 		return false;
 	}
-	const quality = await getProductQuality();
 	const setting = config.inspect(parallelMessageProcessingConfig);
 	// For dev environment, we want to enable the feature by default unless it is set explicitely.
 	// Note: the quality property is not set for dev environment, we can use this to determine whether it is dev environment.
-	return (quality === undefined && setting.globalValue === undefined && setting.workspaceValue === undefined) ? true : config[parallelMessageProcessingConfig];
+	return (azdata.env.quality === azdata.env.AppQuality.dev && setting.globalValue === undefined && setting.workspaceValue === undefined) ? true : config[parallelMessageProcessingConfig];
 }
 
 export function getLogFileName(prefix: string, pid: number): string {
@@ -396,7 +395,3 @@ export async function getOrDownloadServer(config: IConfig, handleServerEvent?: (
 	return serverdownloader.getOrDownloadServer();
 }
 
-async function getProductQuality(): Promise<string> {
-	const content = await fs.readFile(path.join(vscode.env.appRoot, 'product.json'));
-	return JSON.parse(content?.toString())?.quality;
-}

--- a/extensions/query-history/src/queryHistoryProvider.ts
+++ b/extensions/query-history/src/queryHistoryProvider.ts
@@ -16,7 +16,7 @@ import { sendSettingChangedEvent, TelemetryActions, TelemetryReporter, Telemetry
 
 const STORAGE_IV_KEY = 'queryHistory.storage-iv';
 const STORAGE_KEY_KEY = 'queryHistory.storage-key';
-const HISTORY_STORAGE_FILE_NAME = 'queryHistory.bin';
+const HISTORY_STORAGE_FILE_NAME = azdata.env.quality === azdata.env.AppQuality.stable ? 'queryHistory.bin' : `queryHistory.${azdata.env.quality}.bin`;
 const STORAGE_ENCRYPTION_ALGORITHM = 'aes-256-ctr';
 const HISTORY_DEBOUNCE_MS = 10000;
 const DEFAULT_CAPTURE_ENABLED = true;

--- a/extensions/query-history/src/queryHistoryProvider.ts
+++ b/extensions/query-history/src/queryHistoryProvider.ts
@@ -16,6 +16,9 @@ import { sendSettingChangedEvent, TelemetryActions, TelemetryReporter, Telemetry
 
 const STORAGE_IV_KEY = 'queryHistory.storage-iv';
 const STORAGE_KEY_KEY = 'queryHistory.storage-key';
+// We use a different file for every flavor of ADS because the secret storage is unique per-flavor and so we will have
+// a different key/IV pair for each flavor with no easy way to transfer/read them. This means that each flavor of ADS
+// will have its own unique history - even if they're all stored in the same location.
 const HISTORY_STORAGE_FILE_NAME = azdata.env.quality === azdata.env.AppQuality.stable ? 'queryHistory.bin' : `queryHistory.${azdata.env.quality}.bin`;
 const STORAGE_ENCRYPTION_ALGORITHM = 'aes-256-ctr';
 const HISTORY_DEBOUNCE_MS = 10000;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -8,6 +8,23 @@
 import * as vscode from 'vscode';
 
 declare module 'azdata' {
+
+	export namespace env {
+		/**
+		 * Well-known app quality values
+		 */
+		export enum AppQuality {
+			stable = 'stable',
+			insider = 'insider',
+			dev = 'dev'
+		}
+
+		/**
+		 * The version of Azure Data Studio this is currently running as - such as `stable`, or `insider`
+		 */
+		export const quality: AppQuality | string | undefined;
+	}
+
 	export namespace nb {
 		export interface NotebookDocument {
 			/**

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -606,6 +606,11 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				ExecutionPlanGraphElementPropertyBetterValue: sqlExtHostTypes.executionPlan.ExecutionPlanGraphElementPropertyBetterValue
 			};
 
+			const env: typeof azdata.env = {
+				AppQuality: sqlExtHostTypes.env.AppQuality,
+				quality: initData.quality || 'dev' // Dev/OSS builds don't have a quality set - give it a value here so it's more clear
+			};
+
 			return {
 				version: initData.version,
 				accounts,
@@ -658,7 +663,8 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				sqlAssessment,
 				TextType: sqlExtHostTypes.TextType,
 				designers: designers,
-				executionPlan: executionPlan
+				executionPlan: executionPlan,
+				env
 			};
 		},
 		extHostNotebook: extHostNotebook,

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -606,9 +606,13 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				ExecutionPlanGraphElementPropertyBetterValue: sqlExtHostTypes.executionPlan.ExecutionPlanGraphElementPropertyBetterValue
 			};
 
+			// Dev/OSS builds don't have a quality set - give it a value here so it's more clear
+			let quality = initData.quality || 'dev';
+			// Special case rc1 quality, that should be treated as stable by extensions
+			quality = quality === 'rc1' ? 'stable' : quality;
 			const env: typeof azdata.env = {
 				AppQuality: sqlExtHostTypes.env.AppQuality,
-				quality: initData.quality || 'dev' // Dev/OSS builds don't have a quality set - give it a value here so it's more clear
+				quality
 			};
 
 			return {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -1058,3 +1058,14 @@ export namespace executionPlan {
 		None = 4
 	}
 }
+
+export namespace env {
+	/**
+	 * Well-known app quality values
+	 */
+	export enum AppQuality {
+		stable = 'stable',
+		insider = 'insider',
+		dev = 'dev'
+	}
+}

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -102,6 +102,7 @@ export interface IWorkspaceData extends IStaticWorkspaceData {
 export interface IInitData {
 	version: string;
 	vscodeVersion: string; // {{SQL CARBON EDIT}} add vscodeVersion
+	quality?: string; // {{SQL CARBON EDIT}} add quality
 	commit?: string;
 	parentPid: number;
 	environment: IEnvironment;

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -384,6 +384,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 			commit: this._productService.commit,
 			version: this._productService.version,
 			vscodeVersion: this._productService.vscodeVersion, // {{SQL CARBON EDIT}} add vscode version
+			quality: this._productService.quality, // {{SQL CARBON EDIT}} Add quality
 			parentPid: -1,
 			environment: {
 				isExtensionDevelopmentDebug: this._environmentService.debugRenderer,

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -227,6 +227,7 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 			commit: this._productService.commit,
 			version: this._productService.version,
 			vscodeVersion: this._productService.vscodeVersion, // {{SQL CARBON EDIT}} add vscode version
+			quality: this._productService.quality, // {{SQL CARBON EDIT}} Add quality
 			parentPid: remoteInitData.pid,
 			environment: {
 				isExtensionDevelopmentDebug,

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -550,6 +550,7 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 			commit: this._productService.commit,
 			version: this._productService.version,
 			vscodeVersion: this._productService.vscodeVersion, // {{SQL CARBON EDIT}} add vscode version
+			quality: this._productService.quality, // {{SQL CARBON EDIT}} Add quality
 			parentPid: process.pid,
 			environment: {
 				isExtensionDevelopmentDebug: this._isExtensionDevDebug,


### PR DESCRIPTION
There are times we want to know the app quality in extensions - and while they can get it by reading the product.json like MSSQL was doing it'd be a lot easier/safer to instead add it to the extension API directly. 

I chose to make it default to `dev` when there isn't a quality since that's the only (supported) scenario that'd happen right now. Every released version should have an actual quality. 

I also fixed an issue with query history persistence - the storage folder is the same for all flavors of ADS currently but the secret storage is per-flavor so what was happening was that we would generate a new key/IV for each flavor which would then fail to decrypt the persisted file. This seems like fine behavior to me - I'm more of the opinion that the different flavors shouldn't actually share any state at all (like VS Code does) so having separate histories for each flavor is going to be expected behavior for now.