### PR TITLE
fix the server action icon's size issue

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/media/serverTreeActions.css
+++ b/src/sql/workbench/contrib/objectExplorer/browser/media/serverTreeActions.css
@@ -39,3 +39,11 @@
 .monaco-workbench.hc-black .actions-container .action-label.server-page {
 	background-image: url('server_page_inverse.svg') !important;
 }
+
+/* styles for action labels - without these, the buttons for the Servers view will not be sized correctly */
+.monaco-pane-view .pane > .pane-header > .actions .action-label.icon,
+.monaco-pane-view .pane > .pane-header > .actions .action-label.codicon {
+	background-size: 16px;
+	background-position: center center;
+	background-repeat: no-repeat;
+}

--- a/src/vs/base/browser/ui/splitview/paneview.css
+++ b/src/vs/base/browser/ui/splitview/paneview.css
@@ -52,6 +52,14 @@
 	margin-left: auto;
 }
 
+/* {{SQL CARBON EDIT}} Bring back styles for action labels - ours aren't sized correctly without these */
+.monaco-pane-view .pane > .pane-header > .actions .action-label.icon,
+.monaco-pane-view .pane > .pane-header > .actions .action-label.codicon {
+	background-size: 16px;
+	background-position: center center;
+	background-repeat: no-repeat;
+}
+
 .monaco-pane-view .pane > .pane-header > .actions .action-item {
 	margin-right: 4px;
 }

--- a/src/vs/base/browser/ui/splitview/paneview.css
+++ b/src/vs/base/browser/ui/splitview/paneview.css
@@ -52,14 +52,6 @@
 	margin-left: auto;
 }
 
-/* {{SQL CARBON EDIT}} Bring back styles for action labels - ours aren't sized correctly without these */
-.monaco-pane-view .pane > .pane-header > .actions .action-label.icon,
-.monaco-pane-view .pane > .pane-header > .actions .action-label.codicon {
-	background-size: 16px;
-	background-position: center center;
-	background-repeat: no-repeat;
-}
-
 .monaco-pane-view .pane > .pane-header > .actions .action-item {
 	margin-right: 4px;
 }


### PR DESCRIPTION
This PR fixes #20886 

this block of {{SQL CARBON EDIT}} code change was deleted during the merge, bring it back.

with the fix:
![image](https://user-images.githubusercontent.com/13777222/197081997-500963ee-177f-4adc-846c-aced86aec0d8.png)
