### PR TITLE
ModeService to LanguageService var names

### DIFF
--- a/src/sql/workbench/browser/editor/profiler/dashboardInput.ts
+++ b/src/sql/workbench/browser/editor/profiler/dashboardInput.ts
@@ -35,7 +35,7 @@ export class DashboardInput extends EditorInput {
 	constructor(
 		_connectionProfile: IConnectionProfile,
 		@IConnectionManagementService private _connectionService: IConnectionManagementService,
-		@ILanguageService modeService: ILanguageService,
+		@ILanguageService languageService: ILanguageService,
 		@IModelService model: IModelService
 	) {
 		super();
@@ -47,7 +47,7 @@ export class DashboardInput extends EditorInput {
 		// vscode has a comment that Mode's will eventually be removed (not sure the state of this comment)
 		// so this might be able to be undone when that happens
 		if (!model.getModel(this.resource)) {
-			model.createModel('', modeService.createById('dashboard'), this.resource);
+			model.createModel('', languageService.createById('dashboard'), this.resource);
 		}
 		this._initializedPromise = _connectionService.connectIfNotConnected(_connectionProfile, 'dashboard').then(
 			u => {

--- a/src/sql/workbench/browser/modelComponents/editor.component.ts
+++ b/src/sql/workbench/browser/modelComponents/editor.component.ts
@@ -48,7 +48,7 @@ export default class EditorComponent extends ComponentBase<azdata.EditorProperti
 		@Inject(forwardRef(() => ElementRef)) el: ElementRef,
 		@Inject(IInstantiationService) private _instantiationService: IInstantiationService,
 		@Inject(IModelService) private _modelService: IModelService,
-		@Inject(ILanguageService) private _modeService: ILanguageService,
+		@Inject(ILanguageService) private _languageService: ILanguageService,
 		@Inject(ILogService) private _logService: ILogService,
 		@Inject(IEditorService) private readonly editorService: IEditorService,
 		@Inject(ILogService) logService: ILogService
@@ -141,7 +141,7 @@ export default class EditorComponent extends ComponentBase<azdata.EditorProperti
 	private updateLanguageMode() {
 		if (this._editorModel && this._editor) {
 			this._languageMode = this.languageMode;
-			let languageSelection = this._modeService.createById(this._languageMode);
+			let languageSelection = this._languageService.createById(this._languageMode);
 			this._modelService.setMode(this._editorModel, languageSelection);
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -104,7 +104,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService,
 		@Inject(IInstantiationService) private _instantiationService: IInstantiationService,
 		@Inject(IModelService) private _modelService: IModelService,
-		@Inject(ILanguageService) private _modeService: ILanguageService,
+		@Inject(ILanguageService) private _languageService: ILanguageService,
 		@Inject(IConfigurationService) private _configurationService: IConfigurationService,
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
 		@Inject(ILogService) private readonly logService: ILogService,
@@ -407,7 +407,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 
 	private updateLanguageMode(): void {
 		if (this._editorModel && this._editor) {
-			let modeValue = this._modeService.createById(this.cellModel.language);
+			let modeValue = this._languageService.createById(this.cellModel.language);
 			this._modelService.setMode(this._editorModel, modeValue);
 		}
 	}
@@ -490,10 +490,10 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 				description = localize('cellLanguageDescriptionConfigured', "({0})", lang);
 			}
 
-			const languageName = this._modeService.getLanguageName(lang) ?? lang;
+			const languageName = this._languageService.getLanguageName(lang) ?? lang;
 			const item = <ILanguagePickInput>{
 				label: languageName,
-				iconClasses: getIconClasses(this._modelService, this._modeService, this.getFakeResource(languageName, this._modeService)),
+				iconClasses: getIconClasses(this._modelService, this._languageService, this.getFakeResource(languageName, this._languageService)),
 				description,
 				languageId: lang
 			};
@@ -519,14 +519,14 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 	/**
 	 * Copied from coreActions.ts
 	 */
-	private getFakeResource(lang: string, modeService: ILanguageService): URI | undefined {
+	private getFakeResource(lang: string, languageService: ILanguageService): URI | undefined {
 		let fakeResource: URI | undefined;
 
-		const extensions = modeService.getExtensions(lang);
+		const extensions = languageService.getExtensions(lang);
 		if (extensions?.length) {
 			fakeResource = URI.file(extensions[0]);
 		} else {
-			const filenames = modeService.getFilenames(lang);
+			const filenames = languageService.getFilenames(lang);
 			if (filenames?.length) {
 				fakeResource = URI.file(filenames[0]);
 			}

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookEditorFactory.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookEditorFactory.ts
@@ -24,7 +24,7 @@ const editorFactoryRegistry = Registry.as<IEditorFactoryRegistry>(EditorExtensio
 export class NotebookEditorLanguageAssociation implements ILanguageAssociation {
 	/**
 	 * The language IDs that are associated with Notebooks. These are case sensitive for comparing with what's
-	 * registered in the ModeService registry.
+	 * registered in the LanguageService registry.
 	 */
 	static readonly languages = [NotebookLanguage.Notebook, NotebookLanguage.Ipynb];
 

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -740,13 +740,13 @@ export class NotebookEditorOverrideContribution extends Disposable implements IW
 		@ILogService private _logService: ILogService,
 		@IEditorService private _editorService: IEditorService,
 		@IEditorResolverService private _editorResolverService: IEditorResolverService,
-		@ILanguageService private _modeService: ILanguageService
+		@ILanguageService private _languageService: ILanguageService
 	) {
 		super();
 		this.registerEditorOverrides();
 		// Refresh the editor overrides whenever the languages change so we ensure we always have
 		// the latest up to date list of extensions for each language
-		this._modeService.onDidChange(() => {
+		this._languageService.onDidChange(() => {
 			this.registerEditorOverrides();
 		});
 		notebookRegistry.onNewDescriptionRegistration(({ id, registration }) => {
@@ -765,7 +765,7 @@ export class NotebookEditorOverrideContribution extends Disposable implements IW
 
 		// List of built-in language IDs to associate the query editor for. These are case sensitive.
 		NotebookEditorLanguageAssociation.languages.forEach(lang => {
-			const langExtensions = this._modeService.getExtensions(lang);
+			const langExtensions = this._languageService.getExtensions(lang);
 			allExtensions = allExtensions.concat(langExtensions);
 		});
 

--- a/src/sql/workbench/contrib/notebook/test/browser/markdownTextTransformer.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/markdownTextTransformer.test.ts
@@ -94,7 +94,7 @@ suite.skip('MarkdownTextTransformer', () => {
 			onDidChange: (_a: any) => { }
 		};
 
-		let modeService: any = {
+		let languageService: any = {
 			languageIdCodec: {
 				encodeLanguageId: (languageId: string) => { return <LanguageId>undefined; },
 				decodeLanguageId: (languageId: LanguageId) => { return <string>undefined; }
@@ -106,7 +106,7 @@ suite.skip('MarkdownTextTransformer', () => {
 				isForSimpleWidget: true, defaultEOL: DefaultEndOfLine.LF, detectIndentation: true,
 				indentSize: 0, insertSpaces: false, largeFileOptimizations: false, tabSize: 4, trimAutoWhitespace: false,
 				bracketPairColorizationOptions: { independentColorPoolPerBracketType: false, enabled: true }
-			}, undefined, undoRedoService, modeService,
+			}, undefined, undoRedoService, languageService,
 			languageConfigurationService);
 
 		// Couple widget with newly created text model

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -541,13 +541,13 @@ export class QueryEditorOverrideContribution extends Disposable implements IWork
 		@ILogService private _logService: ILogService,
 		@IEditorService private _editorService: IEditorService,
 		@IEditorResolverService private _editorResolverService: IEditorResolverService,
-		@ILanguageService private _modeService: ILanguageService
+		@ILanguageService private _languageService: ILanguageService
 	) {
 		super();
 		this.registerEditorOverrides();
 		// Refresh the editor overrides whenever the languages change so we ensure we always have
 		// the latest up to date list of extensions for each language
-		this._modeService.onDidChange(() => {
+		this._languageService.onDidChange(() => {
 			this.registerEditorOverrides();
 		});
 	}
@@ -556,7 +556,7 @@ export class QueryEditorOverrideContribution extends Disposable implements IWork
 		this._registeredOverrides.clear();
 		// List of language IDs to associate the query editor for. These are case sensitive.
 		QueryEditorLanguageAssociation.languages.map(lang => {
-			const langExtensions = this._modeService.getExtensions(lang);
+			const langExtensions = this._languageService.getExtensions(lang);
 			if (langExtensions.length === 0) {
 				return;
 			}

--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -112,7 +112,7 @@ export class QueryEditor extends EditorPane {
 		@IEditorService private readonly editorService: IEditorService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@ILanguageService private readonly modeService: ILanguageService,
+		@ILanguageService private readonly languageService: ILanguageService,
 		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
 		@ICapabilitiesService private readonly capabilitiesService: ICapabilitiesService
 	) {
@@ -312,10 +312,10 @@ export class QueryEditor extends EditorPane {
 
 		// TODO: Allow query provider to provide the language mode.
 		if (this.input instanceof UntitledQueryEditorInput) {
-			if ((providerId === 'KUSTO') || this.modeService.getExtensions('Kusto').indexOf(fileExtension) > -1) {
+			if ((providerId === 'KUSTO') || this.languageService.getExtensions('Kusto').indexOf(fileExtension) > -1) {
 				this.input.setMode('kusto');
 			}
-			else if (providerId === 'LOGANALYTICS' || this.modeService.getExtensions('LogAnalytics').indexOf(fileExtension) > -1) {
+			else if (providerId === 'LOGANALYTICS' || this.languageService.getExtensions('LogAnalytics').indexOf(fileExtension) > -1) {
 				this.input.setMode('loganalytics');
 			}
 		}

--- a/src/sql/workbench/contrib/query/browser/queryEditorFactory.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditorFactory.ts
@@ -31,7 +31,7 @@ export class QueryEditorLanguageAssociation implements ILanguageAssociation {
 	static readonly isDefault = true;
 	/**
 	 * The language IDs that are associated with the query editor. These are case sensitive for comparing with what's
-	 * registered in the ModeService registry.
+	 * registered in the LanguageService registry.
 	 */
 	static readonly languages = ['kusto', 'loganalytics', 'sql'];	//TODO Add language id here for new languages supported in query editor. Make it easier to contribute new extension's languageID
 

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -102,7 +102,7 @@ export class CellModel extends Disposable implements ICellModel {
 		@ICommandService private _commandService?: ICommandService,
 		@IConfigurationService private _configurationService?: IConfigurationService,
 		@ILogService private _logService?: ILogService,
-		@ILanguageService private _modeService?: ILanguageService
+		@ILanguageService private _languageService?: ILanguageService
 	) {
 		super();
 		this.id = `${modelId++}`;
@@ -414,8 +414,8 @@ export class CellModel extends Disposable implements ICellModel {
 		let result: string;
 		if (this._cellType === CellTypes.Markdown) {
 			result = 'Markdown';
-		} else if (this._modeService) {
-			let language = this._modeService.getLanguageName(this.language);
+		} else if (this._languageService) {
+			let language = this._languageService.getLanguageName(this.language);
 			result = language ?? this.language;
 		} else {
 			result = this.language;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -138,7 +138,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		@IUndoRedoService private undoService: IUndoRedoService,
 		@INotebookService private _notebookService: INotebookService,
 		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService,
-		@ILanguageService private _modeService: ILanguageService,
+		@ILanguageService private _languageService: ILanguageService,
 	) {
 		super();
 		if (!_notebookOptions || !_notebookOptions.notebookUri || !_notebookOptions.executeManagers) {
@@ -165,8 +165,8 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		if (!fileExt) {
 			let languageMode = this._notebookOptions.getInputLanguageMode();
 			if (languageMode) {
-				let languageName = this._modeService.getLanguageName(languageMode);
-				let fileExtensions = this._modeService.getExtensions(languageName);
+				let languageName = this._languageService.getLanguageName(languageMode);
+				let fileExtensions = this._languageService.getExtensions(languageName);
 				if (fileExtensions?.length > 0) {
 					extensions = fileExtensions;
 				} else {


### PR DESCRIPTION
Cleanup - this service changed from `ModeService` to `LanguageService` in the last VS Code merge - just updating the var names to match. I'll be following up with doing a separate PR to clean up any outdated references to mode (it's now languageID). 