### PR TITLE
Update Jupyter extension in insiders to version 2022.4.1021342353

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4581,14 +4581,14 @@
 					},
 					"versions": [
 						{
-							"version": "2021.8.1046824664",
-							"lastUpdated": "3/30/2022",
+							"version": "2022.4.1021342353",
+							"lastUpdated": "10/26/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/jupyter/ms-toolsai.jupyter-2021.8.1046824664.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/jupyter/ms-toolsai.jupyter-2022.4.1021342353.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4610,7 +4610,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.58.0"
+									"value": ">=1.67.0"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",


### PR DESCRIPTION
After the recent VS Code merge, some of the extension APIs changed in such a way that it breaks the current version of the Jupyter extension in our gallery. 

Here's the link to the extension VSIX in the VS Code marketplace: https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-toolsai/vsextensions/jupyter/2022.4.1021342353/vspackage

This PR fixes #20898
