### PR TITLE
fix issue caused by execution plan provider

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -577,6 +577,7 @@
     "connectionProvider": {
       "providerId": "MSSQL",
       "displayName": "%mssql.provider.displayName%",
+      "isExecutionPlanProvider": true,
       "supportedExecutionPlanFileExtensions": [
         "sqlplan"
       ],

--- a/src/sql/platform/capabilities/common/capabilitiesService.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesService.ts
@@ -56,6 +56,7 @@ export interface ConnectionProviderProperties {
 	azureResource?: string;
 	connectionOptions: azdata.ConnectionOption[];
 	isQueryProvider?: boolean;
+	isExecutionPlanProvider?: boolean;
 	supportedExecutionPlanFileExtensions?: string[];
 	connectionStringOptions?: ConnectionStringOptions;
 }


### PR DESCRIPTION
This PR fixes #21451

Problem: 
The following error was logged when trying to open a JSON cell: `No valid execution plan handler is registered`

Root Cause:
When the provider is not an execution plan provider, an error will be thrown when checking whether the string is execution plan.
![image](https://user-images.githubusercontent.com/13777222/210910518-e32d117f-6122-42ae-9c0b-52103d0cc478.png)

Fix:
1. Add `IsExecutionPlanProvider` to the provider metadata so that we know it without needing to activate the extension
2. Update the service so that it returns false if the provider is not an execution plan provider
3. refactor the execution plan service


With the fix:

MySQL - Json
![mysql-json](https://user-images.githubusercontent.com/13777222/210910192-5ecad039-d5b2-4d5c-93c6-17d58b68588b.gif)

MSSQL - Execution Plan
![mssql-execution-plan](https://user-images.githubusercontent.com/13777222/210910193-6311b11b-1f73-464e-8059-6eac4424e2c8.gif)

MSSQL - JSON
![mssql-json](https://user-images.githubusercontent.com/13777222/210910197-b87a69a9-f798-4744-b193-5728ac8bba44.gif)

