### PR TITLE
Make MSAL default auth library

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -128,7 +128,7 @@
           "azure.authenticationLibrary": {
             "type": "string",
             "description": "%config.authenticationLibrary%",
-            "default": "ADAL",
+            "default": "MSAL",
             "enum": [
               "ADAL",
               "MSAL"


### PR DESCRIPTION
Switch MSAL to the default authentication library, as ADAL is going out of support.