### PR TITLE
more control over the release step condition

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -136,8 +136,8 @@ stages:
     #
     # Limitation:
     # Ideally, we should be able to use the condition `and(succeeded(), eq(variables['VSCODE_RELEASE'], 'true')` to achieve what we want. The VSCODE_RELEASE variable can be defined as overwritable or non-overwritable based on whether we want to
-    # release from the pipeline. Unfortunately ADO doesn't allow the use of variables for scheduled job as per:
-    # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#scheduled-triggers, as a result, we cannot set the VSCODE_RELEASE variable to true for scheduled Insider builds.
+    # release from the pipeline. Unfortunately ADO doesn't allow overriding variable values for scheduled runs. (see https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#scheduled-triggers).
+    # This means we can't simply set VSCODE_RELEASE to true only for scheduled builds and have to set it to true for all runs of the pipeline by default.
     #
     # Implementation:
     # Set the VSCODE_RELEASE variable's default value to true and add the release tag for following scenarios:

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -141,7 +141,7 @@ stages:
 
     # Implementation:
     # The variable AUTO_RELEASE_INSIDER is defined as non-overwritable to control whether scheduled builds in the pipeline with insider quality should be released automatically.
-    # The variable VSCODE_RELEASE is defined as overwritable/non-overwritable based on whether we want to release from the pipeline. The default value is always false.
+    # The variable VSCODE_RELEASE is defined as overwritable/non-overwritable based on whether we want to release from the pipeline. The default value is false for both scenarios.
     condition: and(succeeded(), or(eq(variables['VSCODE_RELEASE'], 'true'), and(eq(variables['AUTO_RELEASE_INSIDER'], 'true'), eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['Build.Reason'], 'Schedule'))))
     pool:
       vmImage: 'Ubuntu-20.04'

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -129,7 +129,20 @@ stages:
     #   timeoutInMinutes: 90
 
   - stage: Release
-    condition: and(succeeded(), or(eq(variables['VSCODE_RELEASE'], 'true'), and(eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['Build.Reason'], 'Schedule'))))
+    # Requirements:
+    # 1. Release can be created only from builds in a particular pipeline, but not all builds of it should be released automatically.
+    # 2. A build will be released only when the release variable is set to true.
+    # 3. The daily scheduled Insiders build should be released automatically.
+    #
+    # Limitation:
+    # Ideally, we should be able to use the condition as `and(succeeded(), eq(variables['VSCODE_RELEASE'], 'true')`. The VSCODE_RELEASE variable can be defined as overwritable or non-overwritable based on whether we want to
+    # release from the pipeline. Unfortunately ADO doesn't allow the use of variables for scheduled job as per:
+    # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#scheduled-triggers, as a result, we cannot set the VSCODE_RELEASE variable to true for scheduled Insider builds.
+
+    # Implementation:
+    # The variable AUTO_RELEASE_INSIDER is defined as non-overwritable to control whether scheduled builds in the pipeline with insider quality should be released automatically.
+    # The variable VSCODE_RELEASE is defined as overwritable/non-overwritable based on whether we want to release from the pipeline. The default value is always false.
+    condition: and(succeeded(), or(eq(variables['VSCODE_RELEASE'], 'true'), and(eq(variables['AUTO_RELEASE_INSIDER'], 'true'), eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['Build.Reason'], 'Schedule'))))
     pool:
       vmImage: 'Ubuntu-20.04'
     dependsOn:

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -138,11 +138,13 @@ stages:
     # Ideally, we should be able to use the condition `and(succeeded(), eq(variables['VSCODE_RELEASE'], 'true')` to achieve what we want. The VSCODE_RELEASE variable can be defined as overwritable or non-overwritable based on whether we want to
     # release from the pipeline. Unfortunately ADO doesn't allow the use of variables for scheduled job as per:
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#scheduled-triggers, as a result, we cannot set the VSCODE_RELEASE variable to true for scheduled Insider builds.
-
+    #
     # Implementation:
-    # The variable AUTO_RELEASE_INSIDER is defined as non-overwritable to control whether scheduled builds in the pipeline with insider quality should be released automatically.
-    # The variable VSCODE_RELEASE is defined as overwritable/non-overwritable based on whether we want to release from the pipeline. The default value is false for both scenarios.
-    condition: and(succeeded(), or(eq(variables['VSCODE_RELEASE'], 'true'), and(eq(variables['AUTO_RELEASE_INSIDER'], 'true'), eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['Build.Reason'], 'Schedule'))))
+    # Set the VSCODE_RELEASE variable's default value to true and add the release tag for following scenarios:
+    # 1. The build is a scheduled insiders build.
+    # 2. The build is not an insiders build. e.g. rc1, stable, saw.
+    # To release an ad-hoc insiders build, manually add 'Release' tag to the build.
+    condition: and(succeeded(), eq(variables['VSCODE_RELEASE'], 'true'), or(ne(variables['VSCODE_QUALITY'], 'insider'), and(eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['Build.Reason'], 'Schedule'))))
     pool:
       vmImage: 'Ubuntu-20.04'
     dependsOn:
@@ -150,7 +152,7 @@ stages:
       - Linux
       - Windows
     jobs:
-      - job: Release
+      - job: Add Release Tag
         steps:
         - template: sql-release.yml
 

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -130,12 +130,12 @@ stages:
 
   - stage: Release
     # Requirements:
-    # 1. Release can be created only from builds in a particular pipeline, but not all builds of it should be released automatically.
-    # 2. A build will be released only when the release variable is set to true.
+    # 1. Release can be created only from builds of the official build pipeline, but not all builds of it should be released automatically.
+    # 2. A build should be released only when the release variable is set to true.
     # 3. The daily scheduled Insiders build should be released automatically.
     #
     # Limitation:
-    # Ideally, we should be able to use the condition as `and(succeeded(), eq(variables['VSCODE_RELEASE'], 'true')`. The VSCODE_RELEASE variable can be defined as overwritable or non-overwritable based on whether we want to
+    # Ideally, we should be able to use the condition `and(succeeded(), eq(variables['VSCODE_RELEASE'], 'true')` to achieve what we want. The VSCODE_RELEASE variable can be defined as overwritable or non-overwritable based on whether we want to
     # release from the pipeline. Unfortunately ADO doesn't allow the use of variables for scheduled job as per:
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#scheduled-triggers, as a result, we cannot set the VSCODE_RELEASE variable to true for scheduled Insider builds.
 


### PR DESCRIPTION
When checking the health of the build pipelines, I noticed that the Release step was run for the unstable test pipeline. 
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=174566&view=results
![image](https://user-images.githubusercontent.com/13777222/195413672-3804270e-aece-453e-bef6-847894273fc3.png)

The only recent change for the release step is its level, moved from job level to its own stage. the issue seems to be caused by the result of `succeeded()` in the condition expression is different at stage level vs at job level. But in the meanwhile, there is a bug in our pipeline definition, previously, if an unstable test build passes, the condition would be evaluated as true.

To actually fix the issue, I am introducing another variable to control whether insiders build should be released from it, this will make the logic much clear. I will modify the build pipeline once this pr is merged.

Note: no Insiders build is actually released from the unstable test pipeline because our release pipeline is only monitoring the official build pipeline.