### PR TITLE
Set both labels and values to custom options select Boxes

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -267,14 +267,22 @@ export class ConnectionWidget extends lifecycle.Disposable {
 				let customOptionsContainer = DialogHelper.appendRow(this._tableContainer, option.displayName, 'connection-label', 'connection-input', 'custom-connection-options', false, option.description, 100);
 				switch (option.valueType) {
 					case ServiceOptionType.boolean:
-						// Convert 'defaultValue' to string for comparison as it can be boolean here.
-						let optionValue = (option.defaultValue.toString() === true.toString()) ? this._trueInputValue : this._falseInputValue;
-						this._customOptionWidgets[i] = new SelectBox([this._trueInputValue, this._falseInputValue], optionValue, this._contextViewService, customOptionsContainer, { ariaLabel: option.displayName });
-						DialogHelper.appendInputSelectBox(customOptionsContainer, this._customOptionWidgets[i] as SelectBox);
-						this._register(styler.attachSelectBoxStyler(this._customOptionWidgets[i] as SelectBox, this._themeService));
-						break;
 					case ServiceOptionType.category:
-						this._customOptionWidgets[i] = new SelectBox(option.categoryValues.map(c => c.displayName), option.defaultValue, this._contextViewService, customOptionsContainer, { ariaLabel: option.displayName });
+						let selectedValue = option.defaultValue;
+
+						let options = option.valueType === ServiceOptionType.category
+							? option.categoryValues.map<SelectOptionItemSQL>(v => {
+								return { text: v.displayName, value: v.name } as SelectOptionItemSQL;
+							})
+							:
+							[ // Handle boolean options so we can map displaynames to values.
+								{ displayName: this._trueInputValue, value: 'true' },
+								{ displayName: this._falseInputValue, value: 'false' }
+							].map<SelectOptionItemSQL>(v => {
+								return { text: v.displayName, value: v.value } as SelectOptionItemSQL;
+							});
+
+						this._customOptionWidgets[i] = new SelectBox(options, selectedValue, this._contextViewService, customOptionsContainer, { ariaLabel: option.displayName });
 						DialogHelper.appendInputSelectBox(customOptionsContainer, this._customOptionWidgets[i] as SelectBox);
 						this._register(styler.attachSelectBoxStyler(this._customOptionWidgets[i] as SelectBox, this._themeService));
 						break;


### PR DESCRIPTION
This PR fixes #21353 

Custom Option select boxes were not setting values differently, but labels were only provided. I had identified and fixed this issue in #21256 but the PR is delayed due to internal reasons, so it would be best to get the fix extracted for upcoming release.

The change sets actual values separately so they can be retrieved as-is.

Quick Demo using dummy label:

![FixCustomOptionLabels](https://user-images.githubusercontent.com/13396919/205366423-c49c5895-7c9e-45fc-be14-1fb6390c453f.gif)
