### PR TITLE
Bump to Electron 19.1.6

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,4 +1,4 @@
 disturl "https://electronjs.org/headers"
-target "19.1.3"
+target "19.1.6"
 runtime "electron"
 build_from_source "true"

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "cssnano": "^4.1.11",
     "debounce": "^1.0.0",
     "deemon": "^1.4.0",
-    "electron": "19.1.3",
+    "electron": "19.1.6",
     "eslint": "8.7.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3889,10 +3889,10 @@ electron-to-chromium@^1.4.188:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.189.tgz#4e5b221dc44e09e9dddc9abbc6457857dee7ba25"
   integrity sha512-dQ6Zn4ll2NofGtxPXaDfY2laIa6NyCQdqXYHdwH90GJQW0LpJJib0ZU/ERtbb0XkBEmUD2eJtagbOie3pdMiPg==
 
-electron@19.1.3:
-  version "19.1.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.1.3.tgz#90a2b6c3d738789d657477d87d1539f008be6536"
-  integrity sha512-P2kfFc8UqVvPHE1w9qTZSPNpfOqd+CK34K3wBqJwokzYdVBLsVkbIoLxyByjJ/cU35WaeCL5bsI8kXALfPvebw==
+electron@19.1.6:
+  version "19.1.6"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.1.6.tgz#32443cd293d3d877cd3d224e45880e3fbf264e49"
+  integrity sha512-bT6Mr7JbHbONpr/U7R47lwTkMUvuAyOfnoLlbDqvGocQyZCCN3JB436wtf2+r3/IpMEz3T+dHLweFDY5i2wuxw==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
This updates from 19.1.3 to 19.1.6.  Previous PR caught us up to latest upstream, this one gets the current 19.xx release.