### PR TITLE
Add image tag dropdown for publish to docker in ADS

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -194,6 +194,7 @@ export function invalidSQLPasswordMessage(name: string) { return localize('inval
 export function passwordNotMatch(name: string) { return localize('passwordNotMatch', "{0} password doesn't match the confirmation password", name); }
 export const portMustBeNumber = localize('portMustNotBeNumber', "Port must a be number");
 export const valueCannotBeEmpty = localize('valueCannotBeEmpty', "Value cannot be empty");
+export const imageTag = localize('imageTag', "Image tag");
 export const dockerImageLabelPrefix = 'source=sqldbproject';
 export const dockerImageNamePrefix = 'sqldbproject';
 export const dockerImageDefaultTag = 'latest';

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -246,14 +246,10 @@ export class PublishDatabaseDialog {
 			let dockerBaseImage = this.getBaseDockerImageName();
 			const baseImages = getDockerBaseImages(this.project.getProjectTargetVersion());
 			const imageInfo = baseImages.find(x => x.name === dockerBaseImage);
-
-			// selecting the image tag isn't currently exposed in the publish dialog, so this adds the tag matching the target platform
-			// to make sure the correct image is used for the project's target platform when the docker base image is SQL Server
-			// dockerBaseImage = getDefaultDockerImageWithTag(this.project.getProjectTargetVersion(), dockerBaseImage, imageInfo);
-
-
-			let imageName = imageInfo?.name;
+			const imageName = imageInfo?.name;
 			const imageTag = this.imageTagDropDown!.value;
+
+			// Add the image tag if it's not the latest
 			if (imageTag && imageTag !== constants.dockerImageDefaultTag) {
 				dockerBaseImage = `${imageName}:${imageTag}`;
 			}
@@ -615,26 +611,24 @@ export class PublishDatabaseDialog {
 
 		this.baseDockerImageDropDown = view.modelBuilder.dropDown().withProps({
 			values: baseImagesValues,
-			value: baseImagesValues[0],
 			ariaLabel: constants.baseDockerImage(name),
 			width: cssStyles.publishDialogTextboxWidth,
 			enabled: true
 		}).component();
 
 		const imageInfo = baseImages.find(x => x.displayName === (<azdataType.CategoryValue>this.baseDockerImageDropDown?.value)?.displayName);
-
-		let imageTags = await uiUtils.getImageTags(imageInfo!, this.project.getProjectTargetVersion());
+		const imageTags = await uiUtils.getImageTags(imageInfo!, this.project.getProjectTargetVersion());
 
 		this.imageTagDropDown = view.modelBuilder.dropDown().withProps({
 			values: imageTags,
-			ariaLabel: 'Image tag',
+			ariaLabel: constants.imageTag,
 			width: cssStyles.publishDialogTextboxWidth,
 			enabled: true
 		}).component();
 
 		const agreementInfo = baseImages[0].agreementInfo;
 		const baseImageDropDownRow = this.createFormRow(view, constants.baseDockerImage(name), this.baseDockerImageDropDown);
-		const imageTagDropDownRow = this.createFormRow(view, 'image', this.imageTagDropDown);
+		const imageTagDropDownRow = this.createFormRow(view, constants.imageTag, this.imageTagDropDown);
 
 		this.eulaCheckBox = view.modelBuilder.checkBox().withProps({
 			ariaLabel: getAgreementDisplayText(agreementInfo),
@@ -666,10 +660,10 @@ export class PublishDatabaseDialog {
 				}
 			}
 
+			// update image tag dropdown with the image tags for the selected base image
 			const imageInfo = baseImages.find(x => x.displayName === baseImage?.displayName);
-			let imageTags = await uiUtils.getImageTags(imageInfo!, this.project.getProjectTargetVersion());
+			const imageTags = await uiUtils.getImageTags(imageInfo!, this.project.getProjectTargetVersion());
 			this.imageTagDropDown!.values = imageTags;
-			this.imageTagDropDown!.value = imageTags[0];
 		});
 		return this.localDbSection;
 	}

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -617,14 +617,22 @@ export class PublishDatabaseDialog {
 		}).component();
 
 		const imageInfo = baseImages.find(x => x.displayName === (<azdataType.CategoryValue>this.baseDockerImageDropDown?.value)?.displayName);
-		const imageTags = await uiUtils.getImageTags(imageInfo!, this.project.getProjectTargetVersion());
+		const imageTags = await uiUtils.getImageTags(imageInfo!, this.project.getProjectTargetVersion(), true);
 
 		this.imageTagDropDown = view.modelBuilder.dropDown().withProps({
 			values: imageTags,
+			value: imageTags[0],
 			ariaLabel: constants.imageTag,
 			width: cssStyles.publishDialogTextboxWidth,
-			enabled: true
+			enabled: true,
+			editable: true,
+			required: true,
+			fireOnTextChange: true
 		}).component();
+
+		this.imageTagDropDown.onValueChanged(() => {
+			this.tryEnableGenerateScriptAndOkButtons();
+		});
 
 		const agreementInfo = baseImages[0].agreementInfo;
 		const baseImageDropDownRow = this.createFormRow(view, constants.baseDockerImage(name), this.baseDockerImageDropDown);
@@ -662,8 +670,9 @@ export class PublishDatabaseDialog {
 
 			// update image tag dropdown with the image tags for the selected base image
 			const imageInfo = baseImages.find(x => x.displayName === baseImage?.displayName);
-			const imageTags = await uiUtils.getImageTags(imageInfo!, this.project.getProjectTargetVersion());
+			const imageTags = await uiUtils.getImageTags(imageInfo!, this.project.getProjectTargetVersion(), true);
 			this.imageTagDropDown!.values = imageTags;
+			this.imageTagDropDown!.value = imageTags[0];
 		});
 		return this.localDbSection;
 	}
