### PR TITLE
Upgrading mysql extension insider to 0.2.3

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4768,14 +4768,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.2.2",
-							"lastUpdated": "10/11/2022",
+							"version": "0.2.3",
+							"lastUpdated": "11/08/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/mysql/azuredatastudio-mysql-0.2.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/mysql/azuredatastudio-mysql-0.2.3.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
This PR upgrades the version of mysql extension in insider gallery to 0.2.3.

VSIX Link: https://github.com/microsoft/azuredatastudio-mysql/releases/download/v0.2.3/azuredatastudio-mysql-0.2.3.vsix