### PR TITLE
Add dashboard navigation to database when connected to a database

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/dashboard.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboard.component.ts
@@ -45,6 +45,9 @@ export class DashboardComponent extends AngularDisposable implements OnInit {
 			// Route to the server page as this is the default database
 			this._router.navigate(['server-dashboard'], { relativeTo: this._activeRoute, skipLocationChange: true }).catch(onUnexpectedError);
 		}
+		else {
+			this._router.navigate(['database-dashboard'], { relativeTo: this._activeRoute, skipLocationChange: true }).catch(onUnexpectedError);
+		}
 	}
 
 	private updateTheme(theme: IColorTheme): void {


### PR DESCRIPTION
When connected to a database and not server, I noticed the zoom reset happening, since navigation was not controlled.
This PR fixes the behavior by navigating to database-dashboard when connection is based on a database.