### PR TITLE
fix h-scrollbar cutoff issue

### DIFF
--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -342,6 +342,7 @@ export class QueryEditor extends EditorPane {
 		}
 
 		this.taskbar.setContent(content);
+		this.layout(this.dimension);
 	}
 
 	public override async setInput(newInput: QueryEditorInput, options: IEditorOptions, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
@@ -507,10 +508,12 @@ export class QueryEditor extends EditorPane {
 	 * To be called when the container of this editor changes size.
 	 */
 	public layout(dimension: DOM.Dimension): void {
-		this.dimension = dimension;
-		const queryEditorHeight = dimension.height - DOM.getTotalHeight(this.taskbar.getContainer());
-		this.splitviewContainer.style.height = queryEditorHeight + 'px';
-		this.splitview.layout(queryEditorHeight);
+		if (dimension?.height && dimension?.width && this.splitview) {
+			this.dimension = dimension;
+			const queryEditorHeight = dimension.height - DOM.getTotalHeight(this.taskbar.getContainer());
+			this.splitviewContainer.style.height = queryEditorHeight + 'px';
+			this.splitview.layout(queryEditorHeight);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes #21231

redo the layout after the content of taskbar changes since it could impact the height of the taskbar.

Before:
![image](https://user-images.githubusercontent.com/13777222/206819578-6b82ad2f-c7d2-4b35-a206-0882fa63438b.png)

After:
![image](https://user-images.githubusercontent.com/13777222/206819595-c58c7904-3136-44ff-a0da-3522dc621fa2.png)


