### PR TITLE
Fix publish types CI task

### DIFF
--- a/build/azure-pipelines/publish-types/publish-types.yml
+++ b/build/azure-pipelines/publish-types/publish-types.yml
@@ -20,7 +20,7 @@ steps:
 
   # - bash: |
   #     TAG_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
-      CHANNEL="G1C14HJ2F"
+  #    CHANNEL="G1C14HJ2F"
 
   #     if [ "$TAG_VERSION" == "1.999.0" ]; then
   #       MESSAGE="<!here>. Someone pushed 1.999.0 tag. Please delete it ASAP from remote and local."


### PR DESCRIPTION
Typo in yaml causes failed CI task to publish types.