### PR TITLE
table cell selection improvement

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -3,6 +3,7 @@
 
 import { mixin } from 'vs/base/common/objects';
 import { isUndefinedOrNull } from 'vs/base/common/types';
+import * as platform from 'vs/base/common/platform';
 
 import { CellRangeSelector, ICellRangeSelector } from 'sql/base/browser/ui/table/plugins/cellRangeSelector';
 
@@ -106,6 +107,10 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 		}
 	}
 
+	private isMultiSelection(e: MouseEvent): boolean {
+		return platform.isMacintosh ? e.metaKey : e.ctrlKey;
+	}
+
 	private handleHeaderClick(e: MouseEvent, args: Slick.OnHeaderClickEventArgs<T>) {
 		if ((e.target as EventTargetWithClassName).className === 'slick-resizable-handle') {
 			return;
@@ -127,7 +132,7 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 					: new Slick.Range(0, columnIndex, rowCount - 1, columnIndex);
 
 				// When CTRL is pressed, we need to merge the new selection with existing selections
-				const rangesToBeMerged: Slick.Range[] = e.ctrlKey ? this.getSelectedRanges() : [];
+				const rangesToBeMerged: Slick.Range[] = this.isMultiSelection(e) ? this.getSelectedRanges() : [];
 				const result = this.insertIntoSelections(rangesToBeMerged, newlySelectedRange);
 				this.setSelectedRanges(result);
 				newActiveCell = { row: this.grid.getViewport()?.top ?? 0, cell: columnIndex };
@@ -254,7 +259,7 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 		}
 
 		// When the CTRL key is pressed, we need to merge the new selection with the existing selections.
-		const rangesToBeMerged: Slick.Range[] = e.ctrlKey ? this.getSelectedRanges() : [];
+		const rangesToBeMerged: Slick.Range[] = this.isMultiSelection(e) ? this.getSelectedRanges() : [];
 		const result = this.insertIntoSelections(rangesToBeMerged, newlySelectedRange);
 		this.setSelectedRanges(result);
 

--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -124,6 +124,7 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 			if (this.options.hasRowSelector && columnIndex === 0) {
 				// When the row selector's header is clicked, all cells should be selected
 				this.setSelectedRanges([new Slick.Range(0, 1, rowCount - 1, columnCount - 1)]);
+				// The first data cell in the view should be selected.
 				newActiveCell = { row: this.grid.getViewport()?.top ?? 0, cell: 1 };
 			}
 			else if (this.grid.canCellBeSelected(0, columnIndex)) {
@@ -135,6 +136,7 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 				const rangesToBeMerged: Slick.Range[] = this.isMultiSelection(e) ? this.getSelectedRanges() : [];
 				const result = this.insertIntoSelections(rangesToBeMerged, newlySelectedRange);
 				this.setSelectedRanges(result);
+				// The first data cell of the target column in the view should be selected.
 				newActiveCell = { row: this.grid.getViewport()?.top ?? 0, cell: columnIndex };
 			}
 
@@ -264,6 +266,8 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 		this.setSelectedRanges(result);
 
 		// Find out the new active cell
+		// If the row selector is clicked, the first data cell in the row should be the new active cell,
+		// otherwise, the target cell should be the new active cell.
 		const newActiveCell: Slick.Cell = isRowSelectorClicked ? { cell: 1, row: args.row } : { cell: args.cell, row: args.row };
 		this.grid.setActiveCell(newActiveCell.row, newActiveCell.cell);
 	}

