### PR TITLE
Add functionality to expand and collapse all property rows.

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExecutionPlanPropertiesViewBase, PropertiesSortType, PropertyRowExpansionState } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
+import { ExecutionPlanPropertiesViewBase, PropertiesSortType } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import * as azdata from 'azdata';
 import { localize } from 'vs/nls';
@@ -148,7 +148,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		this.populateTable(columns, tableRows);
 	}
 
-	public expandOrCollapsePropertiesTable(): void {
+	public expandOrCollapsePropertiesTable(expand: boolean): void {
 		const columns: Slick.Column<Slick.SlickData>[] = this.getPropertyTableColumns();
 
 		let primaryProps = [];
@@ -162,16 +162,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 		let tableRows = this.convertPropertiesToTableRows(primaryProps, secondaryProps);
 		tableRows = this.sortPropertiesByDisplayValueEquivalency(tableRows);
-
-		switch (this.propertyRowExpansionState) {
-			case PropertyRowExpansionState.ExpandAll:
-				this.expandOrCollapsePropertyTableRows(tableRows, true);
-				break;
-			case PropertyRowExpansionState.CollapseAll:
-				this.expandOrCollapsePropertyTableRows(tableRows, false);
-				break;
-		}
-
+		this.expandOrCollapsePropertyTableRows(tableRows, expand);
 		this.populateTable(columns, tableRows);
 	}
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExecutionPlanPropertiesViewBase, PropertiesSortType } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
+import { ExecutionPlanPropertiesViewBase, PropertiesSortType, PropertyRowExpansionMode } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { isNumber } from 'sql/base/common/numbers';
 import * as azdata from 'azdata';
@@ -176,8 +176,27 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 		let tableRows = this.convertPropertiesToTableRows(primaryProps, secondaryProps);
 		tableRows = this.sortPropertiesByDisplayValueEquivalency(tableRows);
+		switch (this.propertyRowExpansionMode) {
+			case PropertyRowExpansionMode.ExpandAll:
+				this.setExpansionModeForAllCollapsiblePropertyRows(tableRows, true);
+				break;
+			case PropertyRowExpansionMode.CollapseAll:
+				this.setExpansionModeForAllCollapsiblePropertyRows(tableRows, false);
+				break;
+		}
+
 		this.setSummaryElement(this.getExpensivePropertySummary(tableRows));
 		this.populateTable(columns, tableRows);
