### PR TITLE
fix designer grid sizing issue

### DIFF
--- a/src/sql/workbench/browser/designer/media/designer.css
+++ b/src/sql/workbench/browser/designer/media/designer.css
@@ -92,7 +92,7 @@
 .designer-component .components-grid {
 	display: grid;
 	/* grid-template-columns: column 1 is for label, column 2 is for component.*/
-	grid-template-columns: max-content auto;
+	grid-template-columns: max-content 1fr;
 	grid-template-rows: max-content;
 	grid-gap: 5px;
 	padding: 5px;


### PR DESCRIPTION
This PR fixes #20925 

There are some changes between Chromium 91 and 98 in sizing calculation for CSS grid layout. after reviewing all the options, according to https://www.w3.org/TR/css-grid-1/#fr-unit, I found that using '1fr' is the correct value for what we want: 1st column takes whatever it needs, and 2nd column takes the rest. 

before: 
![image](https://user-images.githubusercontent.com/13777222/197318830-d0de43dd-ef88-4a00-a577-3c65d61a0ede.png)

after:
![image](https://user-images.githubusercontent.com/13777222/197581549-60274dca-0f34-4286-9849-45c6ce0d2ad4.png)
