### PR TITLE
Fix tenant Id design for Azure accounts

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -183,7 +183,12 @@ export abstract class AzureAuth implements vscode.Disposable {
 			return undefined;
 		}
 
-		const tenant = account.properties.owningTenant.id === tenantId
+		if (!account.properties.owningTenant) {
+			// Should never happen
+			throw new AzureAuthError(localize('azure.owningTenantNotFound', "Owning Tenant information not found for account."), 'Owning tenant not found.', undefined);
+		}
+
+		const tenant = account.properties.owningTenant?.id === tenantId
 			? account.properties.owningTenant
 			: account.properties.tenants.find(t => t.id === tenantId);
 

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -183,7 +183,9 @@ export abstract class AzureAuth implements vscode.Disposable {
 			return undefined;
 		}
 
-		const tenant = account.properties.tenants.find(t => t.id === tenantId);
+		const tenant = account.properties.owningTenant.id === tenantId
+			? account.properties.owningTenant
+			: account.properties.tenants.find(t => t.id === tenantId);
 
 		if (!tenant) {
 			throw new AzureAuthError(localize('azure.tenantNotFound', "Specified tenant with ID '{0}' not found.", tenantId), `Tenant ${tenantId} not found.`, undefined);
@@ -553,7 +555,10 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 		const name = tokenClaims.name ?? tokenClaims.email ?? tokenClaims.unique_name;
 		const email = tokenClaims.email ?? tokenClaims.unique_name;
-		const owningTenant = tenants.find(t => t.id === tokenClaims.tid);
+
+		// Read more about tid > https://learn.microsoft.com/azure/active-directory/develop/id-tokens
+		const owningTenant = tenants.find(t => t.id === tokenClaims.tid)
+			?? { 'id': tokenClaims.tid, 'displayName': 'Microsoft Account' };
 
 		let displayName = name;
 		if (email) {

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -38,11 +38,16 @@ declare module 'azurecore' {
 		azureAuthType?: AzureAuthType
 
 		providerSettings: AzureAccountProviderMetadata;
+
 		/**
 		 * Whether or not the account is a Microsoft account
 		 */
 		isMsAccount: boolean;
 
+		/**
+		 * Defines the tenant the Azure Account belongs to.
+		 */
+		owningTenant: Tenant;
 		/**
 		 * A list of tenants (aka directories) that the account belongs to
 		 */
@@ -356,10 +361,10 @@ declare module 'azurecore' {
 		}
 
 		export interface IAzureResourceTreeDataProvider {
-			 /**
-			  * Gets the root tree item nodes for this provider - these will be used as
-			  * direct children of the Account node in the Azure tree view.
-			  */
+			/**
+			 * Gets the root tree item nodes for this provider - these will be used as
+			 * direct children of the Account node in the Azure tree view.
+			 */
 			getRootChildren(): Promise<azdata.TreeItem[]>;
 			/**
 			 * Gets the children for a given {@link IAzureResourceNode}

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -45,7 +45,8 @@ declare module 'azurecore' {
 		isMsAccount: boolean;
 
 		/**
-		 * Defines the tenant the Azure Account belongs to.
+		 * Represents the tenant that the user would be signing in to. For work and school accounts, the GUID is the immutable tenant ID of the organization that the user is signing in to.
+		 * For sign-ins to the personal Microsoft account tenant (services like Xbox, Teams for Life, or Outlook), the value is 9188040d-6c67-4c5b-b112-36a304b66dad.
 		 */
 		owningTenant: Tenant;
 		/**

--- a/extensions/azurecore/src/test/account-provider/auths/azureAuth.test.ts
+++ b/extensions/azurecore/src/test/account-provider/auths/azureAuth.test.ts
@@ -53,6 +53,7 @@ describe('Azure Authentication', function () {
 		mockAccount = {
 			isStale: false,
 			properties: {
+				owningTenant: mockTenant,
 				tenants: [mockTenant]
 			}
 		} as AzureAccount;

--- a/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
@@ -35,6 +35,10 @@ const mockAccount: AzureAccount = {
 	properties: {
 		providerSettings: settings[0].metadata,
 		isMsAccount: true,
+		owningTenant: {
+			id: 'tenantId',
+			displayName: 'tenantDisplayName',
+		},
 		tenants: []
 	},
 	isStale: false

--- a/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
@@ -35,6 +35,10 @@ const mockAccount: AzureAccount = {
 	properties: {
 		providerSettings: settings[0].metadata,
 		isMsAccount: true,
+		owningTenant: {
+			id: 'tenantId',
+			displayName: 'tenantDisplayName',
+		},
 		tenants: []
 	},
 	isStale: false

--- a/extensions/azurecore/src/test/azureResource/resourceService.test.ts
+++ b/extensions/azurecore/src/test/azureResource/resourceService.test.ts
@@ -28,13 +28,17 @@ const mockAccount: AzureAccount = {
 	properties: {
 		providerSettings: settings[0].metadata,
 		isMsAccount: true,
+		owningTenant: {
+			id: 'tenantId',
+			displayName: 'tenantDisplayName',
+		},
 		tenants: []
 	},
 	isStale: false
 };
 
 const mockTenantId: string = 'mock_tenant';
-const mockSubscriptionId ='mock_subscription';
+const mockSubscriptionId = 'mock_subscription';
 
 const mockSubscription: azureResource.AzureResourceSubscription = {
 	id: mockSubscriptionId,
@@ -50,7 +54,7 @@ let mockResourceProvider2: TypeMoq.IMock<azureResource.IAzureResourceProvider>;
 
 let resourceService: AzureResourceService;
 
-describe('AzureResourceService.listResourceProviderIds', function(): void {
+describe('AzureResourceService.listResourceProviderIds', function (): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
 		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
@@ -71,7 +75,7 @@ describe('AzureResourceService.listResourceProviderIds', function(): void {
 		resourceService.areResourceProvidersLoaded = true;
 	});
 
-	it('Should be correct when registering providers.', async function(): Promise<void> {
+	it('Should be correct when registering providers.', async function (): Promise<void> {
 		resourceService.registerResourceProvider(mockResourceProvider1.object);
 		let providerIds = await resourceService.listResourceProviderIds();
 		should(providerIds).Array();
@@ -87,7 +91,7 @@ describe('AzureResourceService.listResourceProviderIds', function(): void {
 	});
 });
 
-describe('AzureResourceService.getRootChildren', function(): void {
+describe('AzureResourceService.getRootChildren', function (): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
 		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
@@ -101,13 +105,13 @@ describe('AzureResourceService.getRootChildren', function(): void {
 		resourceService.areResourceProvidersLoaded = true;
 	});
 
-	it('Should be correct when provider id is correct.', async function(): Promise<void> {
+	it('Should be correct when provider id is correct.', async function (): Promise<void> {
 		const children = await resourceService.getRootChildren(mockResourceProvider1.object.providerId, mockAccount, mockSubscription, mockTenantId);
 
 		should(children).Array();
 	});
 
-	it('Should throw exceptions when provider id is incorrect.', async function(): Promise<void> {
+	it('Should throw exceptions when provider id is incorrect.', async function (): Promise<void> {
 		const providerId = 'non_existent_provider_id';
 		try {
 			await resourceService.getRootChildren(providerId, mockAccount, mockSubscription, mockTenantId);
@@ -120,7 +124,7 @@ describe('AzureResourceService.getRootChildren', function(): void {
 	});
 });
 
-describe('AzureResourceService.getChildren', function(): void {
+describe('AzureResourceService.getChildren', function (): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
 		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
@@ -135,12 +139,12 @@ describe('AzureResourceService.getChildren', function(): void {
 		resourceService.areResourceProvidersLoaded = true;
 	});
 
-	it('Should be correct when provider id is correct.', async function(): Promise<void> {
+	it('Should be correct when provider id is correct.', async function (): Promise<void> {
 		const children = await resourceService.getChildren(mockResourceProvider1.object.providerId, TypeMoq.It.isAny());
 		should(children).Array();
 	});
 
-	it('Should throw exceptions when provider id is incorrect.', async function(): Promise<void> {
+	it('Should throw exceptions when provider id is incorrect.', async function (): Promise<void> {
 		const providerId = 'non_existent_provider_id';
 		try {
 			await resourceService.getRootChildren(providerId, mockAccount, mockSubscription, mockTenantId);
@@ -153,7 +157,7 @@ describe('AzureResourceService.getChildren', function(): void {
 	});
 });
 
-describe('AzureResourceService.getTreeItem', function(): void {
+describe('AzureResourceService.getTreeItem', function (): void {
 	beforeEach(() => {
 		mockResourceTreeDataProvider1 = TypeMoq.Mock.ofType<azureResource.IAzureResourceTreeDataProvider>();
 		mockResourceTreeDataProvider1.setup((o) => o.getRootChildren()).returns(() => Promise.resolve([TypeMoq.Mock.ofType<azdata.TreeItem>().object]));
@@ -168,12 +172,12 @@ describe('AzureResourceService.getTreeItem', function(): void {
 		resourceService.areResourceProvidersLoaded = true;
 	});
 
-	it('Should be correct when provider id is correct.', async function(): Promise<void> {
+	it('Should be correct when provider id is correct.', async function (): Promise<void> {
 		const treeItem = await resourceService.getTreeItem(mockResourceProvider1.object.providerId, TypeMoq.It.isAny());
 		should(treeItem).Object();
 	});
 
-	it('Should throw exceptions when provider id is incorrect.', async function(): Promise<void> {
+	it('Should throw exceptions when provider id is incorrect.', async function (): Promise<void> {
 		const providerId = 'non_existent_provider_id';
 		try {
 			await resourceService.getRootChildren(providerId, mockAccount, mockSubscription, mockTenantId);

--- a/extensions/azurecore/src/test/azureResource/resourceTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/resourceTreeNode.test.ts
@@ -31,6 +31,10 @@ const mockAccount: AzureAccount = {
 	properties: {
 		providerSettings: settings[0].metadata,
 		isMsAccount: true,
+		owningTenant: {
+			id: 'tenantId',
+			displayName: 'tenantDisplayName',
+		},
 		tenants: []
 	},
 	isStale: false

--- a/extensions/azurecore/src/test/azureResource/tree/accountTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/tree/accountTreeNode.test.ts
@@ -35,7 +35,10 @@ let mockTreeChangeHandler: TypeMoq.IMock<IAzureResourceTreeChangeHandler>;
 
 // Mock test data
 const mockTenantId = 'mock_tenant_id';
-
+const mockTenant = {
+	id: mockTenantId,
+	displayName: 'Mock Tenant'
+};
 const mockAccount: AzureAccount = {
 	key: {
 		accountId: '97915f6d-84fa-4926-b60c-38db64327ad7',
@@ -50,11 +53,9 @@ const mockAccount: AzureAccount = {
 	},
 	properties: {
 		tenants: [
-			{
-				id: mockTenantId,
-				displayName: 'Mock Tenant'
-			}
+			mockTenant
 		],
+		owningTenant: mockTenant,
 		providerSettings: {
 			settings: allSettings[0].metadata.settings,
 			id: 'azure',
@@ -360,8 +361,7 @@ describe('AzureResourceAccountTreeNode.clearCache', function (): void {
 		sinon.stub(azdata.accounts, 'getAccountSecurityToken').returns(Promise.resolve(mockToken));
 		mockCacheService.setup((o) => o.generateKey(TypeMoq.It.isAnyString())).returns(() => generateGuid());
 		mockCacheService.setup((o) => o.get(TypeMoq.It.isAnyString())).returns(() => mockSubscriptionCache);
-		mockCacheService.setup((o) => o.update(TypeMoq.It.isAnyString(), TypeMoq.It.isAny())).returns(() =>
-		{
+		mockCacheService.setup((o) => o.update(TypeMoq.It.isAnyString(), TypeMoq.It.isAny())).returns(() => {
 			mockSubscriptionCache = mockSubscriptions;
 			return Promise.resolve();
 		});

--- a/extensions/azurecore/tsconfig.json
+++ b/extensions/azurecore/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./out",
 		"noUnusedParameters": false,
+		"sourceMap": true,
 		"typeRoots": [
 			"./node_modules/@types"
 		],


### PR DESCRIPTION
This PR shall fix #20701 #20517 and many more similar issues where tenant IDs are not respected.

Current implementation contained a logic to fetch home tenant, which would look into all tenants and find the first 'Home' tenant. It is entirely possible that an Azure account contains multiple 'Home' tenants (as it is in my account), so this implementation was incorrect.

### Consequences and what changed:

* Wrong tenant identified can lead to different account Id being fetched when refreshing token. This is why when reopening ADS, we would see multiple account entries in Azure Tree for same Corp account generally observed by users also have a personal AD. https://github.com/microsoft/azuredatastudio/issues/20701#issuecomment-1301483198

The implementation is now updated to fetch the tenant Id from `token claims > tid` as fetched with the access token - is the one that user authorized from. We should be using this `tid` for future connections and refreshing, which seems to fix the issue, as the respective Azure Account will always receive token from this federation authority. Thanks @cssuh for validating the change. 

Defining tid from [MS Docs](https://learn.microsoft.com/azure/active-directory/develop/id-tokens):

**tid (String, a GUID) =** Represents the tenant that the user is signing in to. For work and school accounts, the GUID is the immutable tenant ID of the organization that the user is signing in to. For sign-ins to the personal Microsoft account tenant (services like Xbox, Teams for Life, or Outlook), the value is 9188040d-6c67-4c5b-b112-36a304b66dad.

* #20517 is also seemingly fixed when testing, we're able to see when clicking the 'Connect' icon near server/db names, correct tenant shows up relative to where Server/DB belongs to (mainly impacts multi-tenant user accounts), this was always defaulting to the same first Home tenant as saved previously., 
  * Looking at codebase [here](https://github.com/microsoft/azuredatastudio/blob/68b91089db3d1e6ee52e958ee179f360ce3eb278/src/sql/workbench/services/connection/browser/connectionWidget.ts#L796-L812) it makes sense that now the correct tenant is being loaded as associated with the connection profile.

The changes in this PR will also apply to MSAL as they apply to core design of how tenant id is used for authenticating user.