### PR TITLE
Add column-aligner-ads

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4816,6 +4816,67 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+{
+					"extensionId": "94",
+					"extensionName": "column-aligner-ads",
+					"displayName": "Column Aligner",
+					"shortDescription": "This extension provides a shortcut key to consistently align the selected rows to the nearest tabstop",
+					"publisher": {
+						"displayName": "Richard Tallent",
+						"publisherId": "RichardTallentVS",
+						"publisherName": "Richard Tallent"
+					},
+					"versions": [
+						{
+							"version": "1.0.0",
+							"lastUpdated": "10/23/2022",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.SQLOps.DownloadPage",
+									"source": "https://tallent.us/column-aligner-ads/column-aligner-ads-1.0.0.vsix"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/CHANGELOG.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/LICENSE"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": ">=1.62.0"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/richardtallent/column-aligner-ads"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": ""
 				}
 			],
 			"resultMetadata": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4839,6 +4839,10 @@
 									"source": "https://github.com/richardtallent/column-aligner/releases/tag/v1.0.0"
 								},
 								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/images/icon.png"
+								},
+								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
 									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/README.md"
 								},

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4836,7 +4836,7 @@
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://tallent.us/column-aligner-ads/column-aligner-ads-1.0.0.vsix"
+									"source": "https://github.com/richardtallent/column-aligner/releases/tag/v1.0.0"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4885,7 +4885,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 79
+							"count": 80
 						}
 					]
 				}

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4775,7 +4775,7 @@
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://tallent.us/column-aligner-ads/column-aligner-ads-1.0.0.vsix"
+									"source": "https://github.com/richardtallent/column-aligner/releases/tag/v1.0.0"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4778,6 +4778,10 @@
 									"source": "https://github.com/richardtallent/column-aligner/releases/tag/v1.0.0"
 								},
 								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/images/icon.png"
+								},
+								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
 									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/README.md"
 								},

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4801,7 +4801,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.39.0"
+									"value": ">=1.62.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4757,7 +4757,7 @@
 					"flags": "preview"
 				},
 				{
-					"extensionId": "93",
+					"extensionId": "94",
 					"extensionName": "column-aligner-ads",
 					"displayName": "Column Aligner",
 					"shortDescription": "This extension provides a shortcut key to consistently align the selected rows to the nearest tabstop",
@@ -4774,12 +4774,8 @@
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"assetType": "Microsoft.SQLOps.DownloadPage",
 									"source": "https://tallent.us/column-aligner-ads/column-aligner-ads-1.0.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Azure/azure-cosmosdb-ads-extension/main/resources/catalog/CosmosDBExtension.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4755,6 +4755,71 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+				{
+					"extensionId": "93",
+					"extensionName": "column-aligner-ads",
+					"displayName": "Column Aligner",
+					"shortDescription": "This extension provides a shortcut key to consistently align the selected rows to the nearest tabstop",
+					"publisher": {
+						"displayName": "Richard Tallent",
+						"publisherId": "RichardTallentVS",
+						"publisherName": "Richard Tallent"
+					},
+					"versions": [
+						{
+							"version": "1.0.0",
+							"lastUpdated": "10/23/2022",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"source": "https://tallent.us/column-aligner-ads/column-aligner-ads-1.0.0.vsix"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/Azure/azure-cosmosdb-ads-extension/main/resources/catalog/CosmosDBExtension.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/CHANGELOG.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/richardtallent/column-aligner-ads/main/LICENSE"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": ">=1.39.0"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/Azure/azure-cosmosdb-ads-extension"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": ""
 				}
 			],
 			"resultMetadata": [
@@ -4763,7 +4828,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 78
+							"count": 79
 						}
 					]
 				}


### PR DESCRIPTION
Added a new little extension I initially developed for VS Code, but it's equally (or even more) useful in ADS, so I made an ADS version as well. (I goofed up and accidentally added an icon for this due to copy/paste error, but can't edit it here since I used GitHub's direct-edit. Sent a different PR for fix that.)

This PR fixes #20936
