### PR TITLE
Show a message if kernel is not supported when first opening a notebook.

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -1085,7 +1085,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				this._providerId = provider;
 			} else if (!provider) {
 				this._providerId = SQL_NOTEBOOK_PROVIDER;
-				this.notificationService?.notify({ severity: Severity.Info, message: localize('savedKernelNotSupported', "This notebook's '{0}' kernel is not supported. Defaulting to SQL kernel instead.", this._savedKernelInfo.display_name ?? this._savedKernelInfo.name) });
+				this._notebookOptions.notificationService.notify({ severity: Severity.Info, message: localize('savedKernelNotSupported', "This notebook's '{0}' kernel is not supported. Defaulting to SQL kernel instead.", this._savedKernelInfo.display_name ?? this._savedKernelInfo.name) });
 			}
 			this._defaultKernel = this._savedKernelInfo;
 		} else if (this._defaultKernel) {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -1085,6 +1085,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				this._providerId = provider;
 			} else if (!provider) {
 				this._providerId = SQL_NOTEBOOK_PROVIDER;
+				this.notificationService.notify({ severity: Severity.Info, message: localize('savedKernelNotSupported', "This notebook's '{0}' kernel is not supported. Defaulting to SQL kernel instead.", this._savedKernelInfo.display_name ?? this._savedKernelInfo.name) });
 			}
 			this._defaultKernel = this._savedKernelInfo;
 		} else if (this._defaultKernel) {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -1085,7 +1085,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				this._providerId = provider;
 			} else if (!provider) {
 				this._providerId = SQL_NOTEBOOK_PROVIDER;
-				this.notificationService.notify({ severity: Severity.Info, message: localize('savedKernelNotSupported', "This notebook's '{0}' kernel is not supported. Defaulting to SQL kernel instead.", this._savedKernelInfo.display_name ?? this._savedKernelInfo.name) });
+				this.notificationService?.notify({ severity: Severity.Info, message: localize('savedKernelNotSupported', "This notebook's '{0}' kernel is not supported. Defaulting to SQL kernel instead.", this._savedKernelInfo.display_name ?? this._savedKernelInfo.name) });
 			}
 			this._defaultKernel = this._savedKernelInfo;
 		} else if (this._defaultKernel) {


### PR DESCRIPTION
I was testing some Spark notebooks after we removed the spark kernels in the BDC cleanup, and noticed that we switch to the default SQL kernel without any notification. This change adds a message saying we don't support the kernel the notebook was saved with.
