### PR TITLE
Add/update providerConnectionInfo.getOptionsKey tests

### DIFF
--- a/src/sql/platform/connection/test/common/providerConnectionInfo.test.ts
+++ b/src/sql/platform/connection/test/common/providerConnectionInfo.test.ts
@@ -215,14 +215,25 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('getOptionsKey should create a valid unique id', () => {
-		let options: { [key: string]: string } = {};
-		// Setting custom options are not yet considered for profile identity
-		options['encrypt'] = 'true';
-		connectionProfile.options = options;
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
+		// **IMPORTANT** This should NEVER change without thorough review and consideration of side effects. This key controls
+		//				 things like how passwords are saved, which means if its changed then serious side effects will occur.
 		let expectedId = 'providerName:MSSQL|authenticationType:|databaseName:database|serverName:new server|userName:user';
 		let id = conn.getOptionsKey();
 		assert.strictEqual(id, expectedId);
+	});
+
+	test('getOptionsKey should create the same ID regardless of optional options', () => {
+		const conn1 = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
+		let id1 = conn1.getOptionsKey();
+
+		connectionProfile.options = {
+			'encrypt': true
+		};
+		const conn2 = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
+		const id2 = conn2.getOptionsKey();
+
+		assert.strictEqual(id1, id2);
 	});
 
 	test('getOptionsKey should create different id for different server names', () => {


### PR DESCRIPTION
Split options check into its own test.

Also added big warning to the original test to try and prevent issues like https://github.com/microsoft/azuredatastudio/issues/20972 from happening again