### PR TITLE
fix sql projects vscode extension not activating because it can't find azdata

### DIFF
--- a/extensions/sql-database-projects/src/models/connections/connectionService.ts
+++ b/extensions/sql-database-projects/src/models/connections/connectionService.ts
@@ -3,11 +3,11 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as azdata from 'azdata';
+import type * as azdataType from 'azdata';
 import * as constants from '../../common/constants';
 import * as utils from '../../common/utils';
 import * as vscode from 'vscode';
-import { IFireWallRuleError } from 'vscode-mssql';
+import { IFireWallRuleError, AuthenticationType } from 'vscode-mssql';
 import { ISqlConnectionProperties } from 'sqldbproj';
 
 /**
@@ -28,7 +28,7 @@ export class ConnectionService {
 	 * @param database database name
 	 * @returns
 	 */
-	private async connectToDatabase(profile: ISqlConnectionProperties, saveConnectionAndPassword: boolean, database: string): Promise<azdata.ConnectionResult | string | undefined> {
+	private async connectToDatabase(profile: ISqlConnectionProperties, saveConnectionAndPassword: boolean, database: string): Promise<azdataType.ConnectionResult | string | undefined> {
 		const azdataApi = utils.getAzdataApi();
 		const vscodeMssqlApi = azdataApi ? undefined : await utils.getVscodeMssqlApi();
 		if (azdataApi) {
@@ -43,7 +43,7 @@ export class ConnectionService {
 				id: '',
 				connectionName: profile.profileName,
 				options: [],
-				authenticationType: azdata.connection.AuthenticationType.SqlLogin
+				authenticationType: azdataApi.connection.AuthenticationType.SqlLogin
 			};
 			return await azdataApi.connection.connect(connectionProfile, saveConnectionAndPassword, false);
 		} else if (vscodeMssqlApi) {
@@ -54,7 +54,7 @@ export class ConnectionService {
 				database: database,
 				savePassword: saveConnectionAndPassword,
 				user: profile.userName,
-				authenticationType: azdata.connection.AuthenticationType.SqlLogin,
+				authenticationType: AuthenticationType.SqlLogin,
 				encrypt: false,
 				connectTimeout: 30,
 				applicationName: 'SQL Database Project',
@@ -112,12 +112,12 @@ export class ConnectionService {
 	 * @param connection connection result or connection Id
 	 * @returns validation result
 	 */
-	private async validateConnection(connection: azdata.ConnectionResult | string | undefined): Promise<utils.ValidationResult> {
+	private async validateConnection(connection: azdataType.ConnectionResult | string | undefined): Promise<utils.ValidationResult> {
 		const azdataApi = utils.getAzdataApi();
 		if (!connection) {
 			return { validated: false, errorMessage: constants.connectionFailedError('No result returned') };
 		} else if (azdataApi) {
-			const connectionResult = <azdata.ConnectionResult>connection;
+			const connectionResult = <azdataType.ConnectionResult>connection;
 			if (connectionResult) {
 				const connected = connectionResult !== undefined && connectionResult.connected && connectionResult.connectionId !== undefined;
 				return { validated: connected, errorMessage: connected ? '' : constants.connectionFailedError(connectionResult?.errorMessage!) };
@@ -134,9 +134,9 @@ export class ConnectionService {
 	 * @param connection connection result or connection Id
 	 * @returns formatted connection result
 	 */
-	private async formatConnectionResult(connection: azdata.ConnectionResult | string | undefined): Promise<string> {
+	private async formatConnectionResult(connection: azdataType.ConnectionResult | string | undefined): Promise<string> {
 		const azdataApi = utils.getAzdataApi();
-		const connectionResult = connection !== undefined && azdataApi ? <azdata.ConnectionResult>connection : undefined;
+		const connectionResult = connection !== undefined && azdataApi ? <azdataType.ConnectionResult>connection : undefined;
 		return connectionResult?.connected ? connectionResult.connectionId! : <string>connection;
 	}
 
@@ -160,7 +160,7 @@ export class ConnectionService {
 			this.defaultSqlNumberOfRetries, profile.connectionRetryTimeout || this.defaultSqlRetryTimeoutInSec);
 
 		if (connection) {
-			const connectionResult = <azdata.ConnectionResult>connection;
+			const connectionResult = <azdataType.ConnectionResult>connection;
 			if (azdataApi) {
 				utils.throwIfNotConnected(connectionResult);
 				return azdataApi.connection.getUriForConnection(connectionResult.connectionId!);


### PR DESCRIPTION
Fixing this error causing the sql-database-projects-vscode extension to not activate, introduced in https://github.com/microsoft/azuredatastudio/pull/20699:
![image](https://user-images.githubusercontent.com/31145923/195203719-8c32fa95-b215-40b7-9f4d-3b735826d142.png)
