### PR TITLE
Fixing result grid plans not opening execution plan editor.

### DIFF
--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -726,7 +726,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 						graphFileType: result.queryExecutionPlanFileExtension
 					};
 
-					const executionPlanInput = this._register(this.instantiationService.createInstance(ExecutionPlanInput, undefined, executionPlanGraphInfo));
+					const executionPlanInput = this.instantiationService.createInstance(ExecutionPlanInput, undefined, executionPlanGraphInfo);
 					await this.editorService.openEditor(executionPlanInput);
 				}
 				else {


### PR DESCRIPTION
This PR fixes #20964
It seems it had nothing to do with the merge. When the new execution plan editor tab was opened, dispose was called and the editor input was disposed causing the new tab to close.