### PR TITLE
handle the line breaks in link cells

### DIFF
--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -127,7 +127,8 @@ export function textFormatter(row: number | undefined, cell: any | undefined, va
 }
 
 function getCellDisplayValue(cellValue: string): string {
-	let valueToDisplay = cellValue.replace(/(\r\n|\n|\r)/g, ' ');
+	// allow-any-unicode-next-line
+	let valueToDisplay = cellValue.replace(/(\r\n|\n|\r)/g, '↵');
 	return escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
 }
 

--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -71,13 +71,14 @@ export function hyperLinkFormatter(row: number | undefined, cell: any | undefine
 		valueToDisplay = 'NULL';
 		if (!value.isNull) {
 			cellClasses += ' xmlLink';
-			valueToDisplay = escape(value.displayValue);
+			valueToDisplay = getCellDisplayValue(value.displayValue);
 			return `<a class="${cellClasses}">${valueToDisplay}</a>`;
 		} else {
 			cellClasses += ' missing-value';
 		}
 	} else if (isHyperlinkCellValue(value)) {
-		return `<a class="${cellClasses}" title="${escape(value.displayText)}">${escape(value.displayText)}</a>`;
+		valueToDisplay = getCellDisplayValue(value.displayText);
+		return `<a class="${cellClasses}" title="${valueToDisplay}">${valueToDisplay}</a>`;
 	}
 	return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
 }
@@ -93,8 +94,7 @@ export function textFormatter(row: number | undefined, cell: any | undefined, va
 	if (DBCellValue.isDBCellValue(value)) {
 		valueToDisplay = 'NULL';
 		if (!value.isNull) {
-			valueToDisplay = value.displayValue.replace(/(\r\n|\n|\r)/g, ' ');
-			valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
+			valueToDisplay = getCellDisplayValue(value.displayValue)
 			titleValue = valueToDisplay;
 		} else {
 			cellClasses += ' missing-value';
@@ -108,7 +108,7 @@ export function textFormatter(row: number | undefined, cell: any | undefined, va
 		} else {
 			valueToDisplay = value;
 		}
-		valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
+		valueToDisplay = getCellDisplayValue(valueToDisplay);
 		titleValue = valueToDisplay;
 	}
 	else if (value && value.title) {
@@ -119,11 +119,16 @@ export function textFormatter(row: number | undefined, cell: any | undefined, va
 				cellStyle = value.style;
 			}
 		}
-		valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
+		valueToDisplay = getCellDisplayValue(valueToDisplay);
 		titleValue = valueToDisplay;
 	}
 
 	return `<span title="${titleValue}" style="${cellStyle}" class="${cellClasses}">${valueToDisplay}</span>`;
+}
+
+function getCellDisplayValue(cellValue: string): string {
+	let valueToDisplay = cellValue.replace(/(\r\n|\n|\r)/g, ' ');
+	return escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
 }
 
 


### PR DESCRIPTION
this PR fixes #10078

1. apply the line breaking and maximum length logic used in text cells to link cells
2. display line break characters.

before:
![image](https://user-images.githubusercontent.com/13777222/210491516-41dbb9a9-beb2-491e-bf1a-44dc050e2b35.png)

after:
![image](https://user-images.githubusercontent.com/13777222/210491297-caefad00-1cdf-4004-9d27-c2c0ffb61a04.png)

