### PR TITLE
Handle default tenant to be set when no dropdown exists

### DIFF
--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -146,6 +146,7 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 		if (azureAuth) {
 			Logger.pii(`Getting account security token for ${JSON.stringify(account.key)} (tenant ${tenantId}). Auth Method = ${azureAuth.userFriendlyName}`, [], []);
 			if (this.authLibrary === Constants.AuthLibrary.MSAL) {
+				tenantId = tenantId || account.properties.owningTenant.id;
 				let authResult = await azureAuth.getTokenMsal(account.key.accountId, resource, tenantId);
 				if (!authResult || !authResult.account || !authResult.account.idTokenClaims) {
 					Logger.error(`MSAL: getToken call failed`);

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -689,6 +689,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 				}
 			}
 			else {
+				this._azureTenantId = selectedAccount.properties.tenants[0].id;
 				this.onAzureTenantSelected(0);
 			}
 
@@ -859,6 +860,13 @@ export class ConnectionWidget extends lifecycle.Disposable {
 							this._logService.error(`fillInConnectionInputs : Could not find tenant with ID ${this._azureTenantId} for account ${accountName}`);
 						}
 						this.onAzureTenantSelected(this._azureTenantDropdown.values.indexOf(this._azureTenantDropdown.value));
+					}
+					else if (account && account.properties.tenants && account.properties.tenants.length === 1) {
+						this._azureTenantId = account.properties.tenants[0].id;
+						this.onAzureTenantSelected(0);
+					}
+					else {
+						this._logService.error(`fillInConnectionInputs : Could not find any tenants for account ${accountName}`);
 					}
 				}).catch(err => this._logService.error(`Unexpected error populating initial Azure Account options : ${err}`));
 			}


### PR DESCRIPTION
Fixes a use-case for issue #21371 when user account has no tenant dropdown, i.e. only 1 tenant.
Azure core doesn't receive tenant info in that case, so the owning tenant should be set to the default tenant in that case.
