### PR TITLE
Fixes resize bug affecting the find node widget

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
+++ b/src/sql/workbench/contrib/executionPlan/browser/media/executionPlan.css
@@ -17,6 +17,7 @@
 .eps-container .execution-plan {
 	width: 100%;
 	min-height: 500px;
+	min-width: 470px;
 	display: flex;
 	overflow: hidden;
 	flex: 1;
@@ -68,7 +69,7 @@ However we always want it to be the width of the container it is resizing.
 	flex-direction: row;
 	padding: 5px;
 	height: auto;
-	width: 470px;
+	width: 420px;
 }
 
 /* input bar styling in search node action view */
@@ -81,6 +82,10 @@ However we always want it to be the width of the container it is resizing.
 .eps-container .execution-plan .plan .plan-action-container .search-node-widget .select-container>select,
 .eps-container .comparison-editor .plan-comparison-container .split-view-container .plan-container .plan-action-container .search-node-widget .select-container>select {
 	height: 100%;
+}
+
+.eps-container .execution-plan .plan .plan-action-container .search-node-widget .input {
+	width: 100px;
 }
 
 /* Custom zoom action view */


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes an issue around the find node widget's combo box hiding behind the object explorer panel, which is making it unusable.
![Execution Plan - find node widget](https://user-images.githubusercontent.com/87730006/195439647-0222b1dd-d7e8-463b-bd02-41175835cadd.gif)

