### PR TITLE
update vscode-mssql.d.ts to match the one in vscode-mssql

### DIFF
--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -178,35 +178,35 @@ declare module 'vscode-mssql' {
 		osVersion: string;
 	}
 
+	/**
+	 * Well-known Authentication types.
+	 */
+	export const enum AuthenticationType {
 		/**
-		 * Well-known Authentication types.
+		 * Username and password
 		 */
-		 export const enum AuthenticationType {
-			/**
-			 * Username and password
-			 */
-			SqlLogin = 'SqlLogin',
-			/**
-			 * Windows Authentication
-			 */
-			Integrated = 'Integrated',
-			/**
-			 * Azure Active Directory - Universal with MFA support
-			 */
-			AzureMFA = 'AzureMFA',
-			/**
-			 * Azure Active Directory - Password
-			 */
-			AzureMFAAndUser = 'AzureMFAAndUser',
-			/**
-			 * Datacenter Security Token Service Authentication
-			 */
-			DSTSAuth = 'dstsAuth',
-			/**
-			 * No authentication required
-			 */
-			None = 'None'
-		}
+		SqlLogin = 'SqlLogin',
+		/**
+		 * Windows Authentication
+		 */
+		Integrated = 'Integrated',
+		/**
+		 * Azure Active Directory - Universal with MFA support
+		 */
+		AzureMFA = 'AzureMFA',
+		/**
+		 * Azure Active Directory - Password
+		 */
+		AzureMFAAndUser = 'AzureMFAAndUser',
+		/**
+		 * Datacenter Security Token Service Authentication
+		 */
+		DSTSAuth = 'dstsAuth',
+		/**
+		 * No authentication required
+		 */
+		None = 'None'
+	}
 
 	/**
 	 * The possible values of the server engine edition

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -118,8 +118,64 @@ declare module 'vscode-mssql' {
 		/**
 		 * Get the server info for a connection
 		 * @param connectionInfo connection info of the connection
+		 * @returns server information
 		 */
 		getServerInfo(connectionInfo: IConnectionInfo): ServerInfo
+	}
+
+	/**
+	 * Information about a SQL Server instance.
+	 */
+	export interface ServerInfo {
+		/**
+		 * The major version of the SQL Server instance.
+		 */
+		serverMajorVersion: number;
+
+		/**
+		 * The minor version of the SQL Server instance.
+		 */
+		serverMinorVersion: number;
+
+		/**
+		 * The build of the SQL Server instance.
+		 */
+		serverReleaseVersion: number;
+
+		/**
+		 * The ID of the engine edition of the SQL Server instance.
+		 */
+		engineEditionId: number;
+
+		/**
+		 * String containing the full server version text.
+		 */
+		serverVersion: string;
+
+		/**
+		 * String describing the product level of the server.
+		 */
+		serverLevel: string;
+
+		/**
+		 * The edition of the SQL Server instance.
+		 */
+		serverEdition: string;
+
+		/**
+		 * Whether the SQL Server instance is running in the cloud (Azure) or not.
+		 */
+		isCloud: boolean;
+
+		/**
+		 * The version of Azure that the SQL Server instance is running on, if applicable.
+		 */
+		azureVersion: number;
+
+		/**
+		 * The Operating System version string of the machine running the SQL Server instance.
+		 */
+		osVersion: string;
 	}
 
 		/**
@@ -168,7 +224,6 @@ declare module 'vscode-mssql' {
 		SqlManagedInstance = 8,
 		SqlOnDemand = 11
 	}
-
 
 	/**
 	 * Information about a database connection
@@ -341,61 +396,6 @@ declare module 'vscode-mssql' {
 		 * Gets or sets the connection string to use for this connection.
 		 */
 		connectionString: string | undefined;
-	}
-
-	/**
-	 * Information about a SQL Server instance.
-	 */
-	export interface ServerInfo {
-		/**
-		 * The major version of the SQL Server instance.
-		 */
-		serverMajorVersion: number;
-
-		/**
-		 * The minor version of the SQL Server instance.
-		 */
-		serverMinorVersion: number;
-
-		/**
-		 * The build of the SQL Server instance.
-		 */
-		serverReleaseVersion: number;
-
-		/**
-		 * The ID of the engine edition of the SQL Server instance.
-		 */
-		engineEditionId: number;
-
-		/**
-		 * String containing the full server version text.
-		 */
-		serverVersion: string;
-
-		/**
-		 * String describing the product level of the server.
-		 */
-		serverLevel: string;
-
-		/**
-		 * The edition of the SQL Server instance.
-		 */
-		serverEdition: string;
-
-		/**
-		 * Whether the SQL Server instance is running in the cloud (Azure) or not.
-		 */
-		isCloud: boolean;
-
-		/**
-		 * The version of Azure that the SQL Server instance is running on, if applicable.
-		 */
-		azureVersion: number;
-
-		/**
-		 * The Operating System version string of the machine running the SQL Server instance.
-		 */
-		osVersion: string;
 	}
 
 	export const enum ExtractTarget {
@@ -672,6 +672,7 @@ declare module 'vscode-mssql' {
 		ownerUri: string;
 		extractTarget?: ExtractTarget;
 		taskExecutionMode: TaskExecutionMode;
+		includePermissions?: boolean;
 	}
 
 	export interface DeployParams {


### PR DESCRIPTION
I missed adding `includePermissions` to the `ExtractParams` interface in my last PR #20845. I also noticed a few differences between this vscode-mssql.d.ts and the [vscode-mssql.d.ts](https://github.com/microsoft/vscode-mssql/blob/main/typings/vscode-mssql.d.ts) in vscode-mssql extension repo, so fixing them here so the two files match. 