### PR TITLE
show error when scripting fails

### DIFF
--- a/src/sql/workbench/browser/scriptingActions.ts
+++ b/src/sql/workbench/browser/scriptingActions.ts
@@ -21,7 +21,8 @@ export class ScriptSelectAction extends Action {
 		id: string, label: string,
 		@IQueryEditorService protected _queryEditorService: IQueryEditorService,
 		@IConnectionManagementService protected _connectionManagementService: IConnectionManagementService,
-		@IScriptingService protected _scriptingService: IScriptingService
+		@IScriptingService protected _scriptingService: IScriptingService,
+		@IErrorMessageService protected _errorMessageService: IErrorMessageService
 	) {
 		super(id, label);
 	}
@@ -32,7 +33,8 @@ export class ScriptSelectAction extends Action {
 			actionContext.object!,
 			this._connectionManagementService,
 			this._queryEditorService,
-			this._scriptingService
+			this._scriptingService,
+			this._errorMessageService
 		);
 	}
 }
@@ -97,9 +99,10 @@ export class EditDataAction extends Action {
 
 	constructor(
 		id: string, label: string,
-		@IQueryEditorService protected _queryEditorService: IQueryEditorService,
-		@IConnectionManagementService protected _connectionManagementService: IConnectionManagementService,
-		@IScriptingService protected _scriptingService: IScriptingService
+		@IQueryEditorService private _queryEditorService: IQueryEditorService,
+		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
+		@IScriptingService private _scriptingService: IScriptingService,
+		@IErrorMessageService private _errorMessageService: IErrorMessageService
 	) {
 		super(id, label);
 	}
@@ -110,7 +113,8 @@ export class EditDataAction extends Action {
 			actionContext.object!,
 			this._connectionManagementService,
 			this._queryEditorService,
-			this._scriptingService
+			this._scriptingService,
+			this._errorMessageService
 		);
 	}
 }

--- a/src/sql/workbench/browser/scriptingUtils.ts
+++ b/src/sql/workbench/browser/scriptingUtils.ts
@@ -37,55 +37,61 @@ const targetDatabaseEngineEditionMap = {
 	11: 'SqlServerOnDemandEdition',
 };
 
+const ScriptingFailedDialogTitle = nls.localize('scriptingFailed', "Scripting Failed");
+const SelectScriptNotGeneratedError = nls.localize('selectScriptNotGeneratedError', "Failed to generate select script for the selected object.");
+
 /**
  * Select the top rows from an object
  */
-export async function scriptSelect(connectionProfile: IConnectionProfile, metadata: azdata.ObjectMetadata, connectionService: IConnectionManagementService, queryEditorService: IQueryEditorService, scriptingService: IScriptingService): Promise<boolean> {
-	const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
-	let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
-	const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails);
-	if (result && result.script) {
-		const owner = await queryEditorService.newSqlEditor({ initalContent: result.script }, connectionProfile?.providerName);
-		// Connect our editor to the input connection
-		let options: IConnectionCompletionOptions = {
-			params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery, input: owner },
-			saveTheConnection: false,
-			showDashboard: false,
-			showConnectionDialogOnError: true,
-			showFirewallRuleOnError: true
-		};
-		const innerConnectionResult = await connectionService.connect(connectionProfile, owner.uri, options);
-
-		return Boolean(innerConnectionResult) && innerConnectionResult.connected;
-	} else {
-		let errMsg: string = nls.localize('scriptSelectNotFound', "No script was returned when calling select script on object ");
-		throw new Error(errMsg.concat(metadata.metadataTypeName));
+export async function scriptSelect(connectionProfile: IConnectionProfile, metadata: azdata.ObjectMetadata, connectionService: IConnectionManagementService, queryEditorService: IQueryEditorService, scriptingService: IScriptingService, errorMessageService: IErrorMessageService): Promise<void> {
+	try {
+		const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
+		let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
+		const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails);
+		if (result && result.script) {
+			const owner = await queryEditorService.newSqlEditor({ initalContent: result.script }, connectionProfile?.providerName);
+			// Connect our editor to the input connection
+			let options: IConnectionCompletionOptions = {
+				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery, input: owner },
+				saveTheConnection: false,
+				showDashboard: false,
+				showConnectionDialogOnError: true,
+				showFirewallRuleOnError: true
+			};
+			await connectionService.connect(connectionProfile, owner.uri, options);
+		} else {
+			throw new Error(SelectScriptNotGeneratedError);
+		}
+	} catch (err) {
+		errorMessageService.showDialog(Severity.Error, ScriptingFailedDialogTitle, err?.message ?? err);
 	}
 }
 
 /**
  * Opens a new Edit Data session
  */
