### PR TITLE
Removes summary section from plan comparison properties view

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -5,7 +5,6 @@
 
 import { ExecutionPlanPropertiesViewBase, PropertiesSortType } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
-import { isNumber } from 'sql/base/common/numbers';
 import * as azdata from 'azdata';
 import { localize } from 'vs/nls';
 import { iconCssFormatter, textFormatter } from 'sql/base/browser/ui/table/formatters';
@@ -17,7 +16,6 @@ import { executionPlanComparisonPropertiesDifferent } from 'sql/workbench/contri
 import * as sqlExtHostType from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
 import { Codicon } from 'vs/base/common/codicons';
 import { deepClone } from 'vs/base/common/objects';
 
@@ -42,22 +40,6 @@ function getRightOperationLabel(target: string): string {
 	return localize('nodePropertyViewRightOperation', 'Right operation: {0}', target);
 }
 
-function getTopPlanIsGreaterThanBottomPlanSummaryTextTemplate(rowName: string): string {
-	return localize('nodePropertyViewTopPlanGreaterThanBottomPlan', '{0} is greater for the top plan than it is for the bottom plan.', rowName);
-}
-
-function getBottomPlanIsGreaterThanTopPlanSummaryTextTemplate(rowName: string): string {
-	return localize('nodePropertyViewBottomPlanGreaterThanTopPlan', '{0} is greater for the bottom plan than it is for the top plan.', rowName);
-}
-
-function getLeftPlanIsGreaterThanRightPlanSummaryTextTemplate(rowName: string): string {
-	return localize('nodePropertyViewLeftPlanGreaterThanRightPlan', '{0} is greater for the left plan than it is for the right plan.', rowName);
-}
-
-function getRightPlanIsGreaterThanLeftPlanSummaryTextTemplate(rowName: string): string {
-	return localize('nodePropertyViewRightPlanGreaterThanLeftPlan', '{0} is greater for the right plan than it is for the left plan.', rowName);
-}
-
 const notEqualTitle = localize('nodePropertyViewNameNotEqualTitle', 'Not equal to');
 const lessThanTitle = localize('nodePropertyViewNameLessThanTitle', 'Less than');
 const greaterThanTitle = localize('nodePropertyViewNameGreaterThanTitle', 'Greater than');
