### PR TITLE
fix prompt for auth/device auth method

### DIFF
--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -63,7 +63,8 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 
 		if (codeGrantMethod === true && !this.forceDeviceCode) {
 			this.authMappings.set(AzureAuthType.AuthCodeGrant, new AzureAuthCodeGrant(metadata, tokenCache, context, uriEventHandler));
-		} else if (deviceCodeMethod === true || this.forceDeviceCode) {
+		}
+		if (deviceCodeMethod === true || this.forceDeviceCode) {
 			this.authMappings.set(AzureAuthType.DeviceCode, new AzureDeviceCode(metadata, tokenCache, context, uriEventHandler));
 		} else {
 			console.error('No authentication methods selected');

--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -66,8 +66,9 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 		}
 		if (deviceCodeMethod === true || this.forceDeviceCode) {
 			this.authMappings.set(AzureAuthType.DeviceCode, new AzureDeviceCode(metadata, tokenCache, context, uriEventHandler));
-		} else {
-			console.error('No authentication methods selected');
+		}
+		if (codeGrantMethod === false && deviceCodeMethod === false && !this.forceDeviceCode) {
+			Logger.error('Error: No authentication methods selected');
 		}
 	}
 


### PR DESCRIPTION
The prompt to select auth / device code does not appear anymore, this PR fixes that.

Old behavior (doesn't prompt for auth/device code when both options are selected in settings):
![Screen_Recording_2022-11-18_at_12_33_22_PM_AdobeExpress](https://user-images.githubusercontent.com/18150417/202797605-fe498f36-e329-4ab5-b5f2-79d953c20b2a.gif)


New behavior (prompts for auth/device code now):
![Screen_Recording_2022-11-18_at_12_25_14_PM_AdobeExpress](https://user-images.githubusercontent.com/18150417/202796688-f39d156e-2edb-4b47-9fa8-c7e9ec3d60bb.gif)
This PR fixes #21269