### PR TITLE
Patch langpack to 1.40.1

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1779,14 +1779,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-de-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-de-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1844,14 +1844,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-es-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-es-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1909,14 +1909,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-fr-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-fr-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1974,14 +1974,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-it-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-it-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2039,14 +2039,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-ko-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-ko-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2104,14 +2104,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-pt-br-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-pt-br-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2169,14 +2169,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-ru-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-ru-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2234,14 +2234,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-zh-hans-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-zh-hans-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2299,14 +2299,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-zh-hant-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-zh-hant-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2364,14 +2364,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-ja-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-ja-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1779,14 +1779,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-de-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-de-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1844,14 +1844,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-es-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-es-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1909,14 +1909,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-fr-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-fr-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1974,14 +1974,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-it-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-it-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2039,14 +2039,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-ko-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-ko-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2104,14 +2104,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-pt-br-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-pt-br-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2169,14 +2169,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-ru-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-ru-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2234,14 +2234,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-zh-hans-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-zh-hans-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2299,14 +2299,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-zh-hant-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-zh-hant-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2364,14 +2364,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.40.0",
-							"lastUpdated": "11/9/2022",
+							"version": "1.40.1",
+							"lastUpdated": "11/16/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.0/ads-language-pack-ja-1.40.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.40.1/ads-language-pack-ja-1.40.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR adds in strings from the VS 1.67.0 release into ADS, the build to get the langpack are from this build: 

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=179573&view=artifacts&pathAsName=false&type=publishedArtifacts

If this needs to only go into Insiders, I can remove the entries.