### PR TITLE
Directly install missing provider extensions

### DIFF
--- a/src/sql/platform/capabilities/common/capabilitiesService.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesService.ts
@@ -23,6 +23,8 @@ export const clientCapabilities = {
 /**
  * The map containing the connection provider names and the owning extensions.
  * This is to workaround the issue that we don't have the ability to store and query the information from extension gallery.
+ * IMPORTANT : Every extension in this list is assumed to be directly installable (not 3rd party). If that changes then
+ * 			handleUnsupportedProvider needs to be updated to handle those cases.
  */
 export const ConnectionProviderAndExtensionMap = new Map<string, string>([
 	['PGSQL', 'microsoft.azuredatastudio-postgresql'],


### PR DESCRIPTION
Was working on https://github.com/microsoft/azuredatastudio/issues/20712 and noticed that currently we don't actually install the extension when a user tries to connect with a provider that is known but not installed. 

I'm changing that here to directly install the extension - which is a much better experience overall. 

![DirectlyInstall](https://user-images.githubusercontent.com/28519865/194673102-676357a9-5f21-4097-b336-e4050db4f733.gif)