@@ -69,7 +51,6 @@ const bottomTitleColumnHeader = localize('nodePropertyViewNameValueColumnBottomH
 
 export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanPropertiesViewBase {
 	private _model: ExecutionPlanComparisonPropertiesViewModel;
-	private _summaryTextContainer: HTMLElement;
 	private _primaryContainer: HTMLElement;
 	private _secondaryContainer: HTMLElement;
 	private _orientation: ExecutionPlanCompareOrientation = ExecutionPlanCompareOrientation.Horizontal;
@@ -81,16 +62,12 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		@IThemeService themeService: IThemeService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextMenuService contextMenuService: IContextMenuService,
-		@IContextViewService contextViewService: IContextViewService,
-		@ITextResourcePropertiesService private readonly textResourcePropertiesService: ITextResourcePropertiesService
+		@IContextViewService contextViewService: IContextViewService
 	) {
 		super(parentContainer, themeService, instantiationService, contextMenuService, contextViewService);
 		this._model = <ExecutionPlanComparisonPropertiesViewModel>{};
 		this._parentContainer.style.display = 'none';
 		const header = DOM.$('.compare-operation-name');
-
-		this._summaryTextContainer = DOM.$('.compare-operation-summary-text');
-		this.setSummary(this._summaryTextContainer);
 
 		this._primaryContainer = DOM.$('.compare-operation-name-text');
 		header.appendChild(this._primaryContainer);
@@ -99,14 +76,6 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		header.appendChild(this._secondaryContainer);
 
 		this.setHeader(header);
-	}
-
-	private setSummaryElement(summary: string[]): void {
-		const EOL = this.textResourcePropertiesService.getEOL(undefined);
-		let summaryText = summary.join(EOL);
-		let summaryContainerText = localize('executionPlanSummaryForExpensiveOperators', "Summary: {0}{1}", EOL, summaryText);
-		this._summaryTextContainer.innerText = summaryContainerText;
-		this._summaryTextContainer.title = summaryContainerText;
 	}
 
 	public setPrimaryElement(e: InternalExecutionPlanElement): void {
@@ -176,58 +145,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 		let tableRows = this.convertPropertiesToTableRows(primaryProps, secondaryProps);
 		tableRows = this.sortPropertiesByDisplayValueEquivalency(tableRows);
-		this.setSummaryElement(this.getExpensivePropertySummary(tableRows));
 		this.populateTable(columns, tableRows);
-	}
-
-	/**
-	 * This method returns an array of strings that that will make up the properties summary. The properties summary
-	 * will appear above the properties table when execution plans are being compared.
-	 * Each segment of that summary is in the following generic format:
-	 *
-	 * <row-name> is greater for the top plan than it is for the bottom plan.
-	 * <row-name> is greater for the bottom plan than it is for the top plan.
-	 *
-	 * @param tableRows The table rows that will appear in the properties table.
-	 * @returns The string array containing the segments of the summary.
-	 */
-	private getExpensivePropertySummary(tableRows: TableRow[]): string[] {
-		let summary: string[] = [];
-
-		tableRows.forEach(row => {
-			const rowName = (<RowContent>row.name).text;
-			if (row.primary && row.secondary) {
-				const primaryText = row.primary.text.split(' ');
-				const secondaryTitle = row.secondary.title.split(' ');
-
-				if (primaryText.length === secondaryTitle.length && primaryText.length <= 2 && secondaryTitle.length <= 2) {
-					const MAX_PROPERTY_SUMMARY_LENGTH = 3;
-
-					for (let i = 0; i < primaryText.length && summary.length < MAX_PROPERTY_SUMMARY_LENGTH; ++i) {
-						if (isNumber(primaryText[i]) && isNumber(secondaryTitle[i])) {
-							const primaryValue = Number(primaryText);
-							const secondaryValue = Number(secondaryTitle);
-
-							let summaryText: string;
-							if (primaryValue > secondaryValue) {
-								summaryText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
-									? getTopPlanIsGreaterThanBottomPlanSummaryTextTemplate(rowName)
-									: getLeftPlanIsGreaterThanRightPlanSummaryTextTemplate(rowName);
-							}
-							else {
-								summaryText = this._orientation === ExecutionPlanCompareOrientation.Horizontal
-									? getBottomPlanIsGreaterThanTopPlanSummaryTextTemplate(rowName)
-									: getRightPlanIsGreaterThanLeftPlanSummaryTextTemplate(rowName);
-							}
-
-							summary.push(summaryText);
-						}
-					}
-				}
-			}
-		});
-
-		return summary;
 	}
 
 	private getPropertyTableColumns() {

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -43,9 +43,6 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	// Header container
 	private _headerContainer: HTMLElement;
 
-	// Summary container
-	private _summaryContainer: HTMLElement;
-
 	// Properties actions
 	private _headerActionsContainer!: HTMLElement;
 	private _headerActions: ActionBar;
@@ -112,9 +109,6 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 
 		this._headerContainer = DOM.$('.header');
 		propertiesContent.appendChild(this._headerContainer);
-
-		this._summaryContainer = DOM.$('.summary');
-		propertiesContent.appendChild(this._summaryContainer);
 
 		this._searchAndActionBarContainer = DOM.$('.search-action-bar-container');
 		propertiesContent.appendChild(this._searchAndActionBarContainer);
@@ -229,10 +223,6 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 		this._headerContainer.appendChild(c);
 	}
 
-	public setSummary(c: HTMLElement): void {
-		this._summaryContainer.appendChild(c);
-	}
-
 	public set tableHeight(value: number) {
 		if (this.tableHeight !== value) {
 			this._tableHeight = value;
@@ -275,7 +265,6 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	private resizeTable(): void {
 		const spaceOccupied = (this._titleBarContainer.getBoundingClientRect().height
 			+ this._headerContainer.getBoundingClientRect().height
-			+ this._summaryContainer.getBoundingClientRect().height
 			+ this._headerActionsContainer.getBoundingClientRect().height);
 
 		this.tableHeight = (this._parentContainer.getBoundingClientRect().height - spaceOccupied - 15);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #20734 

The properties summary section wasn't found to be very helpful and this PR is to remove that from the execution plan comparison properties section. Below is a screenshot of what that view now looks like:
![image](https://user-images.githubusercontent.com/87730006/194169305-8209d492-aa2e-4875-a1a5-63bfbb05a299.png)

