### PR TITLE
Reset expiresOn property for non-Azure connections

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -873,6 +873,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			&& connection.authenticationType !== Constants.AuthenticationType.AzureMFAAndUser
 			&& connection.authenticationType !== Constants.AuthenticationType.DSTSAuth) {
 			connection.options['azureAccountToken'] = undefined;
+			connection.options['expiresOn'] = undefined;
 			return true;
 		}
 


### PR DESCRIPTION
This PR resets 'expiresOn' property alongwith 'azureAccountToken' for non-Azure connections.
Fixes #21320 as a bug in Stable build causes reconnect, thereby cancelling running query on a non-Azure connection.
