### PR TITLE
Fix connections issues in resource deployment notebooks.

### DIFF
--- a/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-azure-sshkey.ipynb
+++ b/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-azure-sshkey.ipynb
@@ -2,12 +2,12 @@
     "metadata": {
         "kernelspec": {
             "name": "python3",
-            "display_name": "Python 3",
+            "display_name": "Python 3 (ipykernel)",
             "language": "python"
         },
         "language_info": {
             "name": "python",
-            "version": "3.6.6",
+            "version": "3.8.10",
             "mimetype": "text/x-python",
             "codemirror_mode": {
                 "name": "ipython",
@@ -75,7 +75,8 @@
                 "azdata_cell_guid": "70b9744f-eb59-44e8-9b35-db590ac4651d",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -102,7 +103,8 @@
                 "azdata_cell_guid": "55bb2f96-6f7f-4aa0-9daf-d0f7f9d9243c",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -145,7 +147,8 @@
                 "azdata_cell_guid": "dde9388b-f623-4d62-bb74-36a05f5d2ea3",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -177,7 +180,8 @@
                 "azdata_cell_guid": "19ebeaf4-94c9-4d2b-bd9f-e3c6bf7f2dda",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -200,7 +204,8 @@
                 "azdata_cell_guid": "f9e8ddee-aefa-4951-b767-b318d941d2cd",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -227,7 +232,8 @@
                 "azdata_cell_guid": "6e085676-2cc5-4af8-819c-fa210244e6c3",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -255,7 +261,8 @@
                 "azdata_cell_guid": "f29b439e-cf05-4c35-aa47-1482ccd653bf",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -283,7 +290,8 @@
                 "azdata_cell_guid": "f9f5e4ec-82a5-45df-a408-ddb0fb21847c",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -334,7 +342,8 @@
                 "azdata_cell_guid": "7ab2b3ec-0832-40b3-98c0-4aa87320e7ce",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -364,7 +373,8 @@
                 "azdata_cell_guid": "c183c3e3-8699-4f29-993b-07bf848336e3",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -402,7 +412,8 @@
                 "azdata_cell_guid": "c8590c65-b274-460d-9659-97e81d2fd3ea",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -433,7 +444,8 @@
                 "azdata_cell_guid": "81a86ff6-5a83-48be-8be7-654d152eea89",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -452,7 +464,7 @@
             "cell_type": "code",
             "source": [
                 "from IPython.display import *\n",
-                "connectionParameter = '{\"serverName\":\"' + f'{ip_address},{sql_port}' + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\": \"sa\",\"password\":' + json.dumps(sa_password) + '}'\n",
+                "connectionParameter = '{\"serverName\":\"' + f'{ip_address},{sql_port}' + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\": \"sa\",\"password\":' + json.dumps(sa_password) + ',\"options\": {\"trustServerCertificate\":true}}'\n",
                 "display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to the Azure SQL Edge instance</font></a><br/>'))\n",
                 "display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The Azure SQL Edge instance password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
             ],
@@ -460,7 +472,8 @@
                 "azdata_cell_guid": "8bc29cce-96a7-4a78-89af-5c73a6431c24",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -477,7 +490,8 @@
                 "azdata_cell_guid": "8b74ac43-a871-4d28-832d-e6da586f6d3a",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null

--- a/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-azure.ipynb
+++ b/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-azure.ipynb
@@ -2,12 +2,12 @@
     "metadata": {
         "kernelspec": {
             "name": "python3",
-            "display_name": "Python 3",
+            "display_name": "Python 3 (ipykernel)",
             "language": "python"
         },
         "language_info": {
             "name": "python",
-            "version": "3.6.6",
+            "version": "3.8.10",
             "mimetype": "text/x-python",
             "codemirror_mode": {
                 "name": "ipython",
@@ -75,7 +75,8 @@
                 "azdata_cell_guid": "70b9744f-eb59-44e8-9b35-db590ac4651d",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -102,7 +103,8 @@
                 "azdata_cell_guid": "55bb2f96-6f7f-4aa0-9daf-d0f7f9d9243c",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -145,7 +147,8 @@
                 "azdata_cell_guid": "dde9388b-f623-4d62-bb74-36a05f5d2ea3",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -177,7 +180,8 @@
                 "azdata_cell_guid": "19ebeaf4-94c9-4d2b-bd9f-e3c6bf7f2dda",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -200,7 +204,8 @@
                 "azdata_cell_guid": "f9e8ddee-aefa-4951-b767-b318d941d2cd",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -227,7 +232,8 @@
                 "azdata_cell_guid": "6e085676-2cc5-4af8-819c-fa210244e6c3",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -255,7 +261,8 @@
                 "azdata_cell_guid": "f29b439e-cf05-4c35-aa47-1482ccd653bf",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -283,7 +290,8 @@
                 "azdata_cell_guid": "f9f5e4ec-82a5-45df-a408-ddb0fb21847c",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -334,7 +342,8 @@
                 "azdata_cell_guid": "7ab2b3ec-0832-40b3-98c0-4aa87320e7ce",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -364,7 +373,8 @@
                 "azdata_cell_guid": "c183c3e3-8699-4f29-993b-07bf848336e3",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -402,7 +412,8 @@
                 "azdata_cell_guid": "c8590c65-b274-460d-9659-97e81d2fd3ea",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -433,7 +444,8 @@
                 "azdata_cell_guid": "81a86ff6-5a83-48be-8be7-654d152eea89",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -452,7 +464,7 @@
             "cell_type": "code",
             "source": [
                 "from IPython.display import *\n",
-                "connectionParameter = '{\"serverName\":\"' + f'{ip_address},{sql_port}' + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\": \"sa\",\"password\":' + json.dumps(sa_password) + '}'\n",
+                "connectionParameter = '{\"serverName\":\"' + f'{ip_address},{sql_port}' + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\": \"sa\",\"password\":' + json.dumps(sa_password) + ',\"options\": {\"trustServerCertificate\":true}}'\n",
                 "display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to the Azure SQL Edge instance</font></a><br/>'))\n",
                 "display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The Azure SQL Edge instance password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
             ],
@@ -460,7 +472,8 @@
                 "azdata_cell_guid": "8bc29cce-96a7-4a78-89af-5c73a6431c24",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -477,7 +490,8 @@
                 "azdata_cell_guid": "8b74ac43-a871-4d28-832d-e6da586f6d3a",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null

--- a/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-local.ipynb
+++ b/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-local.ipynb
@@ -2,11 +2,12 @@
     "metadata": {
         "kernelspec": {
             "name": "python3",
-            "display_name": "Python 3"
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python"
         },
         "language_info": {
             "name": "python",
-            "version": "3.6.6",
+            "version": "3.8.10",
             "mimetype": "text/x-python",
             "codemirror_mode": {
                 "name": "ipython",
@@ -65,7 +66,8 @@
                 "azdata_cell_guid": "a0a8cd9b-ab0f-4ba2-b568-0c68d950c8bf",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -90,7 +92,8 @@
                 "azdata_cell_guid": "5a253372-1a98-4b07-a3e0-9ae5f47cb0a5",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -143,7 +146,8 @@
                 "azdata_cell_guid": "c0af4e4e-4232-4a67-9a21-05a4d54fd0f4",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -170,7 +174,8 @@
                 "azdata_cell_guid": "58b2156b-da0c-47d5-9706-4bd9f630d28b",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -195,7 +200,8 @@
                 "azdata_cell_guid": "4cdcf011-06fd-4df4-bd20-3024d0a5ab9d",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -219,7 +225,8 @@
                 "azdata_cell_guid": "345dc24f-0028-47b4-b35b-aaac047b7a62",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -238,7 +245,7 @@
             "cell_type": "code",
             "source": [
                 "from IPython.display import *\n",
-                "connectionParameter = '{\"serverName\":\"localhost,' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + '}'\n",
+                "connectionParameter = '{\"serverName\":\"localhost,' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + ',\"options\": {\"trustServerCertificate\":true}}'\n",
                 "display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to the Azure SQL Edge instance</font></a><br/>'))\n",
                 "display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The Azure SQL Edge instance password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
             ],
@@ -246,7 +253,8 @@
                 "azdata_cell_guid": "187a0067-a04c-4afb-a684-3103bb4522ae",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -273,7 +281,8 @@
                 "azdata_cell_guid": "9b6c34c2-7a47-43f5-971d-ce9768fec587",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null

--- a/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-remote.ipynb
+++ b/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-remote.ipynb
@@ -2,11 +2,12 @@
     "metadata": {
         "kernelspec": {
             "name": "python3",
-            "display_name": "Python 3"
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python"
         },
         "language_info": {
             "name": "python",
-            "version": "3.6.6",
+            "version": "3.8.10",
             "mimetype": "text/x-python",
             "codemirror_mode": {
                 "name": "ipython",
@@ -62,7 +63,8 @@
                 "azdata_cell_guid": "a0a8cd9b-ab0f-4ba2-b568-0c68d950c8bf",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -124,7 +126,8 @@
                 "azdata_cell_guid": "c0af4e4e-4232-4a67-9a21-05a4d54fd0f4",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -162,7 +165,8 @@
                 "azdata_cell_guid": "aadaa458-8c23-4b7a-a87e-cb2ee82046cf",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -187,7 +191,8 @@
                 "azdata_cell_guid": "f3f3946b-d950-477d-83d6-8bae320f619f",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -211,7 +216,8 @@
                 "azdata_cell_guid": "8b2874af-de7e-4a0a-9cad-3be397eaa3e9",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -238,7 +244,8 @@
                 "azdata_cell_guid": "58b2156b-da0c-47d5-9706-4bd9f630d28b",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -262,7 +269,8 @@
                 "azdata_cell_guid": "4cdcf011-06fd-4df4-bd20-3024d0a5ab9d",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -286,7 +294,8 @@
                 "azdata_cell_guid": "345dc24f-0028-47b4-b35b-aaac047b7a62",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -305,7 +314,7 @@
             "cell_type": "code",
             "source": [
                 "from IPython.display import *\n",
-                "connectionParameter = '{\"serverName\":\"' + ssh_target + ',' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + '}'\n",
+                "connectionParameter = '{\"serverName\":\"' + ssh_target + ',' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + ',\"options\": {\"trustServerCertificate\":true}}'\n",
                 "display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to the Azure SQL Edge instance</font></a><br/>'))\n",
                 "display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The Azure SQL Edge instance password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
             ],
@@ -313,7 +322,8 @@
                 "azdata_cell_guid": "187a0067-a04c-4afb-a684-3103bb4522ae",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -340,7 +350,8 @@
                 "azdata_cell_guid": "9b6c34c2-7a47-43f5-971d-ce9768fec587",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -354,7 +365,8 @@
                 "azdata_cell_guid": "9f2c9d3a-b996-4977-81f5-05a79a2e0e12",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null

--- a/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-single-device.ipynb
+++ b/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-single-device.ipynb
@@ -2,11 +2,12 @@
     "metadata": {
         "kernelspec": {
             "name": "python3",
-            "display_name": "Python 3"
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python"
         },
         "language_info": {
             "name": "python",
-            "version": "3.6.6",
+            "version": "3.8.10",
             "mimetype": "text/x-python",
             "codemirror_mode": {
                 "name": "ipython",
@@ -72,7 +73,8 @@
                 "azdata_cell_guid": "70b9744f-eb59-44e8-9b35-db590ac4651d",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -99,7 +101,8 @@
                 "azdata_cell_guid": "55bb2f96-6f7f-4aa0-9daf-d0f7f9d9243c",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -137,7 +140,8 @@
                 "azdata_cell_guid": "dde9388b-f623-4d62-bb74-36a05f5d2ea3",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -162,7 +166,8 @@
             ],
             "metadata": {
                 "azdata_cell_guid": "19ebeaf4-94c9-4d2b-bd9f-e3c6bf7f2dda",
-                "tags": []
+                "tags": [],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -185,7 +190,8 @@
                 "azdata_cell_guid": "f9e8ddee-aefa-4951-b767-b318d941d2cd",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -212,7 +218,8 @@
                 "azdata_cell_guid": "6e085676-2cc5-4af8-819c-fa210244e6c3",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -243,7 +250,8 @@
                 "azdata_cell_guid": "38798c56-b2a0-4af8-b39e-5e26f3c79aeb",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -294,7 +302,8 @@
                 "azdata_cell_guid": "7ab2b3ec-0832-40b3-98c0-4aa87320e7ce",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -325,7 +334,8 @@
                 "azdata_cell_guid": "81a86ff6-5a83-48be-8be7-654d152eea89",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -347,7 +357,7 @@
                 "if ip_address == \"\":\n",
                 "    print('Connect to Azure SQL Edge instance feature not available because device ip address is not provided')\n",
                 "else:\n",
-                "    connectionParameter = '{\"serverName\":\"' + f'{ip_address},{sql_port}' + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\": \"sa\",\"password\":' + json.dumps(sa_password) + '}'\n",
+                "    connectionParameter = '{\"serverName\":\"' + f'{ip_address},{sql_port}' + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\": \"sa\",\"password\":' + json.dumps(sa_password) + ',\"options\": {\"trustServerCertificate\":true}}'\n",
                 "    display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to the Azure SQL Edge instance</font></a><br/>'))\n",
                 "    display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The Azure SQL Edge instance password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
             ],
@@ -355,7 +365,8 @@
                 "azdata_cell_guid": "8bc29cce-96a7-4a78-89af-5c73a6431c24",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -372,7 +383,8 @@
                 "azdata_cell_guid": "e9d4188e-11c8-4aa5-8320-c3d0f6d023b2",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null

--- a/extensions/resource-deployment/notebooks/docker/2017/deploy-sql2017-image.ipynb
+++ b/extensions/resource-deployment/notebooks/docker/2017/deploy-sql2017-image.ipynb
@@ -2,11 +2,12 @@
     "metadata": {
         "kernelspec": {
             "name": "python3",
-            "display_name": "Python 3"
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python"
         },
         "language_info": {
             "name": "python",
-            "version": "3.6.6",
+            "version": "3.8.10",
             "mimetype": "text/x-python",
             "codemirror_mode": {
                 "name": "ipython",
@@ -65,7 +66,8 @@
                 "azdata_cell_guid": "64f3e119-408a-4b61-bce4-68114e2a727c",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -90,7 +92,8 @@
                 "azdata_cell_guid": "dd665751-efbc-4089-af1b-0fa456a4fb58",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -127,7 +130,8 @@
                 "azdata_cell_guid": "a2e06bb2-23f3-4fc7-81bc-d38e250b24c0",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -151,7 +155,8 @@
                 "azdata_cell_guid": "d75ae87c-2e59-4cf5-b61e-43f4bf8ac680",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -183,7 +188,8 @@
                 "azdata_cell_guid": "73585d5d-0c8c-4786-92f2-7e0fd2653f9e",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -207,7 +213,8 @@
                 "azdata_cell_guid": "5e30c110-a631-4c9b-8485-cd64d34c54d5",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -226,7 +233,7 @@
             "cell_type": "code",
             "source": [
                 "from IPython.display import *\n",
-                "connectionParameter = '{\"serverName\":\"localhost,' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + '}'\n",
+                "connectionParameter = '{\"serverName\":\"localhost,' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + ',\"options\": {\"trustServerCertificate\":true}}'\n",
                 "display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to SQL Server</font></a><br/>'))\n",
                 "display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The SQL Server password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
             ],
@@ -234,7 +241,8 @@
                 "azdata_cell_guid": "182517d3-f6d6-4ecc-b2cb-4c21a0f23b4e",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -261,7 +269,8 @@
                 "azdata_cell_guid": "1593a0a6-7009-4d0b-9f3f-ac7ed6d2bb1e",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null

--- a/extensions/resource-deployment/notebooks/docker/2019/deploy-sql2019-image.ipynb
+++ b/extensions/resource-deployment/notebooks/docker/2019/deploy-sql2019-image.ipynb
@@ -2,11 +2,12 @@
     "metadata": {
         "kernelspec": {
             "name": "python3",
-            "display_name": "Python 3"
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python"
         },
         "language_info": {
             "name": "python",
-            "version": "3.6.6",
+            "version": "3.8.10",
             "mimetype": "text/x-python",
             "codemirror_mode": {
                 "name": "ipython",
@@ -65,7 +66,8 @@
                 "azdata_cell_guid": "6196300e-f896-489b-8dca-b2c42eda2d6d",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -90,7 +92,8 @@
                 "azdata_cell_guid": "26170d1b-4332-4383-bcc4-1d97030daffc",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -127,7 +130,8 @@
                 "azdata_cell_guid": "93cb0147-7bf6-4630-b796-3811dfd1354b",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -151,7 +155,8 @@
                 "azdata_cell_guid": "7b102447-3198-488f-a995-982ae1fc8555",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -182,7 +187,8 @@
                 "azdata_cell_guid": "82f27460-88eb-4484-92ee-40305e650d70",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -206,7 +212,8 @@
                 "azdata_cell_guid": "211ee198-f1d1-4781-9daa-8497c2665de6",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -225,7 +232,7 @@
             "cell_type": "code",
             "source": [
                 "from IPython.display import *\n",
-                "connectionParameter = '{\"serverName\":\"localhost,' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + '}'\n",
+                "connectionParameter = '{\"serverName\":\"localhost,' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + ',\"options\": {\"trustServerCertificate\":true}}'\n",
                 "display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to SQL Server</font></a><br/>'))\n",
                 "display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The SQL Server password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
             ],
@@ -233,7 +240,8 @@
                 "azdata_cell_guid": "4bc64915-c5ae-4507-8fb0-9e413ccc2fd0",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null
@@ -260,7 +268,8 @@
                 "azdata_cell_guid": "f9e0f1ad-ba6e-4c17-84ea-cc5dceb1289b",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
             "execution_count": null

--- a/extensions/resource-deployment/notebooks/docker/2022/deploy-sql2022-image.ipynb
+++ b/extensions/resource-deployment/notebooks/docker/2022/deploy-sql2022-image.ipynb
@@ -1,10 +1,33 @@
 {
+    "metadata": {
+        "kernelspec": {
+            "name": "python3",
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python"
+        },
+        "language_info": {
+            "name": "python",
+            "version": "3.8.10",
+            "mimetype": "text/x-python",
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "pygments_lexer": "ipython3",
+            "nbconvert_exporter": "python",
+            "file_extension": ".py"
+        },
+        "vscode": {
+            "interpreter": {
+                "hash": "878db934b706db2770cee331c11f15a67312cefb4f2334de757c7c9b6e34ef9f"
+            }
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
     "cells": [
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "e5fb2be9-e904-4821-8473-b69b90760c6a"
-            },
             "source": [
                 "![Microsoft](https://raw.githubusercontent.com/microsoft/azuredatastudio/main/extensions/resource-deployment/images/microsoft-small-logo.png)\n",
                 "## Run SQL Server 2022 Preview container image with Docker\n",
@@ -14,27 +37,22 @@
                 "- Docker Engine. For more information, see [Install Docker](https://docs.docker.com/engine/installation/).\n",
                 "\n",
                 "<span style=\"color:red\"><font size=\"3\">Please press the \"Run all\" button to run the notebook</font></span>"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "e5fb2be9-e904-4821-8473-b69b90760c6a"
+            }
         },
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "76c571ab-358a-4b07-810c-53020ee1745a"
-            },
             "source": [
                 "### Check dependencies"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "76c571ab-358a-4b07-810c-53020ee1745a"
+            }
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "azdata_cell_guid": "6196300e-f896-489b-8dca-b2c42eda2d6d",
-                "tags": [
-                    "hide_input"
-                ]
-            },
-            "outputs": [],
             "source": [
                 "import sys,os,getpass,json,html,time\n",
                 "from string import Template\n",
@@ -48,52 +66,54 @@
                 "\n",
                 "cmd = 'docker version'\n",
                 "run_command()"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "6196300e-f896-489b-8dca-b2c42eda2d6d",
+                "tags": [
+                    "hide_input"
+                ],
+                "language": "python"
+            },
+            "outputs": [],
+            "execution_count": null
         },
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "87b07614-d57d-4731-ac3e-a8b324d231f2"
-            },
             "source": [
                 "### List existing containers\n",
                 "You can view the ports that have been used by existing containers"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "87b07614-d57d-4731-ac3e-a8b324d231f2"
+            }
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "source": [
+                "cmd = f'docker ps -a'\n",
+                "run_command()"
+            ],
             "metadata": {
                 "azdata_cell_guid": "26170d1b-4332-4383-bcc4-1d97030daffc",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
-            "source": [
-                "cmd = f'docker ps -a'\n",
-                "run_command()"
-            ]
+            "execution_count": null
         },
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "52b1faf2-d7c7-446b-ba0b-4f8b744da0bb"
-            },
             "source": [
                 "### Required information"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "52b1faf2-d7c7-446b-ba0b-4f8b744da0bb"
+            }
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "azdata_cell_guid": "93cb0147-7bf6-4630-b796-3811dfd1354b",
-                "tags": [
-                    "hide_input"
-                ]
-            },
-            "outputs": [],
             "source": [
                 "env_var_flag = \"AZDATA_NB_VAR_DOCKER_PASSWORD\" in os.environ\n",
                 "password_name = 'SQL Server sa account password'\n",
@@ -110,51 +130,53 @@
                 "        sql_port = '1433'\n",
                 "print(f'{password_name}: ******')\n",
                 "print(f'Port: {sql_port}')"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "93cb0147-7bf6-4630-b796-3811dfd1354b",
+                "tags": [
+                    "hide_input"
+                ],
+                "language": "python"
+            },
+            "outputs": [],
+            "execution_count": null
         },
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "643ccaca-fd1d-4482-b81e-aee29b627e34"
-            },
             "source": [
                 "### Pull the container image"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "643ccaca-fd1d-4482-b81e-aee29b627e34"
+            }
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "source": [
+                "cmd = f'docker pull mcr.microsoft.com/mssql/server:2022-latest'\n",
+                "run_command()"
+            ],
             "metadata": {
                 "azdata_cell_guid": "7b102447-3198-488f-a995-982ae1fc8555",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
-            "source": [
-                "cmd = f'docker pull mcr.microsoft.com/mssql/server:2022-latest'\n",
-                "run_command()"
-            ]
+            "execution_count": null
         },
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "a4527a5f-c2c5-4f60-bfd1-b119576178c5"
-            },
             "source": [
                 "### Start a new container"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "a4527a5f-c2c5-4f60-bfd1-b119576178c5"
+            }
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "azdata_cell_guid": "82f27460-88eb-4484-92ee-40305e650d70",
-                "tags": [
-                    "hide_input"
-                ]
-            },
-            "outputs": [],
             "source": [
                 "if env_var_flag:\n",
                 "    container_name = os.environ[\"AZDATA_NB_VAR_DOCKER_CONTAINER_NAME\"]\n",
@@ -165,111 +187,97 @@
                 "template = Template(f'docker run -e ACCEPT_EULA=Y -e \"SA_PASSWORD=$password\" -p {sql_port}:1433 --name {container_name} -d mcr.microsoft.com/mssql/server:2022-latest')\n",
                 "cmd = template.substitute(password=sql_password)\n",
                 "run_command(template.substitute(password='******'))"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "82f27460-88eb-4484-92ee-40305e650d70",
+                "tags": [
+                    "hide_input"
+                ],
+                "language": "python"
+            },
+            "outputs": [],
+            "execution_count": null
         },
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "e267aa7d-dd22-43ac-9b03-cf282ef15f67"
-            },
             "source": [
                 "### List all the containers"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "e267aa7d-dd22-43ac-9b03-cf282ef15f67"
+            }
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "source": [
+                "cmd = f'docker ps -a'\n",
+                "run_command()"
+            ],
             "metadata": {
                 "azdata_cell_guid": "211ee198-f1d1-4781-9daa-8497c2665de6",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
-            "source": [
-                "cmd = f'docker ps -a'\n",
-                "run_command()"
-            ]
+            "execution_count": null
         },
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "5f5860c4-7962-439e-a15b-7f24f504dc18"
-            },
             "source": [
                 "### Connect to SQL Server in Azure Data Studio\n",
                 "It might take a couple minutes for SQL Server to launch"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "5f5860c4-7962-439e-a15b-7f24f504dc18"
+            }
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "source": [
+                "from IPython.display import *\n",
+                "connectionParameter = '{\"serverName\":\"localhost,' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + ',\"options\": {\"trustServerCertificate\":true}}'\n",
+                "display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to SQL Server</font></a><br/>'))\n",
+                "display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The SQL Server password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
+            ],
             "metadata": {
                 "azdata_cell_guid": "4bc64915-c5ae-4507-8fb0-9e413ccc2fd0",
                 "tags": [
                     "hide_input"
-                ]
+                ],
+                "language": "python"
             },
             "outputs": [],
-            "source": [
-                "from IPython.display import *\n",
-                "connectionParameter = '{\"serverName\":\"localhost,' + sql_port + '\",\"providerName\":\"MSSQL\",\"authenticationType\":\"SqlLogin\",\"userName\":\"sa\",\"password\":' + json.dumps(sql_password) + '}'\n",
-                "display(HTML('<br/><a href=\"command:azdata.connect?' + html.escape(connectionParameter)+'\"><font size=\"3\">Click here to connect to SQL Server</font></a><br/>'))\n",
-                "display(HTML('<br/><span style=\"color:red\"><font size=\"2\">NOTE: The SQL Server password is included in this link, you may want to clear the results of this code cell before saving the notebook.</font></span>'))"
-            ]
+            "execution_count": null
         },
         {
             "cell_type": "markdown",
-            "metadata": {
-                "azdata_cell_guid": "9a1039fa-fdd3-408b-b649-8fde0fcee660"
-            },
             "source": [
                 "### Stop and remove the container"
-            ]
+            ],
+            "metadata": {
+                "azdata_cell_guid": "9a1039fa-fdd3-408b-b649-8fde0fcee660"
+            }
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "azdata_cell_guid": "f9e0f1ad-ba6e-4c17-84ea-cc5dceb1289b",
-                "tags": [
-                    "hide_input"
-                ]
-            },
-            "outputs": [],
             "source": [
                 "stop_container_command = f'docker stop {container_name}'\n",
                 "remove_container_command = f'docker rm {container_name}'\n",
                 "display(HTML(\"Use this link to: <a href=\\\"command:workbench.action.terminal.focus\\\">open the terminal window in Azure Data Studio</a> and use the links below to paste the command to the terminal.\"))\n",
                 "display(HTML(\"Stop the container: <a href=\\\"command:workbench.action.terminal.sendSequence?%7B%22text%22%3A%22\"+stop_container_command.replace(\" \",\"%20\")+\"%22%7D\\\">\" + stop_container_command + \"</a>\"))\n",
                 "display(HTML(\"Remove the container: <a href=\\\"command:workbench.action.terminal.sendSequence?%7B%22text%22%3A%22\"+remove_container_command.replace(\" \",\"%20\")+\"%22%7D\\\">\" + remove_container_command + \"</a>\"))"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3.10.1 64-bit",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
+            ],
+            "metadata": {
+                "azdata_cell_guid": "f9e0f1ad-ba6e-4c17-84ea-cc5dceb1289b",
+                "tags": [
+                    "hide_input"
+                ],
+                "language": "python"
             },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.10.1"
-        },
-        "vscode": {
-            "interpreter": {
-                "hash": "878db934b706db2770cee331c11f15a67312cefb4f2334de757c7c9b6e34ef9f"
-            }
+            "outputs": [],
+            "execution_count": null
         }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 2
+    ]
 }

--- a/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
@@ -118,7 +118,8 @@ CommandsRegistry.registerCommand('azdata.connect',
 		authenticationType?: AuthenticationType,
 		userName?: string,
 		password?: string,
-		databaseName?: string
+		databaseName?: string,
+		options?: { [name: string]: any }
 	}) {
 		const capabilitiesServices = accessor.get(ICapabilitiesService);
 		const connectionManagementService = accessor.get(IConnectionManagementService);
@@ -139,7 +140,7 @@ CommandsRegistry.registerCommand('azdata.connect',
 				saveProfile: true,
 				id: undefined,
 				groupId: undefined,
-				options: {}
+				options: args.options
 			};
 			const connectionProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesServices, profile);
 


### PR DESCRIPTION
This PR fixes #20987
for locally deployed SQL Server instances, we should make the experience smoother by automatically set the trustServerCertificate parameter in order to connect.

1. the only actual change in the notebooks is to add `"options": {"trustServerCertificate":true}` as additional parameter to connect. the other changes are generated by the notebooks automatically. NOTE: I didn't run these notebooks, simply added the string and saved the notebooks, testing was done using copies of these notebooks.
2. modified the azdata.connect command to accept additional options.