+	}
+
+	private setExpansionModeForAllCollapsiblePropertyRows(tableRows: Slick.SlickData[], expand: boolean): void {
+		tableRows.forEach(row => {
+			if (row.treeGridChildren && row.treeGridChildren.length > 0) {
+				row.expanded = expand;
+
+				this.setExpansionModeForAllCollapsiblePropertyRows(row.treeGridChildren, expand);
+			}
+		});
 	}
 
 	/**

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -189,16 +189,6 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		this.populateTable(columns, tableRows);
 	}
 
-	private setExpansionModeForAllCollapsiblePropertyRows(tableRows: Slick.SlickData[], expand: boolean): void {
-		tableRows.forEach(row => {
-			if (row.treeGridChildren && row.treeGridChildren.length > 0) {
-				row.expanded = expand;
-
-				this.setExpansionModeForAllCollapsiblePropertyRows(row.treeGridChildren, expand);
-			}
-		});
-	}
-
 	/**
 	 * This method returns an array of strings that that will make up the properties summary. The properties summary
 	 * will appear above the properties table when execution plans are being compared.

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -148,24 +148,6 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		this.populateTable(columns, tableRows);
 	}
 
-	public setPropertyRowsExpanded(expand: boolean): void {
-		const columns: Slick.Column<Slick.SlickData>[] = this.getPropertyTableColumns();
-
-		let primaryProps = [];
-		let secondaryProps = [];
-		if (this._model.primaryElement?.properties) {
-			primaryProps = this._model.primaryElement.properties;
-		}
-		if (this._model.secondaryElement?.properties) {
-			secondaryProps = this._model.secondaryElement.properties;
-		}
-
-		let tableRows = this.convertPropertiesToTableRows(primaryProps, secondaryProps);
-		tableRows = this.sortPropertiesByDisplayValueEquivalency(tableRows);
-		this.expandOrCollapsePropertyTableRows(tableRows, expand);
-		this.populateTable(columns, tableRows);
-	}
-
 	private getPropertyTableColumns() {
 		const columns: Slick.Column<Slick.SlickData>[] = [];
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -148,7 +148,7 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 		this.populateTable(columns, tableRows);
 	}
 
-	public expandOrCollapsePropertiesTable(expand: boolean): void {
+	public setPropertyRowsExpanded(expand: boolean): void {
 		const columns: Slick.Column<Slick.SlickData>[] = this.getPropertyTableColumns();
 
 		let primaryProps = [];

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonPropertiesView.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExecutionPlanPropertiesViewBase, PropertiesSortType, PropertyRowExpansionMode } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
+import { ExecutionPlanPropertiesViewBase, PropertiesSortType, PropertyRowExpansionState } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import * as azdata from 'azdata';
 import { localize } from 'vs/nls';
@@ -145,12 +145,30 @@ export class ExecutionPlanComparisonPropertiesView extends ExecutionPlanProperti
 
 		let tableRows = this.convertPropertiesToTableRows(primaryProps, secondaryProps);
 		tableRows = this.sortPropertiesByDisplayValueEquivalency(tableRows);
-		switch (this.propertyRowExpansionMode) {
-			case PropertyRowExpansionMode.ExpandAll:
-				this.setExpansionModeForAllCollapsiblePropertyRows(tableRows, true);
+		this.populateTable(columns, tableRows);
+	}
+
+	public expandOrCollapsePropertiesTable(): void {
+		const columns: Slick.Column<Slick.SlickData>[] = this.getPropertyTableColumns();
+
+		let primaryProps = [];
+		let secondaryProps = [];
+		if (this._model.primaryElement?.properties) {
+			primaryProps = this._model.primaryElement.properties;
+		}
+		if (this._model.secondaryElement?.properties) {
+			secondaryProps = this._model.secondaryElement.properties;
+		}
+
+		let tableRows = this.convertPropertiesToTableRows(primaryProps, secondaryProps);
+		tableRows = this.sortPropertiesByDisplayValueEquivalency(tableRows);
+
+		switch (this.propertyRowExpansionState) {
+			case PropertyRowExpansionState.ExpandAll:
+				this.expandOrCollapsePropertyTableRows(tableRows, true);
 				break;
-			case PropertyRowExpansionMode.CollapseAll:
-				this.setExpansionModeForAllCollapsiblePropertyRows(tableRows, false);
+			case PropertyRowExpansionState.CollapseAll:
+				this.expandOrCollapsePropertyTableRows(tableRows, false);
 				break;
 		}
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
@@ -113,31 +113,6 @@ export class ExecutionPlanPropertiesView extends ExecutionPlanPropertiesViewBase
 		this.populateTable(columns, tableRows);
 	}
 
-	public setPropertyRowsExpanded(expand: boolean): void {
-		const columns: Slick.Column<Slick.SlickData>[] = [
-			{
-				id: 'name',
-				name: localize('nodePropertyViewNameNameColumnHeader', "Name"),
-				field: 'name',
-				width: 250,
-				headerCssClass: 'prop-table-header',
-				formatter: textFormatter
-			},
-			{
-				id: 'value',
-				name: localize('nodePropertyViewNameValueColumnHeader', "Value"),
-				field: 'value',
-				width: 250,
-				headerCssClass: 'prop-table-header',
-				formatter: textFormatter
-			}
-		];
-
-		const tableRows = this.convertPropertiesToTableRows(this._model.graphElement?.properties);
-		this.expandOrCollapsePropertyTableRows(tableRows, expand);
-		this.populateTable(columns, tableRows);
-	}
-
 	private convertPropertiesToTableRows(properties: azdata.executionPlan.ExecutionPlanGraphElementProperty[] | undefined): Slick.SlickData[] {
 		if (!properties) {
 			return [];

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
@@ -10,7 +10,7 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { removeLineBreaks } from 'sql/base/common/strings';
 import { isString } from 'vs/base/common/types';
 import { textFormatter } from 'sql/base/browser/ui/table/formatters';
-import { ExecutionPlanPropertiesViewBase, PropertiesSortType, PropertyRowExpansionMode } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
+import { ExecutionPlanPropertiesViewBase, PropertiesSortType, PropertyRowExpansionState } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
@@ -110,12 +110,36 @@ export class ExecutionPlanPropertiesView extends ExecutionPlanPropertiesViewBase
 		];
 
 		const tableRows = this.convertPropertiesToTableRows(this._model.graphElement?.properties);
-		switch (this.propertyRowExpansionMode) {
-			case PropertyRowExpansionMode.ExpandAll:
-				this.setExpansionModeForAllCollapsiblePropertyRows(tableRows, true);
+		this.populateTable(columns, tableRows);
+	}
+
+	public expandOrCollapsePropertiesTable(): void {
+		const columns: Slick.Column<Slick.SlickData>[] = [
+			{
+				id: 'name',
+				name: localize('nodePropertyViewNameNameColumnHeader', "Name"),
+				field: 'name',
+				width: 250,
+				headerCssClass: 'prop-table-header',
+				formatter: textFormatter
+			},
+			{
+				id: 'value',
+				name: localize('nodePropertyViewNameValueColumnHeader', "Value"),
+				field: 'value',
+				width: 250,
+				headerCssClass: 'prop-table-header',
+				formatter: textFormatter
+			}
+		];
+
+		const tableRows = this.convertPropertiesToTableRows(this._model.graphElement?.properties);
+		switch (this.propertyRowExpansionState) {
+			case PropertyRowExpansionState.ExpandAll:
+				this.expandOrCollapsePropertyTableRows(tableRows, true);
 				break;
-			case PropertyRowExpansionMode.CollapseAll:
-				this.setExpansionModeForAllCollapsiblePropertyRows(tableRows, false);
+			case PropertyRowExpansionState.CollapseAll:
+				this.expandOrCollapsePropertyTableRows(tableRows, false);
 				break;
 		}
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
@@ -10,7 +10,7 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { removeLineBreaks } from 'sql/base/common/strings';
 import { isString } from 'vs/base/common/types';
 import { textFormatter } from 'sql/base/browser/ui/table/formatters';
-import { ExecutionPlanPropertiesViewBase, PropertiesSortType, PropertyRowExpansionState } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
+import { ExecutionPlanPropertiesViewBase, PropertiesSortType } from 'sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
@@ -113,7 +113,7 @@ export class ExecutionPlanPropertiesView extends ExecutionPlanPropertiesViewBase
 		this.populateTable(columns, tableRows);
 	}
 
-	public expandOrCollapsePropertiesTable(): void {
+	public expandOrCollapsePropertiesTable(expand: boolean): void {
 		const columns: Slick.Column<Slick.SlickData>[] = [
 			{
 				id: 'name',
@@ -134,15 +134,7 @@ export class ExecutionPlanPropertiesView extends ExecutionPlanPropertiesViewBase
 		];
 
 		const tableRows = this.convertPropertiesToTableRows(this._model.graphElement?.properties);
-		switch (this.propertyRowExpansionState) {
-			case PropertyRowExpansionState.ExpandAll:
-				this.expandOrCollapsePropertyTableRows(tableRows, true);
-				break;
-			case PropertyRowExpansionState.CollapseAll:
-				this.expandOrCollapsePropertyTableRows(tableRows, false);
-				break;
-		}
-
+		this.expandOrCollapsePropertyTableRows(tableRows, expand);
 		this.populateTable(columns, tableRows);
 	}
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
@@ -109,8 +109,7 @@ export class ExecutionPlanPropertiesView extends ExecutionPlanPropertiesViewBase
 			}
 		];
 
-		const tableRows = this.convertPropertiesToTableRows(this._model.graphElement?.properties);
-		this.populateTable(columns, tableRows);
+		this.populateTable(columns, this.convertPropertiesToTableRows(this._model.graphElement?.properties));
 	}
 
 	private convertPropertiesToTableRows(properties: azdata.executionPlan.ExecutionPlanGraphElementProperty[] | undefined): Slick.SlickData[] {

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
@@ -122,16 +122,6 @@ export class ExecutionPlanPropertiesView extends ExecutionPlanPropertiesViewBase
 		this.populateTable(columns, tableRows);
 	}
 
-	private setExpansionModeForAllCollapsiblePropertyRows(tableRows: Slick.SlickData[], expand: boolean): void {
-		tableRows.forEach(row => {
-			if (row.treeGridChildren && row.treeGridChildren.length > 0) {
-				row.expanded = expand;
-
-				this.setExpansionModeForAllCollapsiblePropertyRows(row.treeGridChildren, expand);
-			}
-		});
-	}
-
 	private convertPropertiesToTableRows(properties: azdata.executionPlan.ExecutionPlanGraphElementProperty[] | undefined): Slick.SlickData[] {
 		if (!properties) {
 			return [];

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesView.ts
@@ -113,7 +113,7 @@ export class ExecutionPlanPropertiesView extends ExecutionPlanPropertiesViewBase
 		this.populateTable(columns, tableRows);
 	}
 
-	public expandOrCollapsePropertiesTable(expand: boolean): void {
+	public setPropertyRowsExpanded(expand: boolean): void {
 		const columns: Slick.Column<Slick.SlickData>[] = [
 			{
 				id: 'name',

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -446,8 +446,8 @@ export class ExpandAllPropertiesAction extends Action {
 }
 
 export class CollapseAllPropertiesAction extends Action {
-	public static ID = 'ep.propertiesView.expandAllProperties';
-	public static LABEL = localize('executionPlanExpandAllProperties', 'Expand All');
+	public static ID = 'ep.propertiesView.collapseAllProperties';
+	public static LABEL = localize('executionPlanCollapseAllProperties', 'Collapse All');
 
 	constructor() {
 		super(CollapseAllPropertiesAction.ID, CollapseAllPropertiesAction.LABEL, Codicon.collapseAll.classNames);

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -279,6 +279,16 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 		this._tableComponent.columns = columns;
 	}
 
+	protected setExpansionModeForAllCollapsiblePropertyRows(tableRows: Slick.SlickData[], expand: boolean): void {
+		tableRows.forEach(row => {
+			if (row.treeGridChildren && row.treeGridChildren.length > 0) {
+				row.expanded = expand;
+
+				this.setExpansionModeForAllCollapsiblePropertyRows(row.treeGridChildren, expand);
+			}
+		});
+	}
+
 	private resizeTable(): void {
 		const spaceOccupied = (this._titleBarContainer.getBoundingClientRect().height
 			+ this._headerContainer.getBoundingClientRect().height

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -250,7 +250,7 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	}
 
 	public abstract refreshPropertiesTable();
-	public abstract expandOrCollapsePropertiesTable(expand: boolean);
+	public abstract setPropertyRowsExpanded(expand: boolean);
 
 	public toggleVisibility(): void {
 		this._parentContainer.style.display = this._parentContainer.style.display === 'none' ? 'flex' : 'none';
@@ -432,7 +432,7 @@ export class ExpandAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.expandOrCollapsePropertiesTable(true);
+		context.setPropertyRowsExpanded(true);
 	}
 }
 
@@ -445,7 +445,7 @@ export class CollapseAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.expandOrCollapsePropertiesTable(false);
+		context.setPropertyRowsExpanded(false);
 	}
 }
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -250,7 +250,6 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	}
 
 	public abstract refreshPropertiesTable();
-	public abstract setPropertyRowsExpanded(expand: boolean);
 
 	public toggleVisibility(): void {
 		this._parentContainer.style.display = this._parentContainer.style.display === 'none' ? 'flex' : 'none';
@@ -265,8 +264,18 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 		this.resizeTable();
 	}
 
+	private repopulateTable() {
+		this._tableComponent.setData(this.flattenTableData(this._tableData, -1));
+		this.resizeTable();
+	}
+
 	public updateTableColumns(columns: Slick.Column<Slick.SlickData>[]) {
 		this._tableComponent.columns = columns;
+	}
+
+	public expandOrCollapsePropertyTableRows(expand: boolean): void {
+		this.expandOrCollapsePropertyTableRowsHelper(this._tableComponent.getData().getItems(), expand);
+		this.repopulateTable();
 	}
 
 	/**
@@ -275,12 +284,12 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	 * @param rows The rows to be expanded or collapsed.
 	 * @param expand Flag indicating if the rows should be expanded or collapsed.
 	 */
