### PR TITLE
Fix disabled state for debug toolbar icons (#149172)

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -54,7 +54,7 @@
 .monaco-action-bar .action-item.disabled .action-label,
 .monaco-action-bar .action-item.disabled .action-label::before,
 .monaco-action-bar .action-item.disabled .action-label:hover {
-	color: var(--vscode-disabledForeground);
+	opacity: 0.6;
 }
 
 /* Vertical actions */


### PR DESCRIPTION
This PR fixes #20941

This issue has been fixed in vscode, cherry-pick the commit to ADS, original PR: https://github.com/microsoft/vscode/pull/149172

before:
![image](https://user-images.githubusercontent.com/13777222/197589950-6927ab07-b413-49c1-9a70-80ab278f372f.png)
![image](https://user-images.githubusercontent.com/13777222/197590181-63894d97-fd5f-44d5-a679-76f00ccc87cc.png)
after:
![image](https://user-images.githubusercontent.com/13777222/197590435-14786947-3d51-454a-8699-9ff6862105c6.png)
![image](https://user-images.githubusercontent.com/13777222/197590607-01e09afc-fc60-4ab0-917d-df7fa9afb002.png)
