### PR TITLE
Fix module load issue in azurecore

### DIFF
--- a/extensions/azurecore/extension.webpack.config.js
+++ b/extensions/azurecore/extension.webpack.config.js
@@ -16,6 +16,7 @@ const externals = {
 	'bufferutil': 'commonjs bufferutil',
 	'utf-8-validate': 'commonjs utf-8-validate',
 	'keytar': 'commonjs keytar',
+	'universalify': 'commonjs universalify',
 	'@azure/arm-subscriptions': 'commonjs @azure/arm-subscriptions',
 	'@azure/arm-resourcegraph': 'commonjs @azure/arm-resourcegraph',
 	'@azure/storage-blob': 'commonjs @azure/storage-blob'


### PR DESCRIPTION
The `universalify` package needs to be webpacked for bundled builds.