### PR TITLE
[SQL Migration] Fix assessment UI issues

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -122,8 +122,8 @@ export function CAN_BE_MIGRATED(eligibleDbs: number, totalDbs: number): string {
 }
 
 export const ASSESSMENT_MIGRATION_WARNING = localize('sql.migration.assessment.migration.warning', "Databases that are not ready for migration to Azure SQL Managed Instance or Azure SQL Database can be migrated to SQL Server on Azure Virtual Machines.");
-export const ASSESSMENT_MIGRATION_WARNING_SQLDB = localize('sql.migration.assessment.migration.warning.sqldb', "Databases that are not ready for migration to Azure SQL Database can be migrated to SQL Server on Azure Virtual Machines or Azure SQL Managed Instance.");
-export const ASSESSMENT_MIGRATION_WARNING_SQLMI = localize('sql.migration.assessment.migration.warning.sqlmi', "Databases that are not ready for migration to Azure SQL Managed Instance can be migrated to SQL Server on Azure Virtual Machines or Azure SQL Database.");
+export const ASSESSMENT_MIGRATION_WARNING_SQLDB = localize('sql.migration.assessment.migration.warning.sqldb', "Databases that are not ready for migration to Azure SQL Database can be migrated to SQL Server on Azure Virtual Machines. Alternatively, review assessment results for Azure SQL Managed Instance migration readiness.");
+export const ASSESSMENT_MIGRATION_WARNING_SQLMI = localize('sql.migration.assessment.migration.warning.sqlmi', "Databases that are not ready for migration to Azure SQL Managed Instance can be migrated to SQL Server on Azure Virtual Machines. Alternatively, review assessment results for Azure SQL Database migration readiness.");
 export const DATABASES_TABLE_TILE = localize('sql.migration.databases.table.title', "Databases");
 export const SQL_SERVER_INSTANCE = localize('sql.migration.sql.server.instance', "SQL Server instance");
 export const SAVE_ASSESSMENT_REPORT = localize('sql.migration.save.assessment.report', "Save assessment report");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -118,7 +118,7 @@ export function ASSESSMENT_TILE(serverName: string): string {
 	return localize('sql.migration.assessment', "Assessment results for '{0}'", serverName);
 }
 export function CAN_BE_MIGRATED(eligibleDbs: number, totalDbs: number): string {
-	return localize('sql.migration.can.be.migrated', "{0}/{1} databases can be migrated", eligibleDbs, totalDbs);
+	return localize('sql.migration.can.be.migrated', "{0}/{1} databases can be migrated without issues", eligibleDbs, totalDbs);
 }
 export const ASSESSMENT_MIGRATION_WARNING = localize('sql.migration.assessment.migration.warning', "Databases that are not ready for migration to Azure SQL Managed Instance can be migrated to SQL Server on Azure Virtual Machines.");
 export const DATABASES_TABLE_TILE = localize('sql.migration.databases.table.title', "Databases");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -120,7 +120,10 @@ export function ASSESSMENT_TILE(serverName: string): string {
 export function CAN_BE_MIGRATED(eligibleDbs: number, totalDbs: number): string {
 	return localize('sql.migration.can.be.migrated', "{0}/{1} databases can be migrated without issues", eligibleDbs, totalDbs);
 }
-export const ASSESSMENT_MIGRATION_WARNING = localize('sql.migration.assessment.migration.warning', "Databases that are not ready for migration to Azure SQL Managed Instance can be migrated to SQL Server on Azure Virtual Machines.");
+
+export const ASSESSMENT_MIGRATION_WARNING = localize('sql.migration.assessment.migration.warning', "Databases that are not ready for migration to Azure SQL Managed Instance or Azure SQL Database can be migrated to SQL Server on Azure Virtual Machines.");
+export const ASSESSMENT_MIGRATION_WARNING_SQLDB = localize('sql.migration.assessment.migration.warning.sqldb', "Databases that are not ready for migration to Azure SQL Database can be migrated to SQL Server on Azure Virtual Machines or Azure SQL Managed Instance.");
+export const ASSESSMENT_MIGRATION_WARNING_SQLMI = localize('sql.migration.assessment.migration.warning.sqlmi', "Databases that are not ready for migration to Azure SQL Managed Instance can be migrated to SQL Server on Azure Virtual Machines or Azure SQL Database.");
 export const DATABASES_TABLE_TILE = localize('sql.migration.databases.table.title', "Databases");
 export const SQL_SERVER_INSTANCE = localize('sql.migration.sql.server.instance', "SQL Server instance");
 export const SAVE_ASSESSMENT_REPORT = localize('sql.migration.save.assessment.report', "Save assessment report");

--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -883,7 +883,7 @@ export class SqlDatabaseTree {
 			this._dbNames = this._model._assessmentResults?.databaseAssessments.map(da => da.name);
 			this._model._assessmentResults?.databaseAssessments.forEach((db) => {
 				let selectable = true;
-				if (db.issues.find(item => item.databaseRestoreFails)) {
+				if (db.issues.find(issue => issue.databaseRestoreFails && issue.appliesToMigrationTargetPlatform === this._targetType)) {
 					selectable = false;
 				}
 				this._databaseTableValues.push([

--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -108,13 +108,18 @@ export class SqlDatabaseTree {
 		this._rootContainer.addItem(this._resultComponent, { flex: '0 0 auto' });
 		this._rootContainer.addItem(selectDbMessage, { flex: '1 1 auto' });
 
-		if (this._targetType === MigrationTargetType.SQLMI ||
-			this._targetType === MigrationTargetType.SQLDB) {
-			if (!!this._model._assessmentResults?.issues.find(value => value.databaseRestoreFails) ||
-				!!this._model._assessmentResults?.databaseAssessments.find(d => !!d.issues.find(issue => issue.databaseRestoreFails))) {
+		if (this._targetType === MigrationTargetType.SQLMI) {
+			if (this._model._assessmentResults?.databaseAssessments.some(db => db.issues.find(issue => issue.databaseRestoreFails && issue.appliesToMigrationTargetPlatform === MigrationTargetType.SQLMI))) {
 				dialog.message = {
 					level: azdata.window.MessageLevel.Warning,
-					text: constants.ASSESSMENT_MIGRATION_WARNING,
+					text: constants.ASSESSMENT_MIGRATION_WARNING_SQLMI,
+				};
+			}
+		} else if (this._targetType === MigrationTargetType.SQLDB) {
+			if (this._model._assessmentResults?.databaseAssessments.some(db => db.issues.find(issue => issue.databaseRestoreFails && issue.appliesToMigrationTargetPlatform === MigrationTargetType.SQLDB))) {
+				dialog.message = {
+					level: azdata.window.MessageLevel.Warning,
+					text: constants.ASSESSMENT_MIGRATION_WARNING_SQLDB,
 				};
 			}
 		}

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -616,7 +616,14 @@ export class SKURecommendationPage extends MigrationWizardPage {
 		}
 
 		const dbCount = this.migrationStateModel._assessmentResults?.databaseAssessments?.length;
-		const dbWithoutIssuesCount = this.migrationStateModel._assessmentResults?.databaseAssessments?.filter(db => db.issues?.length === 0).length;
+		const dbWithoutIssuesForMiCount = this.migrationStateModel._assessmentResults?.databaseAssessments?.filter(db =>
+			!db.issues?.some(issue => issue.appliesToMigrationTargetPlatform === MigrationTargetType.SQLMI)
+		).length;
+		const dbWithoutIssuesForVmCount = dbCount;
+		const dbWithoutIssuesForDbCount = this.migrationStateModel._assessmentResults?.databaseAssessments?.filter(db =>
+			!db.issues?.some(issue => issue.appliesToMigrationTargetPlatform === MigrationTargetType.SQLDB)
+		).length;
+
 		this._supportedProducts.forEach((product, index) => {
 			if (!this.migrationStateModel._assessmentResults) {
 				this._rbg.cards[index].descriptions[CardDescriptionIndex.ASSESSMENT_STATUS].textValue = '';
@@ -646,7 +653,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 				switch (product.type) {
 					case MigrationTargetType.SQLMI:
 						this._rbg.cards[index].descriptions[CardDescriptionIndex.ASSESSMENT_STATUS].textValue =
-							constants.CAN_BE_MIGRATED(dbWithoutIssuesCount, dbCount);
+							constants.CAN_BE_MIGRATED(dbWithoutIssuesForMiCount, dbCount);
 
 						if (this.hasRecommendations()) {
 							if (this.migrationStateModel._skuEnableElastic) {
@@ -681,7 +688,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 
 					case MigrationTargetType.SQLVM:
 						this._rbg.cards[index].descriptions[CardDescriptionIndex.ASSESSMENT_STATUS].textValue =
-							constants.CAN_BE_MIGRATED(dbCount, dbCount);
+							constants.CAN_BE_MIGRATED(dbWithoutIssuesForVmCount, dbCount);
 
 						if (this.hasRecommendations()) {
 							// elastic model currently doesn't support SQL VM, so show the baseline model results regardless of user preference
@@ -718,7 +725,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 
 					case MigrationTargetType.SQLDB:
 						this._rbg.cards[index].descriptions[CardDescriptionIndex.ASSESSMENT_STATUS].textValue =
-							constants.CAN_BE_MIGRATED(dbWithoutIssuesCount, dbCount);
+							constants.CAN_BE_MIGRATED(dbWithoutIssuesForDbCount, dbCount);
 
 						if (this.hasRecommendations()) {
 							const recommendations = this.migrationStateModel._skuEnableElastic


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In this PR, we:
- fix a bug where the SQL MI target card showed the incorrect number of databases which can be migrated (without issues)
- update assessment results card to say "xxx/yyy databases can be migrated **without issues**", since the old card text was slightly confusing
- fix a bug where SQL DB assessment results would grey out and prevent users from migrating databases with blocking issues to MI, even if there were no blocking issues to DB
- fix a bug where the error banner message that would appear in the assessment results when a database has blocking issues informing the user to use another target platform would 1) display the wrong text, as we now support more than MI+VM, and 2) erroneously appear in the SQL DB scenario when it wasn't supposed to