### PR TITLE
Fix issues with loading aliased kernels in notebooks

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -597,7 +597,7 @@ export class KernelsDropdown extends SelectBox {
 		this._register(this.model.kernelChanged((changedArgs: azdata.nb.IKernelChangedArgs) => {
 			this.updateKernel(changedArgs.newValue, changedArgs.nbKernelAlias);
 		}));
-		this._register(this.model.kernelsChanged(kernel => {
+		this._register(this.model.kernelsAdded(kernel => {
 			this.updateKernel(kernel);
 		}));
 		let kernel = this.model.clientSession && this.model.clientSession.kernel;

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -1085,7 +1085,7 @@ suite('notebook model', function (): void {
 			supportedFileExtensions: [DEFAULT_NOTEBOOK_FILETYPE]
 		};
 		let kernelsAddedPromise = new Promise<void>(resolve => {
-			model.kernelsChanged(kernel => {
+			model.kernelsAdded(kernel => {
 				resolve();
 			});
 		});
@@ -1110,7 +1110,7 @@ suite('notebook model', function (): void {
 			supportedFileExtensions: ['.html']
 		};
 		kernelsAddedPromise = new Promise<void>((resolve, reject) => {
-			model.kernelsChanged(kernel => {
+			model.kernelsAdded(kernel => {
 				reject('Should not have added a new kernel');
 			});
 		});

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -257,6 +257,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return this._activeClientSession;
 	}
 
+	/**
+	 * Event that gets fired after the kernel is changed from starting a session or selecting one from the kernel dropdown.
+	 */
 	public get kernelChanged(): Event<nb.IKernelChangedArgs> {
 		return this._kernelChangedEmitter.event;
 	}
@@ -265,6 +268,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return this._kernelsChangedEmitter.event;
 	}
 
+	/**
+	 * Event that gets fired when new kernels are added to the model from new notebook providers in the registry.
+	 */
 	public get kernelsAdded(): Event<nb.IKernel> {
 		return this._kernelsAddedEmitter.event;
 	}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -1280,7 +1280,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel, kernelAlias?: string) {
 		await this.updateKernelInfo(kernel);
-		kernelAlias = this.kernelAliases.find(kernel => this._defaultLanguageInfo?.name === kernel.toLowerCase()) ?? kernelAlias;
+
 		// In order to change from kernel alias to other kernel, set kernelAlias to undefined in order to update to new kernel language info
 		if (this._selectedKernelDisplayName !== kernelAlias && this._selectedKernelDisplayName) {
 			kernelAlias = undefined;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -1280,7 +1280,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel, kernelAlias?: string) {
 		await this.updateKernelInfo(kernel);
-
+		if (!kernelAlias) {
+			kernelAlias = this.kernelAliases.find(k => this._defaultLanguageInfo?.name === k.toLowerCase());
+		}
 		// In order to change from kernel alias to other kernel, set kernelAlias to undefined in order to update to new kernel language info
 		if (this._selectedKernelDisplayName !== kernelAlias && this._selectedKernelDisplayName) {
 			kernelAlias = undefined;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -84,6 +84,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _contextsLoadingEmitter = new Emitter<void>();
 	private _contentChangedEmitter = new Emitter<NotebookContentChange>();
 	private _kernelsChangedEmitter = new Emitter<nb.IKernel>();
+	private _kernelsAddedEmitter = new Emitter<nb.IKernel>();
 	private _kernelChangedEmitter = new Emitter<nb.IKernelChangedArgs>();
 	private _viewModeChangedEmitter = new Emitter<ViewMode>();
 	private _layoutChanged = new Emitter<void>();
@@ -187,7 +188,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			let manager = await this._notebookService.getOrCreateExecuteManager(kernels[0].notebookProvider, this.notebookUri);
 			this._notebookOptions.executeManagers.push(manager);
 
-			this._kernelsChangedEmitter.fire(this._activeClientSession?.kernel);
+			this._kernelsAddedEmitter.fire(this._activeClientSession?.kernel);
 		}
 	}
 
@@ -262,6 +263,10 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	public get kernelsChanged(): Event<nb.IKernel> {
 		return this._kernelsChangedEmitter.event;
+	}
+
+	public get kernelsAdded(): Event<nb.IKernel> {
+		return this._kernelsAddedEmitter.event;
 	}
 
 	public get layoutChanged(): Event<void> {


### PR DESCRIPTION
This PR address 2 issues related to using aliased kernels in notebooks e.g. Kusto and LogAnalytics.
1. Fixes a problem where the Kusto kernel was being reset to SQL when first opening a Kusto kernel notebook. When I added the new event for handle kernel additions, I re-used an existing "kernelChanged" event to notify the KernelDropdown, but that event was actually meant to notify when a client session had been initialized instead. Thus we were overwriting the saved kernel with the SQL default as soon as the session started. I'll removed that client session event in a subsequent PR, since it isn't actually used anywhere that I could tell.

2. Fixes a problem where trying to change between aliased kernels would fail, like changing to LogAnalytics from Kusto and vice versa. We were overwriting the new kernel alias when changing the kernel, which actually caused the kernelAlias to be cleared entirely and subsequently revert to SQL.

This PR fixes #20995 
