### PR TITLE
[SQL Migration] Update server name query

### DIFF
--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -380,7 +380,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			const connectionProfile = await this.getSourceConnectionProfile();
 			const connectionUri = await azdata.connection.getUriForConnection(this._sourceConnectionId);
 			const queryProvider = azdata.dataprotocol.getProvider<azdata.QueryProvider>(connectionProfile.providerId, azdata.DataProviderType.QueryProvider);
-			const queryString = 'SELECT SERVERPROPERTY('ServerName');';
+			const queryString = 'SELECT SERVERPROPERTY(\'ServerName\');';
 			const queryResult = await queryProvider.runQueryAndReturn(connectionUri, queryString);
 
 			if (queryResult.rowCount > 0) {

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -380,7 +380,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			const connectionProfile = await this.getSourceConnectionProfile();
 			const connectionUri = await azdata.connection.getUriForConnection(this._sourceConnectionId);
 			const queryProvider = azdata.dataprotocol.getProvider<azdata.QueryProvider>(connectionProfile.providerId, azdata.DataProviderType.QueryProvider);
-			const queryString = 'select @@servername;';
+			const queryString = 'SELECT SERVERPROPERTY('ServerName');';
 			const queryResult = await queryProvider.runQueryAndReturn(connectionUri, queryString);
 
 			if (queryResult.rowCount > 0) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the query that is used during SKU recommendation to fetch the server name of the current connection, since the file names of the performance data files that it's looking for are derived from the server name. This query is the correct one that is also used by the recommendation NuGet when the files are being written. 

This was causing an issue where recommendations would fail in situations like this: https://stackoverflow.com/questions/26097229/servername-vs-serverpropertyservername
