### PR TITLE
Mongoext

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4763,9 +4763,8 @@
 					],
 					"statistics": [],
 					"flags": ""
-				}
-			],
-
+				},
+				{
 					"extensionId": "95",
 					"extensionName": "mongodb-ads-extension",
 					"displayName": "MongoDB for Azure Data Studio",
@@ -4829,7 +4828,8 @@
 					],
 					"statistics": [],
 					"flags": "preview"
-				},
+				}
+			],
 			"resultMetadata": [
 				{
 					"metadataType": "ResultCount",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4787,7 +4787,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"https://github.com/mongodb-js/vscode/blob/v0.9.3/images/mongodb.png"
+									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/images/mongodb.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4765,13 +4765,78 @@
 					"flags": ""
 				}
 			],
+
+					"extensionId": "95",
+					"extensionName": "mongodb-ads-extension",
+					"displayName": "MongoDB for Azure Data Studio",
+					"shortDescription": "Connect to MongoDB and Atlas directly from your VS Code environment, navigate your databases and collections, inspect your schema and use playgrounds to prototype queries and aggregations.",
+					"publisher": {
+						"displayName": "MongoDB",
+						"publisherId": "MongoDB",
+						"publisherName": "MongoDB"
+					},
+					"versions": [
+						{
+							"version": "0.9.3",
+							"lastUpdated": "04/26/2022",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"source": "https://github.com/mongodb-js/vscode/releases/download/v0.9.3/mongodb-vscode-0.9.3.vsix"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"https://github.com/mongodb-js/vscode/blob/v0.9.3/images/mongodb.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
+									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/CHANGELOG.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/LICENSE.txt"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": ">=1.40.0"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/mongodb-js/vscode"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": "preview"
+				},
 			"resultMetadata": [
 				{
 					"metadataType": "ResultCount",
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 78
+							"count": 79
 						}
 					]
 				}

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4782,28 +4782,28 @@
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://github.com/mongodb-js/vscode/releases/download/v0.9.3/mongodb-vscode-0.9.3.vsix"
+									"assetType": "Microsoft.SQLOps.DownloadPage",
+									"source": "https://github.com/mongodb-js/vscode/releases/v0.9.3"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/images/mongodb.png"
+									"source": "https://raw.githubusercontent.com/mongodb-js/vscode/v0.9.3/images/mongodb.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/README.md"
+									"source": "https://raw.githubusercontent.com/mongodb-js/vscode/v0.9.3/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/CHANGELOG.md"
+									"source": "https://raw.githubusercontent.com/mongodb-js/vscode/v0.9.3/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/package.json"
+									"source": "https://raw.githubusercontent.com/mongodb-js/vscode/v0.9.3/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://github.com/mongodb-js/vscode/blob/v0.9.3/LICENSE.txt"
+									"source": "https://raw.githubusercontent.com/mongodb-js/vscode/v0.9.3/LICENSE.txt"
 								}
 							],
 							"properties": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21521 

This is to make available (hopefully) the MongoDB extension that is currently in VS Code.  Testing with version 0.9.3 (from April: https://github.com/mongodb-js/vscode/releases/tag/v0.9.3) due to the ADS shell at 1.67 (from May) via a manual install was successful.  We would like to make this available in the Insider build in the extension library for the MongoDB team to test with.

Please note: it's quite possible I missed a step in this.