### PR TITLE
Fix open file on drop-n-drop

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
+++ b/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
@@ -367,9 +367,7 @@ class DropOverlay extends Themable {
 
 			// {{SQL CARBON EDIT}}
 			let untitledOrFileResources: any = undefined;
-			await this.instantiationService.invokeFunction(accessor => {
-				untitledOrFileResources = extractEditorsDropData(accessor, event);
-			});
+			untitledOrFileResources = await this.instantiationService.invokeFunction(extractEditorsDropData, event);
 			if (untitledOrFileResources && !untitledOrFileResources.length) {
 				return;
 			}


### PR DESCRIPTION
This PR fixes #https://github.com/microsoft/azuredatastudio/issues/20986.  The `untitledOrFileResources` is being assigned a promise instead of the result of the promise as intended.
