### PR TITLE
Fix compilation error with Notification Error Dialog

### DIFF
--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -56,7 +56,7 @@ export class ErrorMessageDialog extends Modal {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ILogService logService: ILogService,
 		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService,
-		@IOpenerService private readonly _openerService: IOpenerService
+		@IOpenerService private readonly _openerService?: IOpenerService
 	) {
 		super('', TelemetryKeys.ModalDialogName.ErrorMessage, telemetryService, layoutService, clipboardService, themeService, logService, textResourcePropertiesService, contextKeyService, { dialogStyle: 'normal', hasTitleIcon: true });
 		this._okLabel = localize('errorMessageDialog.ok', "OK");


### PR DESCRIPTION
With both PRs #21036 and #21048 merging together, we got unaware of conflicting changes and got a compilation issue:

Error: E:/azuredatastudio/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryptionDialog.ts(36,3): Expected 8 arguments, but got 7.       

This PR fixes that by making `_openerService` optional.