### PR TITLE
remove dotnet-interactive-vscode extension

### DIFF
--- a/product.json
+++ b/product.json
@@ -67,7 +67,6 @@
 		"Microsoft.sql-database-projects",
 		"Microsoft.sql-migration",
 		"Microsoft.machine-learning",
-		"ms-dotnettools.dotnet-interactive-vscode",
 		"Redgate.sql-prompt",
 		"Redgate.sql-search",
 		"SentryOne.plan-explorer"


### PR DESCRIPTION
this extension has been removed from the gallery by @corivera.