### PR TITLE
target database mapping and selection bug

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -777,7 +777,9 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 
 						const dbIndex = this.migrationStateModel._sourceDatabaseNames?.indexOf(sourceDatabaseName);
 						if (dbIndex > -1) {
-							targetDatabaseName = originalTargetDatabaseNames[dbIndex] ?? targetDatabaseName;
+							targetDatabaseName = isSqlDbTarget
+								? targetDatabaseName
+								: originalTargetDatabaseNames[dbIndex] ?? targetDatabaseName;
 							networkShare = originalNetworkShares[dbIndex] ?? networkShare;
 							blob = originalBlobs[dbIndex] ?? blob;
 						} else {


### PR DESCRIPTION
this pr:
* fixes an issue in the sql db targeting scenario when the user selects an initial target database and tables for a migration then changes the target database and table selection resulting in displaying and using wrong target database for migration.
* bumps the version to 1.1.0 for next insiders release.