### PR TITLE
Removed plan tree as default for screen reader mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
     "applicationinsights": "1.4.2",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.54",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.55",
     "chart.js": "^2.9.4",
     "chokidar": "3.5.1",
     "graceful-fs": "4.2.8",

--- a/remote/package.json
+++ b/remote/package.json
@@ -19,7 +19,7 @@
     "applicationinsights": "1.4.2",
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.54",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.55",
     "chart.js": "^2.9.4",
     "cookie": "^0.4.0",
     "graceful-fs": "4.2.8",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -16,7 +16,7 @@
 		"@vscode/vscode-languagedetection": "1.0.21",
 		"angular2-grid": "2.0.6",
 		"ansi_up": "^5.1.0",
-		"azdataGraph": "github:Microsoft/azdataGraph#0.0.54",
+		"azdataGraph": "github:Microsoft/azdataGraph#0.0.55",
 		"chart.js": "^2.9.4",
 		"gridstack": "^3.1.3",
 		"kburtram-query-plan": "2.6.1",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -155,9 +155,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.54":
-  version "0.0.52"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/4cce41781e138614007c4239b23fc6954af59703"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.55":
+  version "0.0.55"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/29151cd7e16f5241865eb9b32eb246fb72cfdfba"
 
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -220,9 +220,9 @@ async-listener@^0.6.0:
     semver "^5.3.0"
     shimmer "^1.1.0"
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.54":
-  version "0.0.52"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/4cce41781e138614007c4239b23fc6954af59703"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.55":
+  version "0.0.55"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/29151cd7e16f5241865eb9b32eb246fb72cfdfba"
 
 base64-js@^1.3.1:
   version "1.5.1"

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -27,7 +27,6 @@ import { ExecutionPlanTab } from 'sql/workbench/contrib/executionPlan/browser/ex
 import { ExecutionPlanFileViewCache } from 'sql/workbench/contrib/executionPlan/browser/executionPlanFileViewCache';
 import { TopOperationsTab } from 'sql/workbench/contrib/executionPlan/browser/topOperationsTab';
 import { ExecutionPlanTreeTab } from 'sql/workbench/contrib/executionPlan/browser/executionPlanTreeTab';
-import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 class MessagesView extends Disposable implements IPanelView {
 	private messagePanel: MessagePanel;
@@ -180,7 +179,6 @@ export class QueryResultsView extends Disposable {
 		@IQueryModelService private queryModelService: IQueryModelService,
 		@INotificationService private notificationService: INotificationService,
 		@ILogService private logService: ILogService,
-		@IAccessibilityService private accessibilityService: IAccessibilityService
 	) {
 		super();
 		this.resultsTab = this._register(new ResultsTab(instantiationService));
@@ -465,11 +463,6 @@ export class QueryResultsView extends Disposable {
 			this.input?.state.visibleTabs.add(this.planTreeTab.identifier);
 			if (!this._panelView.contains(this.planTreeTab.identifier)) {
 				this._panelView.pushTab(this.planTreeTab);
-			}
-
-			// Switching to plan tree as default view when screen reader mode is on.
-			if (this.accessibilityService.isScreenReaderOptimized()) {
-				this._panelView.showTab(this.planTreeTab.identifier);
 			}
 		}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,9 +2064,9 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.54":
-  version "0.0.52"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/4cce41781e138614007c4239b23fc6954af59703"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.55":
+  version "0.0.55"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/29151cd7e16f5241865eb9b32eb246fb72cfdfba"
 
 bach@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
Previously, whenever a query returned an execution plan in screen reader optimized mode, we switched to plan tree in the results grid. Now, since the execution plan graph is accessible, there is no need to do that.
Also updating azdata graph library for an undefined error fix.