### PR TITLE
Add more memory to watch extension task

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "watch-client": "node --max_old_space_size=4095 ./node_modules/gulp/bin/gulp.js watch-client",
     "watch-clientd": "deemon yarn watch-client",
     "kill-watch-clientd": "deemon --kill yarn watch-client",
-    "watch-extensions": "node --max_old_space_size=4095 ./node_modules/gulp/bin/gulp.js watch-extensions watch-extension-media",
+    "watch-extensions": "node --max_old_space_size=8192 ./node_modules/gulp/bin/gulp.js watch-extensions watch-extension-media",
     "watch-extensionsd": "deemon yarn watch-extensions",
     "kill-watch-extensionsd": "deemon --kill yarn watch-extensions",
     "precommit": "node build/hygiene.js",


### PR DESCRIPTION
with the most recent build, a memory allocation error occurs when you run Yarn Run Watch. Specifically, when running watch extensions on Azurecore. To fix this, the memory for that process has been bumped up to allow it to work.