### PR TITLE
Dispose underlying text input in notebook input to clear editor service references correctly.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -257,6 +257,7 @@ export abstract class NotebookInput extends EditorInput implements INotebookInpu
 		this._notebookEditorOpenedTimestamp = Date.now();
 		if (this._textInput) {
 			this.hookDirtyListener(this._textInput.onDidChangeDirty, () => this._onDidChangeDirty.fire());
+			this._register(this._textInput);
 		}
 	}
 


### PR DESCRIPTION
We were only disposing the underlying text model after the notebook editor had been created, so if a notebook editor was already open when starting ADS and we hadn't clicked on it yet, then the text model wouldn't be able to be disposed when closing that editor. A practical consequence of this is that editor numbers wouldn't be freed in the untitled editor service when closing notebook tabs that haven't been clicked on yet, so when opening a new untitled notebook the tab numbers would skip to higher numbers for no obvious reason.

This PR fixes #21134
