### PR TITLE
Fix account name to display UTF8 characters

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -642,7 +642,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 	protected getTokenClaims(accessToken: string): TokenClaims {
 		try {
 			const split = accessToken.split('.');
-			return JSON.parse(Buffer.from(split[1], 'base64').toString('binary'));
+			return JSON.parse(Buffer.from(split[1], 'base64').toString('UTF8'));
 		} catch (ex) {
 			throw new Error('Unable to read token claims: ' + JSON.stringify(ex));
 		}


### PR DESCRIPTION
This PR fixes #12629

### Before:

![image](https://user-images.githubusercontent.com/13396919/199451850-8e085a50-3504-4531-a61c-580e65049ae3.png)


### With fix (Hindi characters as expected):

![image](https://user-images.githubusercontent.com/13396919/199451314-6c873cd6-ee53-4476-bdaa-06b320d16380.png)

![image](https://user-images.githubusercontent.com/13396919/199452648-4c37ef9e-0f1d-48ca-bf8a-438a688bd023.png)