-	protected expandOrCollapsePropertyTableRows(rows: Slick.SlickData[], expand: boolean): void {
+	private expandOrCollapsePropertyTableRowsHelper(rows: Slick.SlickData[], expand: boolean): void {
 		rows.forEach(row => {
 			if (row.treeGridChildren && row.treeGridChildren.length > 0) {
 				row.expanded = expand;
 
-				this.expandOrCollapsePropertyTableRows(row.treeGridChildren, expand);
+				this.expandOrCollapsePropertyTableRowsHelper(row.treeGridChildren, expand);
 			}
 		});
 	}
@@ -432,7 +441,7 @@ export class ExpandAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.setPropertyRowsExpanded(true);
+		context.expandOrCollapsePropertyTableRows(true);
 	}
 }
 
@@ -445,7 +454,7 @@ export class CollapseAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.setPropertyRowsExpanded(false);
+		context.expandOrCollapsePropertyTableRows(false);
 	}
 }
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -272,7 +272,7 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	/**
 	 * Expands or collapses the rows of the properties table recursively.
 	 *
-	 * @param rows The rows to be expanded.
+	 * @param rows The rows to be expanded or collapsed.
 	 * @param expand Flag indicating if the rows should be expanded or collapsed.
 	 */
 	protected expandOrCollapsePropertyTableRows(rows: Slick.SlickData[], expand: boolean): void {

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -58,6 +58,7 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	private _tableHeight;
 
 	public sortType: PropertiesSortType = PropertiesSortType.DisplayOrder;
+	public propertyRowExpansionMode: PropertyRowExpansionMode = PropertyRowExpansionMode.Default;
 
 	public resizeSash: Sash;
 
@@ -124,7 +125,13 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 		this._headerActions = this._register(new ActionBar(this._headerActionsContainer, {
 			orientation: ActionsOrientation.HORIZONTAL, context: this
 		}));
-		this._headerActions.pushAction([new SortPropertiesByDisplayOrderAction(), new SortPropertiesAlphabeticallyAction(), new SortPropertiesReverseAlphabeticallyAction()], { icon: true, label: false });
+		this._headerActions.pushAction([
+			new SortPropertiesByDisplayOrderAction(),
+			new SortPropertiesAlphabeticallyAction(),
+			new SortPropertiesReverseAlphabeticallyAction(),
+			new ExpandAllPropertiesAction(),
+			new CollapseAllPropertiesAction()
+		], { icon: true, label: false });
 
 		this._propertiesSearchInputContainer = DOM.$('.table-search');
 		this._propertiesSearchInputContainer.classList.add('codicon', searchIconClassNames);
@@ -409,6 +416,40 @@ export enum PropertiesSortType {
 	DisplayOrder,
 	Alphabetical,
 	ReverseAlphabetical
+}
+
+export class ExpandAllPropertiesAction extends Action {
+	public static ID = 'ep.propertiesView.expandAllProperties';
+	public static LABEL = localize('executionPlanExpandAllProperties', 'Expand All');
+
+	constructor() {
+		super(ExpandAllPropertiesAction.ID, ExpandAllPropertiesAction.LABEL, Codicon.expandAll.classNames);
+	}
+
+	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
+		context.propertyRowExpansionMode = PropertyRowExpansionMode.ExpandAll;
+		context.refreshPropertiesTable();
+	}
+}
+
+export class CollapseAllPropertiesAction extends Action {
+	public static ID = 'ep.propertiesView.expandAllProperties';
+	public static LABEL = localize('executionPlanExpandAllProperties', 'Expand All');
+
+	constructor() {
+		super(CollapseAllPropertiesAction.ID, CollapseAllPropertiesAction.LABEL, Codicon.collapseAll.classNames);
+	}
+
+	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
+		context.propertyRowExpansionMode = PropertyRowExpansionMode.CollapseAll;
+		context.refreshPropertiesTable();
+	}
+}
+
+export enum PropertyRowExpansionMode {
+	Default,
+	ExpandAll,
+	CollapseAll
 }
 
 registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -55,7 +55,6 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	private _tableHeight;
 
 	public sortType: PropertiesSortType = PropertiesSortType.DisplayOrder;
