### PR TITLE
Remove unstable test step from win32 product build

### DIFF
--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -154,14 +154,6 @@ steps:
   #   displayName: Run integration tests (Electron)
   #   condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
-  - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
-      $ErrorActionPreference = "Stop"
-      exec { .\scripts\test-unstable.bat --build --tfs }
-    continueOnError: true
-    condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
-    displayName: Run unstable tests
-
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'Sign out code'
     inputs:


### PR DESCRIPTION
Per discussion, removing unstable test step from `sql-product-build-win32.yml`