### PR TITLE
select cell after keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "rxjs": "5.4.0",
     "sanitize-html": "1.19.1",
     "semver-umd": "^5.5.7",
-    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.39",
+    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.40",
     "spdlog": "^0.13.0",
     "tas-client-umd": "0.1.4",
     "turndown": "^7.0.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -44,7 +44,7 @@
     "sanitize-html": "1.19.1",
     "semver-umd": "^5.5.7",
     "spdlog": "^0.13.0",
-    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.39",
+    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.40",
     "turndown": "^7.0.0",
     "turndown-plugin-gfm": "^1.0.2",
     "tas-client-umd": "0.1.4",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -32,7 +32,7 @@
 		"rxjs": "5.4.0",
 		"sanitize-html": "1.19.1",
 		"semver-umd": "^5.5.7",
-		"slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.39",
+		"slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.40",
 		"turndown": "^7.0.0",
 		"turndown-plugin-gfm": "^1.0.2",
 		"tas-client-umd": "0.1.4",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -442,9 +442,9 @@ semver-umd@^5.5.7:
   resolved "https://registry.yarnpkg.com/semver-umd/-/semver-umd-5.5.7.tgz#966beb5e96c7da6fbf09c3da14c2872d6836c528"
   integrity sha512-XgjPNlD0J6aIc8xoTN6GQGwWc2Xg0kq8NzrqMVuKG/4Arl6ab1F8+Am5Y/XKKCR+FceFr2yN/Uv5ZJBhRyRqKg==
 
-"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.39":
-  version "2.3.39"
-  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/4ead9291ec4aab107767940ab0a6eac1455e0627"
+"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.40":
+  version "2.3.40"
+  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/e6d99d4220d576406a244b5c6aaacebefaab491c"
 
 source-map@^0.6.1:
   version "0.6.1"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -904,9 +904,9 @@ simple-get@^4.0.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.39":
-  version "2.3.39"
-  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/4ead9291ec4aab107767940ab0a6eac1455e0627"
+"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.40":
+  version "2.3.40"
+  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/e6d99d4220d576406a244b5c6aaacebefaab491c"
 
 smart-buffer@^4.2.0:
   version "4.2.0"

--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -45,6 +45,7 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 	public init(grid: Slick.Grid<T>) {
 		this.grid = grid;
 		this._handler.subscribe(this.grid.onKeyDown, (e: DOMEvent) => this.handleKeyDown(e as KeyboardEvent));
+		this._handler.subscribe(this.grid.onAfterKeyboardNavigation, (e: Event) => this.handleAfterKeyboardNavigationEvent());
 		this._handler.subscribe(this.grid.onClick, (e: DOMEvent, args: Slick.OnClickEventArgs<T>) => this.handleCellClick(e as MouseEvent, args));
 		this._handler.subscribe(this.grid.onHeaderClick, (e: DOMEvent, args: Slick.OnHeaderClickEventArgs<T>) => this.handleHeaderClick(e as MouseEvent, args));
 		this.grid.registerPlugin(this.selector);
@@ -332,6 +333,13 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 
 			e.preventDefault();
 			e.stopPropagation();
+		}
+	}
+
+	private handleAfterKeyboardNavigationEvent(): void {
+		const activeCell = this.grid.getActiveCell();
+		if (activeCell) {
+			this.setSelectedRanges([new Slick.Range(activeCell.row, activeCell.cell)]);
 		}
 	}
 }

--- a/src/typings/slickgrid.d.ts
+++ b/src/typings/slickgrid.d.ts
@@ -1233,6 +1233,7 @@ declare namespace Slick {
 		public onCellCssStylesChanged: Slick.Event<OnCellCssStylesChangedEventArgs<T>>;
 		public onViewportChanged: Slick.Event<OnViewportChangedEventArgs<T>>;
 		public onRendered: Slick.Event<OnRenderedEventArgs<T>>;
+		public onAfterKeyboardNavigation: Slick.Event<OnAfterKeyboardNavigationEventArgs<T>>;
 		// #endregion Events
 
 		// #region Plugins
@@ -1449,6 +1450,9 @@ declare namespace Slick {
 	export interface OnRenderedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		startRow: number;
 		endRow: number;
+	}
+
+	export interface OnAfterKeyboardNavigationEventArgs<T extends SlickData> extends GridEventArgs<T> {
 	}
 
 	export interface SortColumn<T extends SlickData> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9526,9 +9526,9 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.39":
-  version "2.3.39"
-  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/4ead9291ec4aab107767940ab0a6eac1455e0627"
+"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.40":
+  version "2.3.40"
+  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/e6d99d4220d576406a244b5c6aaacebefaab491c"
 
 smart-buffer@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
This PR fixes #14541

before:
![select-cell-after-navigation-before](https://user-images.githubusercontent.com/13777222/205775636-f9964e57-fb5c-43d7-a1a7-676c2ed4ab47.gif)


after:
![select-cell-after-navigation](https://user-images.githubusercontent.com/13777222/205775739-85892564-63de-48ae-9183-0216fe27619a.gif)