-	public propertyRowExpansionState: PropertyRowExpansionState = PropertyRowExpansionState.Default;
 
 	public resizeSash: Sash;
 
@@ -251,7 +250,7 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	}
 
 	public abstract refreshPropertiesTable();
-	public abstract expandOrCollapsePropertiesTable();
+	public abstract expandOrCollapsePropertiesTable(expand: boolean);
 
 	public toggleVisibility(): void {
 		this._parentContainer.style.display = this._parentContainer.style.display === 'none' ? 'flex' : 'none';
@@ -433,8 +432,7 @@ export class ExpandAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.propertyRowExpansionState = PropertyRowExpansionState.ExpandAll;
-		context.expandOrCollapsePropertiesTable();
+		context.expandOrCollapsePropertiesTable(true);
 	}
 }
 
@@ -447,15 +445,8 @@ export class CollapseAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.propertyRowExpansionState = PropertyRowExpansionState.CollapseAll;
-		context.expandOrCollapsePropertiesTable();
+		context.expandOrCollapsePropertiesTable(false);
 	}
-}
-
-export enum PropertyRowExpansionState {
-	Default,
-	ExpandAll,
-	CollapseAll
 }
 
 registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -273,8 +273,8 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 		this._tableComponent.columns = columns;
 	}
 
