### PR TITLE
Shows not equal operator when comparing non-null props to null props

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -501,9 +501,16 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 			} else if (primaryProp && !secondaryProp) {
 				row.displayOrder = v.primaryProp.displayOrder;
+
 				row.primary = {
 					text: v.primaryProp.displayValue
 				};
+
+				row.icon = {
+					iconCssClass: executionPlanComparisonPropertiesDifferent,
+					title: notEqualTitle
+				};
+
 				rows.push(row);
 				if (!isString(primaryProp.value)) {
 					row.name.iconCssClass += ` parent-row-styling`;
@@ -512,10 +519,17 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 				}
 			} else if (!primaryProp && secondaryProp) {
 				row.displayOrder = v.secondaryProp.displayOrder;
+
 				row.secondary = {
 					title: v.secondaryProp.displayValue,
 					iconCssClass: ''
 				};
+
+				row.icon = {
+					iconCssClass: executionPlanComparisonPropertiesDifferent,
+					title: notEqualTitle
+				};
+
 				rows.push(row);
 				if (!isString(secondaryProp.value)) {
 					row.name.iconCssClass += ` parent-row-styling`;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #20738 by showing a not equal to operator when comparing property values that are non-null to null values.

Before:
![image](https://user-images.githubusercontent.com/87730006/194180977-cbf0d368-9ad6-4e99-b58d-2000c3c36bb1.png)

After:
![image](https://user-images.githubusercontent.com/87730006/194181015-d7865027-08ec-4415-979e-92cfe5377b52.png)
