### PR TITLE
Rename to security token to match STS

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -469,14 +469,14 @@ declare module 'azdata' {
 		/**
 		 * Authentication token for the current session.
 		 */
-		token?: accounts.AccountSecurityToken | undefined;
+		securityToken?: accounts.AccountSecurityToken | undefined;
 	}
 
 	export interface ExpandNodeInfo {
 		/**
 		 * Authentication token for the current session.
 		 */
-		token?: accounts.AccountSecurityToken | undefined;
+		securityToken?: accounts.AccountSecurityToken | undefined;
 	}
 	// End Object Explorer interfaces  ----------------------------
 

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -441,7 +441,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 							self.callExpandOrRefreshFromProvider(provider, {
 								sessionId: session.sessionId!,
 								nodePath: node.nodePath,
-								token: session.token
+								securityToken: session.securityToken
 							}, refresh).then(isExpanding => {
 								if (!isExpanding) {
 									// The provider stated it's not going to expand the node, therefore do not need to track when merging results
@@ -601,7 +601,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 			// Refresh access token on connection if needed.
 			let refreshResult = await this._connectionManagementService.refreshAzureAccountTokenIfNecessary(connection);
 			if (refreshResult) {
-				session.token = {
+				session.securityToken = {
 					token: connection.options['azureAccountToken'],
 					expiresOn: connection.options['expiresOn']
 				};


### PR DESCRIPTION
Fixes receiving token in backend for refresh logic as property name mismatched to that in STS (introduced in #21308) 
Renaming to fix the issue.
