### PR TITLE
Auto closing issues that needs logs after 7 days of inactivity. 

### DIFF
--- a/.github/workflows/cleanup-stale-issues.yml
+++ b/.github/workflows/cleanup-stale-issues.yml
@@ -8,14 +8,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Close old issues that need reply
+      - name: Close old issues labeled 'Need logs' that need reply.
         uses: dwieeb/needs-reply@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-label: |
-            Needs Logs
-            Needs Logs - Azure
-            Needs More Info
+          issue-label: Needs Logs
+          days-before-close: 7
+          close-comment: "This issue hasn't had any recent activity and we are marking it as closed. If you are still experiencing this issue, please reopen this issue"
+      - name: Close old issues labeled 'Need Logs - Azure ' that need reply.
+        uses: dwieeb/needs-reply@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-label: Needs Logs - Azure
+          days-before-close: 7
+          close-comment: "This issue hasn't had any recent activity and we are marking it as closed. If you are still experiencing this issue, please reopen this issue"
+      - name: Close old issues labeled 'Need More Info' that need reply.
+        uses: dwieeb/needs-reply@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-label: Needs More Info
           days-before-close: 7
           close-comment: "This issue hasn't had any recent activity and we are marking it as closed. If you are still experiencing this issue, please reopen this issue"
 

--- a/.github/workflows/cleanup-stale-issues.yml
+++ b/.github/workflows/cleanup-stale-issues.yml
@@ -1,0 +1,20 @@
+name: Close old issues that need reply
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close old issues that need reply
+        uses: dwieeb/needs-reply@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-label: |
+            Needs Logs
+            Needs Logs - Azure
+          days-before-close: 7
+          close-comment: "This issue hasn't had any recent activity and we are marking it as closed. If you are still experiencing this issue, please reopen this issue"
+

--- a/.github/workflows/cleanup-stale-issues.yml
+++ b/.github/workflows/cleanup-stale-issues.yml
@@ -15,6 +15,7 @@ jobs:
           issue-label: |
             Needs Logs
             Needs Logs - Azure
+            Needs More Info
           days-before-close: 7
           close-comment: "This issue hasn't had any recent activity and we are marking it as closed. If you are still experiencing this issue, please reopen this issue"
 

--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -1,0 +1,25 @@
+name: On issue comment
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.comment.author_association != 'OWNER' &&
+      github.event.comment.author_association != 'COLLABORATOR'
+    steps:
+      - name: Remove needs-reply label
+        uses: octokit/request-action@v2.x
+        continue-on-error: true
+        with:
+          route: DELETE /repos/:repository/issues/:issue/labels/:label
+          repository: ${{ github.repository }}
+          issue: ${{ github.event.issue.number }}
+          labels: |
+            Needs Logs
+            Needs Logs - Azure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -20,6 +20,7 @@ jobs:
           labels: |
             Needs Logs
             Needs Logs - Azure
+            Needs More Info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR will auto close issues that have need logs label after 7 days of inactivity. However, if there is a comment made on an issue from anyone outside the team, the need logs label will be removed. 