-	public expandOrCollapsePropertyTableRows(expand: boolean): void {
-		this.expandOrCollapsePropertyTableRowsHelper(this._tableComponent.getData().getItems(), expand);
+	public setPropertyRowsExpanded(expand: boolean): void {
+		this.setPropertyRowsExpandedHelper(this._tableComponent.getData().getItems(), expand);
 		this.repopulateTable();
 	}
 
@@ -284,12 +284,12 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	 * @param rows The rows to be expanded or collapsed.
 	 * @param expand Flag indicating if the rows should be expanded or collapsed.
 	 */
-	private expandOrCollapsePropertyTableRowsHelper(rows: Slick.SlickData[], expand: boolean): void {
+	private setPropertyRowsExpandedHelper(rows: Slick.SlickData[], expand: boolean): void {
 		rows.forEach(row => {
 			if (row.treeGridChildren && row.treeGridChildren.length > 0) {
 				row.expanded = expand;
 
-				this.expandOrCollapsePropertyTableRowsHelper(row.treeGridChildren, expand);
+				this.setPropertyRowsExpandedHelper(row.treeGridChildren, expand);
 			}
 		});
 	}
@@ -441,7 +441,7 @@ export class ExpandAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.expandOrCollapsePropertyTableRows(true);
+		context.setPropertyRowsExpanded(true);
 	}
 }
 
