### PR TITLE
Fix access token refresh design

### DIFF
--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -176,7 +176,7 @@ export interface IConnectionManagementService {
 
 	isConnected(fileUri: string): boolean;
 
-	refreshAzureAccountTokenIfNecessary(uri: string): Promise<boolean>;
+	refreshAzureAccountTokenIfNecessary(uri: string, connectionProfile?: ConnectionProfile): Promise<boolean>;
 	/**
 	 * Returns true if the connection profile is connected
 	 */

--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -176,7 +176,7 @@ export interface IConnectionManagementService {
 
 	isConnected(fileUri: string): boolean;
 
-	refreshAzureAccountTokenIfNecessary(uri: string, connectionProfile?: ConnectionProfile): Promise<boolean>;
+	refreshAzureAccountTokenIfNecessary(uriOrConnectionProfile: string | ConnectionProfile): Promise<boolean>;
 	/**
 	 * Returns true if the connection profile is connected
 	 */

--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -319,7 +319,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 		return undefined!;
 	}
 
-	refreshAzureAccountTokenIfNecessary(uri: string, connectionProfile?: ConnectionProfile): Promise<boolean> {
+	refreshAzureAccountTokenIfNecessary(uriOrConnectionProfile: string | ConnectionProfile): Promise<boolean> {
 		return undefined;
 	}
 

--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -319,7 +319,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 		return undefined!;
 	}
 
-	refreshAzureAccountTokenIfNecessary(uri: string): Promise<boolean> {
+	refreshAzureAccountTokenIfNecessary(uri: string, connectionProfile?: ConnectionProfile): Promise<boolean> {
 		return undefined;
 	}
 

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
@@ -403,6 +403,7 @@ suite('SQL Connection Tree Action tests', () => {
 			resolve(connection);
 		}));
 		connectionManagementService.setup(x => x.isConnected(undefined, TypeMoq.It.isAny())).returns(() => isConnectedReturnValue);
+		connectionManagementService.setup(x => x.refreshAzureAccountTokenIfNecessary(TypeMoq.It.isAny())).returns(async () => true);
 
 		let objectExplorerSession = {
 			success: true,
@@ -449,6 +450,7 @@ suite('SQL Connection Tree Action tests', () => {
 
 		return refreshAction.run().then((value) => {
 			connectionManagementService.verify(x => x.isConnected(undefined, TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());
+			connectionManagementService.verify(x => x.refreshAzureAccountTokenIfNecessary(TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());
 			objectExplorerService.verify(x => x.getObjectExplorerNode(TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());
 			objectExplorerService.verify(x => x.refreshTreeNode(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.exactly(0));
 			tree.verify(x => x.refresh(TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -907,7 +907,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				const tenantId = connection.azureTenantId;
 				const token = await this._accountManagementService.getAccountSecurityToken(account, tenantId, azureResource);
 				if (!token) {
-					this._logService.info(`No security tokens found for account`);
+					this._logService.warn(`No security tokens found for account`);
 				} else {
 					this._logService.debug(`Got access token for tenant ${tenantId} that expires in ${(token.expiresOn - new Date().getTime()) / 1000} seconds`);
 					connection.options['azureAccountToken'] = token.token;
@@ -942,7 +942,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			uri = uriOrConnectionProfile;
 			connectionProfile = this._connectionStatusManager.getConnectionProfile(uri);
 			if (!connectionProfile) {
-				this._logService.warn(`Connection not found for uri ${uri}`);
+				this._logService.warn(`Connection not found for uri ${uri} when refreshing token`);
 				return false;
 			}
 		} else {

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -995,6 +995,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				else {
 					this._logService.debug(`No need to refresh Azure acccount token for connection ${connectionProfile.id} with uri ${uri}`);
 				}
+			} else {
+				this._logService.info(`Invalid expiry time ${expiry} for connection ${connectionProfile.id} with uri ${uri}`);
 			}
 		}
 		return true;

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -929,6 +929,11 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 * @returns true if no need to refresh or successfully refreshed token
 	 */
 	public async refreshAzureAccountTokenIfNecessary(uriOrConnectionProfile: string | ConnectionProfile): Promise<boolean> {
+		if (!uriOrConnectionProfile) {
+			this._logService.warn(`refreshAzureAccountTokenIfNecessary: Neither Connection uri nor connection profile received.`);
+			return false;
+		}
+
 		let uri: string;
 		let connectionProfile: ConnectionProfile;
 
@@ -944,7 +949,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			uri = this.getConnectionUri(connectionProfile);
 		}
 
-		//wait for the pending reconnction promise if any
+		// Wait for the pending reconnction promise if any
+		// We expect uri to be defined
 		const previousReconnectPromise = this._uriToReconnectPromiseMap[uri];
 		if (previousReconnectPromise) {
 			this._logService.debug(`Found pending reconnect promise for uri ${uri}, waiting.`);
@@ -960,7 +966,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			}
 		}
 
-		if (connectionProfile.authenticationType === Constants.AuthenticationType.AzureMFA) {
+		// We expect connectionProfile to be defined
+		if (connectionProfile && connectionProfile.authenticationType === Constants.AuthenticationType.AzureMFA) {
 			const expiry = connectionProfile.options.expiresOn;
 			if (typeof expiry === 'number' && !Number.isNaN(expiry)) {
 				const currentTime = new Date().getTime() / 1000;

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -996,7 +996,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 					this._logService.debug(`No need to refresh Azure acccount token for connection ${connectionProfile.id} with uri ${uri}`);
 				}
 			} else {
-				this._logService.info(`Invalid expiry time ${expiry} for connection ${connectionProfile.id} with uri ${uri}`);
+				this._logService.warn(`Invalid expiry time ${expiry} for connection ${connectionProfile.id} with uri ${uri}`);
 			}
 		}
 		return true;

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -906,14 +906,15 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				}
 				const tenantId = connection.azureTenantId;
 				const token = await this._accountManagementService.getAccountSecurityToken(account, tenantId, azureResource);
-				this._logService.debug(`Got access token for tenant ${token} that expires in ${(token.expiresOn - new Date().getTime()) / 1000} seconds`);
 				if (!token) {
 					this._logService.info(`No security tokens found for account`);
+				} else {
+					this._logService.debug(`Got access token for tenant ${tenantId} that expires in ${(token.expiresOn - new Date().getTime()) / 1000} seconds`);
+					connection.options['azureAccountToken'] = token.token;
+					connection.options['expiresOn'] = token.expiresOn;
+					connection.options['password'] = '';
+					return true;
 				}
-				connection.options['azureAccountToken'] = token.token;
-				connection.options['expiresOn'] = token.expiresOn;
-				connection.options['password'] = '';
-				return true;
 			} else {
 				this._logService.info(`Could not find Azure account with name ${accountId}`);
 			}

--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -48,7 +48,7 @@ export class RefreshAction extends Action {
 		if (this.element instanceof ConnectionProfile) {
 			let connection: ConnectionProfile = this.element;
 			if (this._connectionManagementService.isConnected(undefined, connection)) {
-				await this._connectionManagementService.refreshAzureAccountTokenIfNecessary(undefined, connection);
+				await this._connectionManagementService.refreshAzureAccountTokenIfNecessary(connection);
 				treeNode = this._objectExplorerService.getObjectExplorerNode(connection);
 				if (treeNode === undefined) {
 					await this._objectExplorerService.updateObjectExplorerNodes(connection.toIConnectionProfile());
@@ -57,7 +57,7 @@ export class RefreshAction extends Action {
 			}
 		} else if (this.element instanceof TreeNode) {
 			let connection: ConnectionProfile = this.element.getConnectionProfile();
-			this._connectionManagementService.refreshAzureAccountTokenIfNecessary(undefined, connection);
+			this._connectionManagementService.refreshAzureAccountTokenIfNecessary(connection);
 			treeNode = this.element;
 		}
 

--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -48,6 +48,7 @@ export class RefreshAction extends Action {
 		if (this.element instanceof ConnectionProfile) {
 			let connection: ConnectionProfile = this.element;
 			if (this._connectionManagementService.isConnected(undefined, connection)) {
+				await this._connectionManagementService.refreshAzureAccountTokenIfNecessary(undefined, connection);
 				treeNode = this._objectExplorerService.getObjectExplorerNode(connection);
 				if (treeNode === undefined) {
 					await this._objectExplorerService.updateObjectExplorerNodes(connection.toIConnectionProfile());
@@ -55,6 +56,8 @@ export class RefreshAction extends Action {
 				}
 			}
 		} else if (this.element instanceof TreeNode) {
+			let connection: ConnectionProfile = this.element.getConnectionProfile();
+			this._connectionManagementService.refreshAzureAccountTokenIfNecessary(undefined, connection);
 			treeNode = this.element;
 		}
 


### PR DESCRIPTION
This PR fixes multiple issues including #21174 where access token refresh design had some issues:

- When opening/refreshing a treeNode, corresponding `connectionProfile` would sometimes contain expired access token which is possible if connections are kept open and not used for a long time. This led to STS layer failing to connect to target servers.

With this change, we make sure to check whether the parent connection is connected which will in-turn refresh any expired access token **before** sending request to the STS layer.