### PR TITLE
fix caching issue with connection profile

### DIFF
--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -113,21 +113,23 @@ function getConnectionProfile(
 	azureResourceId: string,
 	userName: string,
 	password: string): azdata.IConnectionProfile {
+
+	const connectId = generateGuid();
 	return {
 		serverName: serverName,
-		id: generateGuid(),
-		connectionName: undefined,
+		id: connectId,
+		connectionName: connectId,
 		azureResourceId: azureResourceId,
 		userName: userName,
 		password: password,
 		authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 		savePassword: false,
-		groupFullName: '',
-		groupId: '',
+		groupFullName: connectId,
+		groupId: connectId,
 		providerName: 'MSSQL',
 		saveProfile: false,
 		options: {
-			conectionName: '',
+			conectionName: connectId,
 			server: serverName,
 			authenticationType: azdata.connection.AuthenticationType.SqlLogin,
 			user: userName,


### PR DESCRIPTION
this PR fixes an issue when creating a temporary connection / caching that returns a successful cached connection after changing the password to a different / invalid value.