### PR TITLE
Correctly route notebook serialization requests to SQL Tools Service.

### DIFF
--- a/src/sql/platform/serialization/common/serializationService.ts
+++ b/src/sql/platform/serialization/common/serializationService.ts
@@ -116,7 +116,7 @@ export class SerializationService implements ISerializationService {
 		}
 		try {
 			// Create a new session with the provider and send initial data
-			let provider = this.providers.find(provider => provider.providerId === serializationRequest.serializationProviderId).provider;
+			let provider = this.providers.find(provider => provider.providerId === serializationRequest.serializationProviderId)?.provider;
 			if (!provider) {
 				return <azdata.SerializeDataResult>{
 					messages: localize('missingSerializationProviderError', "Could not find a serialization provider with the specified ID '{0}'", serializationRequest.serializationProviderId),

--- a/src/sql/platform/serialization/common/serializationService.ts
+++ b/src/sql/platform/serialization/common/serializationService.ts
@@ -17,7 +17,10 @@ const saveAsNotSupported = localize('saveAsNotSupported', "Saving results into d
 const defaultBatchSize = 500;
 
 export interface SerializeDataParams {
-	serializationProviderId: string; // The serializer to use for this request. Typically this is the ID of the connection provider used to run the query.
+	/**
+	 *  The serializer to use for this request. Typically this is the ID of the connection provider used to run the query.
+	 */
+	serializationProviderId: string;
 	/**
 	 * 'csv', 'json', 'excel', 'xml'
 	 */

--- a/src/sql/platform/serialization/common/serializationService.ts
+++ b/src/sql/platform/serialization/common/serializationService.ts
@@ -17,7 +17,7 @@ const saveAsNotSupported = localize('saveAsNotSupported', "Saving results into d
 const defaultBatchSize = 500;
 
 export interface SerializeDataParams {
-	serializationProviderId: string;
+	serializationProviderId: string; // The serializer to use for this request. Typically this is the ID of the connection provider used to run the query.
 	/**
 	 * 'csv', 'json', 'excel', 'xml'
 	 */

--- a/src/sql/platform/serialization/common/serializationService.ts
+++ b/src/sql/platform/serialization/common/serializationService.ts
@@ -17,6 +17,7 @@ const saveAsNotSupported = localize('saveAsNotSupported', "Saving results into d
 const defaultBatchSize = 500;
 
 export interface SerializeDataParams {
+	serializationProviderId: string;
 	/**
 	 * 'csv', 'json', 'excel', 'xml'
 	 */
@@ -115,7 +116,13 @@ export class SerializationService implements ISerializationService {
 		}
 		try {
 			// Create a new session with the provider and send initial data
-			let provider = this.providers[0].provider;
+			let provider = this.providers.find(provider => provider.providerId === serializationRequest.serializationProviderId).provider;
+			if (!provider) {
+				return <azdata.SerializeDataResult>{
+					messages: localize('missingSerializationProviderError', "Could not find a serialization provider with the specified ID '{0}'", serializationRequest.serializationProviderId),
+					succeeded: false
+				};
+			}
 			let index = 0;
 			let startRequestParams = this.createStartRequest(serializationRequest, index);
 			index = index + startRequestParams.rows.length;

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -488,19 +488,11 @@ export class DataResourceDataProvider implements IGridDataProvider {
 		// interface than the query execution service's saveResults handlers. Here, we take the
 		// format-specific request params (eg, includeHeaders for CSV) and merge the format-agnostic
 		// request params for the serialization request (eg, saveFormat, filePath).
-		let providerId: string;
-		switch (this.cellModel.notebookModel.currentKernelAlias) {
-			case 'Kusto':
-			case 'LogAnalytics':
-				providerId = this.cellModel.notebookModel.currentKernelAlias.toUpperCase();
-				break;
-			default:
-				providerId = mssqlProviderName;
-				break;
-		}
+		let connProviders = this.cellModel.notebookModel.getApplicableConnectionProviderIds(this.cellModel.notebookModel.selectedKernelDisplayName);
+		let provider = connProviders?.length ? connProviders[0] : mssqlProviderName;
 		let formatSpecificParams = serializer.getBasicSaveParameters(format);
 		let formatAgnosticParams = <Partial<SerializeDataParams>>{
-			serializationProviderId: providerId,
+			serializationProviderId: provider,
 			saveFormat: format,
 			filePath: filePath.fsPath,
 			columns: columns,

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -488,7 +488,17 @@ export class DataResourceDataProvider implements IGridDataProvider {
 		// interface than the query execution service's saveResults handlers. Here, we take the
 		// format-specific request params (eg, includeHeaders for CSV) and merge the format-agnostic
 		// request params for the serialization request (eg, saveFormat, filePath).
-		let provider = this.cellModel.notebookModel.context?.providerName ?? mssqlProviderName;
+		let provider = this.cellModel.notebookModel.context?.providerName;
+		if (!provider) {
+			// If no connection currently exists, then pick the first connection provider for the current kernel.
+			// If there's still no provider, then fallback to the default MSSQL one.
+			let connProviders = this.cellModel.notebookModel.getApplicableConnectionProviderIds(this.cellModel.notebookModel.selectedKernelDisplayName);
+			if (connProviders?.length > 0) {
+				provider = connProviders[0];
+			} else {
+				provider = mssqlProviderName;
+			}
+		}
 		let formatSpecificParams = serializer.getBasicSaveParameters(format);
 		let formatAgnosticParams = <Partial<SerializeDataParams>>{
 			serializationProviderId: provider,

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -488,9 +488,19 @@ export class DataResourceDataProvider implements IGridDataProvider {
 		// interface than the query execution service's saveResults handlers. Here, we take the
 		// format-specific request params (eg, includeHeaders for CSV) and merge the format-agnostic
 		// request params for the serialization request (eg, saveFormat, filePath).
+		let providerId: string;
+		switch (this.cellModel.notebookModel.currentKernelAlias) {
+			case 'Kusto':
+			case 'LogAnalytics':
+				providerId = this.cellModel.notebookModel.currentKernelAlias.toUpperCase();
+				break;
+			default:
+				providerId = mssqlProviderName;
+				break;
+		}
 		let formatSpecificParams = serializer.getBasicSaveParameters(format);
 		let formatAgnosticParams = <Partial<SerializeDataParams>>{
-			serializationProviderId: mssqlProviderName,
+			serializationProviderId: providerId,
 			saveFormat: format,
 			filePath: filePath.fsPath,
 			columns: columns,

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -488,8 +488,7 @@ export class DataResourceDataProvider implements IGridDataProvider {
 		// interface than the query execution service's saveResults handlers. Here, we take the
 		// format-specific request params (eg, includeHeaders for CSV) and merge the format-agnostic
 		// request params for the serialization request (eg, saveFormat, filePath).
-		let connProviders = this.cellModel.notebookModel.getApplicableConnectionProviderIds(this.cellModel.notebookModel.selectedKernelDisplayName);
-		let provider = connProviders?.length ? connProviders[0] : mssqlProviderName;
+		let provider = this.cellModel.notebookModel.context?.providerName ?? mssqlProviderName;
 		let formatSpecificParams = serializer.getBasicSaveParameters(format);
 		let formatAgnosticParams = <Partial<SerializeDataParams>>{
 			serializationProviderId: provider,

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -48,6 +48,7 @@ import { getChartMaxRowCount, notifyMaxRowCountExceeded } from 'sql/workbench/co
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IExecutionPlanService } from 'sql/workbench/services/executionPlan/common/interfaces';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 @Component({
 	selector: GridOutputComponent.SELECTOR,
@@ -489,6 +490,7 @@ export class DataResourceDataProvider implements IGridDataProvider {
 		// request params for the serialization request (eg, saveFormat, filePath).
 		let formatSpecificParams = serializer.getBasicSaveParameters(format);
 		let formatAgnosticParams = <Partial<SerializeDataParams>>{
+			serializationProviderId: mssqlProviderName,
 			saveFormat: format,
 			filePath: filePath.fsPath,
 			columns: columns,

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -79,7 +79,7 @@ suite('Data Resource Data Provider', function () {
 		fileDialogService = new TestFileDialogService(pathService);
 		notificationService = new TestNotificationService();
 		serializationService = new SerializationService(undefined, undefined); //_connectionService _capabilitiesService
-		serializationService.registerProvider('testProviderId', new TestSerializationProvider());
+		serializationService.registerProvider('MSSQL', new TestSerializationProvider());
 		serializer = new ResultSerializer(
 			undefined, // IQueryManagementService
 			undefined, // IConfigurationService


### PR DESCRIPTION
When trying to convert query results into different file types, we were always picking the first registered serialization provider, which meant the request would get routed to the Kusto service rather than the SQL Tools one. This change routes that request to the right service, while also adding a new providerID field in case we want to use this serialization service for other file types in the future.

This PR fixes #20432
