### PR TITLE
Bump STS to v4.3.0.42

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.3.0.39",
+	"version": "4.3.0.42",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
Brings below changes over v4.3.0.39:
- Update Microsoft.Data.SqlClient to v5.0.1 ([microsoft/sqltoolservice#1708](https://github.com/microsoft/sqltoolsservice/pull/1708))
- Update parser & autocomplete list ([microsoft/sqltoolservice#1729](https://github.com/microsoft/sqltoolsservice/pull/1729))
- Update packages validation comment action ([microsoft/sqltoolservice#1730](https://github.com/microsoft/sqltoolsservice/pull/1730))
- Fix schema comparing empty project showing more differences than expected ([microsoft/sqltoolservice#1727](https://github.com/microsoft/sqltoolsservice/pull/1727))
- Make SerializeDataStartRequestParams properties public so they can be populated properly wehn deserializing the RPC request. ([microsoft/sqltoolservice#1726](https://github.com/microsoft/sqltoolsservice/pull/1726))


![image](https://user-images.githubusercontent.com/13396919/197834190-45396061-2cb1-4916-9d3f-cfb51a116d1f.png)
