### PR TITLE
Updates azdataGraph version from 0.0.45 to 0.0.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
     "applicationinsights": "1.0.8",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.45",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.46",
     "chart.js": "^2.9.4",
     "chokidar": "3.5.1",
     "graceful-fs": "4.2.8",

--- a/remote/package.json
+++ b/remote/package.json
@@ -17,7 +17,7 @@
     "applicationinsights": "1.0.8",
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.45",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.46",
     "chart.js": "^2.9.4",
     "cookie": "^0.4.0",
     "graceful-fs": "4.2.8",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -15,7 +15,7 @@
 		"@vscode/vscode-languagedetection": "1.0.21",
 		"angular2-grid": "2.0.6",
 		"ansi_up": "^5.1.0",
-		"azdataGraph": "github:Microsoft/azdataGraph#0.0.45",
+		"azdataGraph": "github:Microsoft/azdataGraph#0.0.46",
 		"chart.js": "^2.9.4",
 		"gridstack": "^3.1.3",
 		"kburtram-query-plan": "2.6.1",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -150,9 +150,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.45":
-  version "0.0.45"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/8675ac6dfc60aad331ccbf7e4145b9eaa25e7304"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.46":
+  version "0.0.46"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/1b9745bbf343b958e44e739c7bcde0d6bdf16c48"
 
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -198,9 +198,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.45":
-  version "0.0.45"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/8675ac6dfc60aad331ccbf7e4145b9eaa25e7304"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.46":
+  version "0.0.46"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/1b9745bbf343b958e44e739c7bcde0d6bdf16c48"
 
 bindings@^1.5.0:
   version "1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,9 +1891,9 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.45":
-  version "0.0.45"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/8675ac6dfc60aad331ccbf7e4145b9eaa25e7304"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.46":
+  version "0.0.46"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/1b9745bbf343b958e44e739c7bcde0d6bdf16c48"
 
 bach@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the azdataGraph version from 0.0.45 to 0.0.46. The update makes the following improvements:
- Narrator will no longer say childless operations in query execution plans are expanded
- Expensive operator highlighting and selection colors have been adjusted to be more accessible.
