### PR TITLE
Fix bug where username/password values won't clear on auth type change

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -527,8 +527,8 @@ export class ConnectionWidget extends lifecycle.Disposable {
 
 	protected onAuthTypeSelected(selectedAuthType: string) {
 		let currentAuthType = this.getMatchingAuthType(selectedAuthType);
-		this._userNameInputBox.value === '';
-		this._passwordInputBox.value === '';
+		this._userNameInputBox.value = '';
+		this._passwordInputBox.value = '';
 		this._userNameInputBox.hideMessage();
 		this._passwordInputBox.hideMessage();
 		this._azureAccountDropdown.hideMessage();


### PR DESCRIPTION
This PR fixes #21032 as username/password were not clearing on auth type change, due to bug.