### PR TITLE
Remove extra scrollbars from manage packages dialog

### DIFF
--- a/extensions/notebook/src/dialog/managePackages/installedPackagesTab.ts
+++ b/extensions/notebook/src/dialog/managePackages/installedPackagesTab.ts
@@ -93,7 +93,7 @@ export class InstalledPackagesTab {
 						}
 					],
 					data: [[]],
-					height: '500px',
+					height: '430px',
 					width: '400px'
 				}).component();
 			this.disposables.push(this.installedPackagesTable.onCellAction(async (rowState) => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/16088 by shortening the installed package table to remove extra scrollbars in the dialog.