-export async function scriptEditSelect(connectionProfile: IConnectionProfile, metadata: azdata.ObjectMetadata, connectionService: IConnectionManagementService, queryEditorService: IQueryEditorService, scriptingService: IScriptingService): Promise<boolean> {
-	const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
-	let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata);
-	const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails!);
-	if (result && result.script) {
-		const owner = await queryEditorService.newEditDataEditor(metadata.schema, metadata.name, result.script);
-		// Connect our editor
-		let options: IConnectionCompletionOptions = {
-			params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
-			saveTheConnection: false,
-			showDashboard: false,
-			showConnectionDialogOnError: true,
-			showFirewallRuleOnError: true
-		};
-		const innerConnectionResult = await connectionService.connect(connectionProfile, owner.uri, options);
-
-		return Boolean(innerConnectionResult) && innerConnectionResult.connected;
-	} else {
-		let errMsg: string = nls.localize('scriptSelectNotFound', "No script was returned when calling select script on object ");
-		throw new Error(errMsg.concat(metadata.metadataTypeName));
+export async function scriptEditSelect(connectionProfile: IConnectionProfile, metadata: azdata.ObjectMetadata, connectionService: IConnectionManagementService, queryEditorService: IQueryEditorService, scriptingService: IScriptingService, errorMessageService: IErrorMessageService): Promise<void> {
+	try {
+		const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
+		let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata);
+		const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails!);
+		if (result && result.script) {
+			const owner = await queryEditorService.newEditDataEditor(metadata.schema, metadata.name, result.script);
+			// Connect our editor
+			let options: IConnectionCompletionOptions = {
+				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
+				saveTheConnection: false,
+				showDashboard: false,
+				showConnectionDialogOnError: true,
+				showFirewallRuleOnError: true
+			};
+			await connectionService.connect(connectionProfile, owner.uri, options);
+		} else {
+			throw new Error(SelectScriptNotGeneratedError);
+		}
+	}
+	catch (err) {
+		errorMessageService.showDialog(Severity.Error, ScriptingFailedDialogTitle, err?.message ?? err);
 	}
 }
 
