### PR TITLE
Update extension galleries for Arc and Azcli 1.7.0

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.6.0",
-							"lastUpdated": "9/13/2022",
+							"version": "1.7.0",
+							"lastUpdated": "11/8/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.6.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.7.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4211,14 +4211,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.6.0",
-							"lastUpdated": "9/13/2022",
+							"version": "1.7.0",
+							"lastUpdated": "11/8/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.6.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.7.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.6.0",
-							"lastUpdated": "9/13/2022",
+							"version": "1.7.0",
+							"lastUpdated": "11/8/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.6.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.7.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4211,14 +4211,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.6.0",
-							"lastUpdated": "9/13/2022",
+							"version": "1.7.0",
+							"lastUpdated": "11/8/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.6.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.7.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Please use vsix files **arc-1.7.0.vsix** and **azcli-1.7.0.vsix** from the below link, but please don't merge in the PR until I give the OK: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=178506&view=artifacts&pathAsName=false&type=publishedArtifacts


