### PR TITLE
remove "New File..." from File menu

### DIFF
--- a/src/vs/workbench/contrib/welcomeViews/common/newFile.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeViews/common/newFile.contribution.ts
@@ -32,13 +32,12 @@ registerAction2(class extends Action2 {
 				primary: KeyMod.Alt + KeyMod.CtrlCmd + KeyMod.WinCtrl + KeyCode.KeyN,
 				weight: KeybindingWeight.WorkbenchContrib,
 			},
-			// {{SQL CARBON EDIT}} - Start
+			// {{SQL CARBON EDIT}} - ADS has its own New File menu
 			// menu: {
 			// 	id: MenuId.MenubarFileMenu,
 			// 	group: '1_new',
 			// 	order: 2
 			// }
-			// {{SQL CARBON EDIT}} - End
 		});
 	}
 

--- a/src/vs/workbench/contrib/welcomeViews/common/newFile.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeViews/common/newFile.contribution.ts
@@ -32,11 +32,13 @@ registerAction2(class extends Action2 {
 				primary: KeyMod.Alt + KeyMod.CtrlCmd + KeyMod.WinCtrl + KeyCode.KeyN,
 				weight: KeybindingWeight.WorkbenchContrib,
 			},
-			menu: {
-				id: MenuId.MenubarFileMenu,
-				group: '1_new',
-				order: 2
-			}
+			// {{SQL CARBON EDIT}} - Start
+			// menu: {
+			// 	id: MenuId.MenubarFileMenu,
+			// 	group: '1_new',
+			// 	order: 2
+			// }
+			// {{SQL CARBON EDIT}} - End
 		});
 	}
 


### PR DESCRIPTION
This PR fixes #20993

VSCode added a new `New File...` entry to the `File` menu. This PR removes this entry as ADS has its own `New File` entry

Before this PR:
![image](https://user-images.githubusercontent.com/21186993/198155631-3432fc45-8cbb-4ed0-a209-3f40f7fffd30.png)

After this PR:
![image](https://user-images.githubusercontent.com/21186993/198155733-c3d0acf4-3d47-4142-a6fb-b9b49a1f1cbd.png)


For comparison, ADS 1.39.1:
![image](https://user-images.githubusercontent.com/21186993/198155834-7a2df1fe-ea19-4379-97ae-9f04d4bb5ea9.png)
