### PR TITLE
put Generate project from OpenApi/Swagger spec behind preview flag

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -219,7 +219,7 @@
         },
         {
           "command": "sqlDatabaseProjects.generateProjectFromOpenApiSpec",
-          "when": "view == dataworkspace.views.main",
+          "when": "view == dataworkspace.views.main && config.workbench.enablePreviewFeatures",
           "group": "1_currentWorkspace@3"
         }
       ],
@@ -322,6 +322,10 @@
         {
           "command": "sqlDatabaseProjects.openInDesigner",
           "when": "false"
+        },
+        {
+          "command": "sqlDatabaseProjects.generateProjectFromOpenApiSpec",
+          "when": "config.workbench.enablePreviewFeatures"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
Putting Generate project form OpenApi/Swagger spec behind the preview flag so the command will only show in the command palette and Database Projects overflow menu when "Enable Preview Features" is checked. 