### PR TITLE
add a welcome message for encryption change

### DIFF
--- a/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryption.contribution.ts
+++ b/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryption.contribution.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry, IWorkbenchContribution } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { NotifyEncryptionDialog } from 'sql/workbench/contrib/welcome/notifyEncryption/notifyEncryptionDialog'
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+
+export class NotifyEncryption extends Disposable implements IWorkbenchContribution {
+
+	constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) {
+		super();
+		const dialog = this._instantiationService.createInstance(NotifyEncryptionDialog);
+		dialog.render();
+		dialog.open();
+	}
+}
+
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(NotifyEncryption, LifecyclePhase.Starting);

--- a/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryptionDialog.ts
+++ b/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryptionDialog.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import Severity from 'vs/base/common/severity';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { localize } from 'vs/nls';
+import * as DOM from 'vs/base/browser/dom';
+import { ILogService } from 'vs/platform/log/common/log';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfiguration';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { ErrorMessageDialog } from 'sql/workbench/services/errorMessage/browser/errorMessageDialog';
+import { Link } from 'vs/platform/opener/browser/link';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+
+export class NotifyEncryptionDialog extends ErrorMessageDialog {
+	private static NOTIFY_ENCRYPT_SHOWN = 'workbench.notifyEncryptionShown';
+	private static NOTIFY_ENCRYPT_LINK = 'https://aka.ms/azuredatastudio-connection';
+
+	constructor(
+		@IThemeService themeService: IThemeService,
+		@IClipboardService clipboardService: IClipboardService,
+		@ILayoutService layoutService: ILayoutService,
+		@IAdsTelemetryService telemetryService: IAdsTelemetryService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILogService logService: ILogService,
+		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService,
+		@IInstantiationService private _instantiationService: IInstantiationService,
+		@IStorageService private _storageService: IStorageService
+	) {
+		super(themeService, clipboardService, layoutService, telemetryService, contextKeyService, logService, textResourcePropertiesService);
+	}
+
+	public override open(): void {
+		if (this._storageService.get(NotifyEncryptionDialog.NOTIFY_ENCRYPT_SHOWN, StorageScope.GLOBAL)) {
+			return;
+		}
+
+		super.open(Severity.Info,
+			localize('notifyEncryption.title', 'Important Update'),
+			localize('notifyEncryption.message', 'Azure Data Studio now has encryption enabled by default for all SQL Server connections. This may result in your existing connections no longer working.{0}We recommend you review the link below for more details.', '\n\n'),
+			null,
+			null);
+		this._storageService.store(NotifyEncryptionDialog.NOTIFY_ENCRYPT_SHOWN, true, StorageScope.GLOBAL, StorageTarget.MACHINE);
+	}
+
+	protected override updateDialogBody(): void {
+		super.updateDialogBody();
+		let moreInfoLink = DOM.append(this.getBody()!, DOM.$('.more-info'));
+		this._instantiationService.createInstance(Link, moreInfoLink,
+			{
+				label: localize('notifyEncryption.moreInfoLink', 'More information'),
+				href: NotifyEncryptionDialog.NOTIFY_ENCRYPT_LINK
+			}, undefined);
+	}
+}

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -106,9 +106,13 @@ export class ErrorMessageDialog extends Modal {
 		// Nothing to re-layout
 	}
 
-	private updateDialogBody(): void {
+	protected updateDialogBody(): void {
 		DOM.clearNode(this._body!);
 		DOM.append(this._body!, DOM.$('div.error-message')).innerText = this._message!;
+	}
+
+	protected getBody(): HTMLElement {
+		return this._body;
 	}
 
 	private updateIconTitle(): void {

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -412,6 +412,7 @@ import 'vs/workbench/contrib/surveys/browser/languageSurveys.contribution';
 // Welcome
 import 'vs/workbench/contrib/welcomeOverlay/browser/welcomeOverlay';
 import 'sql/workbench/contrib/welcome/page/browser/welcomePage.contribution'; // {{SQL CARBON EDIT}} - add welcome page contribution
+import 'sql/workbench/contrib/welcome/notifyEncryption/notifyEncryption.contribution'; // {{SQL CARBON EDIT}} - add notifying Encrypt change contribution
 // import 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution'; // {{SQL CARBON EDIT}} - remove vscode getting started
 import 'vs/workbench/contrib/welcomeWalkthrough/browser/walkThrough.contribution';
 import 'vs/workbench/contrib/welcomeViews/common/viewsWelcome.contribution';


### PR DESCRIPTION
This PR adds a welcome message for the encryption change when ADS launches. This dialog will only show up once.

The link https://aka.ms/azuredatastudio-connection is not working yet and will be correctly updated later by @erinstellato-ms 

![image](https://user-images.githubusercontent.com/21186993/199115384-cdb88571-4502-48d3-b9bd-c149228f6662.png)
