### PR TITLE
bump STS

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.3.0.47",
+	"version": "4.3.1.1",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
This PR ports STS 4.3.1.1 to ADS.
https://github.com/microsoft/sqltoolsservice/compare/4.3.0.47...4.3.1.1
![image](https://user-images.githubusercontent.com/21186993/200700600-12058463-068d-4950-81af-e4d309399263.png)
