### PR TITLE
vBump extensions with updates to 1DS key

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -2,7 +2,7 @@
   "name": "admin-tool-ext-win",
   "displayName": "%adminToolExtWin.displayName%",
   "description": "%adminToolExtWin.description%",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/extensions/admin-tool-ext-win/license/Azure%20Data%20Studio%20Extension%20-%20Standalone%20(free)%20Use%20Terms.txt",

--- a/extensions/agent/package.json
+++ b/extensions/agent/package.json
@@ -7,7 +7,6 @@
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
-  "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
   "engines": {
     "vscode": "^1.25.0"
   },

--- a/extensions/azurehybridtoolkit/package.json
+++ b/extensions/azurehybridtoolkit/package.json
@@ -7,7 +7,6 @@
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
-  "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
   "engines": {
     "vscode": "*",
     "azdata": "*"

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -2,7 +2,7 @@
   "name": "import",
   "displayName": "SQL Server Import",
   "description": "SQL Server Import for Azure Data Studio supports importing CSV or JSON files into SQL Server.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "publisher": "Microsoft",
   "preview": false,
   "engines": {

--- a/extensions/liveshare/package.json
+++ b/extensions/liveshare/package.json
@@ -2,7 +2,6 @@
   "name": "liveshare",
   "version": "0.1.0",
   "publisher": "Microsoft",
-  "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
   "activationEvents": [
     "*"
   ],

--- a/extensions/machine-learning/package.json
+++ b/extensions/machine-learning/package.json
@@ -17,7 +17,6 @@
   ],
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extensionIcon.png",
-  "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
   "main": "./out/main",
   "repository": {
     "type": "git",

--- a/extensions/profiler/package.json
+++ b/extensions/profiler/package.json
@@ -7,7 +7,6 @@
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
 	"icon": "images/extension.png",
-	"aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
 	"engines": {
 		"vscode": "0.10.x"
 	},

--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -2,7 +2,7 @@
   "name": "query-history",
   "displayName": "%queryHistory.displayName%",
   "description": "%queryHistory.description%",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "publisher": "Microsoft",
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",

--- a/extensions/sql-assessment/package.json
+++ b/extensions/sql-assessment/package.json
@@ -2,7 +2,7 @@
   "name": "sql-assessment",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -2,7 +2,7 @@
   "name": "sql-bindings-vscode",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "ms-mssql",
   "preview": true,
   "engines": {


### PR DESCRIPTION
Follow up to https://github.com/microsoft/azuredatastudio/pull/20769/files

I'll be releasing new versions of these extensions that use the new key now that the 1DS onboarding is completed. 

Also removed the key value from extensions that don't actually have send any telemetry. 

Note there's already a number of extensions that were updated that already had their version bumped so I'll just be releasing with that version so they aren't included in this PR. 