### PR TITLE
Fix action dropdowns focusing hidden button & fix ext action button

### DIFF
--- a/src/sql/base/browser/ui/dropdownList/media/dropdownList.css
+++ b/src/sql/base/browser/ui/dropdownList/media/dropdownList.css
@@ -3,14 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-dropdown {
-	width: 100%;
-	/* TODO: Determine a more permanent fix; vs/dropdown is overwriting this selector in packaged builds */
-	display: flex !important;
-	align-items: flex-start;
-	cursor: pointer;
-}
-
 .monaco-dropdown > .dropdown-label {
 	width: 100%;
 }

--- a/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
@@ -186,6 +186,10 @@ export class ActionWithDropdownActionViewItem extends ActionViewItem {
 			this.dropdownMenuActionViewItem.render(this.element);
 
 			this._register(addDisposableListener(this.element, EventType.KEY_DOWN, e => {
+				// {{SQL CARBON EDIT}} If we don't have any items then the dropdown is hidden so don't try to focus it #20877
+				if (menuActionsProvider.getActions().length === 0) {
+					return;
+				}
 				const event = new StandardKeyboardEvent(e);
 				let handled: boolean = false;
 				if (this.dropdownMenuActionViewItem?.isFocused() && event.equals(KeyCode.LeftArrow)) {

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
@@ -56,12 +56,6 @@
 	display: none;
 }
 
-/* {{SQL CARBON EDIT}} - hide drop-down to avoid rendering bug */
-.extension-editor .details .monaco-action-bar .monaco-dropdown,
-.extensions-viewlet > .extensions .monaco-action-bar .monaco-dropdown {
-	width: 0px;
-}
-
 .extensions-viewlet > .extensions .extensions-list.hidden,
 .extensions-viewlet > .extensions .message-container.hidden {
 	display: none;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/20877

There's two things being fixed here : 

1. Fixes the arrow key issue. I plan on submitting this to VS Code too since they have the same issue (https://github.com/microsoft/vscode/issues/164050)
2. Bring back the action menu for the extension gallery editor. This was hidden in the latest merge because it was "broken" (see before picture). I tracked this down to the styles applied globally in dropdownList.css. Those have been around forever so there isn't any history of why it was done in the first place - but I removed them and am not seeing any of our dropdowns looking broken. And even if they were doing global changes to all dropdowns like that isn't something we should need to be doing so we should be fixing those on a case-by-case basis. 

Before - "Broken" action buttons

![image](https://user-images.githubusercontent.com/28519865/204668858-a24714b3-1b13-47e7-aab2-d039d12eb287.png)

After 

![image](https://user-images.githubusercontent.com/28519865/204669017-58c17ed9-ae49-40ce-b7a5-56b6705672f1.png)