@@ -919,7 +928,7 @@ export class PublishDatabaseDialog {
 			!utils.isEmptyString(this.serverAdminPasswordTextBox?.value) &&
 			utils.isValidSQLPassword(this.serverAdminPasswordTextBox?.value || '', constants.defaultLocalServerAdminName) &&
 			this.serverAdminPasswordTextBox?.value === this.serverConfigAdminPasswordTextBox?.value
-			&& this.eulaCheckBox?.checked) {
+			&& this.imageTagDropDown!.value && this.eulaCheckBox?.checked) {
 			publishEnabled = true; // only publish is supported for container
 		}
 

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -247,7 +247,7 @@ export class PublishDatabaseDialog {
 			const baseImages = getDockerBaseImages(this.project.getProjectTargetVersion());
 			const imageInfo = baseImages.find(x => x.name === dockerBaseImage);
 			const imageName = imageInfo?.name;
-			const imageTag = this.imageTagDropDown!.value;
+			const imageTag = this.imageTagDropDown?.value;
 
 			// Add the image tag if it's not the latest
 			if (imageTag && imageTag !== constants.dockerImageDefaultTag) {

--- a/extensions/sql-database-projects/src/dialogs/utils.ts
+++ b/extensions/sql-database-projects/src/dialogs/utils.ts
@@ -53,9 +53,10 @@ export function getDockerImagePlaceHolder(target: string): string {
  * Returns the list of image tags for given target
  * @param imageInfo docker image info
  * @param target project target version
+ * @param defaultTagFirst whether the default tag should be the first entry in the array
  * @returns image tags
  */
-export async function getImageTags(imageInfo: DockerImageInfo, target: string): Promise<string[]> {
+export async function getImageTags(imageInfo: DockerImageInfo, target: string, defaultTagFirst?: boolean): Promise<string[]> {
 	let imageTags: string[] | undefined = [];
 	const versionToImageTags: Map<number, string[]> = new Map<number, string[]>();
 
@@ -87,6 +88,14 @@ export async function getImageTags(imageInfo: DockerImageInfo, target: string): 
 
 			imageTags = imageTags ?? [];
 			imageTags = imageTags.sort((a, b) => a.indexOf(constants.dockerImageDefaultTag) > 0 ? -1 : a.localeCompare(b));
+
+			if (defaultTagFirst) {
+				const defaultIndex = imageTags.findIndex(i => i === imageInfo.defaultTag);
+				if (defaultIndex > -1) {
+					imageTags.splice(defaultIndex, 1);
+					imageTags.unshift(imageInfo.defaultTag);
+				}
+			}
 		}
 	} catch (err) {
 		// Ignore the error. If http request fails, we just use the default tag


### PR DESCRIPTION
This adds the ability to select the image tag used when publishing a sql project to docker in ADS. This is already an option in the vscode extension. The value in adding this is that users can have the option of publishing their project to a 2019 container, rather than forcing them to use the latest, which is currently 2022.

The image tags can be filtered and the image tag options are updated when the base docker image is changed:
https://user-images.githubusercontent.com/31145923/198695504-a454fbec-2d79-47e6-98dc-df682e4ec344.mp4