--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -8,11 +8,14 @@ import { CellRangeSelector, ICellRangeSelector } from 'sql/base/browser/ui/table
 
 export interface ICellSelectionModelOptions {
 	cellRangeSelector?: any;
-	selectActiveCell?: boolean;
+	/**
+	 * Whether the grid has a row selection column. Needs to take this into account to decide the cell click's selection range.
+	 */
+	hasRowSelector?: boolean,
 }
 
 const defaults: ICellSelectionModelOptions = {
-	selectActiveCell: true
+	hasRowSelector: false
 };
 
 interface EventTargetWithClassName extends EventTarget {
@@ -40,9 +43,8 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 
 	public init(grid: Slick.Grid<T>) {
 		this.grid = grid;
-		this._handler.subscribe(this.grid.onClick, (e: DOMEvent, args: Slick.OnActiveCellChangedEventArgs<T>) => this.handleActiveCellChange(e as MouseEvent, args));
 		this._handler.subscribe(this.grid.onKeyDown, (e: DOMEvent) => this.handleKeyDown(e as KeyboardEvent));
-		this._handler.subscribe(this.grid.onClick, (e: DOMEvent, args: Slick.OnClickEventArgs<T>) => this.handleIndividualCellSelection(e as MouseEvent, args));
+		this._handler.subscribe(this.grid.onClick, (e: DOMEvent, args: Slick.OnClickEventArgs<T>) => this.handleCellClick(e as MouseEvent, args));
 		this._handler.subscribe(this.grid.onHeaderClick, (e: DOMEvent, args: Slick.OnHeaderClickEventArgs<T>) => this.handleHeaderClick(e as MouseEvent, args));
 		this.grid.registerPlugin(this.selector);
 		this._handler.subscribe(this.selector.onCellRangeSelected, (e: Event, range: Slick.Range) => this.handleCellRangeSelected(e, range, false));
@@ -104,31 +106,35 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 		}
 	}
 
-	private handleActiveCellChange(e: MouseEvent, args: Slick.OnActiveCellChangedEventArgs<T>) {
-		if (this.options.selectActiveCell && !isUndefinedOrNull(args.row) && !isUndefinedOrNull(args.cell) && !e.ctrlKey) {
-			this.setSelectedRanges([new Slick.Range(args.row, args.cell)]);
-		} else if (!this.options.selectActiveCell) {
-			// clear the previous selection once the cell changes
-			this.setSelectedRanges([]);
-		}
-	}
-
 	private handleHeaderClick(e: MouseEvent, args: Slick.OnHeaderClickEventArgs<T>) {
 		if ((e.target as EventTargetWithClassName).className === 'slick-resizable-handle') {
 			return;
 		}
 		if (!isUndefinedOrNull(args.column)) {
-			let columnIndex = this.grid.getColumnIndex(args.column.id!);
-			if (this.grid.canCellBeSelected(0, columnIndex)) {
-				let ranges: Array<Slick.Range>;
-				if (e.ctrlKey) {
-					ranges = this.getSelectedRanges();
-					ranges.push(new Slick.Range(0, columnIndex, this.grid.getDataLength() - 1, columnIndex));
-				} else {
-					ranges = [new Slick.Range(0, columnIndex, this.grid.getDataLength() - 1, columnIndex)];
-				}
-				this.grid.setActiveCell(this.grid.getViewport()?.top ?? 0, columnIndex);
-				this.setSelectedRanges(ranges);
+			const columnIndex = this.grid.getColumnIndex(args.column.id!);
+			const rowCount = this.grid.getDataLength();
+			const columnCount = this.grid.getColumns().length;
+			const currentActiveCell = this.grid.getActiveCell();
+			let newActiveCell: Slick.Cell;
+			if (this.options.hasRowSelector && columnIndex === 0) {
+				// When the row selector's header is clicked, all cells should be selected
+				this.setSelectedRanges([new Slick.Range(0, 1, rowCount - 1, columnCount - 1)]);
+				newActiveCell = { row: this.grid.getViewport()?.top ?? 0, cell: 1 };
+			}
+			else if (this.grid.canCellBeSelected(0, columnIndex)) {
+				// When SHIFT is pressed, all the columns between active cell's column and target column should be selected
+				const newlySelectedRange = (e.shiftKey && currentActiveCell) ? new Slick.Range(0, currentActiveCell.cell, rowCount - 1, columnIndex)
+					: new Slick.Range(0, columnIndex, rowCount - 1, columnIndex);
+
+				// When CTRL is pressed, we need to merge the new selection with existing selections
+				const rangesToBeMerged: Slick.Range[] = e.ctrlKey ? this.getSelectedRanges() : [];
+				const result = this.insertIntoSelections(rangesToBeMerged, newlySelectedRange);
+				this.setSelectedRanges(result);
+				newActiveCell = { row: this.grid.getViewport()?.top ?? 0, cell: columnIndex };
+			}
+
+			if (newActiveCell) {
+				this.grid.setActiveCell(newActiveCell.row, newActiveCell.cell);
 			}
 		}
 	}
@@ -228,29 +234,33 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 		return newRanges;
 	}
 
