### PR TITLE
remove tests variable for windows on arm build

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -123,7 +123,6 @@ stages:
       - job: Windows_ARM64
         variables:
           VSCODE_ARCH: arm64
-          RUN_TESTS: false # Do not run tests for arm64 build
         condition: and(succeeded(), eq(variables['VSCODE_BUILD_WIN32_ARM64'], 'true'))
         steps:
         - template: win32/sql-product-build-win32.yml


### PR DESCRIPTION
remove the RunTests variable, I took another look, we don't run tests in Windows build job. so, no reason to have this variable to avoid confusion.