### PR TITLE
Update error dialog to include instructions text for SSL cert validation failure

### DIFF
--- a/resources/xlf/en/sql.xlf
+++ b/resources/xlf/en/sql.xlf
@@ -5253,7 +5253,7 @@ Error: {1}</source>
     <trans-unit id="trustServerCertInstructionText">
       <source xml:lang="en">Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
 
-			Note: A self-signed certificate offers only limited protection and is not a recommended practice for production environments. Do you want to enable 'Trust server certificate' on this connection and retry?</source>
+			Note: A self-signed certificate offers only limited protection and is not a recommended practice for production environments. Do you want to enable 'Trust server certificate' on this connection and retry? </source>
     </trans-unit>
 </body></file>
   <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext"><body>

--- a/resources/xlf/en/sql.xlf
+++ b/resources/xlf/en/sql.xlf
@@ -5253,7 +5253,7 @@ Error: {1}</source>
     <trans-unit id="trustServerCertInstructionText">
       <source xml:lang="en">Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
 
-			Do you want to enable 'Trust server certificate' on this connection and retry?</source>
+			Note: A self-signed certificate offers only limited protection and is not a recommended practice for production environments. Do you want to enable 'Trust server certificate' on this connection and retry?</source>
     </trans-unit>
 </body></file>
   <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext"><body>

--- a/resources/xlf/en/sql.xlf
+++ b/resources/xlf/en/sql.xlf
@@ -5244,6 +5244,17 @@ Error: {1}</source>
     <trans-unit id="kerberosKinit">
       <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
     </trans-unit>
+    <trans-unit id="runKinit">
+      <source xml:lang="en">Run Kinit</source>
+    </trans-unit>
+    <trans-unit id="enableTrustServerCertificate">
+      <source xml:lang="en">Enable Trust server certificate</source>
+    </trans-unit>
+    <trans-unit id="trustServerCertInstructionText">
+      <source xml:lang="en">Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
+
+			Do you want to enable 'Trust server certificate' on this connection and retry?</source>
+    </trans-unit>
 </body></file>
   <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext"><body>
     <trans-unit id="connectType">

--- a/src/sql/platform/connection/common/constants.ts
+++ b/src/sql/platform/connection/common/constants.ts
@@ -24,6 +24,9 @@ export const passwordChars = '***************';
 /* default authentication type setting name*/
 export const defaultAuthenticationType = 'defaultAuthenticationType';
 
+/* Connection Properties */
+export const trustServerCertificate = 'trustServerCertificate';
+
 /**
  * Well-known Authentication types commonly supported by connection providers.
  */

--- a/src/sql/platform/errorMessage/common/errorMessageService.ts
+++ b/src/sql/platform/errorMessage/common/errorMessageService.ts
@@ -10,5 +10,5 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const IErrorMessageService = createDecorator<IErrorMessageService>('errorMessageService');
 export interface IErrorMessageService {
 	_serviceBrand: undefined;
-	showDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[]): void;
+	showDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string): void;
 }