-	private handleIndividualCellSelection(e: MouseEvent, args: Slick.OnClickEventArgs<T>) {
-		if (!e.ctrlKey) {
-			return;
-		}
+	private handleCellClick(e: MouseEvent, args: Slick.OnClickEventArgs<T>) {
+		const activeCell = this.grid.getActiveCell();
+		const columns = this.grid.getColumns();
+		const isRowSelectorClicked: boolean = this.options.hasRowSelector && args.cell === 0;
 
-		let ranges: Array<Slick.Range>;
-
-		ranges = this.getSelectedRanges();
-
-		let selectedRange: Slick.Range;
-		if (args.cell === 0) {
-			selectedRange = new Slick.Range(args.row, 1, args.row, args.grid.getColumns().length - 1);
+		let newlySelectedRange: Slick.Range;
+		// The selection is a range when there is an active cell and the SHIFT key is pressed.
+		if (activeCell !== undefined && e.shiftKey) {
+			// When the row selector cell is clicked, the new selection is all rows from current active row to target row.
+			// Otherwise, the new selection is the cells in the rectangle between current active cell and target cell.
+			newlySelectedRange = isRowSelectorClicked ? new Slick.Range(activeCell.row, columns.length - 1, args.row, 1)
+				: new Slick.Range(activeCell.row, activeCell.cell, args.row, args.cell);
 		} else {
-			selectedRange = new Slick.Range(args.row, args.cell);
-
+			// If the row selector cell is clicked, the new selection is all the cells in the target row.
+			// Otherwise, the new selection is the target cell
+			newlySelectedRange = isRowSelectorClicked ? new Slick.Range(args.row, 1, args.row, columns.length - 1)
+				: new Slick.Range(args.row, args.cell, args.row, args.cell);
 		}
-		ranges = this.insertIntoSelections(ranges, selectedRange);
 
-		this.grid.setActiveCell(selectedRange.toRow, selectedRange.toCell);
-		this.setSelectedRanges(ranges);
+		// When the CTRL key is pressed, we need to merge the new selection with the existing selections.
+		const rangesToBeMerged: Slick.Range[] = e.ctrlKey ? this.getSelectedRanges() : [];
+		const result = this.insertIntoSelections(rangesToBeMerged, newlySelectedRange);
+		this.setSelectedRanges(result);
 
-		e.preventDefault();
-		e.stopImmediatePropagation();
+		// Find out the new active cell
+		const newActiveCell: Slick.Cell = isRowSelectorClicked ? { cell: 1, row: args.row } : { cell: args.cell, row: args.row };
+		this.grid.setActiveCell(newActiveCell.row, newActiveCell.cell);
 	}
 
 	private handleKeyDown(e: KeyboardEvent) {

--- a/src/sql/base/browser/ui/table/plugins/rowNumberColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/rowNumberColumn.plugin.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { FilterableColumn } from 'sql/base/browser/ui/table/interfaces';
+import { mixin } from 'vs/base/common/objects';
 
 export interface IRowNumberColumnOptions {
 	cssClass?: string;
@@ -14,11 +15,16 @@ export interface IRowNumberColumnOptions {
 	autoCellSelection?: boolean;
 }
 
+const defaultOptions: IRowNumberColumnOptions = {
+	autoCellSelection: true
+};
+
 export class RowNumberColumn<T> implements Slick.Plugin<T> {
 	private handler = new Slick.EventHandler();
 	private grid!: Slick.Grid<T>;
 
-	constructor(private options: IRowNumberColumnOptions = {}) {
+	constructor(private options?: IRowNumberColumnOptions) {
+		this.options = mixin(this.options, defaultOptions, false);
 	}
 
 	public init(grid: Slick.Grid<T>) {
@@ -33,7 +39,7 @@ export class RowNumberColumn<T> implements Slick.Plugin<T> {
 	}
 
 	private handleClick(e: MouseEvent, args: Slick.OnClickEventArgs<T>): void {
-		if (this.grid.getColumns()[args.cell].id === 'rowNumber' && this.options.autoCellSelection !== false) {
+		if (this.grid.getColumns()[args.cell].id === 'rowNumber' && this.options.autoCellSelection) {
 			this.grid.setActiveCell(args.row, 1);
 			if (this.grid.getSelectionModel()) {
 				this.grid.setSelectedRows([args.row]);
@@ -42,7 +48,7 @@ export class RowNumberColumn<T> implements Slick.Plugin<T> {
 	}
 
 	private handleHeaderClick(e: MouseEvent, args: Slick.OnHeaderClickEventArgs<T>): void {
-		if (args.column.id === 'rowNumber' && this.options.autoCellSelection !== false) {
+		if (args.column.id === 'rowNumber' && this.options.autoCellSelection) {
 			this.grid.setActiveCell(this.grid.getViewport()?.top ?? 0, 1);
 			let selectionModel = this.grid.getSelectionModel();
 			if (selectionModel) {

--- a/src/sql/base/browser/ui/table/plugins/rowNumberColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/rowNumberColumn.plugin.ts
@@ -6,15 +6,19 @@
 import { FilterableColumn } from 'sql/base/browser/ui/table/interfaces';
 
 export interface IRowNumberColumnOptions {
-	numberOfRows: number;
 	cssClass?: string;
+	/**
+	 * Controls the cell selection behavior. If the value is true or not specified, the entire row will be selected when a cell is clicked,
+	 * and when the header is clicked, the entire table will be selected. If the value is false, the auto selection will not happen.
+	 */
+	autoCellSelection?: boolean;
 }
 
 export class RowNumberColumn<T> implements Slick.Plugin<T> {
 	private handler = new Slick.EventHandler();
 	private grid!: Slick.Grid<T>;
 
-	constructor(private options: IRowNumberColumnOptions) {
+	constructor(private options: IRowNumberColumnOptions = {}) {
 	}
 
 	public init(grid: Slick.Grid<T>) {
@@ -29,7 +33,7 @@ export class RowNumberColumn<T> implements Slick.Plugin<T> {
 	}
 
 	private handleClick(e: MouseEvent, args: Slick.OnClickEventArgs<T>): void {
-		if (this.grid.getColumns()[args.cell].id === 'rowNumber') {
+		if (this.grid.getColumns()[args.cell].id === 'rowNumber' && this.options.autoCellSelection !== false) {
 			this.grid.setActiveCell(args.row, 1);
 			if (this.grid.getSelectionModel()) {
 				this.grid.setSelectedRows([args.row]);
@@ -38,7 +42,7 @@ export class RowNumberColumn<T> implements Slick.Plugin<T> {
 	}
 
 	private handleHeaderClick(e: MouseEvent, args: Slick.OnHeaderClickEventArgs<T>): void {
-		if (args.column.id === 'rowNumber') {
+		if (args.column.id === 'rowNumber' && this.options.autoCellSelection !== false) {
 			this.grid.setActiveCell(this.grid.getViewport()?.top ?? 0, 1);
 			let selectionModel = this.grid.getSelectionModel();
 			if (selectionModel) {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -392,7 +392,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		let maxHeight = this.getMaxHeight(resultSet.rowCount);
 		let minHeight = this.getMinHeight(resultSet.rowCount);
 
-		let rowNumberColumn = new RowNumberColumn({ numberOfRows: resultSet.rowCount });
+		let rowNumberColumn = new RowNumberColumn();
 
 		// Store the result set from the event
 		let dataSet: IGridDataSet = {

--- a/src/sql/workbench/contrib/executionPlan/browser/topOperationsTab.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/topOperationsTab.ts
@@ -181,7 +181,7 @@ export class TopOperationsTabView extends Disposable implements IPanelView {
 		topOperationContainer.appendChild(tableContainer);
 		this._topOperationsContainers.push(topOperationContainer);
 
-		const rowNumberColumn = new RowNumberColumn({ numberOfRows: dataMap.length });
+		const rowNumberColumn = new RowNumberColumn({ autoCellSelection: false });
 		columns.unshift(rowNumberColumn.getColumnDefinition());
 
 		let copyHandler = new CopyKeybind<any>();
@@ -222,7 +222,7 @@ export class TopOperationsTabView extends Disposable implements IPanelView {
 			});
 		}));
 
-		const selectionModel = new CellSelectionModel<Slick.SlickData>();
+		const selectionModel = new CellSelectionModel<Slick.SlickData>({ hasRowSelector: true });
 
 		const table = new Table<Slick.SlickData>(tableContainer, {
 			columns: columns,

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -353,7 +353,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	private table: Table<T>;
 	private actionBar: ActionBar;
 	private container = document.createElement('div');
-	private selectionModel = new CellSelectionModel<T>();
+	private selectionModel = new CellSelectionModel<T>({ hasRowSelector: true });
 	private styles: ITableStyles;
 	private currentHeight: number;
 	private dataProvider: HybridDataProvider<T>;
@@ -498,7 +498,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		collection.setCollectionChangedCallback((startIndex, count) => {
 			this.renderGridDataRowsRange(startIndex, count);
 		});
-		this.rowNumberColumn = new RowNumberColumn({ numberOfRows: this.resultSet.rowCount });
+		this.rowNumberColumn = new RowNumberColumn({ autoCellSelection: false });
 		this.columns.unshift(this.rowNumberColumn.getColumnDefinition());
 		let tableOptions: Slick.GridOptions<T> = {
 			rowHeight: this.rowHeight,

--- a/src/sql/workbench/services/notebook/browser/outputs/tableRenderers.ts
+++ b/src/sql/workbench/services/notebook/browser/outputs/tableRenderers.ts
@@ -49,7 +49,7 @@ export function renderDataResource(
 
 	// In order to show row numbers, we need to put the row number column
 	// ahead of all of the other columns, and register the plugin below
-	let rowNumberColumn = new RowNumberColumn({ numberOfRows: source.length });
+	let rowNumberColumn = new RowNumberColumn();
 	columnsTransformed.unshift(rowNumberColumn.getColumnDefinition());
 
 	let transformedData = transformData(sourceObject.data, columnsTransformed);


### PR DESCRIPTION
Fixes the following issues:
1. This PR fixes #2727
2. Support cell selections on macOS (previously the multi-selection using keyboard never worked)
3. The rowNumber plugin and cellSelectionModel is conflicting since they both do selection management; it is just a matter of the event registration order to decide who gets called first. To fix the issue, I am adding options to the plugins and the consumer of the components can set those options properly. 

**NOTE**: The multi-selection key is CTRL for Windows/Linux, CMD key for macOS.

**Scenarios**
1. Select all - click the header of row number column
![select-all](https://user-images.githubusercontent.com/13777222/195930089-9b29a3f2-6c74-4961-bf11-2e4852cfaf16.gif)

4. Select a single column - click the column header
![select-single-column](https://user-images.githubusercontent.com/13777222/195930545-15630d3a-3dc9-4cc3-9f44-deb8c3885e1e.gif)

5. Select columns individually - click the header of the columns with CTRL/CMD key pressed
![select-multiple-columns-ctrl](https://user-images.githubusercontent.com/13777222/195931525-22805a97-d443-4674-a960-33ed5ec03159.gif)

6. Select columns in a range - select the start column (a cell or entire column), then select the end column header with SHIFT key pressed
![select-multiple-columns-shift](https://user-images.githubusercontent.com/13777222/195932277-0dc5e89c-fff9-49d1-87d8-f4d23a6dbf77.gif)

7. Select a row - click the row number cell
![single-row-selection](https://user-images.githubusercontent.com/13777222/195932862-87936b00-33e5-4bf2-881d-85db247f7659.gif)

8. Select muliple rows individually - click the row number cells with CTRL/CMD key pressed
![multi-row-selection-ctrl](https://user-images.githubusercontent.com/13777222/195933162-6d91aeb2-487f-45f7-af70-b5fc19badb7a.gif)

9. Select rows in a range - select the start row (a cell or the row header), then select the end row header with SHIFT key pressed
![multi-row-selection-shift](https://user-images.githubusercontent.com/13777222/195934588-02f7572e-5a1b-4d92-bf48-81b1490907ae.gif)

10. Select cells in a range with mouse - press and hold the select button in the start cell, then move the cursor to the end cell and release the button
![cell-range-selection-mouse](https://user-images.githubusercontent.com/13777222/195935885-869e2d6d-b377-42da-b765-1f071a84d372.gif)

11. Select cells in a range with keyboard only - select the start cell, press and hold SHIFT key, then use the arrow keys to select the range
![cell-range-selection-keyboard-only](https://user-images.githubusercontent.com/13777222/195937607-33369094-0684-469d-9253-d45a09ae3a5a.gif)

12. Select cells in a range with mouse and SHIFT key - select the start cell, press and hold SHIFT key, then click the end cell
![cell-range-selection-mouse-shift](https://user-images.githubusercontent.com/13777222/195937951-d52cd9f5-c059-4861-ae48-81cd47f7fce7.gif)

13.  Select multiple ranges - Select a range with the options listed above and then with CTRL/CMD pressed and keep adding new selections.
![select-multiple-ranges](https://user-images.githubusercontent.com/13777222/195940406-e51911c7-2aee-4c7d-bf39-ef306df8433d.gif)