@@ -118,45 +124,44 @@ export async function script(connectionProfile: IConnectionProfile, metadata: az
 	queryEditorService: IQueryEditorService,
 	scriptingService: IScriptingService,
 	operation: ScriptOperation,
-	errorMessageService: IErrorMessageService): Promise<boolean> {
-	const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
-	let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
-	const result = await scriptingService.script(connectionResult, metadata, operation, paramDetails);
-	if (result) {
-		let script: string = result.script;
+	errorMessageService: IErrorMessageService): Promise<void> {
+	try {
+		const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
+		let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
+		const result = await scriptingService.script(connectionResult, metadata, operation, paramDetails);
+		if (result) {
+			let script: string = result.script;
 
-		if (script) {
-			let description = (metadata.schema && metadata.schema !== '') ? `${metadata.schema}.${metadata.name}` : metadata.name;
-			const owner = await queryEditorService.newSqlEditor({ initalContent: script, description }, connectionProfile.providerName);
-			// Connect our editor to the input connection
-			let options: IConnectionCompletionOptions = {
-				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
-				saveTheConnection: false,
-				showDashboard: false,
-				showConnectionDialogOnError: true,
-				showFirewallRuleOnError: true
-			};
-			const innerConnectionResult = await connectionService.connect(connectionProfile, owner.uri, options);
-
-			return Boolean(innerConnectionResult) && innerConnectionResult.connected;
-
+			if (script) {
+				let description = (metadata.schema && metadata.schema !== '') ? `${metadata.schema}.${metadata.name}` : metadata.name;
+				const owner = await queryEditorService.newSqlEditor({ initalContent: script, description }, connectionProfile.providerName);
+				// Connect our editor to the input connection
+				let options: IConnectionCompletionOptions = {
+					params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
+					saveTheConnection: false,
+					showDashboard: false,
+					showConnectionDialogOnError: true,
+					showFirewallRuleOnError: true
+				};
+				await connectionService.connect(connectionProfile, owner.uri, options);
+			} else {
+				let scriptNotFoundMsg = nls.localize('scriptNotFoundForObject', "No script was returned when scripting as {0} on object {1}",
+					GetScriptOperationName(operation), metadata.metadataTypeName);
+				let messageDetail = '';
+				let operationResult = scriptingService.getOperationFailedResult(result.operationId);
+				if (operationResult && operationResult.hasError && operationResult.errorMessage) {
+					scriptNotFoundMsg = operationResult.errorMessage;
+					messageDetail = operationResult.errorDetails;
+				}
+				if (errorMessageService) {
+					errorMessageService.showDialog(Severity.Error, ScriptingFailedDialogTitle, scriptNotFoundMsg, messageDetail);
+				}
+			}
 		} else {
-			let scriptNotFoundMsg = nls.localize('scriptNotFoundForObject', "No script was returned when scripting as {0} on object {1}",
-				GetScriptOperationName(operation), metadata.metadataTypeName);
-			let messageDetail = '';
-			let operationResult = scriptingService.getOperationFailedResult(result.operationId);
-			if (operationResult && operationResult.hasError && operationResult.errorMessage) {
-				scriptNotFoundMsg = operationResult.errorMessage;
-				messageDetail = operationResult.errorDetails;
-			}
-			if (errorMessageService) {
-				let title = nls.localize('scriptingFailed', "Scripting Failed");
-				errorMessageService.showDialog(Severity.Error, title, scriptNotFoundMsg, messageDetail);
-			}
-			throw new Error(scriptNotFoundMsg);
+			throw new Error(nls.localize('scriptNotFound', "No script was returned when scripting as {0}", GetScriptOperationName(operation)));
 		}
-	} else {
-		throw new Error(nls.localize('scriptNotFound', "No script was returned when scripting as {0}", GetScriptOperationName(operation)));
+	} catch (err) {
+		errorMessageService.showDialog(Severity.Error, ScriptingFailedDialogTitle, err?.message ?? err);
 	}
 }
 

--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -96,13 +96,14 @@ CommandsRegistry.registerCommand({
 			const connectionManagementService = accessor.get(IConnectionManagementService);
 			const scriptingService = accessor.get(IScriptingService);
 			const progressService = accessor.get(IProgressService);
+			const errorMessageService = accessor.get(IErrorMessageService);
 			const profile = new ConnectionProfile(capabilitiesService, args.$treeItem.payload);
 			const baseContext: BaseActionContext = {
 				profile: profile,
 				object: oeShimService.getNodeInfoForTreeItem(args.$treeItem)!.metadata
 			};
 			const scriptSelectAction = new ScriptSelectAction(ScriptSelectAction.ID, ScriptSelectAction.LABEL,
-				queryEditorService, connectionManagementService, scriptingService);
+				queryEditorService, connectionManagementService, scriptingService, errorMessageService);
 			await progressService.withProgress({ location: VIEWLET_ID }, async () => await scriptSelectAction.run(baseContext));
 		}
 	}
@@ -167,13 +168,14 @@ CommandsRegistry.registerCommand({
 			const connectionManagementService = accessor.get(IConnectionManagementService);
 			const scriptingService = accessor.get(IScriptingService);
 			const progressService = accessor.get(IProgressService);
+			const errorMessageService = accessor.get(IErrorMessageService);
 			const profile = new ConnectionProfile(capabilitiesService, args.$treeItem.payload);
 			const baseContext: BaseActionContext = {
 				profile: profile,
 				object: oeShimService.getNodeInfoForTreeItem(args.$treeItem)!.metadata
 			};
 			const editDataAction = new EditDataAction(EditDataAction.ID, EditDataAction.LABEL,
-				queryEditorService, connectionManagementService, scriptingService);
+				queryEditorService, connectionManagementService, scriptingService, errorMessageService);
 			await progressService.withProgress({ location: VIEWLET_ID }, async () => await editDataAction.run(baseContext));
 		}
 	}
@@ -356,9 +358,10 @@ export class ExplorerScriptSelectAction extends ScriptSelectAction {
 		@IQueryEditorService queryEditorService: IQueryEditorService,
 		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
 		@IScriptingService scriptingService: IScriptingService,
-		@IProgressService private readonly progressService: IProgressService
+		@IProgressService private readonly progressService: IProgressService,
+		@IErrorMessageService errorMessageService: IErrorMessageService
 	) {
-		super(id, label, queryEditorService, connectionManagementService, scriptingService);
+		super(id, label, queryEditorService, connectionManagementService, scriptingService, errorMessageService);
 	}
 
 	public override async run(actionContext: BaseActionContext): Promise<void> {


### PR DESCRIPTION
noticed that we don't actually surface the scripting errors to the user while investigating: https://github.com/microsoft/azuredatastudio/issues/20241, actual fix for this issue is in STS: https://github.com/microsoft/sqltoolsservice/pull/1724

changes: 
1. Show error dialog when scripting failed.
2. Updated the methods that doesn't need to have a boolean return type to void.

![image](https://user-images.githubusercontent.com/13777222/195718274-f6436368-8e80-490f-875b-0e5c2db3bdb9.png)

