### PR TITLE
[Insiders] Update extensions with new aiKey

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1230,14 +1230,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.10.1",
-							"lastUpdated": "7/6/2022",
+							"version": "1.11.0",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.10.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.11.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1474,14 +1474,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.16.0",
-							"lastUpdated": "8/18/2022",
+							"version": "1.17.0",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.16.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.17.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1718,14 +1718,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.1.0",
-							"lastUpdated": "9/26/2022",
+							"version": "0.1.1",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/admin-tool-ext-win/admin-tool-ext-win-0.1.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/admin-tool-ext-win/admin-tool-ext-win-0.1.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2608,14 +2608,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.5.2",
-							"lastUpdated": "10/25/2022",
+							"version": "0.5.3",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/query-history/query-history-0.5.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/query-history/query-history-0.5.3.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2787,14 +2787,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.12.0",
-							"lastUpdated": "11/11/2020",
+							"version": "1.12.2",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/datavirtualization-1.12.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/datavirtualization-1.12.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3259,14 +3259,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.6.3",
-							"lastUpdated": "7/6/2022",
+							"version": "0.6.4",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-assessment/sql-assessment-0.6.3.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-assessment/sql-assessment-0.6.4.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3434,14 +3434,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.19.0",
-							"lastUpdated": "8/18/2022",
+							"version": "0.20.0",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.19.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.20.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3617,14 +3617,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.5.7",
-							"lastUpdated": "09/30/2021",
+							"version": "0.5.8",
+							"lastUpdated": "11/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/kusto/kusto-0.5.7.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/kusto/kusto-0.5.8.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4154,14 +4154,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.1.8",
-							"lastUpdated": "09/30/2021",
+							"version": "0.1.9",
+							"lastUpdated": "11/3/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuremonitor/azuremonitor-0.1.8.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azuremonitor/azuremonitor-0.1.9.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1511,7 +1511,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.38.0"
+									"value": ">=1.40.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -3471,7 +3471,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.40.0"
+									"value": ">=1.38.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -2655,7 +2655,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": ""
 				},
 				{
 					"extensionId": "56",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3471,7 +3471,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.38.0"
+									"value": ">=1.40.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",


### PR DESCRIPTION
For extensions that had been bumped in the repo already I left the version as that version - which is why some have build version bumps and some have minor version bumps. 

Went through and verified that the extensions all still at least start up and can do some basic functionality to make sure that telemetry package updates didn't break anything. 