### PR TITLE
Status dictionary update for MIAA

### DIFF
--- a/extensions/arc/src/models/miaaModel.ts
+++ b/extensions/arc/src/models/miaaModel.ts
@@ -123,7 +123,7 @@ export class MiaaModel extends ResourceModel {
 			}
 
 			// If we have an external endpoint configured then fetch the databases now
-			if (this._config.status.primaryEndpoint) {
+			if (this._config.status.endpoints.primaryEndpoint) {
 				this.getDatabases(false).catch(_err => {
 					// If an error occurs still fire the event so callers can know to
 					// update (e.g. so dashboards don't show the loading icon forever)
@@ -205,7 +205,7 @@ export class MiaaModel extends ResourceModel {
 	}
 
 	protected createConnectionProfile(): azdata.IConnectionProfile {
-		const ipAndPort = parseIpAndPort(this.config?.status.primaryEndpoint || '');
+		const ipAndPort = parseIpAndPort(this.config?.status.endpoints.primaryEndpoint || '');
 		return {
 			serverName: `${ipAndPort.ip},${ipAndPort.port}`,
 			databaseName: '',

--- a/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaBackupsPage.ts
@@ -278,7 +278,7 @@ export class MiaaBackupsPage extends DashboardPage {
 		} else {
 			// If we don't have an endpoint then there's no point in showing the connect button - but the logic
 			// to display text informing the user of this is already handled by the handleMiaaConfigUpdated
-			if (this._miaaModel?.config?.status.primaryEndpoint) {
+			if (this._miaaModel?.config?.status.endpoints.primaryEndpoint) {
 				this._connectToServerLoading.loading = false;
 				this._connectToServerButton.enabled = true;
 			}

--- a/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
@@ -74,11 +74,11 @@ export class MiaaConnectionStringsPage extends DashboardPage {
 
 	private getConnectionStrings(): KeyValue[] {
 		const config = this._miaaModel.config;
-		if (!config?.status.primaryEndpoint) {
+		if (!config?.status.endpoints.primaryEndpoint) {
 			return [];
 		}
 
-		const externalEndpoint = parseIpAndPort(config.status.primaryEndpoint);
+		const externalEndpoint = parseIpAndPort(config.status.endpoints.primaryEndpoint);
 		const username = this._miaaModel.username ?? '{your_username_here}';
 
 		return [
@@ -97,7 +97,7 @@ $conn = sqlsrv_connect($serverName, $connectionInfo);`),
 	}
 
 	private updateConnectionStrings(): void {
-		this._connectionStringsMessage.value = !this._miaaModel.config?.status.primaryEndpoint ? loc.noExternalEndpoint : '';
+		this._connectionStringsMessage.value = !this._miaaModel.config?.status.endpoints.primaryEndpoint ? loc.noExternalEndpoint : '';
 		this._keyValueContainer.refresh(this.getConnectionStrings());
 	}
 }

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -343,10 +343,10 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 	private handleMiaaConfigUpdated(): void {
 		if (this._miaaModel.config) {
 			this._instanceProperties.status = this._miaaModel.config.status.state || '-';
-			this._instanceProperties.externalEndpoint = this._miaaModel.config.status.primaryEndpoint || loc.notConfigured;
+			this._instanceProperties.externalEndpoint = this._miaaModel.config.status.endpoints.primaryEndpoint || loc.notConfigured;
 			this._instanceProperties.vCores = this._miaaModel.config.spec?.scheduling?.default?.resources?.limits?.cpu?.toString() || '';
-			this._databasesMessage.value = !this._miaaModel.config.status.primaryEndpoint ? loc.noExternalEndpoint : '';
-			if (!this._miaaModel.config.status.primaryEndpoint) {
+			this._databasesMessage.value = !this._miaaModel.config.status.endpoints.primaryEndpoint ? loc.noExternalEndpoint : '';
+			if (!this._miaaModel.config.status.endpoints.primaryEndpoint) {
 				this._databasesContainer.removeItem(this._connectToServerLoading);
 			}
 		}
@@ -375,7 +375,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 		} else {
 			// If we don't have an endpoint then there's no point in showing the connect button - but the logic
 			// to display text informing the user of this is already handled by the handleMiaaConfigUpdated
-			if (this._miaaModel?.config?.status.primaryEndpoint) {
+			if (this._miaaModel?.config?.status.endpoints.primaryEndpoint) {
 				this._connectToServerLoading.loading = false;
 				this._connectToServerButton.enabled = true;
 			}
@@ -426,12 +426,12 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 
 	private refreshDashboardLinks(): void {
 		if (this._miaaModel.config) {
-			const kibanaUrl = this._miaaModel.config.status.logSearchDashboard ?? '';
+			const kibanaUrl = this._miaaModel.config.status.endpoints.logSearchDashboard ?? '';
 			this._kibanaLink.label = kibanaUrl;
 			this._kibanaLink.url = kibanaUrl;
 			this._kibanaLoading!.loading = false;
 
-			const grafanaUrl = this._miaaModel.config.status.metricsDashboard ?? '';
+			const grafanaUrl = this._miaaModel.config.status.endpoints.metricsDashboard ?? '';
 			this._grafanaLink.label = grafanaUrl;
 			this._grafanaLink.url = grafanaUrl;
 			this._grafanaLoading!.loading = false;

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -149,7 +149,7 @@ declare module 'az-ext' {
 				retentionPeriodInDays: number, // 1
 			},
 			readableSecondaries: string, // 0
-            syncSecondaryToCommit: string, // -1,
+			syncSecondaryToCommit: string, // -1,
 			scheduling?: {
 				default?: {
 					resources?: {
@@ -171,12 +171,26 @@ declare module 'az-ext' {
 			}
 		},
 		status: {
-			readyReplicas: string, // "1/1"
-			state: string, // "Ready",
-			logSearchDashboard: string, // https://127.0.0.1:30777/kibana/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:miaa1'))
-			metricsDashboard: string, // https://127.0.0.1:30777/grafana/d/40q72HnGk/sql-managed-instance-metrics?var-hostname=miaa1-0
-			primaryEndpoint?: string // "10.91.86.39:32718"
-			runningVersion: string // "v1.5.0_2022-04-05"
+			endpoints: {
+				logSearchDashboard: string, // https://127.0.0.1:30777/kibana/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:miaa1'))
+				metricsDashboard: string, // https://127.0.0.1:30777/grafana/d/40q72HnGk/sql-managed-instance-metrics?var-hostname=miaa1-0
+				mirroring: string,
+				primaryEndpoint?: string // "10.91.86.39:32718"
+			},
+			highAvailability: {
+				lastUpdateTime: string,
+				mirroringCertificate: string
+			},
+			lastUpdateTime: string,
+			observedGeneration: string,
+			roles: {
+				sql: {
+					lastUpdateTime: string,
+					readyReplicas: string // "1/1"
+				}
+			},
+			runningVersion: string, // "v1.5.0_2022-04-05"
+			state: string // "Ready",
 		}
 	}
 
@@ -219,173 +233,182 @@ declare module 'az-ext' {
 			}
 		},
 		status: {
-			readyReplicas: string, // "1/1"
-			state: string, // "Ready",
-			logSearchDashboard: string, // https://127.0.0.1:30777/kibana/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:miaa1'))
-			metricsDashboard: string, // https://127.0.0.1:30777/grafana/d/40q72HnGk/sql-managed-instance-metrics?var-hostname=miaa1-0
-			primaryEndpoint?: string // "10.91.86.39:32718"
-			runningVersion: string // "v1.5.0_2022-04-05"
+			endpoints: {
+				logSearchDashboard: string, // https://127.0.0.1:30777/kibana/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:miaa1'))
+				metricsDashboard: string, // https://127.0.0.1:30777/grafana/d/40q72HnGk/sql-managed-instance-metrics?var-hostname=miaa1-0
+				mirroring: string,
+				primaryEndpoint?: string // "10.91.86.39:32718"
+			},
+			highAvailability: {
+				lastUpdateTime: string,
+				mirroringCertificate: string
+			},
+			lastUpdateTime: string,
+			observedGeneration: string,
+			roles: {
+				sql: {
+					lastUpdateTime: string,
+					readyReplicas: string // "1/1"
+				}
+			},
+			runningVersion: string, // "v1.5.0_2022-04-05"
+			state: string // "Ready",
 		}
 	}
 
 	export interface SqlMiShowResultDirect {
 		extendedLocation: {
-		  name: string, // /subscriptions/a2382b66-3h2k-3h2k-2gdd-8ef45dgfdc33/resourcegroups/name-rg/providers/microsoft.extendedlocation/customlocations/custom-loc,
-		  type: string, // CustomLocation
+			name: string, // /subscriptions/a2382b66-3h2k-3h2k-2gdd-8ef45dgfdc33/resourcegroups/name-rg/providers/microsoft.extendedlocation/customlocations/custom-loc,
+			type: string, // CustomLocation
 		},
 		id: string, // /subscriptions/a2382b66-3h2k-3h2k-2gdd-8ef45dgfdc33/resourceGroups/name-rg/providers/Microsoft.AzureArcData/sqlManagedInstances/sql1,
 		location: string, // eastus2,
 		name: string, // sql2,
 		properties: {
-		  activeDirectoryInformation: string, // null,
-		  admin: string, // admin,
-		  basicLoginInformation: string, // null,
-		  clusterId: string, // null,
-		  dataControllerId: string, // dc-name,
-		  endTime: string, // null,
-		  extensionId: string, // null,
-		  k8SRaw: {
-			spec: {
-			  backup: {
-				retentionPeriodInDays: number, // 7
-			  },
-			  dev: boolean, // true,
-			  licenseType: string, // BasePrice,
-			  metadata: {
-				annotations: string, // ,
-				labels: string, // ,
-				namespace: string, // namespace-name
-			  },
-			  replicas: number, // 1,
-			  readableSecondaries: string, // 0
-              syncSecondaryToCommit: string, // -1,
-			  scheduling: {
-				additionalProperties: string, // null,
-				default: {
-				  additionalProperties: string, // null,
-				  resources: {
-					additionalProperties: string, // null,
-					limits: {
-					  cpu: string, // 4,
-					  memory: string, // 8Gi
+			activeDirectoryInformation: string, // null,
+			admin: string, // admin,
+			basicLoginInformation: string, // null,
+			clusterId: string, // null,
+			dataControllerId: string, // dc-name,
+			endTime: string, // null,
+			extensionId: string, // null,
+			k8SRaw: {
+				spec: {
+					backup: {
+						retentionPeriodInDays: number, // 7
 					},
-					requests: {
-					  cpu: string, // 2,
-					  memory: string, // 4Gi
-					}
-				  }
+					dev: boolean, // true,
+					licenseType: string, // BasePrice,
+					metadata: {
+						annotations: string, // ,
+						labels: string, // ,
+						namespace: string, // namespace-name
+					},
+					replicas: number, // 1,
+					readableSecondaries: string, // 0
+					syncSecondaryToCommit: string, // -1,
+					scheduling: {
+						additionalProperties: string, // null,
+						default: {
+							additionalProperties: string, // null,
+							resources: {
+								additionalProperties: string, // null,
+								limits: {
+									cpu: string, // 4,
+									memory: string, // 8Gi
+								},
+								requests: {
+									cpu: string, // 2,
+									memory: string, // 4Gi
+								}
+							}
+						}
+					},
+					security: {
+						adminLoginSecret: string, // sql-login-secret,
+						serviceCertificateSecret: string, //
+					},
+					services: {
+						primary: {
+							annotations: string, // ,
+							labels: string, // ,
+							type: string, // NodePort
+						}
+					},
+					settings: {
+						collation: string, // SQL_Latin1_General_CP1_CI_AS,
+						language: {
+							lcid: number, // 1234
+						},
+						sqlagent: {
+							enabled: boolean, // false
+						},
+						timezone: string, // UTC,
+						traceFlags: boolean, // false
+					},
+					storage: {
+						backups: {
+							volumes: [
+								{
+									annotations: string, // ,
+									className: string, // azurefile,
+									labels: string, // ,
+									size: string, // 5Gi
+								}
+							]
+						},
+						data: {
+							volumes: [
+								{
+									annotations: string, // ,
+									className: string, // default,
+									labels: string, // ,
+									size: string, // 5Gi
+								}
+							]
+						},
+						datalogs: {
+							volumes: [
+								{
+									annotations: string, // ,
+									className: string, // default,
+									labels: string, // ,
+									size: string, // 5Gi
+								}
+							]
+						},
+						logs: {
+							volumes: [
+								{
+									annotations: string, // ,
+									className: string, // default,
+									labels: string, // ,
+									size: string, // 5Gi
+								}
+							]
+						}
+					},
+					tier: string, // GeneralPurpose
+				},
+				status: {
+					endpoints: {
+						logSearchDashboard: string, // https://127.0.0.1:30777/kibana/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:miaa1'))
+						metricsDashboard: string, // https://127.0.0.1:30777/grafana/d/40q72HnGk/sql-managed-instance-metrics?var-hostname=miaa1-0
+						mirroring: string,
+						primaryEndpoint?: string // "10.91.86.39:32718"
+					},
+					highAvailability: {
+						lastUpdateTime: string,
+						mirroringCertificate: string
+					},
+					lastUpdateTime: string,
+					observedGeneration: string,
+					roles: {
+						sql: {
+							lastUpdateTime: string,
+							readyReplicas: string // "1/1"
+						}
+					},
+					runningVersion: string, // "v1.5.0_2022-04-05"
+					state: string // "Ready",
 				}
-			  },
-			  security: {
-				adminLoginSecret: string, // sql-login-secret,
-				serviceCertificateSecret: string, //
-			  },
-			  services: {
-				primary: {
-				  annotations: string, // ,
-				  labels: string, // ,
-				  type: string, // NodePort
-				}
-			  },
-			  settings: {
-				collation: string, // SQL_Latin1_General_CP1_CI_AS,
-				language: {
-				  lcid: number, // 1234
-				},
-				sqlagent: {
-				  enabled: boolean, // false
-				},
-				timezone: string, // UTC,
-				traceFlags: boolean, // false
-			  },
-			  storage: {
-				backups: {
-				  volumes: [
-					{
-					  annotations: string, // ,
-					  className: string, // azurefile,
-					  labels: string, // ,
-					  size: string, // 5Gi
-					}
-				  ]
-				},
-				data: {
-				  volumes: [
-					{
-					  annotations: string, // ,
-					  className: string, // default,
-					  labels: string, // ,
-					  size: string, // 5Gi
-					}
-				  ]
-				},
-				datalogs: {
-				  volumes: [
-					{
-					  annotations: string, // ,
-					  className: string, // default,
-					  labels: string, // ,
-					  size: string, // 5Gi
-					}
-				  ]
-				},
-				logs: {
-				  volumes: [
-					{
-					  annotations: string, // ,
-					  className: string, // default,
-					  labels: string, // ,
-					  size: string, // 5Gi
-					}
-				  ]
-				}
-			  },
-			  tier: string, // GeneralPurpose
 			},
-			status: {
-			  endpoints: {
-				logSearchDashboard: string, // https://localhost:12345/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:sql1')),
-				metricsDashboard: string, // https://12.123.1.4:12345/d/sdfgwseg/sql-managed-instance-metrics?var-hostname=sql1-0,
-				mirroring: string, // 10.224.0.4:32040,
-				primary: string, // 10.224.0.4,32477
-			  },
-			  highAvailability: {
-				lastUpdateTime: string, // 2022-05-09T23:40:19.626856Z,
-				mirroringCertificate: string,
-			  },
-			  lastUpdateTime: string, // 2022-05-09T23:41:00.137919Z,
-			  logSearchDashboard: string,
-			  metricsDashboard: string,
-			  observedGeneration: number, // 1,
-			  primaryEndpoint: string, // 10.224.0.4,32477,
-			  readyReplicas: string, // 1/1,
-			  roles: {
-				sql: {
-				  lastUpdateTime: string, // 2022-05-09T23:39:53.364002Z,
-				  readyReplicas: number, // 1,
-				  replicas: number, // 1
-				}
-			  },
-			  runningVersion: string, // v1.4.0_2022-02-25,
-			  state: string, // Ready
-			}
-		  },
-		  lastUploadedDate: string, // null,
-		  licenseType: string, // BasePrice,
-		  provisioningState: string, // Succeeded,
-		  startTime: string, // null
+			lastUploadedDate: string, // null,
+			licenseType: string, // BasePrice,
+			provisioningState: string, // Succeeded,
+			startTime: string, // null
 		},
 		resourceGroup: string, // rg-name,
 		sku: {
-		  capacity: string, // null,
-		  dev: string, // null,
-		  family: string, // null,
-		  size: string, // null,
-		  tier: string, // GeneralPurpose
+			capacity: string, // null,
+			dev: string, // null,
+			family: string, // null,
+			size: string, // null,
+			tier: string, // GeneralPurpose
 		},
 		tags: {},
 		type: string, // microsoft.azurearcdata/sqlmanagedinstances
-	  }
+	}
 
 	export interface SqlMiDbRestoreResult {
 		destDatabase: string, //testDbToRestore
@@ -546,16 +569,16 @@ declare module 'az-ext' {
 						resourceGroup?: string,
 						// K8s API arguments
 						namespace?: string
-						},
-						// Additional arguments
-						additionalEnvVars?: AdditionalEnvVars
+					},
+					// Additional arguments
+					additionalEnvVars?: AdditionalEnvVars
 				): Promise<AzOutput<void>>,
 				list(
 					args: {
-					// ARM API arguments
-					resourceGroup?: string,
-					// K8s API arguments
-					namespace?: string
+						// ARM API arguments
+						resourceGroup?: string,
+						// K8s API arguments
+						namespace?: string
 					},
 					// Additional arguments
 					additionalEnvVars?: AdditionalEnvVars

--- a/extensions/azcli/src/typings/az-ext.d.ts
+++ b/extensions/azcli/src/typings/az-ext.d.ts
@@ -174,18 +174,18 @@ declare module 'az-ext' {
 			endpoints: {
 				logSearchDashboard: string, // https://127.0.0.1:30777/kibana/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:miaa1'))
 				metricsDashboard: string, // https://127.0.0.1:30777/grafana/d/40q72HnGk/sql-managed-instance-metrics?var-hostname=miaa1-0
-				mirroring: string,
+				mirroring: string, // 10.91.90.25:3448
 				primaryEndpoint?: string // "10.91.86.39:32718"
 			},
 			highAvailability: {
-				lastUpdateTime: string,
-				mirroringCertificate: string
+				lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
+				mirroringCertificate: string // "-----BEGIN CERTIFICATE-----****-----END CERTIFICATE-----\n"
 			},
-			lastUpdateTime: string,
-			observedGeneration: string,
+			lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
+			observedGeneration: string, // 1
 			roles: {
 				sql: {
-					lastUpdateTime: string,
+					lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
 					readyReplicas: string // "1/1"
 				}
 			},
@@ -236,18 +236,18 @@ declare module 'az-ext' {
 			endpoints: {
 				logSearchDashboard: string, // https://127.0.0.1:30777/kibana/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:miaa1'))
 				metricsDashboard: string, // https://127.0.0.1:30777/grafana/d/40q72HnGk/sql-managed-instance-metrics?var-hostname=miaa1-0
-				mirroring: string,
+				mirroring: string, // 10.91.90.25:3448
 				primaryEndpoint?: string // "10.91.86.39:32718"
 			},
 			highAvailability: {
-				lastUpdateTime: string,
-				mirroringCertificate: string
+				lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
+				mirroringCertificate: string // "-----BEGIN CERTIFICATE-----****-----END CERTIFICATE-----\n"
 			},
-			lastUpdateTime: string,
-			observedGeneration: string,
+			lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
+			observedGeneration: string, // 1
 			roles: {
 				sql: {
-					lastUpdateTime: string,
+					lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
 					readyReplicas: string // "1/1"
 				}
 			},
@@ -374,18 +374,18 @@ declare module 'az-ext' {
 					endpoints: {
 						logSearchDashboard: string, // https://127.0.0.1:30777/kibana/app/kibana#/discover?_a=(query:(language:kuery,query:'custom_resource_name:miaa1'))
 						metricsDashboard: string, // https://127.0.0.1:30777/grafana/d/40q72HnGk/sql-managed-instance-metrics?var-hostname=miaa1-0
-						mirroring: string,
+						mirroring: string, // 10.91.90.25:3448
 						primaryEndpoint?: string // "10.91.86.39:32718"
 					},
 					highAvailability: {
-						lastUpdateTime: string,
-						mirroringCertificate: string
+						lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
+						mirroringCertificate: string // "-----BEGIN CERTIFICATE-----****-----END CERTIFICATE-----\n"
 					},
-					lastUpdateTime: string,
-					observedGeneration: string,
+					lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
+					observedGeneration: string, // 1
 					roles: {
 						sql: {
-							lastUpdateTime: string,
+							lastUpdateTime: string, // "2022-02-07T06:08:20.500688Z"
 							readyReplicas: string // "1/1"
 						}
 					},


### PR DESCRIPTION
Changes: 
- Added status.endpoints (dictionary)
- Added status.highAvailability and status.roles.sql
- Replaced status.logSearchDashboard to use status.endpoints.logSearchDashboard instead.
- Replaced status.metricsDashboard to use status.endpoints.metricsDashboard instead.
- Replaced status.primaryEndpoint to use status.endpoints.primary instead.
- Replaced status.readyReplicas to use status.roles.sql.readyReplicas instead.