### PR TITLE
fix unstable test build pipeline issue

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -208,19 +208,9 @@ steps:
       set -e
       mkdir -p .build/darwin/archive
       pushd ../azuredatastudio-darwin-$(VSCODE_ARCH)
-      ditto -c -k --keepParent *.app $(Build.SourcesDirectory)/.build/darwin/archive/azuredatastudio-darwin-$(VSCODE_ARCH).zip
-      popd
-    displayName: 'Archive (no signing)'
-    condition: and(succeeded(), eq(variables['signed'], false))
-
-  - script: |
-      set -e
-      mkdir -p .build/darwin/archive
-      pushd ../azuredatastudio-darwin-$(VSCODE_ARCH)
       ditto -c -k --keepParent *.app $(Build.SourcesDirectory)/.build/darwin/archive/azuredatastudio-darwin-$(VSCODE_ARCH)-unsigned.zip
       popd
     displayName: 'Archive'
-    condition: and(succeeded(), eq(variables['signed'], true))
 
   - script: |
       set -e


### PR DESCRIPTION
not sure why I decided to generate macos archive with different names based on whether signing is enabled. the new universal app related script failed because it was not able to find the xxx-unsigned.zip file. 

Instead of fixing the new script to know what file to look for, I am making it consistent so that regardless of signing or not, the file name is consistent.
