### PR TITLE
remove edge template from sql projects new project dialog

### DIFF
--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -59,15 +59,6 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 				defaultTargetPlatform: constants.defaultTargetPlatform,
 				sdkStyleOption: true,
 				sdkStyleLearnMoreUrl: constants.sdkLearnMoreUrl
-			},
-			{
-				id: constants.edgeSqlDatabaseProjectTypeId,
-				projectFileExtension: constants.sqlprojExtension.replace(/\./g, ''),
-				displayName: constants.edgeProjectTypeDisplayName,
-				description: constants.edgeProjectTypeDescription,
-				icon: IconPathHelper.sqlEdgeProject,
-				sdkStyleOption: true,
-				sdkStyleLearnMoreUrl: constants.sdkLearnMoreUrl
 			}
 		];
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

As discussed, removing the Edge specific sql project template due to low usage and to avoid confusion for users. Now there's only the Azure template and Sql Server database template.

ADS:
![image](https://user-images.githubusercontent.com/31145923/200434902-ed35c32e-63cf-4dcd-bf27-88343aeecdb2.png)

vscode:
![image](https://user-images.githubusercontent.com/31145923/200434769-a6f13fb3-905d-4cce-a382-dd1a318eecef.png)
