### PR TITLE
Fix population of username/password on loading saved profile

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -531,8 +531,12 @@ export class ConnectionWidget extends lifecycle.Disposable {
 
 	protected onAuthTypeSelected(selectedAuthType: string) {
 		let currentAuthType = this.getMatchingAuthType(selectedAuthType);
-		this._userNameInputBox.value = '';
-		this._passwordInputBox.value = '';
+		if (currentAuthType !== AuthenticationType.SqlLogin) {
+			if (currentAuthType !== AuthenticationType.AzureMFA && currentAuthType !== AuthenticationType.AzureMFAAndUser) {
+				this._userNameInputBox.value = '';
+			}
+			this._passwordInputBox.value = '';
+		}
 		this._userNameInputBox.hideMessage();
 		this._passwordInputBox.hideMessage();
 		this._azureAccountDropdown.hideMessage();


### PR DESCRIPTION
PR https://github.com/microsoft/azuredatastudio/pull/21033 led to a new bug being discovered where username/password wouldn't populate when loading saved profile, this change fixes that scenario, retaining the original fix.

_P.S. I'll proceed to merge this to prevent regression from being captured in insider build._