### PR TITLE
Restore the SQL Server 2019 notebook download

### DIFF
--- a/product.json
+++ b/product.json
@@ -92,5 +92,11 @@
 		"serviceUrl": "https://sqlopsextensions.blob.core.windows.net/marketplace/v1/extensionsGallery.json"
 	},
 	"builtInExtensions": [
+		{
+			"version": "1.61.0",
+			"name": "Microsoft.sqlservernotebook",
+			"version": "0.5.0",
+			"repo": "https://github.com/microsoft/azuredatastudio"
+		}
 	]
 }


### PR DESCRIPTION
This restores the SQL 19 notebook download related to https://github.com/microsoft/azuredatastudio/issues/20947.  The custom gulp task was failing with latest build lib updates from vscode merge.
