### PR TITLE
add missing .dll in list of dlls used for project build

### DIFF
--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -29,7 +29,7 @@ const buildFiles: string[] = [
 	'System.ComponentModel.Composition.dll',
 	'System.IO.Packaging.dll',
 	'Microsoft.Data.Tools.Schema.SqlTasks.targets',
-	'Microsoft.SqlServer.Server'
+	'Microsoft.SqlServer.Server.dll'
 ];
 
 export class BuildHelper {


### PR DESCRIPTION
I missed the '.dll' to 'Microsoft.SqlServer.Server' in https://github.com/microsoft/azuredatastudio/pull/21242, so it wasn't getting copied over as expected. Thanks for catching this @SakshiS-harma!