### PR TITLE
Revert gulp-rename

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -274,7 +274,7 @@ gulp.task(packageLocalizationExtensionsTask);
 const compileLocalizationExtensionsBuildTask = task.define('compile-localization-extensions-build', task.series(
 	cleanExtensionsBuildTask,
 	compileExtensionsTask,
-	task.define('bundle-marketplace-extensions-build', () => { ext.packageMarketplaceExtensionsStream(false, product.extensionsGallery?.serviceUrl).pipe(gulp.dest('.build')) }),
+	task.define('bundle-marketplace-extensions-build', () => ext.packageMarketplaceExtensionsStream(false, product.extensionsGallery?.serviceUrl).pipe(gulp.dest('.build'))),
 	packageLocalizationExtensionsTask,
 ));
 

--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -231,7 +231,7 @@ const cleanExtensionsBuildTask = task.define('clean-extensions-build', util.rimr
 const compileExtensionsBuildTask = task.define('compile-extensions-build', task.series(
 	cleanExtensionsBuildTask,
 	task.define('bundle-extensions-build', () => ext.packageLocalExtensionsStream(false).pipe(gulp.dest('.build'))),
-	task.define('bundle-marketplace-extensions-build', () => { ext.packageMarketplaceExtensionsStream(false, product.extensionsGallery?.serviceUrl).pipe(gulp.dest('.build')) }), // {{SQL CARBON EDIT}}
+	task.define('bundle-marketplace-extensions-build', () => ext.packageMarketplaceExtensionsStream(false, product.extensionsGallery?.serviceUrl).pipe(gulp.dest('.build'))),
 ));
 
 gulp.task(compileExtensionsBuildTask);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5376,15 +5376,10 @@ gulp-remote-retry-src@^0.8.0:
     through2 "~2.0.3"
     vinyl "~2.0.1"
 
-gulp-rename@1.2.2:
+gulp-rename@1.2.2, gulp-rename@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.2.2.tgz#3ad4428763f05e2764dec1c67d868db275687817"
-  integrity sha512-qhfUlYwq5zIP4cpRjx+np2vZVnr0xCRQrF3RsGel8uqL47Gu3yjmllSfnvJyl/39zYuxS68e1nnxImbm7388vw==
-
-gulp-rename@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
-  integrity sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==
+  integrity sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=
 
 gulp-replace@^0.5.4:
   version "0.5.4"


### PR DESCRIPTION
This was updated during the merge, but this update broke the bundle-marketplace-extensions-build task. Reverting it for now until we can investigate further to see what needs to change to be able to update it. 

Also reverts the changes done in https://github.com/microsoft/azuredatastudio/pull/21063 and https://github.com/microsoft/azuredatastudio/pull/20979 - those never actually fixed the issue, just hid it since we no longer returned the stream that was timing out which meant it completed immediately regardless of there being issues in the tasks themselves. 

Fixes https://github.com/microsoft/azuredatastudio/issues/20947