### PR TITLE
Send telemetry action event when user selects 'Enable Trust Server Certificate'

### DIFF
--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -75,6 +75,7 @@ export const enum TelemetryAction {
 	DeleteAgentProxy = 'DeleteAgentProxy',
 	DeleteConnection = 'DeleteConnection',
 	DeleteServerGroup = 'DeleteServerGroup',
+	EnableTrustServerCertificate = 'EnableTrustServerCertificate',
 	FindNode = 'FindNode',
 	FirewallRuleRequested = 'FirewallRuleCreated',
 	GenerateScript = 'GenerateScript',

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -527,7 +527,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			Note: A self-signed certificate offers only limited protection and is not a recommended practice for production environments. Do you want to enable 'Trust server certificate' on this connection and retry? `);
 			let readMoreLink = "https://learn.microsoft.com/sql/database-engine/configure-windows/enable-encrypted-connections-to-the-database-engine"
 			actions.push(new Action('trustServerCert', enableTrustServerCert, undefined, true, async () => {
-				this._telemetryService?.createActionEvent(TelemetryKeys.TelemetryView.ConnectionDialog, TelemetryKeys.TelemetryAction.EnableTrustServerCertificate)
+				this._telemetryService.sendActionEvent(TelemetryKeys.TelemetryView.ConnectionDialog, TelemetryKeys.TelemetryAction.EnableTrustServerCertificate);
 				this._model.options[Constants.trustServerCertificate] = true;
 				await this.handleOnConnect(this._connectionDialog.newConnectionParams, this._model as IConnectionProfile);
 				return;

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -27,6 +27,8 @@ import * as types from 'vs/base/common/types';
 import { trim } from 'vs/base/common/strings';
 import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { CmsConnectionController } from 'sql/workbench/services/connection/browser/cmsConnectionController';
 import { entries } from 'sql/base/common/collections';
 import { onUnexpectedError } from 'vs/base/common/errors';
@@ -89,6 +91,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		@IClipboardService private _clipboardService: IClipboardService,
 		@ICommandService private _commandService: ICommandService,
 		@ILogService private _logService: ILogService,
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		this.initializeConnectionProviders();
 	}
@@ -524,6 +527,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			Note: A self-signed certificate offers only limited protection and is not a recommended practice for production environments. Do you want to enable 'Trust server certificate' on this connection and retry? `);
 			let readMoreLink = "https://learn.microsoft.com/sql/database-engine/configure-windows/enable-encrypted-connections-to-the-database-engine"
 			actions.push(new Action('trustServerCert', enableTrustServerCert, undefined, true, async () => {
+				this._telemetryService?.createActionEvent(TelemetryKeys.TelemetryView.ConnectionDialog, TelemetryKeys.TelemetryAction.EnableTrustServerCertificate)
 				this._model.options[Constants.trustServerCertificate] = true;
 				await this.handleOnConnect(this._connectionDialog.newConnectionParams, this._model as IConnectionProfile);
 				return;

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -108,8 +108,10 @@ suite('ConnectionDialogService tests', () => {
 		testInstantiationService.stub(ICapabilitiesService, new TestCapabilitiesService());
 
 		let logService: ILogService = new NullLogService();
+		let telemetryService: IAdsTelemetryService = new NullAdsTelemetryService();
+
 		connectionDialogService = new ConnectionDialogService(testInstantiationService, capabilitiesService, errorMessageService.object,
-			new TestConfigurationService(), new BrowserClipboardService(layoutService, logService), NullCommandService, logService);
+			new TestConfigurationService(), new BrowserClipboardService(layoutService, logService), NullCommandService, logService, telemetryService);
 		(connectionDialogService as any)._connectionManagementService = mockConnectionManagementService.object;
 		let providerDisplayNames = ['Mock SQL Server'];
 		let providerNameToDisplayMap = { 'MSSQL': 'Mock SQL Server' };


### PR DESCRIPTION
PR adds a telemetry action event when user clicks on the newly added action button.
I believe the error message is already captured with 'createErrorEvent' from connectionManagementService (onConnectionComplete), so we need not log it again.

Would appreciate any other feedback for capturing better telemetry with the new changes.