--- a/src/sql/platform/errorMessage/common/errorMessageService.ts
+++ b/src/sql/platform/errorMessage/common/errorMessageService.ts
@@ -10,5 +10,15 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const IErrorMessageService = createDecorator<IErrorMessageService>('errorMessageService');
 export interface IErrorMessageService {
 	_serviceBrand: undefined;
-	showDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string): void;
+	/**
+	 * Shows error dialog with given parameters
+	 * @param severity Severity of the error
+	 * @param headerTitle Title to show on Error modal dialog
+	 * @param message Message containng error message
+	 * @param messageDetails Message details containing stacktrace along with error message
+	 * @param actions Custom actions to display on the error message dialog
+	 * @param instructionText Spcial instructions to display to user when displaying error message
+	 * @param readMoreLink External link to read more about the instructions.
+	 */
+	showDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string, readMoreLink?: string): void;
 }

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -521,7 +521,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			let enableTrustServerCert = localize('enableTrustServerCertificate', "Enable Trust server certificate");
 			let instructionText = localize('trustServerCertInstructionText', `Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
 
-			Note: A self-signed certificate offers only limited protection and is not a recommended practice for production environments. Do you want to enable 'Trust server certificate' on this connection and retry?`);
+			Note: A self-signed certificate offers only limited protection and is not a recommended practice for production environments. Do you want to enable 'Trust server certificate' on this connection and retry? `);
 			let readMoreLink = "https://learn.microsoft.com/sql/database-engine/configure-windows/enable-encrypted-connections-to-the-database-engine"
 			actions.push(new Action('trustServerCert', enableTrustServerCert, undefined, true, async () => {
 				this._model.options[Constants.trustServerCertificate] = true;

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -517,18 +517,18 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		this._logService.error(message);
 
 		// Set instructionText for MSSQL Provider Encryption error code -2146893019 thrown by SqlClient when certificate validation fails.
-		let instructionText: string;
 		if (errorCode === -2146893019) {
 			let enableTrustServerCert = localize('enableTrustServerCertificate', "Enable Trust server certificate");
-			instructionText = localize('trustServerCertInstructionText', `Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
+			let instructionText = localize('trustServerCertInstructionText', `Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
 
-			Do you want to enable 'Trust server certificate' on this connection and retry?`);
+			Note: A self-signed certificate offers only limited protection and is not a recommended practice for production environments. Do you want to enable 'Trust server certificate' on this connection and retry?`);
+			let readMoreLink = "https://learn.microsoft.com/sql/database-engine/configure-windows/enable-encrypted-connections-to-the-database-engine"
 			actions.push(new Action('trustServerCert', enableTrustServerCert, undefined, true, async () => {
-				this._model.options['trustServerCertificate'] = true;
+				this._model.options[Constants.trustServerCertificate] = true;
 				await this.handleOnConnect(this._connectionDialog.newConnectionParams, this._model as IConnectionProfile);
 				return;
 			}));
-			this._errorMessageService.showDialog(severity, headerTitle, message, messageDetails, actions, instructionText);
+			this._errorMessageService.showDialog(severity, headerTitle, message, messageDetails, actions, instructionText, readMoreLink);
 		} else {
 			this._errorMessageService.showDialog(severity, headerTitle, message, messageDetails, actions);
 		}

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -516,7 +516,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 
 		this._logService.error(message);
 
-		// Special handling for MSSQL Provider Encryption error codes -2146893019 and -2146893022
+		// Set instructionText for MSSQL Provider Encryption error code -2146893019 thrown by SqlClient when certificate validation fails.
 		let instructionText: string;
 		if (errorCode === -2146893019) {
 			instructionText = `Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable Trust server certificate in the connection dialog.

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -502,7 +502,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 				localize('kerberosHelpLink', "Help configuring Kerberos is available at {0}", helpLink),
 				localize('kerberosKinit', "If you have previously connected you may need to re-run kinit.")
 			].join('\r\n');
