### PR TITLE
Adds add execution plan button and context menu to the bottom half of the plan comparison screen

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
@@ -12,7 +12,7 @@ import { ExecutionPlanCompareOrientation, ExecutionPlanComparisonPropertiesView 
 import { IExecutionPlanService } from 'sql/workbench/services/executionPlan/common/interfaces';
 import { IHorizontalSashLayoutProvider, ISashEvent, IVerticalSashLayoutProvider, Orientation, Sash } from 'vs/base/browser/ui/sash/sash';
 import { Action } from 'vs/base/common/actions';
-import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
+import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IColorTheme, ICssStyleCollector, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
@@ -128,7 +128,8 @@ export class ExecutionPlanComparisonEditorView {
 		@IContextViewService readonly contextViewService: IContextViewService,
 		@ITextFileService private readonly _textFileService: ITextFileService,
 		@INotificationService private _notificationService: INotificationService,
-		@IProgressService private _progressService: IProgressService
+		@IProgressService private _progressService: IProgressService,
+		@IContextMenuService private _contextMenuService: IContextMenuService
 	) {
 
 		this.container = DOM.$('.comparison-editor');
@@ -184,7 +185,27 @@ export class ExecutionPlanComparisonEditorView {
 		this.planSplitViewContainer = DOM.$('.split-view-container');
 		this._planComparisonContainer.appendChild(this.planSplitViewContainer);
 
+		const self = this;
 		this._placeholderContainer = DOM.$('.placeholder');
+
+		const contextMenuAction = [
+			this._instantiationService.createInstance(AddExecutionPlanAction)
+		];
+		this._placeholderContainer.oncontextmenu = (e: MouseEvent) => {
+			if (contextMenuAction) {
+				this._contextMenuService.showContextMenu({
+					getAnchor: () => {
+						return {
+							x: e.x,
+							y: e.y
+						};
+					},
+					getActions: () => contextMenuAction,
+					getActionsContext: () => (self)
+				});
+			}
+		};
+
 		this._placeholderInfoboxContainer = DOM.$('.placeholder-infobox');
 		this._placeholderLoading = new LoadingSpinner(this._placeholderContainer, {
 			fullSize: true,

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
@@ -23,7 +23,6 @@ import { addIconClassName, disableTooltipIconClassName, enableTooltipIconClassNa
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { extname } from 'vs/base/common/path';
 import { INotificationService } from 'vs/platform/notification/common/notification';
-import { InfoBox } from 'sql/workbench/browser/ui/infoBox/infoBox';
 import { LoadingSpinner } from 'sql/base/browser/ui/loadingSpinner/loadingSpinner';
 import { contrastBorder, editorWidgetBackground, errorForeground, listHoverBackground, textLinkForeground, widgetShadow } from 'vs/platform/theme/common/colorRegistry';
 import { ExecutionPlanViewHeader } from 'sql/workbench/contrib/executionPlan/browser/executionPlanViewHeader';
@@ -69,8 +68,8 @@ export class ExecutionPlanComparisonEditorView {
 	public bottomWidgetController: ExecutionPlanWidgetController;
 
 	private _placeholderContainer: HTMLElement;
+	private _placeholderTaskbar: Taskbar;
 	private _placeholderInfoboxContainer: HTMLElement;
-	private _placeholderInfobox: InfoBox;
 	private _placeholderLoading: LoadingSpinner;
 
 	private _topPlanContainer: HTMLElement;
@@ -207,6 +206,17 @@ export class ExecutionPlanComparisonEditorView {
 		};
 
 		this._placeholderInfoboxContainer = DOM.$('.placeholder-infobox');
+
+		this._placeholderTaskbar = new Taskbar(this._placeholderInfoboxContainer, {
+			orientation: ActionsOrientation.HORIZONTAL
+		});
+		this._placeholderTaskbar.context = this;
+
+		const content: ITaskbarContent[] = [
+			{ action: this._instantiationService.createInstance(AddExecutionPlanAction) }
+		];
+		this._placeholderTaskbar.setContent(content);
+
 		this._placeholderLoading = new LoadingSpinner(this._placeholderContainer, {
 			fullSize: true,
 			showText: true
@@ -214,11 +224,6 @@ export class ExecutionPlanComparisonEditorView {
 		this._placeholderContainer.appendChild(this._placeholderInfoboxContainer);
 		this._placeholderLoading.loadingMessage = localize('epComapre.LoadingPlanMessage', "Loading execution plan");
 		this._placeholderLoading.loadingCompletedMessage = localize('epComapre.LoadingPlanCompleteMessage', "Execution plan successfully loaded");
-		this._placeholderInfobox = this._instantiationService.createInstance(InfoBox, this._placeholderInfoboxContainer, {
-			style: 'information',
-			text: ''
-		});
-		this._placeholderInfobox.text = localize('epComapre.placeholderInfoboxText', "Add execution plans to compare");
 
 		this._topPlanContainer = DOM.$('.plan-container');
 		this.planSplitViewContainer.appendChild(this._topPlanContainer);

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
@@ -211,7 +211,7 @@ export class ExecutionPlanComparisonEditorView {
 
 		this._placeholderInfoboxContainer = DOM.$('.placeholder-infobox');
 
-		this._placeholderButton = new Button(this._placeholderInfoboxContainer);
+		this._placeholderButton = new Button(this._placeholderInfoboxContainer, { secondary: true });
 		attachButtonStyler(this._placeholderButton, this.themeService);
 		this._placeholderButton.label = ADD_EXECUTION_PLAN_STRING;
 		this._placeholderButton.ariaLabel = ADD_EXECUTION_PLAN_STRING;

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditorView.ts
@@ -32,6 +32,10 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { ExecutionPlanWidgetController } from 'sql/workbench/contrib/executionPlan/browser/executionPlanWidgetController';
 import { NodeSearchWidget } from 'sql/workbench/contrib/executionPlan/browser/widgets/nodeSearchWidget';
+import { Button } from 'sql/base/browser/ui/button/button';
+import { attachButtonStyler } from 'vs/platform/theme/common/styler';
+
+const ADD_EXECUTION_PLAN_STRING = localize('epCompare.addExecutionPlanLabel', 'Add execution plan');
 
 export class ExecutionPlanComparisonEditorView {
 
@@ -68,7 +72,7 @@ export class ExecutionPlanComparisonEditorView {
 	public bottomWidgetController: ExecutionPlanWidgetController;
 
 	private _placeholderContainer: HTMLElement;
-	private _placeholderTaskbar: Taskbar;
+	private _placeholderButton: Button;
 	private _placeholderInfoboxContainer: HTMLElement;
 	private _placeholderLoading: LoadingSpinner;
 
@@ -207,15 +211,15 @@ export class ExecutionPlanComparisonEditorView {
 
 		this._placeholderInfoboxContainer = DOM.$('.placeholder-infobox');
 
-		this._placeholderTaskbar = new Taskbar(this._placeholderInfoboxContainer, {
-			orientation: ActionsOrientation.HORIZONTAL
+		this._placeholderButton = new Button(this._placeholderInfoboxContainer);
+		attachButtonStyler(this._placeholderButton, this.themeService);
+		this._placeholderButton.label = ADD_EXECUTION_PLAN_STRING;
+		this._placeholderButton.ariaLabel = ADD_EXECUTION_PLAN_STRING;
+		this._placeholderButton.enabled = true;
+		this._placeholderButton.onDidClick(e => {
+			const addExecutionPlanAction = this._instantiationService.createInstance(AddExecutionPlanAction);
+			addExecutionPlanAction.run(self);
 		});
-		this._placeholderTaskbar.context = this;
-
-		const content: ITaskbarContent[] = [
-			{ action: this._instantiationService.createInstance(AddExecutionPlanAction) }
-		];
-		this._placeholderTaskbar.setContent(content);
 
 		this._placeholderLoading = new LoadingSpinner(this._placeholderContainer, {
 			fullSize: true,

--- a/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
+++ b/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
@@ -878,8 +878,7 @@ However we always want it to be the width of the container it is resizing.
 	overflow: hidden;
 }
 
-.eps-container .comparison-editor .editor-toolbar .action-item .codicon.action-label,
-.eps-container .comparison-editor .plan-comparison-container .split-view-container .placeholder .placeholder-infobox .action-item .codicon.action-label {
+.eps-container .comparison-editor .editor-toolbar .action-item .codicon.action-label {
 	padding-left: 20px;
 }
 

--- a/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
+++ b/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
@@ -879,7 +879,7 @@ However we always want it to be the width of the container it is resizing.
 }
 
 .eps-container .comparison-editor .editor-toolbar .action-item .codicon.action-label,
-.eps-container .comparison-editor .plan-comparison-container  .split-view-container .placeholder .placeholder-infobox .action-item .codicon.action-label {
+.eps-container .comparison-editor .plan-comparison-container .split-view-container .placeholder .placeholder-infobox .action-item .codicon.action-label {
 	padding-left: 20px;
 }
 

--- a/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
+++ b/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
@@ -878,7 +878,8 @@ However we always want it to be the width of the container it is resizing.
 	overflow: hidden;
 }
 
-.eps-container .comparison-editor .editor-toolbar .action-item .codicon.action-label {
+.eps-container .comparison-editor .editor-toolbar .action-item .codicon.action-label,
+.eps-container .comparison-editor .plan-comparison-container  .split-view-container .placeholder .placeholder-infobox .action-item .codicon.action-label {
 	padding-left: 20px;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #20742 by adding the following things:
1. A new context menu to add an execution plan has been added to the bottom half of the execution plan comparison view
2. A button to add an execution plan has also been added to the bottom half of the execution plan comparison view.

### Before:
![image](https://user-images.githubusercontent.com/87730006/194653452-1fdf829e-1f7f-4aab-a117-40be75fdd643.png)

### After:
![image](https://user-images.githubusercontent.com/87730006/194943643-7620d108-76c9-477e-babd-cc86fec26d6a.png)