### PR TITLE
[SQL Migration] Fix incorrect assessment results showing for SQL DB/MI

### DIFF
--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -310,7 +310,7 @@ export class SqlDatabaseTree {
 
 
 		this._disposables.push(this._instanceTable.onRowSelected(async (e) => {
-			this._activeIssues = this._model._assessmentResults?.issues;
+			this._activeIssues = this._model._assessmentResults?.issues.filter(issue => issue.appliesToMigrationTargetPlatform === this._targetType);
 			this._dbName.value = this._serverName;
 			await this._resultComponent.updateCssStyles({
 				'display': 'block'
@@ -877,7 +877,7 @@ export class SqlDatabaseTree {
 					style: styleLeft
 				},
 				{
-					value: this._model._assessmentResults?.issues?.length,
+					value: this._model._assessmentResults?.issues?.filter(issue => issue.appliesToMigrationTargetPlatform === this._targetType).length,
 					style: styleRight
 				}
 			]];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In this PR, we:
- fix an issue where the assessment results dialog for SQL MI and SQL DB targets would show incorrect instance-level issues/warnings:
  - before (note that it shows 8 warnings for MI, yet there are only 3, and it includes random SQL DB warnings which are not relevant to this migration scenario):
  ![image](https://user-images.githubusercontent.com/11844501/194403361-da8fa155-8133-459e-b853-551758d8bde8.png)
  - after (note that it now shows the correct number of warnings, and only displays warnings applicable to this migration scenario): 
  ![image](https://user-images.githubusercontent.com/11844501/194403626-c3de4cc4-758f-4b1e-a0a6-08fc35140c78.png)
