### PR TITLE
Remove unused ClientSession members.

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -60,9 +60,6 @@ export class NotebookModelStub implements INotebookModel {
 	get kernelChanged(): vsEvent.Event<nb.IKernelChangedArgs> {
 		throw new Error('method not implemented.');
 	}
-	get kernelsChanged(): vsEvent.Event<nb.IKernel> {
-		throw new Error('method not implemented.');
-	}
 	get layoutChanged(): vsEvent.Event<void> {
 		throw new Error('method not implemented.');
 	}
@@ -357,19 +354,7 @@ export class ClientSessionStub implements IClientSession {
 	shutdown(): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	selectKernel(): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
 	restart(): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
-	setPath(path: string): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
-	setName(name: string): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
-	setType(type: string): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
 	updateConnection(connection: IConnectionProfile): Promise<void> {
@@ -381,34 +366,10 @@ export class ClientSessionStub implements IClientSession {
 	dispose(): void {
 		throw new Error('Method not implemented.');
 	}
-	get terminated(): vsEvent.Event<void> {
-		throw new Error('Method not implemented.');
-	}
-	get kernelChanged(): vsEvent.Event<nb.IKernelChangedArgs> {
-		throw new Error('Method not implemented.');
-	}
-	get statusChanged(): vsEvent.Event<nb.ISession> {
-		throw new Error('Method not implemented.');
-	}
-	get iopubMessage(): vsEvent.Event<nb.IMessage> {
-		throw new Error('Method not implemented.');
-	}
-	get unhandledMessage(): vsEvent.Event<nb.IMessage> {
-		throw new Error('Method not implemented.');
-	}
-	get propertyChanged(): vsEvent.Event<'path' | 'name' | 'type'> {
-		throw new Error('Method not implemented.');
-	}
 	get kernel(): nb.IKernel | null {
 		throw new Error('Method not implemented.');
 	}
 	get notebookUri(): URI {
-		throw new Error('Method not implemented.');
-	}
-	get name(): string {
-		throw new Error('Method not implemented.');
-	}
-	get type(): string {
 		throw new Error('Method not implemented.');
 	}
 	get status(): nb.KernelStatus {
@@ -421,9 +382,6 @@ export class ClientSessionStub implements IClientSession {
 		throw new Error('Method not implemented.');
 	}
 	get kernelChangeCompleted(): Promise<void> {
-		throw new Error('Method not implemented.');
-	}
-	get kernelDisplayName(): string {
 		throw new Error('Method not implemented.');
 	}
 	get errorMessage(): string {

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -56,36 +56,6 @@ export interface IClientSessionOptions {
  */
 export interface IClientSession extends IDisposable {
 	/**
-	 * A signal emitted when the session is shut down.
-	 */
-	readonly terminated: Event<void>;
-
-	/**
-	 * A signal emitted when the kernel changes.
-	 */
-	readonly kernelChanged: Event<nb.IKernelChangedArgs>;
-
-	/**
-	 * A signal emitted when the kernel status changes.
-	 */
-	readonly statusChanged: Event<nb.ISession>;
-
-	/**
-	 * A signal emitted for a kernel messages.
-	 */
-	readonly iopubMessage: Event<nb.IMessage>;
-
-	/**
-	 * A signal emitted for an unhandled kernel message.
-	 */
-	readonly unhandledMessage: Event<nb.IMessage>;
-
-	/**
-	 * A signal emitted when a session property changes.
-	 */
-	readonly propertyChanged: Event<'path' | 'name' | 'type'>;
-
-	/**
 	 * The current kernel associated with the document.
 	 */
 	readonly kernel: nb.IKernel | undefined;
@@ -94,16 +64,6 @@ export interface IClientSession extends IDisposable {
 	 * The current path associated with the client session.
 	 */
 	readonly notebookUri: URI;
-
-	/**
-	 * The current name associated with the client session.
-	 */
-	readonly name: string;
-
-	/**
-	 * The type of the client session.
-	 */
-	readonly type: string;
 
 	/**
 	 * The current status of the client session.
@@ -133,11 +93,6 @@ export interface IClientSession extends IDisposable {
 	 * A promise that is fulfilled when the session completes a kernel change.
 	 */
 	readonly kernelChangeCompleted: Promise<void>;
-
-	/**
-	 * The display name of the kernel.
-	 */
-	readonly kernelDisplayName: string;
 
 	readonly cachedKernelSpec: nb.IKernelSpec | undefined;
 
@@ -172,11 +127,6 @@ export interface IClientSession extends IDisposable {
 	shutdown(): Promise<void>;
 
 	/**
-	 * Select a kernel for the session.
-	 */
-	selectKernel(): Promise<void>;
-
-	/**
 	 * Restart the session.
 	 *
 	 * @returns A promise that resolves when the kernel has restarted.
@@ -187,29 +137,6 @@ export interface IClientSession extends IDisposable {
 	 * Reject on error.
 	 */
 	restart(): Promise<void>;
-
-	/**
-	 * Change the session path.
-	 *
-	 * @param path - The new session path.
-	 *
-	 * @returns A promise that resolves when the session has renamed.
-	 *
-	 * #### Notes
-	 * This uses the Jupyter REST API, and the response is validated.
-	 * The promise is fulfilled on a valid response and rejected otherwise.
-	 */
-	setPath(path: string): Promise<void>;
-
-	/**
-	 * Change the session name.
-	 */
-	setName(name: string): Promise<void>;
-
-	/**
-	 * Change the session type.
-	 */
-	setType(type: string): Promise<void>;
 
 	/**
 	 * Updates the connection
@@ -271,12 +198,6 @@ export interface INotebookModel {
 	 * Fired on notifications that notebook components should be re-laid out.
 	 */
 	readonly layoutChanged: Event<void>;
-
-	/**
-	 * Event fired on first initialization of the kernels and
-	 * on subsequent change events
-	 */
-	readonly kernelsChanged: Event<nb.IKernel>;
 
 	/**
 	 * Default kernel

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -83,7 +83,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _contextsChangedEmitter = new Emitter<void>();
 	private _contextsLoadingEmitter = new Emitter<void>();
 	private _contentChangedEmitter = new Emitter<NotebookContentChange>();
-	private _kernelsChangedEmitter = new Emitter<nb.IKernel>();
 	private _kernelsAddedEmitter = new Emitter<nb.IKernel>();
 	private _kernelChangedEmitter = new Emitter<nb.IKernelChangedArgs>();
 	private _viewModeChangedEmitter = new Emitter<ViewMode>();
@@ -262,10 +261,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	 */
 	public get kernelChanged(): Event<nb.IKernelChangedArgs> {
 		return this._kernelChangedEmitter.event;
-	}
-
-	public get kernelsChanged(): Event<nb.IKernel> {
-		return this._kernelsChangedEmitter.event;
 	}
 
 	/**
@@ -1030,9 +1025,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 			clientSession.onKernelChanging(async (e) => {
 				await this.loadActiveContexts(e);
-			});
-			clientSession.statusChanged(async (session) => {
-				this._kernelsChangedEmitter.fire(session.kernel);
 			});
 			await clientSession.initialize().then(() => {
 				this._sessionLoadFinished.resolve();


### PR DESCRIPTION
Noticed that the ClientSession statusChanged event wasn't being used for anything, so I went through and removed all the unused members from the ClientSession interface. KernelsChanged in notebookModel wasn't being used either, so I removed that too.
