### PR TITLE
Fix issues when setting azureTenantId

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionController.ts
+++ b/src/sql/workbench/services/connection/browser/connectionController.ts
@@ -112,10 +112,6 @@ export class ConnectionController implements IConnectionComponentController {
 		if (this._model.azureTenantId !== azureTenantId) {
 			this._model.azureTenantId = azureTenantId;
 		}
-
-		if (this._model.options.azureTenantId !== azureTenantId) {
-			this._model.azureTenantId = azureTenantId;
-		}
 	}
 
 	protected handleOnAdvancedProperties(): void {

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -1091,9 +1091,6 @@ export class ConnectionWidget extends lifecycle.Disposable {
 						model.groupId = this.findGroupId(model.groupFullName);
 					}
 				}
-				if (this.authType === AuthenticationType.AzureMFA || this.authType === AuthenticationType.AzureMFAAndUser) {
-					model.azureTenantId = this._azureTenantId;
-				}
 			}
 		}
 		return validInputs;


### PR DESCRIPTION
This PR should address #21371.
I misunderstood the issue to be related with MSAL before and confused it with Azure tree token issue.

The reported issue got introduced with this [change](https://github.com/microsoft/azuredatastudio/commit/405b3bbfdb3e3d963fcc344d9a9e2d333db7d492#diff-6cbed09935af5348af95a7fe0c504191ac5e2ee347e0325d5d89d6237dd90698) to fix the way AzureTenantId was being pulled from Browse Azure tree.

This fix simplifies things with AzureTenantId and will ensure the final selected tenant Id from dropdown ends up being populated in the model when opening the connection, and not the one that arrives to Connection Widget when pre-populating the dialog data (i.e., `this._azureTenantId` - which could be `undefined` as in this case), as the dropdown value should be the final value to be used for connection creation.

I've validated the fix with Azure Tree, standalone connection with multi-tenant user accounts. Also tested Edit connection, Browse > saved Connections, and Azure Connections to ensure the behavior is intact to pre-populate tenant associated with the target server.