### PR TITLE
Fixes same title for reverse alphabetical properties button

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanPropertiesViewBase.ts
@@ -403,7 +403,7 @@ export class SortPropertiesReverseAlphabeticallyAction extends Action {
 	public static LABEL = localize('executionPlanPropertyViewSortReverseAlphabetically', "Reverse Alphabetical");
 
 	constructor() {
-		super(SortPropertiesAlphabeticallyAction.ID, SortPropertiesAlphabeticallyAction.LABEL, sortReverseAlphabeticallyIconClassNames);
+		super(SortPropertiesReverseAlphabeticallyAction.ID, SortPropertiesReverseAlphabeticallyAction.LABEL, sortReverseAlphabeticallyIconClassNames);
 	}
 
 	public override async run(context: ExecutionPlanPropertiesViewBase): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #20786 by correcting the title the narrator reads aloud to a user.