### PR TITLE
Fix headers being exported twice from notebooks

### DIFF
--- a/src/sql/platform/serialization/common/serializationService.ts
+++ b/src/sql/platform/serialization/common/serializationService.ts
@@ -129,10 +129,6 @@ export class SerializationService implements ISerializationService {
 			let index = 0;
 			let startRequestParams = this.createStartRequest(serializationRequest, index);
 			index = index + startRequestParams.rows.length;
-			// Adjust row index based on whether or not header row is included
-			if (serializationRequest.includeHeaders) {
-				index--;
-			}
 
 			let startResult = await provider.startSerialization(startRequestParams);
 

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -467,17 +467,6 @@ export class DataResourceDataProvider implements IGridDataProvider {
 				endIndex = maxRow;
 			}
 			let result: ICellValue[][] = [];
-			if (includeHeaders) {
-				result.push(columns.map(col => {
-					let headerData: azdata.DbCellValue;
-					headerData = {
-						displayValue: col.columnName,
-						isNull: false,
-						invariantCultureDisplayValue: col.columnName
-					};
-					return headerData;
-				}));
-			}
 			result = result.concat(this._rows.slice(index, endIndex).map(row => {
 				if (this.isSelected(singleSelection)) {
 					return row.slice(singleSelection.fromCell, singleSelection.toCell + 1);

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -466,15 +466,14 @@ export class DataResourceDataProvider implements IGridDataProvider {
 			if (endIndex > maxRow) {
 				endIndex = maxRow;
 			}
-			let result: ICellValue[][] = [];
-			result = result.concat(this._rows.slice(index, endIndex).map(row => {
+
+			return [].concat(this._rows.slice(index, endIndex).map(row => {
 				if (this.isSelected(singleSelection)) {
 					return row.slice(singleSelection.fromCell, singleSelection.toCell + 1);
 				} else {
 					return row;
 				}
 			}));
-			return result;
 		};
 
 		// This code path uses the serialization service which uses a different request parameter


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses https://github.com/microsoft/azuredatastudio/issues/21180

Before this fix in STS https://github.com/microsoft/sqltoolsservice/pull/1726, the includeHeaders parameter was not actually being set so we were adding the headers as part of the row data. 
