### PR TITLE
Fix custom option support in CMS + fix updating ProviderName in provided profile

### DIFF
--- a/src/sql/workbench/services/connection/browser/cmsConnectionController.ts
+++ b/src/sql/workbench/services/connection/browser/cmsConnectionController.ts
@@ -28,7 +28,7 @@ export class CmsConnectionController extends ConnectionController {
 	) {
 		super(connectionProperties, callback, providerName, _connectionManagementService, _instantiationService, _serverGroupController, _logService);
 		let specialOptions = this._providerOptions.filter(
-			(property) => (property.specialValueType !== null && property.specialValueType !== undefined));
+			(property) => (property.specialValueType !== null && property.specialValueType !== undefined || property.showOnConnectionDialog));
 		this._connectionWidget = this._instantiationService.createInstance(CmsConnectionWidget, specialOptions, {
 			onSetConnectButton: (enable: boolean) => this._callback.onSetConnectButton(enable),
 			onCreateNewServerGroup: () => this.onCreateNewServerGroup(),

--- a/src/sql/workbench/services/connection/browser/cmsConnectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/cmsConnectionWidget.ts
@@ -74,6 +74,9 @@ export class CmsConnectionWidget extends ConnectionWidget {
 		// Login Options
 		this.addLoginOptions();
 
+		// Add Custom connection options
+		this.addCustomConnectionOptions();
+
 		// Connection Name
 		this.addConnectionNameOptions();
 

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -181,18 +181,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 				}
 				profile = result.connection;
 				profile.serverName = trim(profile.serverName);
-
-				// append the port to the server name for SQL Server connections
-				if (this._currentProviderType === Constants.mssqlProviderName ||
-					this._currentProviderType === Constants.cmsProviderName) {
-					let portPropertyName: string = 'port';
-					let portOption: string = profile.options[portPropertyName];
-					if (portOption && portOption.indexOf(',') === -1) {
-						profile.serverName = profile.serverName + ',' + portOption;
-					}
-					profile.options[portPropertyName] = undefined;
-					profile.providerName = Constants.mssqlProviderName;
-				}
+				this.updatePortAndProvider(profile);
 
 				// Disable password prompt during reconnect if connected with an empty password
 				if (profile.password === '' && profile.savePassword === false) {
@@ -202,10 +191,25 @@ export class ConnectionDialogService implements IConnectionDialogService {
 				this.handleDefaultOnConnect(params, profile).catch(err => onUnexpectedError(err));
 			} else {
 				profile.serverName = trim(profile.serverName);
+				this.updatePortAndProvider(profile);
 				this._connectionManagementService.addSavedPassword(profile).then(async (connectionWithPassword) => {
 					await this.handleDefaultOnConnect(params, connectionWithPassword);
 				}).catch(err => onUnexpectedError(err));
 			}
+		}
+	}
+
+	private updatePortAndProvider(profile: IConnectionProfile): void {
+		// append the port to the server name for SQL Server connections
+		if (this._currentProviderType === Constants.mssqlProviderName ||
+			this._currentProviderType === Constants.cmsProviderName) {
+			let portPropertyName: string = 'port';
+			let portOption: string = profile.options[portPropertyName];
+			if (portOption && portOption.indexOf(',') === -1) {
+				profile.serverName = profile.serverName + ',' + portOption;
+			}
+			profile.options[portPropertyName] = undefined;
+			profile.providerName = Constants.mssqlProviderName;
 		}
 	}
 


### PR DESCRIPTION
This PR will address #21177 

Root causes:
* There were missed changes in cmsConnectionWidget to load custom options on main connection dialog.
* CMS provider name (MSSQL-CMS) was not being updated to MSSQL in provided connection profile in else case (since it was first time use of the 'handleOnConnect' method with profile provided) which led to issues when reconnecting.