### PR TITLE
revert import extension to the actual content of 1.5.0

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -746,14 +746,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.1",
-							"lastUpdated": "11/2/2022",
+							"version": "1.5.3",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-1.5.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-1.5.3.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -746,14 +746,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.1",
-							"lastUpdated": "11/2/2022",
+							"version": "1.5.3",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-1.5.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-1.5.3.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR fixes #21124
This PR fixes #21125

The recent changes to the import extension caused some regressions, since out pipeline is not building the vsix for this extension properly, I made a VSIX with the content of 1.5.0 version. I am not reverting the version to 1.5.0 because a lower version won't trigger auto update. I will v-bump it to 1.5.4 in the source code and I've commented in this issue: https://github.com/microsoft/azuredatastudio/issues/20679 so that @aasimkhan30 is aware of the issues with current code.