### PR TITLE
Bumps azdataGraph version to 0.0.56

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
     "applicationinsights": "1.4.2",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.55",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.56",
     "chart.js": "^2.9.4",
     "chokidar": "3.5.1",
     "graceful-fs": "4.2.8",

--- a/remote/package.json
+++ b/remote/package.json
@@ -19,7 +19,7 @@
     "applicationinsights": "1.4.2",
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.55",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.56",
     "chart.js": "^2.9.4",
     "cookie": "^0.4.0",
     "graceful-fs": "4.2.8",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -16,7 +16,7 @@
 		"@vscode/vscode-languagedetection": "1.0.21",
 		"angular2-grid": "2.0.6",
 		"ansi_up": "^5.1.0",
-		"azdataGraph": "github:Microsoft/azdataGraph#0.0.55",
+		"azdataGraph": "github:Microsoft/azdataGraph#0.0.56",
 		"chart.js": "^2.9.4",
 		"gridstack": "^3.1.3",
 		"kburtram-query-plan": "2.6.1",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -155,9 +155,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.55":
-  version "0.0.55"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/29151cd7e16f5241865eb9b32eb246fb72cfdfba"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.56":
+  version "0.0.56"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/7df642038282389a26efb92bf37bfa3450924ad0"
 
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -220,9 +220,9 @@ async-listener@^0.6.0:
     semver "^5.3.0"
     shimmer "^1.1.0"
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.55":
-  version "0.0.55"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/29151cd7e16f5241865eb9b32eb246fb72cfdfba"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.56":
+  version "0.0.56"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/7df642038282389a26efb92bf37bfa3450924ad0"
 
 base64-js@^1.3.1:
   version "1.5.1"

--- a/src/sql/workbench/contrib/executionPlan/browser/widgets/highlightExpensiveNodeWidget.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/widgets/highlightExpensiveNodeWidget.ts
@@ -301,11 +301,9 @@ export class HighlightExpensiveOperationAction extends Action {
 		const expensiveOperationDelegate: (cell: AzDataGraphCell) => number | undefined = context.getExpensiveOperationDelegate();
 
 		context.executionPlanDiagram.clearExpensiveOperatorHighlighting();
-		let result = context.executionPlanDiagram.highlightExpensiveOperator(expensiveOperationDelegate);
-		if (!result) {
-			const metric = context.expenseMetricSelectBox.value;
-			context.notificationService.warn(localize('invalidPropertyExecutionPlanMetric', 'No nodes found with the {0} metric.', metric));
-		}
+		context.executionPlanDiagram.highlightExpensiveOperator(expensiveOperationDelegate);
+		// lewissanchez TODO: Add focus logic to center the highlighted node. Removed the error message logic since the expensive operation widget
+		// is only populated with plan metrics that are contained in a plan.
 	}
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,9 +2064,9 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.55":
-  version "0.0.55"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/29151cd7e16f5241865eb9b32eb246fb72cfdfba"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.56":
+  version "0.0.56"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/7df642038282389a26efb92bf37bfa3450924ad0"
 
 bach@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #20870

The "no nodes found" warning message was removed since the highlight expensive operation widget only contains metrics that are present in a query execution plan.