### PR TITLE
Hide publish sql project to new azure server behind preview setting

### DIFF
--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -145,7 +145,8 @@ gulp.task('package-external-extensions', task.series(
 							});
 						}
 
-						// add any configuration properties from the package.vscode.json
+						// Add any configuration properties from the package.vscode.json
+						// Currently only supports bringing over properties in the first config object found and doesn't support modifying the title
 						if (updateData.contributes?.configuration[0]?.properties) {
 							Object.keys(updateData.contributes.configuration[0].properties).forEach(key => {
 								data.contributes.configuration[0].properties[key] = updateData.contributes.configuration[0].properties[key];

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -133,10 +133,7 @@ gulp.task('package-external-extensions', task.series(
 						// And now use gulp-json-editor to modify the contents
 						const updateData = JSON.parse(fs.readFileSync(vscodeManifestFullPath)); // Read in the set of values to replace from package.vscode.json
 						Object.keys(updateData).forEach(key => {
-							console.info('current key is ' + key);
-
 							if (key !== 'contributes') {
-								console.info('replacing' + key + ' for ' + packageDir);
 								data[key] = updateData[key];
 							}
 						});
@@ -148,11 +145,11 @@ gulp.task('package-external-extensions', task.series(
 							});
 						}
 
-						console.info('Before checking configuration');
-						// add any configuration properties only in the package.vscode.json
-						if (updateData.contributes?.configuration?.properties) {
-							console.info('adding configuration for to ' + packageDir + ' for ' + updateData.contributes.configuration.properties);
-							data.contributes.configuration.properties += updateData.contributes.configuration.properties;
+						// add any configuration properties from the package.vscode.json
+						if (updateData.contributes?.configuration[0]?.properties) {
+							Object.keys(updateData.contributes.configuration[0].properties).forEach(key => {
+								data.contributes.configuration[0].properties[key] = updateData.contributes.configuration[0].properties[key];
+							});
 						}
 
 						return data;

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -149,10 +149,12 @@ gulp.task('package-external-extensions', task.series(
 						}
 
 						console.info('Before checking configuration');
-						if (updateData.contributes?.configuration) {
-							console.info('replacing configuration for ' + packageDir);
-							data.contributes.configuration = updateData.contributes.configuration;
+						// add any configuration properties only in the package.vscode.json
+						if (updateData.contributes?.configuration?.properties) {
+							console.info('adding configuration for to ' + packageDir + ' for ' + updateData.contributes.configuration.properties);
+							data.contributes.configuration.properties += updateData.contributes.configuration.properties;
 						}
+
 						return data;
 					}, { beautify: false }))
 					.pipe(gulp.dest(packageDir));

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -42,5 +42,6 @@
 	"sqlDatabaseProjects.autorestSqlVersion": "Which version of Autorest.Sql to use from NPM.  Latest will be used if not set.",
 	"sqlDatabaseProjects.collapseProjectNodes": "Whether project nodes start collapsed",
 	"sqlDatabaseProjects.microsoftBuildSqlVersion": "Which version of Microsoft.Build.Sql SDK to use for building legacy sql projects. Example: 0.1.3-preview",
+	"sqlDatabaseProjects.enablePreviewFeatures": "Enable preview SQL Database Projects features",
 	"sqlDatabaseProjects.welcome": "No database projects currently open.\n[New Project](command:sqlDatabaseProjects.new)\n[Open Project](command:sqlDatabaseProjects.open)\n[Create Project From Database](command:sqlDatabaseProjects.importDatabase)"
 }

--- a/extensions/sql-database-projects/package.vscode.json
+++ b/extensions/sql-database-projects/package.vscode.json
@@ -4,5 +4,38 @@
 	"extensionDependencies": [
 		"ms-mssql.mssql",
 		"ms-mssql.data-workspace-vscode"
-	]
+	],
+	"contributes": {
+		"configuration": [
+			{
+				"title": "%sqlDatabaseProjects.Settings%",
+				"properties": {
+					"sqlDatabaseProjects.dotnetSDK Location": {
+						"type": "string",
+						"description": "%sqlDatabaseProjects.dotnetInstallLocation%"
+					},
+					"sqlDatabaseProjects.netCoreDoNotAsk": {
+						"type": "boolean",
+						"description": "%sqlDatabaseProjects.netCoreDoNotAsk%"
+					},
+					"sqlDatabaseProjects.nodejsDoNotAsk": {
+						"type": "boolean",
+						"description": "%sqlDatabaseProjects.nodejsDoNotAsk%"
+					},
+					"sqlDatabaseProjects.autorestSqlVersion": {
+						"type": "string",
+						"description": "%sqlDatabaseProjects.autorestSqlVersion%"
+					},
+					"sqlDatabaseProjects.collapseProjectNodes": {
+						"type": "boolean",
+						"description": "%sqlDatabaseProjects.collapseProjectNodes%"
+					},
+					"sqlDatabaseProjects.microsoftBuildSqlVersion": {
+						"type": "string",
+						"description": "%sqlDatabaseProjects.microsoftBuildSqlVersion%"
+					}
+				}
+			}
+		]
+	}
 }

--- a/extensions/sql-database-projects/package.vscode.json
+++ b/extensions/sql-database-projects/package.vscode.json
@@ -8,31 +8,10 @@
 	"contributes": {
 		"configuration": [
 			{
-				"title": "%sqlDatabaseProjects.Settings%",
 				"properties": {
-					"sqlDatabaseProjects.dotnetSDK Location": {
-						"type": "string",
-						"description": "%sqlDatabaseProjects.dotnetInstallLocation%"
-					},
-					"sqlDatabaseProjects.netCoreDoNotAsk": {
+					"sqlDatabaseProjects.enablePreviewFeatures": {
 						"type": "boolean",
-						"description": "%sqlDatabaseProjects.netCoreDoNotAsk%"
-					},
-					"sqlDatabaseProjects.nodejsDoNotAsk": {
-						"type": "boolean",
-						"description": "%sqlDatabaseProjects.nodejsDoNotAsk%"
-					},
-					"sqlDatabaseProjects.autorestSqlVersion": {
-						"type": "string",
-						"description": "%sqlDatabaseProjects.autorestSqlVersion%"
-					},
-					"sqlDatabaseProjects.collapseProjectNodes": {
-						"type": "boolean",
-						"description": "%sqlDatabaseProjects.collapseProjectNodes%"
-					},
-					"sqlDatabaseProjects.microsoftBuildSqlVersion": {
-						"type": "string",
-						"description": "%sqlDatabaseProjects.microsoftBuildSqlVersion%"
+						"description": "%sqlDatabaseProjects.enablePreviewFeatures%"
 					}
 				}
 			}

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -172,7 +172,7 @@ export function publishToExistingServer(name: string) { return localize('publish
 export function publishToDockerContainer(name: string) { return localize('publishToDockerContainer', "Publish to new {0} local development container", name); }
 export function publishToDockerContainerPreview(name: string) { return localize('publishToDockerContainerPreview', "Publish to new {0} local development container (Preview)", name); }
 export const publishToAzureEmulator = localize('publishToAzureEmulator', "Publish to new Azure SQL Database emulator");
-export const publishToNewAzureServer = localize('publishToNewAzureServer', "Publish to new Azure SQL logical server");
+export const publishToNewAzureServer = localize('publishToNewAzureServer', "Publish to new Azure SQL logical server (Preview)");
 export const azureServerName = localize('azureServerName', "Azure SQL server name");
 export const azureSubscription = localize('azureSubscription', "Azure subscription");
 export const resourceGroup = localize('resourceGroup', "Resource group");
@@ -626,6 +626,7 @@ export enum PublishTargetType {
 // Configuration keys
 export const CollapseProjectNodesKey = 'collapseProjectNodes';
 export const microsoftBuildSqlVersionKey = 'microsoftBuildSqlVersion';
+export const enablePreviewFeaturesKey = 'enablePreviewFeatures';
 
 // httpClient
 export const downloadError = localize('downloadError', "Download error");

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -228,7 +228,6 @@ export async function launchPublishTargetOption(project: Project): Promise<const
 	// Options list based on target
 	let options;
 
-
 	if (target === constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlAzure)) {
 		options = [constants.publishToAzureEmulator, constants.publishToExistingServer(logicalServerName)]
 

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -12,6 +12,7 @@ import { getDefaultPublishDeploymentOptions, getVscodeMssqlApi } from '../common
 import { IConnectionInfo, IFireWallRuleError } from 'vscode-mssql';
 import { getPublishServerName } from './utils';
 import { ISqlProjectPublishSettings, ISqlProject, SqlTargetPlatform } from 'sqldbproj';
+import { DBProjectConfigurationKey } from '../tools/netcoreTool';
 
 /**
  * Create flow for Publishing a database using only VS Code-native APIs such as QuickPick
@@ -225,9 +226,20 @@ export async function launchPublishTargetOption(project: Project): Promise<const
 	const logicalServerName = target === constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlAzure) ? constants.AzureSqlLogicalServerName : constants.SqlServerName;
 
 	// Options list based on target
-	const options = target === constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlAzure) ?
-		[constants.publishToAzureEmulator, constants.publishToNewAzureServer, constants.publishToExistingServer(logicalServerName)] :
-		[constants.publishToDockerContainer(name), constants.publishToExistingServer(logicalServerName)];
+	let options;
+
+
+	if (target === constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlAzure)) {
+		options = [constants.publishToAzureEmulator, constants.publishToExistingServer(logicalServerName)]
+
+		// only show "Publish to New Azure Server" option if preview features are enabled
+		const enablePreviewFeatures = vscode.workspace.getConfiguration(DBProjectConfigurationKey).get(constants.enablePreviewFeaturesKey);
+		if (enablePreviewFeatures) {
+			options.push(constants.publishToNewAzureServer);
+		}
+	} else {
+		options = [constants.publishToDockerContainer(name), constants.publishToExistingServer(logicalServerName)];
+	}
 
 	// Show the options to the user
 	const publishOption = await vscode.window.showQuickPick(


### PR DESCRIPTION
This hides the "Publish to New Azure Server" option in the publish quickpick if the "Enable preview SQL Database Projects features" setting is not checked. 

Because vscode doesn't have an "enable preview features" setting like ADS, I had to add a new setting in the sql database projects vscode extension (it's only added in the vscode extension and does not show in ADS). This PR updates the package-external-extensions gulp task to add support for copying over configuration properties specified in the package.vscode.json. 


![hidePublishToNewAzureServer](https://user-images.githubusercontent.com/31145923/202325154-96b55903-5bae-46cf-98dd-eaddda760ec8.gif)
