### PR TITLE
[SQL Migration] Release v1.1.3 to Worldwide

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.1.2",
-							"lastUpdated": "11/7/2022",
+							"version": "1.1.3",
+							"lastUpdated": "12/7/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.1.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.1.3.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4073,7 +4073,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.39.0"
+									"value": ">=1.40.0"
 								}
 							]
 						}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the Worldwide extension gallery to the latest version of the SQL Migration extension. It also bumps the dependent version of ADS to 1.40, matching the extension definition.

This vsix was already built, uploaded, and released to Insiders as part of https://github.com/microsoft/azuredatastudio/pull/21337.

Closes #21074
Closes #20275 