### PR TITLE
fix json cell handling in query editor

### DIFF
--- a/src/sql/base/browser/ui/table/media/slickColorTheme.css
+++ b/src/sql/base/browser/ui/table/media/slickColorTheme.css
@@ -22,6 +22,8 @@
 .resultsMessageValue a:link {
 	color: var(--color-grid-link);
 	text-decoration: underline;
+	cursor: pointer;
+	white-space: inherit;
 }
 
 .slick-cell a:hover,

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -77,7 +77,7 @@ const MIN_GRID_HEIGHT = (MIN_GRID_HEIGHT_ROWS * ROW_HEIGHT) + HEADER_HEIGHT + ES
 // performant than trying to parse the string to object.
 // Regex explaination: after removing the trailing whitespaces, the string must start with '[' (to support arrays)
 // or '{'. And there must be a '}' to match the '{'.
-const IsJsonRegex = /^\s*\[*\s*{.*?}/g;
+const IsJsonRegex = /({(.|\s)*?})|(\[(.|\s)*?\])/g;
 
 export class GridPanel extends Disposable {
 	private container = document.createElement('div');


### PR DESCRIPTION
This PR fixes #313

1. handle line breaks in the json string
2. use pointer cursor for link cells
3. inherit the whitespace setting from parent cell for link cell to avoid showing things in multiple lines.

Before
![image](https://user-images.githubusercontent.com/17966568/206585430-31d4cc32-09ee-4cb9-bdee-9340f304e1b1.png)

After
![image](https://user-images.githubusercontent.com/13777222/206631320-4031c0bb-fe97-4a16-9f2b-60aaad8e5e2f.png)