@@ -454,7 +454,7 @@ export class CollapseAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.expandOrCollapsePropertyTableRows(false);
+		context.setPropertyRowsExpanded(false);
 	}
 }
 

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -55,7 +55,7 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	private _tableHeight;
 
 	public sortType: PropertiesSortType = PropertiesSortType.DisplayOrder;
-	public propertyRowExpansionMode: PropertyRowExpansionMode = PropertyRowExpansionMode.Default;
+	public propertyRowExpansionState: PropertyRowExpansionState = PropertyRowExpansionState.Default;
 
 	public resizeSash: Sash;
 
@@ -251,6 +251,7 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 	}
 
 	public abstract refreshPropertiesTable();
+	public abstract expandOrCollapsePropertiesTable();
 
 	public toggleVisibility(): void {
 		this._parentContainer.style.display = this._parentContainer.style.display === 'none' ? 'flex' : 'none';
@@ -269,12 +270,18 @@ export abstract class ExecutionPlanPropertiesViewBase extends Disposable impleme
 		this._tableComponent.columns = columns;
 	}
 
-	protected setExpansionModeForAllCollapsiblePropertyRows(tableRows: Slick.SlickData[], expand: boolean): void {
-		tableRows.forEach(row => {
+	/**
+	 * Expands or collapses the rows of the properties table recursively.
+	 *
+	 * @param rows The rows to be expanded.
+	 * @param expand Flag indicating if the rows should be expanded or collapsed.
+	 */
+	protected expandOrCollapsePropertyTableRows(rows: Slick.SlickData[], expand: boolean): void {
+		rows.forEach(row => {
 			if (row.treeGridChildren && row.treeGridChildren.length > 0) {
 				row.expanded = expand;
 
-				this.setExpansionModeForAllCollapsiblePropertyRows(row.treeGridChildren, expand);
+				this.expandOrCollapsePropertyTableRows(row.treeGridChildren, expand);
 			}
 		});
 	}
@@ -426,8 +433,8 @@ export class ExpandAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.propertyRowExpansionMode = PropertyRowExpansionMode.ExpandAll;
-		context.refreshPropertiesTable();
+		context.propertyRowExpansionState = PropertyRowExpansionState.ExpandAll;
+		context.expandOrCollapsePropertiesTable();
 	}
 }
 
@@ -440,12 +447,12 @@ export class CollapseAllPropertiesAction extends Action {
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {
-		context.propertyRowExpansionMode = PropertyRowExpansionMode.CollapseAll;
-		context.refreshPropertiesTable();
+		context.propertyRowExpansionState = PropertyRowExpansionState.CollapseAll;
+		context.expandOrCollapsePropertiesTable();
 	}
 }
 
-export enum PropertyRowExpansionMode {
+export enum PropertyRowExpansionState {
 	Default,
 	ExpandAll,
 	CollapseAll


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #20741 by adding the ability to expand or collapse all property rows for an execution plan. This functionality was added to single execution plans and to execution plans being compared.

### Single Execution Plan Properties:
##### Expand all properties:
![image](https://user-images.githubusercontent.com/87730006/194195529-466be758-e051-421f-9b6a-7441dc5025df.png)

##### Collapse all properties:
![image](https://user-images.githubusercontent.com/87730006/194195596-d8537f01-ad0d-4581-965a-99846e7640f3.png)


### Compared Execution Plan Properties:
##### Expand all properties:
![image](https://user-images.githubusercontent.com/87730006/194195659-48ac55c3-0d18-4b33-941a-1796ddeca954.png)

##### Collapse all properties:
![image](https://user-images.githubusercontent.com/87730006/194195699-952ad168-1751-4884-9a85-3fd5a2e81710.png)



