### PR TITLE
Fix Edit Connection behavior that affects multiple areas working with edited connection

### DIFF
--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -93,8 +93,6 @@ export class ConnectionConfig {
 				});
 				if (sameProfileInList) {
 					let profileIndex = profiles.findIndex(value => value === sameProfileInList);
-					newProfile.id = sameProfileInList.id;
-					connectionProfile.id = sameProfileInList.id;
 					profiles[profileIndex] = newProfile;
 				} else {
 					profiles.push(newProfile);

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -325,9 +325,8 @@ suite('ConnectionConfig', () => {
 		connectionProfile.options['databaseDisplayName'] = existingConnection.options['databaseName'];
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
-		let savedConnectionProfile = await config.addConnection(connectionProfile);
+		await config.addConnection(connectionProfile);
 
-		assert.strictEqual(savedConnectionProfile.id, existingConnection.id);
 		assert.strictEqual(configurationService.inspect<IConnectionProfileStore[]>('datasource.connections').userValue!.length, testConnections.length);
 	});
 

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -177,11 +177,6 @@ export class ConnectionDialogService implements IConnectionDialogService {
 					return;
 				}
 				profile = result.connection;
-
-				if (params.oldProfileId && params.isEditConnection) {
-					profile.id = params.oldProfileId;
-				}
-
 				profile.serverName = trim(profile.serverName);
 
 				// append the port to the server name for SQL Server connections

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -498,17 +498,13 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				// a connection management info. See https://github.com/microsoft/azuredatastudio/issues/16556
 				this.tryAddActiveConnection(connectionMgmtInfo, connection, options.saveTheConnection);
 
-
-
 				if (callbacks.onConnectSuccess) {
 					callbacks.onConnectSuccess(options.params, connectionResult.connectionProfile);
 				}
 				if (options.saveTheConnection || isEdit) {
 					let matcher: interfaces.ProfileMatcher;
 					if (isEdit) {
-						matcher = (a: interfaces.IConnectionProfile, b: interfaces.IConnectionProfile) => {
-							return a.id === b.id;
-						};
+						matcher = (a: interfaces.IConnectionProfile, b: interfaces.IConnectionProfile) => a.id === options.params.oldProfileId;
 					}
 
 					await this.saveToSettings(uri, connection, matcher).then(value => {

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
@@ -70,6 +70,7 @@ export class ServerTreeActionProvider {
 	 */
 	private getConnectionActions(tree: AsyncServerTree | ITree, profile: ConnectionProfile): IAction[] {
 		let node = new TreeNode(NodeType.Server, NodeType.Server, '', false, '', '', '', undefined, undefined, undefined, undefined);
+		this._connectionManagementService.addSavedPassword(profile);
 		node.connection = profile;
 		return this.getAllActions({
 			tree: tree,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #18736, #10424

### Current behavior

1. Editing a connection does not load saved password as the profile loaded via context menu does not populate it.
2. The current design of 'Edit Connection' used the same OLD profile id and assigned it to the new connection profile, so it could refresh the same connection in Server tab. But doing so led to Connection profile manager having to maintain MULTIPLE different connection profiles with same IDs, which is a design flaw as ID needs to be unique among connection profiles. This further led to OE and Extensions and many more code paths picking up wrong connections often if they simply used ID for identification.

### What changed?

1. Added 1 line change to add saved password when loading saved connection profile in context menu.
2. The fix now uses Old profile ID to match with the existing profile ID when adding updated connection to the list. 

### How was it verified?

This change is verifiable with OE and Dashboard > Assessment > Run a New Assessment. Current behavior is that editing a connection does not load saved password and when once edited, the new connection continues to load database list from old connection, and with the fix we see expected behaviors.