-			actions.push(new Action('Kinit', 'Run kinit', null, true, async () => {
+			actions.push(new Action('Kinit', localize('runKinit', "Run Kinit"), undefined, true, async () => {
 				this._connectionDialog.close();
 				await this._clipboardService.writeText('kinit\r');
 				await this._commandService.executeCommand('workbench.action.terminal.focus');
@@ -519,10 +519,11 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		// Set instructionText for MSSQL Provider Encryption error code -2146893019 thrown by SqlClient when certificate validation fails.
 		let instructionText: string;
 		if (errorCode === -2146893019) {
-			instructionText = `Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
+			let enableTrustServerCert = localize('enableTrustServerCertificate', "Enable Trust server certificate");
+			instructionText = localize('trustServerCertInstructionText', `Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
 
-			Do you want to enable 'Trust server certificate' on this connection and retry?`;
-			actions.push(new Action('trustServerCert', "Enable Trust server certificate", null, true, async () => {
+			Do you want to enable 'Trust server certificate' on this connection and retry?`);
+			actions.push(new Action('trustServerCert', enableTrustServerCert, undefined, true, async () => {
 				this._model.options['trustServerCertificate'] = true;
 				await this.handleOnConnect(this._connectionDialog.newConnectionParams, this._model as IConnectionProfile);
 				return;

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -524,7 +524,6 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			Do you want to enable Trust server certificate on this connection and retry?`;
 			actions.push(new Action('trustServerCert', "Enable Trust server certificate", null, true, async () => {
 				this._model.options['trustServerCertificate'] = true;
-				this._connectionDialog.close();
 				await this.handleOnConnect(this._connectionDialog.newConnectionParams, this._model as IConnectionProfile);
 				return;
 			}));

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -519,9 +519,9 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		// Set instructionText for MSSQL Provider Encryption error code -2146893019 thrown by SqlClient when certificate validation fails.
 		let instructionText: string;
 		if (errorCode === -2146893019) {
-			instructionText = `Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable Trust server certificate in the connection dialog.
+			instructionText = `Encryption was enabled on this connection, review your SSL and certificate configuration for the target SQL Server, or enable 'Trust server certificate' in the connection dialog.
 
-			Do you want to enable Trust server certificate on this connection and retry?`;
+			Do you want to enable 'Trust server certificate' on this connection and retry?`;
 			actions.push(new Action('trustServerCert', "Enable Trust server certificate", null, true, async () => {
 				this._model.options['trustServerCertificate'] = true;
 				await this.handleOnConnect(this._connectionDialog.newConnectionParams, this._model as IConnectionProfile);

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -41,6 +41,7 @@ export class ErrorMessageDialog extends Modal {
 	private _messageDetails?: string;
 	private _okLabel: string;
 	private _closeLabel: string;
+	private _readMoreLabel: string;
 
 	private _onOk = new Emitter<void>();
 	public onOk: Event<void> = this._onOk.event;
@@ -57,6 +58,7 @@ export class ErrorMessageDialog extends Modal {
 		super('', TelemetryKeys.ModalDialogName.ErrorMessage, telemetryService, layoutService, clipboardService, themeService, logService, textResourcePropertiesService, contextKeyService, { dialogStyle: 'normal', hasTitleIcon: true });
 		this._okLabel = localize('errorMessageDialog.ok', "OK");
 		this._closeLabel = localize('errorMessageDialog.close', "Close");
+		this._readMoreLabel = localize('errorMessageDialog.readMore', "Read More");
 	}
 
 	protected renderBody(container: HTMLElement) {
@@ -115,7 +117,7 @@ export class ErrorMessageDialog extends Modal {
 			let childElement = DOM.$('div.error-instruction-text');
 			childElement.innerText = this._instructionText!;
 			if (this._readMoreLink) {
-				childElement.innerHTML += ` <a href="${this._readMoreLink}">Read more</a>`;
+				childElement.innerHTML += ` <a href="${this._readMoreLink}">${this._readMoreLabel}</a>`;
 			}
 			DOM.append(this._body!, childElement);
 		}

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -89,7 +89,7 @@ export class ErrorMessageDialog extends Modal {
 	}
 
 	private createStandardButton(label: string, onSelect: () => void): Button {
-		let button = this.addFooterButton(label, onSelect, 'right', true);
+		let button = this.addFooterButton(label, onSelect, 'right', false);
 		this._register(attachButtonStyler(button, this._themeService));
 		return button;
 	}
@@ -170,14 +170,25 @@ export class ErrorMessageDialog extends Modal {
 				button.label = actions[i].label;
 				button.element.style.visibility = 'visible';
 			}
-			this._okButton!.label = this._closeLabel;
+			//Remove and add button again to update style.
+			this.removeFooterButton(this._okLabel);
+			this.removeFooterButton(this._closeLabel);
+			this._okButton = this.addFooterButton(this._closeLabel, () => this.ok(), undefined, true);
 		} else {
-			this._okButton!.label = this._okLabel;
+			//Remove and add button again to update style
+			this.removeFooterButton(this._okLabel);
+			this.removeFooterButton(this._closeLabel);
+			this._okButton = this.addFooterButton(this._okLabel, () => this.ok());
 		}
+		this._register(attachButtonStyler(this._okButton, this._themeService));
 		this.updateIconTitle();
 		this.updateDialogBody();
 		this.show();
-		this._okButton!.focus();
+		if (actions && actions.length > 0) {
+			this._actionButtons[0].focus();
+		} else {
+			this._okButton!.focus();
+		}
 	}
 
 	private resetActions(): void {

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -24,6 +24,8 @@ import { attachModalDialogStyler } from 'sql/workbench/common/styler';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { attachButtonStyler } from 'vs/platform/theme/common/styler';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfiguration';
+import { Link } from 'vs/platform/opener/browser/link';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 
 const maxActions = 1;
 
@@ -53,7 +55,8 @@ export class ErrorMessageDialog extends Modal {
 		@IAdsTelemetryService telemetryService: IAdsTelemetryService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ILogService logService: ILogService,
-		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService
+		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService,
+		@IOpenerService private readonly _openerService: IOpenerService
 	) {
 		super('', TelemetryKeys.ModalDialogName.ErrorMessage, telemetryService, layoutService, clipboardService, themeService, logService, textResourcePropertiesService, contextKeyService, { dialogStyle: 'normal', hasTitleIcon: true });
 		this._okLabel = localize('errorMessageDialog.ok', "OK");
@@ -117,7 +120,11 @@ export class ErrorMessageDialog extends Modal {
 			let childElement = DOM.$('div.error-instruction-text');
 			childElement.innerText = this._instructionText!;
 			if (this._readMoreLink) {
-				childElement.innerHTML += ` <a href="${this._readMoreLink}">${this._readMoreLabel}</a>`;
+				let link = new Link(childElement, {
+					label: this._readMoreLabel,
+					href: this._readMoreLink
+				}, undefined, this._openerService);
+				childElement.appendChild(link.el);
 			}
 			DOM.append(this._body!, childElement);
 		}

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -120,11 +120,10 @@ export class ErrorMessageDialog extends Modal {
 			let childElement = DOM.$('div.error-instruction-text');
 			childElement.innerText = this._instructionText!;
 			if (this._readMoreLink) {
-				let link = new Link(childElement, {
+				new Link(childElement, {
 					label: this._readMoreLabel,
 					href: this._readMoreLink
 				}, undefined, this._openerService);
-				childElement.appendChild(link.el);
 			}
 			DOM.append(this._body!, childElement);
 		}

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -37,6 +37,7 @@ export class ErrorMessageDialog extends Modal {
 	private _severity?: Severity;
 	private _message?: string;
 	private _instructionText?: string;
+	private _readMoreLink?: string;
 	private _messageDetails?: string;
 	private _okLabel: string;
 	private _closeLabel: string;
@@ -111,7 +112,12 @@ export class ErrorMessageDialog extends Modal {
 		DOM.clearNode(this._body!);
 		DOM.append(this._body!, DOM.$('div.error-message')).innerText = this._message!;
 		if (this._instructionText) {
-			DOM.append(this._body!, DOM.$('div.error-instruction-text')).innerText = this._instructionText!;
+			let childElement = DOM.$('div.error-instruction-text');
+			childElement.innerText = this._instructionText!;
+			if (this._readMoreLink) {
+				childElement.innerHTML += ` <a href="${this._readMoreLink}">Read more</a>`;
+			}
+			DOM.append(this._body!, childElement);
 		}
 	}
 
@@ -148,10 +154,11 @@ export class ErrorMessageDialog extends Modal {
 		this.hide(hideReason);
 	}
 
-	public open(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string) {
+	public open(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string, readMoreLink?: string): void {
 		this._severity = severity;
 		this._message = message;
 		this._instructionText = instructionText;
+		this._readMoreLink = readMoreLink;
 		this.title = headerTitle;
 		this._messageDetails = messageDetails;
 		if (this._messageDetails) {
@@ -163,7 +170,7 @@ export class ErrorMessageDialog extends Modal {
 			this._bodyContainer.setAttribute('aria-description', this._message);
 		}
 		this.resetActions();
-		if (actions && actions.length > 0) {
+		if (actions?.length > 0) {
 			for (let i = 0; i < maxActions && i < actions.length; i++) {
 				this._actions.push(actions[i]);
 				let button = this._actionButtons[i];
@@ -180,11 +187,10 @@ export class ErrorMessageDialog extends Modal {
 			this.removeFooterButton(this._closeLabel);
 			this._okButton = this.addFooterButton(this._okLabel, () => this.ok());
 		}
-		this._register(attachButtonStyler(this._okButton, this._themeService));
 		this.updateIconTitle();
 		this.updateDialogBody();
 		this.show();
-		if (actions && actions.length > 0) {
+		if (actions?.length > 0) {
 			this._actionButtons[0].focus();
 		} else {
 			this._okButton!.focus();

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -36,6 +36,7 @@ export class ErrorMessageDialog extends Modal {
 	private _actions: IAction[] = [];
 	private _severity?: Severity;
 	private _message?: string;
+	private _instructionText?: string;
 	private _messageDetails?: string;
 	private _okLabel: string;
 	private _closeLabel: string;
@@ -109,6 +110,9 @@ export class ErrorMessageDialog extends Modal {
 	private updateDialogBody(): void {
 		DOM.clearNode(this._body!);
 		DOM.append(this._body!, DOM.$('div.error-message')).innerText = this._message!;
+		if (this._instructionText) {
+			DOM.append(this._body!, DOM.$('div.error-instruction-text')).innerText = this._instructionText!;
+		}
 	}
 
 	private updateIconTitle(): void {
@@ -144,9 +148,10 @@ export class ErrorMessageDialog extends Modal {
 		this.hide(hideReason);
 	}
 
-	public open(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[]) {
+	public open(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string) {
 		this._severity = severity;
 		this._message = message;
+		this._instructionText = instructionText;
 		this.title = headerTitle;
 		this._messageDetails = messageDetails;
 		if (this._messageDetails) {

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageService.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageService.ts
@@ -24,11 +24,11 @@ export class ErrorMessageService implements IErrorMessageService {
 		@IInstantiationService private _instantiationService: IInstantiationService
 	) { }
 
-	public showDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string): void {
-		this.doShowDialog(severity, headerTitle, message, messageDetails, actions, instructionText);
+	public showDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string, readMoreLink?: string): void {
+		this.doShowDialog(severity, headerTitle, message, messageDetails, actions, instructionText, readMoreLink);
 	}
 
-	private doShowDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string): void {
+	private doShowDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string, readMoreLink?: string): void {
 		if (!this._errorDialog) {
 			this._errorDialog = this._instantiationService.createInstance(ErrorMessageDialog);
 			this._errorDialog.onOk(() => this.handleOnOk());
@@ -36,7 +36,7 @@ export class ErrorMessageService implements IErrorMessageService {
 		}
 
 		let title = headerTitle ? headerTitle : this.getDefaultTitle(severity);
-		return this._errorDialog.open(severity, title, message, messageDetails, actions, instructionText);
+		return this._errorDialog.open(severity, title, message, messageDetails, actions, instructionText, readMoreLink);
 	}
 
 	private getDefaultTitle(severity: Severity) {

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageService.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageService.ts
@@ -24,11 +24,11 @@ export class ErrorMessageService implements IErrorMessageService {
 		@IInstantiationService private _instantiationService: IInstantiationService
 	) { }
 
-	public showDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[]): void {
-		this.doShowDialog(severity, headerTitle, message, messageDetails, actions);
+	public showDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string): void {
+		this.doShowDialog(severity, headerTitle, message, messageDetails, actions, instructionText);
 	}
 
-	private doShowDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[]): void {
+	private doShowDialog(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[], instructionText?: string): void {
 		if (!this._errorDialog) {
 			this._errorDialog = this._instantiationService.createInstance(ErrorMessageDialog);
 			this._errorDialog.onOk(() => this.handleOnOk());
@@ -36,7 +36,7 @@ export class ErrorMessageService implements IErrorMessageService {
 		}
 
 		let title = headerTitle ? headerTitle : this.getDefaultTitle(severity);
-		return this._errorDialog.open(severity, title, message, messageDetails, actions);
+		return this._errorDialog.open(severity, title, message, messageDetails, actions, instructionText);
 	}
 
 	private getDefaultTitle(severity: Severity) {

--- a/src/sql/workbench/services/errorMessage/browser/media/errorMessageDialog.css
+++ b/src/sql/workbench/services/errorMessage/browser/media/errorMessageDialog.css
@@ -6,7 +6,7 @@
 .error-dialog {
 	padding: 15px;
 	overflow: auto;
-	height: 200px;
+	height: 210px;
 }
 
 .error-dialog .codicon.error, .error-dialog .codicon.warning , .error-dialog .codicon.info {
@@ -23,7 +23,7 @@
 }
 
 .error-dialog .error-instruction-text{
-	margin-top: 60px;
+	margin-top: 40px;
 	font-weight: 700;
 }
 

--- a/src/sql/workbench/services/errorMessage/browser/media/errorMessageDialog.css
+++ b/src/sql/workbench/services/errorMessage/browser/media/errorMessageDialog.css
@@ -22,6 +22,11 @@
 	user-select: text;
 }
 
+.error-dialog .error-instruction-text{
+	margin-top: 60px;
+	font-weight: 700;
+}
+
 .modal .footer-button a.monaco-button.monaco-text-button.codicon.scriptToClipboard {
 	width: 120px;
 }


### PR DESCRIPTION
This PR updates error dialog to show instruction text when exception occurs due to SSL cert validation failure.

User is provided option to enable trust server certificate on the connection profile to continue connecting with enabled encryption but skipping certificate validation or they can cancel and return to Connection Dialog.

Updated dialog on SSL cert validation failure to as under:

![image](https://user-images.githubusercontent.com/13396919/199116298-cbfaab57-6b90-4c78-b28a-96cb18501866.png)

The link redirects to [MS docs](https://learn.microsoft.com/sql/database-engine/configure-windows/enable-encrypted-connections-to-the-database-engine) that provides official SQL Server documentation around encryption.

Also updated custom actions to be primary than the 'Close' button.