### PR TITLE
Cleanup encryption dialog

### DIFF
--- a/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryptionDialog.ts
+++ b/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryptionDialog.ts
@@ -31,9 +31,9 @@ export class NotifyEncryptionDialog extends ErrorMessageDialog {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ILogService logService: ILogService,
 		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService,
+		@IOpenerService openerService: IOpenerService,
 		@IInstantiationService private _instantiationService: IInstantiationService,
-		@IStorageService private _storageService: IStorageService,
-		@IOpenerService openerService: IOpenerService
+		@IStorageService private _storageService: IStorageService
 	) {
 		super(themeService, clipboardService, layoutService, telemetryService, contextKeyService, logService, textResourcePropertiesService, openerService);
 	}

--- a/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryptionDialog.ts
+++ b/src/sql/workbench/contrib/welcome/notifyEncryption/notifyEncryptionDialog.ts
@@ -17,6 +17,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ErrorMessageDialog } from 'sql/workbench/services/errorMessage/browser/errorMessageDialog';
 import { Link } from 'vs/platform/opener/browser/link';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 
 export class NotifyEncryptionDialog extends ErrorMessageDialog {
 	private static NOTIFY_ENCRYPT_SHOWN = 'workbench.notifyEncryptionShown';
@@ -31,9 +32,10 @@ export class NotifyEncryptionDialog extends ErrorMessageDialog {
 		@ILogService logService: ILogService,
 		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService,
 		@IInstantiationService private _instantiationService: IInstantiationService,
-		@IStorageService private _storageService: IStorageService
+		@IStorageService private _storageService: IStorageService,
+		@IOpenerService openerService: IOpenerService
 	) {
-		super(themeService, clipboardService, layoutService, telemetryService, contextKeyService, logService, textResourcePropertiesService);
+		super(themeService, clipboardService, layoutService, telemetryService, contextKeyService, logService, textResourcePropertiesService, openerService);
 	}
 
 	public override open(): void {
@@ -43,9 +45,7 @@ export class NotifyEncryptionDialog extends ErrorMessageDialog {
 
 		super.open(Severity.Info,
 			localize('notifyEncryption.title', 'Important Update'),
-			localize('notifyEncryption.message', 'Azure Data Studio now has encryption enabled by default for all SQL Server connections. This may result in your existing connections no longer working.{0}We recommend you review the link below for more details.', '\n\n'),
-			null,
-			null);
+			localize('notifyEncryption.message', 'Azure Data Studio now has encryption enabled by default for all SQL Server connections. This may result in your existing connections no longer working.{0}We recommend you review the link below for more details.', '\n\n'));
 		this._storageService.store(NotifyEncryptionDialog.NOTIFY_ENCRYPT_SHOWN, true, StorageScope.GLOBAL, StorageTarget.MACHINE);
 	}
 

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -56,7 +56,7 @@ export class ErrorMessageDialog extends Modal {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ILogService logService: ILogService,
 		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService,
-		@IOpenerService private readonly _openerService?: IOpenerService
+		@IOpenerService private readonly _openerService: IOpenerService
 	) {
 		super('', TelemetryKeys.ModalDialogName.ErrorMessage, telemetryService, layoutService, clipboardService, themeService, logService, textResourcePropertiesService, contextKeyService, { dialogStyle: 'normal', hasTitleIcon: true });
 		this._okLabel = localize('errorMessageDialog.ok', "OK");


### PR DESCRIPTION
1. We generally shouldn't be making injected services optional - especially when we don't then also update the class to handle the service potentially not being there. It's simple and low-cost to just pass in all the services and makes things much more consistent across the application

(if you wanted to do something like that then it'd be better to make a common abstract class that both can inherit from and just exclude the services that aren't needed by both)

2. Also removed some uses of null - we should prefer to use undefined but in this case they're optional anyways so we can just completely remove them. 