### PR TITLE
hide generate sql project from OpenApi under preview configuration in vscode

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -219,7 +219,7 @@
         },
         {
           "command": "sqlDatabaseProjects.generateProjectFromOpenApiSpec",
-          "when": "view == dataworkspace.views.main && config.workbench.enablePreviewFeatures",
+          "when": "view == dataworkspace.views.main && config.workbench.enablePreviewFeatures || config.sqlDatabaseProjects.enablePreviewFeatures",
           "group": "1_currentWorkspace@3"
         }
       ],
@@ -325,7 +325,7 @@
         },
         {
           "command": "sqlDatabaseProjects.generateProjectFromOpenApiSpec",
-          "when": "config.workbench.enablePreviewFeatures"
+          "when": "config.workbench.enablePreviewFeatures || config.sqlDatabaseProjects.enablePreviewFeatures"
         }
       ],
       "view/item/context": [

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -31,7 +31,7 @@
 	"sqlDatabaseProjects.openContainingFolder": "Open Containing Folder",
 	"sqlDatabaseProjects.editProjectFile": "Edit .sqlproj File",
 	"sqlDatabaseProjects.changeTargetPlatform": "Change Target Platform",
-	"sqlDatabaseProjects.generateProjectFromOpenApiSpec": "Generate SQL Project from OpenAPI/Swagger spec",
+	"sqlDatabaseProjects.generateProjectFromOpenApiSpec": "Generate SQL Project from OpenAPI/Swagger spec (Preview)",
 	"sqlDatabaseProjects.convertToSdkStyleProject": "Convert to SDK-style project",
 	"sqlDatabaseProjects.openInDesigner": "Open in Designer",
 


### PR DESCRIPTION
This change makes it so that "Generate sql project from OpenApi Spec" only shows in vscode when the sql projects "Enable Preview Features" setting is enabled. For ADS, I previously put this feature behind the ADS preview setting in https://github.com/microsoft/azuredatastudio/pull/21108.
![vscodeOpenApi](https://user-images.githubusercontent.com/31145923/202588676-63acfdc0-2841-454c-bbe2-dc900f3f1e90.gif)
