### PR TITLE
Fix GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         id: electron-unit-tests
         run: DISPLAY=:10 ./scripts/test.sh --runGlob "**/sql/**/*.test.js" --coverage
 
-      - name: Run Extension Unit Tests # {{SQL CARBON EDIT}} Rename to core for clarity
+      - name: Run Extension Unit Tests # {{SQL CARBON EDIT}} Rename to extension for clarity
         id: electron-extension-unit-tests
         run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,13 +145,13 @@ jobs:
       - name: Run Extension Unit Tests (Continue on Error) # {{SQL CARBON EDIT}} Run extension unit tests (continue on error)
         id: electron-extension-unit-tests-continue-on-error
         run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
-        continueOnError: true
-        condition: and(succeeded(), eq(variables['EXTENSION_UNIT_TESTS_FAIL_ON_ERROR'], 'false'))
+        continue-on-error: true
+        if: ${{ success() && env.EXTENSION_UNIT_TESTS_FAIL_ON_ERROR == 'false' }}
 
       - name: Run Extension Unit Tests (Fail on Error) # {{SQL CARBON EDIT}} Run extension unit tests (fail on error)
         id: electron-extension-unit-tests-fail-on-error
         run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
-        condition: and(succeeded(), ne(variables['EXTENSION_UNIT_TESTS_FAIL_ON_ERROR'], 'false'))
+        if: ${{ success() && env.EXTENSION_UNIT_TESTS_FAIL_ON_ERROR != 'false' }}
 
       # {{SQL CARBON EDIT}} Add coveralls. We merge first to get around issue where parallel builds weren't being combined correctly
       - name: Combine code coverage files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,16 +142,9 @@ jobs:
         id: electron-unit-tests
         run: DISPLAY=:10 ./scripts/test.sh --runGlob "**/sql/**/*.test.js" --coverage
 
-      - name: Run Extension Unit Tests (Continue on Error) # {{SQL CARBON EDIT}} Run extension unit tests (continue on error)
-        id: electron-extension-unit-tests-continue-on-error
+      - name: Run Extension Unit Tests # {{SQL CARBON EDIT}} Rename to core for clarity
+        id: electron-extension-unit-tests
         run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
-        continue-on-error: true
-        if: ${{ success() && env.EXTENSION_UNIT_TESTS_FAIL_ON_ERROR == 'false' }}
-
-      - name: Run Extension Unit Tests (Fail on Error) # {{SQL CARBON EDIT}} Run extension unit tests (fail on error)
-        id: electron-extension-unit-tests-fail-on-error
-        run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
-        if: ${{ success() && env.EXTENSION_UNIT_TESTS_FAIL_ON_ERROR != 'false' }}
 
       # {{SQL CARBON EDIT}} Add coveralls. We merge first to get around issue where parallel builds weren't being combined correctly
       - name: Combine code coverage files


### PR DESCRIPTION
GH workflow has been failing to trigger GH actions with [Startup failures](https://github.com/microsoft/azuredatastudio/actions) since PR #21099 (inclusive), as the AzDO yml syntax is not same as GH workflow...
Reference: [Workflow syntax for GitHub actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)

