### PR TITLE
Update .NET Interactive extension to version 1.0.3504060.

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4520,14 +4520,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.0.3255010",
-							"lastUpdated": "5/10/2022",
+							"version": "1.0.3504060",
+							"lastUpdated": "10/6/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dotnet-interactive-vscode/dotnet-interactive-vscode-1.0.3255010.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dotnet-interactive-vscode/dotnet-interactive-vscode-1.0.3504060.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4553,7 +4553,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.59.0"
+									"value": ">=1.62.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",


### PR DESCRIPTION
New VSIX can be found here: https://dev.azure.com/dnceng/_apis/resources/Containers/11962194/vscode?itemPath=vscode%2Fads-stable%2Fdotnet-interactive-vscode-1.0.3504060.vsix