### PR TITLE
Fixing NVDA not announcing treeGrid collapse/expanded state.

### DIFF
--- a/src/sql/base/browser/ui/table/treeGrid.ts
+++ b/src/sql/base/browser/ui/table/treeGrid.ts
@@ -89,10 +89,13 @@ export class TreeGrid<T extends Slick.SlickData> extends Table<T> {
 				const rowElement = this._tableContainer.querySelector(`div [role="row"][aria-rowindex="${(i + 1)}"]`);
 				// If the row element is found in the dom, we are setting the required aria attributes for it.
 				if (rowElement) {
-					if (rowData.expanded !== undefined) {
-						rowElement.ariaExpanded = rowData.expanded;
-					} else {
-						rowElement.removeAttribute('aria-expanded');
+					const cellDiv = <HTMLElement>rowElement.querySelector(`.slick-cell.l0`);
+					if (cellDiv) {
+						if (rowData.expanded !== undefined) {
+							cellDiv.ariaExpanded = rowData.expanded;
+						} else {
+							cellDiv.removeAttribute('aria-expanded');
+						}
 					}
 					if (rowData.setSize !== undefined) {
 						rowElement.ariaSetSize = rowData.setSize;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
I used this guide to fix this issue: https://www.w3.org/WAI/ARIA/apg/example-index/treegrid/treegrid-1.html?cell=force

Since, we cannot select the rows in the grid, we have to add the aria-expanded attribute to the cell of the first column.


Issue: #20783
