### PR TITLE
add hostname in profiler

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profiler.contribution.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profiler.contribution.ts
@@ -95,6 +95,10 @@ const profilerViewTemplateSchema: IJSONSchema = {
 				{
 					name: 'DatabaseName',
 					eventsMapped: ['database_name']
+				},
+				{
+					name: 'HostName',
+					eventsMapped: ['client_hostname']
 				}
 			]
 		},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes # https://github.com/microsoft/azuredatastudio/issues/20908

It allows the profiler to extract the host name and display in the window