### PR TITLE
Notebook cleanup

### DIFF
--- a/src/sql/workbench/common/constants.ts
+++ b/src/sql/workbench/common/constants.ts
@@ -41,8 +41,6 @@ export const RESOURCE_VIEWER_TYPEID = 'workbench.editorInput.resourceViewerInput
 export const JUPYTER_PROVIDER_ID = 'jupyter';
 export const IPYKERNEL_DISPLAY_NAME = 'Python 3 (ipykernel)';
 export const INTERACTIVE_PROVIDER_ID = 'dotnet-interactive';
-export const INTERACTIVE_LANGUAGE_MODE = 'dib';
-export const DEFAULT_NB_LANGUAGE_MODE = 'notebook';
 export const TSGOPS_WEB_QUALITY = 'tsgops-image';
 export const CELL_URI_PATH_PREFIX = 'notebook-editor-';
 
@@ -52,7 +50,8 @@ export const NBFORMAT_MINOR = 2;
 
 export const enum NotebookLanguage {
 	Notebook = 'notebook',
-	Ipynb = 'ipynb'
+	Ipynb = 'ipynb',
+	Interactive = 'dib'
 }
 export interface INotebookSearchConfigurationProperties {
 	exclude: glob.IExpression;

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -458,11 +458,11 @@ export abstract class NotebookInput extends EditorInput implements INotebookInpu
 
 	private async assignProviders(): Promise<void> {
 		await this.extensionService.whenInstalledExtensionsRegistered();
-		let mode: string;
+		let languageId: string | undefined = undefined;
 		if (this._textInput instanceof UntitledTextEditorInput) {
-			mode = this._textInput.model.getLanguageId();
+			languageId = this._textInput.model.getLanguageId();
 		}
-		let providerIds: string[] = getProvidersForFileName(this._title, this.notebookService, mode);
+		let providerIds: string[] = getProvidersForFileName(this._title, this.notebookService, languageId);
 		if (providerIds && providerIds.length > 0) {
 			this._providerId = providerIds.filter(provider => provider !== DEFAULT_NOTEBOOK_PROVIDER)[0];
 			this._providers = providerIds;

--- a/src/sql/workbench/services/notebook/browser/models/notebookUtils.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookUtils.ts
@@ -7,7 +7,7 @@ import * as path from 'vs/base/common/path';
 import { nb, ServerInfo } from 'azdata';
 import { DEFAULT_NOTEBOOK_PROVIDER, DEFAULT_NOTEBOOK_FILETYPE, INotebookService, SQL_NOTEBOOK_PROVIDER } from 'sql/workbench/services/notebook/browser/notebookService';
 import { URI } from 'vs/base/common/uri';
-import { DEFAULT_NB_LANGUAGE_MODE } from 'sql/workbench/common/constants';
+import { NotebookLanguage } from 'sql/workbench/common/constants';
 
 export const clusterEndpointsProperty = 'clusterEndpoints';
 export const hadoopEndpointNameGateway = 'gateway';
@@ -18,10 +18,10 @@ export function isStream(output: nb.ICellOutput): output is nb.IStreamResult {
 	return output.output_type === 'stream';
 }
 
-export function getProvidersForFileName(fileName: string, notebookService: INotebookService, languageMode?: string): string[] {
+export function getProvidersForFileName(fileName: string, notebookService: INotebookService, languageId?: string): string[] {
 	let fileExt = path.extname(fileName);
-	if (!fileExt && languageMode && languageMode !== DEFAULT_NB_LANGUAGE_MODE) {
-		fileExt = `.${languageMode}`;
+	if (!fileExt && languageId && languageId !== NotebookLanguage.Notebook) {
+		fileExt = `.${languageId}`;
 	}
 	let providers: string[];
 	// First try to get provider for actual file type

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -47,10 +47,10 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { IExistingUntitledTextEditorOptions, INewUntitledTextEditorWithAssociatedResourceOptions, IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 
-import { IEditorPane } from 'vs/workbench/common/editor';
+import { IEditorPane, IUntypedFileEditorInput } from 'vs/workbench/common/editor';
 import { isINotebookInput } from 'sql/workbench/services/notebook/browser/interface';
 import { INotebookShowOptions } from 'sql/workbench/api/common/sqlExtHost.protocol';
-import { DEFAULT_NB_LANGUAGE_MODE, INTERACTIVE_LANGUAGE_MODE, INTERACTIVE_PROVIDER_ID, NotebookLanguage } from 'sql/workbench/common/constants';
+import { INTERACTIVE_PROVIDER_ID, NotebookLanguage } from 'sql/workbench/common/constants';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { SqlSerializationProvider } from 'sql/workbench/services/notebook/browser/sql/sqlSerializationProvider';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
@@ -292,7 +292,7 @@ export class NotebookService extends Disposable implements INotebookService {
 		let isUntitled: boolean = uri.scheme === Schemas.untitled;
 
 		let fileInput: EditorInput;
-		let languageMode = options.providerId === INTERACTIVE_PROVIDER_ID ? INTERACTIVE_LANGUAGE_MODE : DEFAULT_NB_LANGUAGE_MODE;
+		let languageId = options.providerId === INTERACTIVE_PROVIDER_ID ? NotebookLanguage.Interactive : NotebookLanguage.Notebook;
 		let initialStringContents: string;
 		if (options.initialContent) {
 			if (typeof options.initialContent === 'string') {
@@ -303,14 +303,24 @@ export class NotebookService extends Disposable implements INotebookService {
 			}
 		}
 		if (isUntitled && path.isAbsolute(uri.fsPath)) {
-			const model = this._untitledEditorService.create(<INewUntitledTextEditorWithAssociatedResourceOptions>{ associatedResource: uri, languageId: languageMode, initialValue: initialStringContents });
+			const options: INewUntitledTextEditorWithAssociatedResourceOptions = {
+				associatedResource: uri,
+				languageId,
+				initialValue: initialStringContents
+			}
+			const model = this._untitledEditorService.create(options);
 			fileInput = this._instantiationService.createInstance(UntitledTextEditorInput, model);
 		} else {
 			if (isUntitled) {
-				const model = this._untitledEditorService.create(<IExistingUntitledTextEditorOptions>{ untitledResource: uri, languageId: languageMode, initialValue: initialStringContents });
+				const options: IExistingUntitledTextEditorOptions = {
+					untitledResource: uri,
+					languageId,
+					initialValue: initialStringContents
+				}
+				const model = this._untitledEditorService.create(options);
 				fileInput = this._instantiationService.createInstance(UntitledTextEditorInput, model);
 			} else {
-				let input: any = { forceFile: true, resource: uri, languageId: languageMode };
+				let input: IUntypedFileEditorInput = { forceFile: true, resource: uri, languageId };
 				fileInput = await this._editorService.createEditorInput(input);
 			}
 		}


### PR DESCRIPTION
1. Make typed vars for create calls. This was something broken in the merge (fixed by https://github.com/microsoft/azuredatastudio/pull/20938) because the name of the option changed but passing in an object like this currently doesn't cause a compilation error when there's unknown property names specified (there's a feature coming in TS 4.9 that will add support for that though - `satisfies`). Moving it out like this will make sure this doesn't happen again in the future
2. Rename a few things from mode to languageId
