### PR TITLE
hotfix: updating sql-migration version to 1.1.1 for insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.1.0",
-							"lastUpdated": "10/17/2022",
+							"version": "1.1.1",
+							"lastUpdated": "10/19/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.1.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.1.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
link to extension artifacts:
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=175590&view=artifacts&pathAsName=false&type=publishedArtifacts