### PR TITLE
Remove deprecated "Asynchronous Processing" connection property

### DIFF
--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -168,20 +168,6 @@
         {
           "specialValueType": null,
           "isIdentity": false,
-          "name": "asynchronousProcessing",
-          "displayName": "%cms.connectionOptions.asynchronousProcessing.displayName%",
-          "description": "%cms.connectionOptions.asynchronousProcessing.description%",
-          "groupName": "%cms.connectionOptions.groupName.initialization%",
-          "valueType": "boolean",
-          "defaultValue": null,
-          "objectType": null,
-          "categoryValues": null,
-          "isRequired": false,
-          "isArray": false
-        },
-        {
-          "specialValueType": null,
-          "isIdentity": false,
           "name": "connectTimeout",
           "displayName": "%cms.connectionOptions.connectTimeout.displayName%",
           "description": "%cms.connectionOptions.connectTimeout.description%",

--- a/extensions/cms/package.nls.json
+++ b/extensions/cms/package.nls.json
@@ -60,8 +60,6 @@
 	"cms.connectionOptions.password.description": "Indicates the password to be used when connecting to the data source",
 	"cms.connectionOptions.applicationIntent.displayName": "Application intent",
 	"cms.connectionOptions.applicationIntent.description": "Declares the application workload type when connecting to a server",
-	"cms.connectionOptions.asynchronousProcessing.displayName": "Asynchronous processing",
-	"cms.connectionOptions.asynchronousProcessing.description": "When true, enables usage of the Asynchronous functionality in the .Net Framework Data Provider",
 	"cms.connectionOptions.connectTimeout.displayName": "Connect timeout",
 	"cms.connectionOptions.connectTimeout.description": "The length of time (in seconds) to wait for a connection to the server before terminating the attempt and generating an error",
 	"cms.connectionOptions.currentLanguage.displayName": "Current language",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -949,20 +949,6 @@
         {
           "specialValueType": null,
           "isIdentity": false,
-          "name": "asynchronousProcessing",
-          "displayName": "%mssql.connectionOptions.asynchronousProcessing.displayName%",
-          "description": "%mssql.connectionOptions.asynchronousProcessing.description%",
-          "groupName": "%mssql.connectionOptions.groupName.initialization%",
-          "valueType": "boolean",
-          "defaultValue": null,
-          "objectType": null,
-          "categoryValues": null,
-          "isRequired": false,
-          "isArray": false
-        },
-        {
-          "specialValueType": null,
-          "isIdentity": false,
           "name": "connectTimeout",
           "displayName": "%mssql.connectionOptions.connectTimeout.displayName%",
           "description": "%mssql.connectionOptions.connectTimeout.description%",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -127,8 +127,6 @@
 	"mssql.connectionOptions.password.description": "Indicates the password to be used when connecting to the data source",
 	"mssql.connectionOptions.applicationIntent.displayName": "Application intent",
 	"mssql.connectionOptions.applicationIntent.description": "Declares the application workload type when connecting to a server",
-	"mssql.connectionOptions.asynchronousProcessing.displayName": "Asynchronous processing",
-	"mssql.connectionOptions.asynchronousProcessing.description": "When true, enables usage of the Asynchronous functionality in the .Net Framework Data Provider",
 	"mssql.connectionOptions.connectTimeout.displayName": "Connect timeout",
 	"mssql.connectionOptions.connectTimeout.description": "The length of time (in seconds) to wait for a connection to the server before terminating the attempt and generating an error",
 	"mssql.connectionOptions.currentLanguage.displayName": "Current language",

--- a/resources/xlf/en/cms.xlf
+++ b/resources/xlf/en/cms.xlf
@@ -95,12 +95,6 @@
     <trans-unit id="cms.connectionOptions.applicationName.displayName">
       <source xml:lang="en">Application name</source>
     </trans-unit>
-    <trans-unit id="cms.connectionOptions.asynchronousProcessing.description">
-      <source xml:lang="en">When true, enables usage of the Asynchronous functionality in the .Net Framework Data Provider</source>
-    </trans-unit>
-    <trans-unit id="cms.connectionOptions.asynchronousProcessing.displayName">
-      <source xml:lang="en">Asynchronous processing</source>
-    </trans-unit>
     <trans-unit id="cms.connectionOptions.attachDbFilename.displayName">
       <source xml:lang="en">Attach DB filename</source>
     </trans-unit>

--- a/resources/xlf/en/mssql.xlf
+++ b/resources/xlf/en/mssql.xlf
@@ -724,12 +724,6 @@
     <trans-unit id="mssql.connectionOptions.applicationName.displayName">
       <source xml:lang="en">Application name</source>
     </trans-unit>
-    <trans-unit id="mssql.connectionOptions.asynchronousProcessing.description">
-      <source xml:lang="en">When true, enables usage of the Asynchronous functionality in the .Net Framework Data Provider</source>
-    </trans-unit>
-    <trans-unit id="mssql.connectionOptions.asynchronousProcessing.displayName">
-      <source xml:lang="en">Asynchronous processing</source>
-    </trans-unit>
     <trans-unit id="mssql.connectionOptions.attachDbFilename.displayName">
       <source xml:lang="en">Attach DB filename</source>
     </trans-unit>

--- a/src/sql/workbench/test/browser/modal/optionsDialogHelper.test.ts
+++ b/src/sql/workbench/test/browser/modal/optionsDialogHelper.test.ts
@@ -46,19 +46,6 @@ suite('Advanced options helper tests', () => {
 			isArray: undefined
 		};
 
-		booleanOption = {
-			name: 'asynchronousProcessing',
-			displayName: 'Asynchronous processing enabled',
-			description: 'When true, enables usage of the Asynchronous functionality in the .Net Framework Data Provider',
-			groupName: 'Initialization',
-			categoryValues: null,
-			defaultValue: null,
-			isRequired: false,
-			valueType: ServiceOptionType.boolean,
-			objectType: undefined,
-			isArray: undefined
-		};
-
 		numberOption = {
 			name: 'connectTimeout',
 			displayName: 'Connect Timeout',
@@ -228,7 +215,7 @@ suite('Advanced options helper tests', () => {
 		booleanOption.defaultValue = null;
 		booleanOption.isRequired = false;
 		possibleInputs = [];
-		options['asynchronousProcessing'] = true;
+		options['trustServerCertificate'] = true;
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(booleanOption, options, possibleInputs);
 		assert.strictEqual(optionValue, 'True');
 		assert.strictEqual(possibleInputs.length, 3);
@@ -241,7 +228,7 @@ suite('Advanced options helper tests', () => {
 		booleanOption.defaultValue = null;
 		booleanOption.isRequired = true;
 		possibleInputs = [];
-		options['asynchronousProcessing'] = 'False';
+		options['trustServerCertificate'] = 'False';
 		let optionValue = OptionsDialogHelper.getOptionValueAndCategoryValues(booleanOption, options, possibleInputs);
 		assert.strictEqual(optionValue, 'False');
 		assert.strictEqual(possibleInputs.length, 2);

--- a/src/sql/workbench/test/browser/modal/optionsDialogHelper.test.ts
+++ b/src/sql/workbench/test/browser/modal/optionsDialogHelper.test.ts
@@ -46,6 +46,19 @@ suite('Advanced options helper tests', () => {
 			isArray: undefined
 		};
 
+		booleanOption = {
+			name: 'trustServerCertificate',
+			displayName: 'Trust Server Certificate enabled',
+			description: 'When true (and encrypt=true), SQL Server uses SSL encryption for all data sent between the client and server without validating the server certificate',
+			groupName: 'Initialization',
+			categoryValues: null,
+			defaultValue: null,
+			isRequired: false,
+			valueType: ServiceOptionType.boolean,
+			objectType: undefined,
+			isArray: undefined
+		};
+
 		numberOption = {
 			name: 'connectTimeout',
 			displayName: 'Connect Timeout',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

"Asynchronous Processing" was dropped from MDS 4.0 onwards, and does not apply to MDS 5.0 anymore. This property was also always a no-op for .NET Core, and only applied to .NET Framework driver, but is now removed from driver completely. 
It's a no-op for Azure Data Studio.

Reference links: 
- https://github.com/dotnet/SqlClient/pull/1148
- [SqlConnectionStringBuilder Properties for SqlClient v3.1](https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnectionstringbuilder?view=sqlclient-dotnet-core-3.1#properties)
