### PR TITLE
Add validation for checking for dacpac being on the same drive

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -282,6 +282,7 @@ export const databaseNameServerNameVariableRequired = localize('databaseNameServ
 export const otherServer = 'OtherServer';
 export const otherSeverVariable = 'OtherServer';
 export const databaseProject = localize('databaseProject', "Database project");
+export const dacpacMustBeOnSameDrive = localize('dacpacNotOnSameDrive', "Dacpac references need to be located on the same drive as the project file.");
 export const dacpacNotOnSameDrive = (projectLocation: string): string => { return localize('dacpacNotOnSameDrive', "Dacpac references need to be located on the same drive as the project file. The project file is located at {0}", projectLocation); };
 export const referenceType = localize('referenceType', "Reference type");
 

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceQuickpick.ts
@@ -46,7 +46,7 @@ export async function addDatabaseReferenceQuickpick(project: Project): Promise<A
 		case constants.systemDatabase:
 			return addSystemDatabaseReference(project);
 		case constants.dacpacText:
-			return addDacpacReference();
+			return addDacpacReference(project);
 		default:
 			console.log(`Unknown reference type ${referenceType}`);
 			return undefined;
@@ -130,7 +130,7 @@ async function addSystemDatabaseReference(project: Project): Promise<ISystemData
 	};
 }
 
-async function addDacpacReference(): Promise<IDacpacReferenceSettings | undefined> {
+async function addDacpacReference(project: Project): Promise<IDacpacReferenceSettings | undefined> {
 	// (steps continued from addDatabaseReferenceQuickpick)
 	// 2. Prompt for location
 	const location = await promptLocation();
@@ -152,6 +152,12 @@ async function addDacpacReference(): Promise<IDacpacReferenceSettings | undefine
 	if (!dacPacLocation) {
 		// User cancelled
 		return undefined;
+	}
+
+	const projectDrive = path.parse(project.projectFilePath).root;
+	const dacpacDrive = path.parse(dacPacLocation.fsPath).root;
+	if (projectDrive !== dacpacDrive) {
+		void vscode.window.showErrorMessage(constants.dacpacNotOnSameDrive(project.projectFilePath));
 	}
 
 	// 4. Prompt for db/server values


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #19062. This validation was previously added in the dialog in ADS in https://github.com/microsoft/azuredatastudio/pull/14877, but wasn't added in the vscode quickpick.

Adds a placeholder in the browse step mentioning that the dacpac reference needs to be on the same drive as the project:
![image](https://user-images.githubusercontent.com/31145923/208174982-c5a57f7f-4f21-4b76-94f3-9d311e216c42.png)

If the user selects a dacpac on a different drive, then an error notification shows and the browse quickpick shows again:
![image](https://user-images.githubusercontent.com/31145923/208175042-223839fa-c756-4fec-8007-4661b7ae3e15.png)
