### PR TITLE
additional variable for macOS arm64 jobs

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -51,6 +51,7 @@ stages:
           # Do not run tests for arm64 build
           RUN_TESTS: false
           RUN_SMOKE_TESTS: false
+        condition: and(succeeded(), eq(variables['VSCODE_BUILD_MACOS_ARM64'], 'true'))
         steps:
         - template: darwin/sql-product-build-darwin.yml
         timeoutInMinutes: 90
@@ -58,7 +59,7 @@ stages:
       - job: macOS_Signing_ARM64
         variables:
           VSCODE_ARCH: arm64
-        condition: and(succeeded(), eq(variables['signed'], true))
+        condition: and(succeeded(), eq(variables['signed'], true), eq(variables['VSCODE_BUILD_MACOS_ARM64'], 'true'))
         dependsOn:
         - macOS_ARM64
         steps:
@@ -72,6 +73,7 @@ stages:
           # Do not run tests for universal build
           RUN_TESTS: false
           RUN_SMOKE_TESTS: false
+        condition: and(succeeded(), eq(variables['VSCODE_BUILD_MACOS_ARM64'], 'true'))
         dependsOn:
         - macOS
         - macOS_ARM64
@@ -82,7 +84,7 @@ stages:
       - job: macOS_Signing_Universal
         variables:
           VSCODE_ARCH: universal
-        condition: and(succeeded(), eq(variables['signed'], true))
+        condition: and(succeeded(), eq(variables['signed'], true), eq(variables['VSCODE_BUILD_MACOS_ARM64'], 'true'))
         dependsOn:
         - macOS_Universal
         steps:

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -73,7 +73,6 @@ stages:
           # Do not run tests for universal build
           RUN_TESTS: false
           RUN_SMOKE_TESTS: false
-        condition: and(succeeded(), eq(variables['VSCODE_BUILD_MACOS_ARM64'], 'true'))
         dependsOn:
         - macOS
         - macOS_ARM64
@@ -84,7 +83,7 @@ stages:
       - job: macOS_Signing_Universal
         variables:
           VSCODE_ARCH: universal
-        condition: and(succeeded(), eq(variables['signed'], true), eq(variables['VSCODE_BUILD_MACOS_ARM64'], 'true'))
+        condition: and(succeeded(), eq(variables['signed'], true))
         dependsOn:
         - macOS_Universal
         steps:

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -59,7 +59,7 @@ stages:
       - job: macOS_Signing_ARM64
         variables:
           VSCODE_ARCH: arm64
-        condition: and(succeeded(), eq(variables['signed'], true), eq(variables['VSCODE_BUILD_MACOS_ARM64'], 'true'))
+        condition: and(succeeded(), eq(variables['signed'], true))
         dependsOn:
         - macOS_ARM64
         steps:


### PR DESCRIPTION
This will only be enabled on the official build pipeline so that other pipelines don't have to run these steps to save build time.
