### PR TITLE
Updating component icon id generation logic to avoid substring overlaps

### DIFF
--- a/src/vs/base/common/idGenerator.ts
+++ b/src/vs/base/common/idGenerator.ts
@@ -14,7 +14,7 @@ export class IdGenerator {
 	}
 
 	public nextId(): string {
-		return this._prefix + (++this._lastId);
+		return this._prefix + (++this._lastId) + '-id';
 	}
 }
 


### PR DESCRIPTION
This bug is called due to https://github.com/microsoft/azuredatastudio/blob/0aefecf0c2568ca0f7ee63de0c4af39caeed373f/src/vs/base/browser/dom.ts#L822

The line selects and clears all the css rules for components starting with the substring.
For example: 
If we are trying to clear css rules for 'model-view-component-icon-7' we will also clear css rules for  model-view-component-icon-7<any string>

Causing the images to disappear on all components sharing the same prefix. 

Issue: #19226