### PR TITLE
Fix resource endpoints to end with slash

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -280,8 +280,6 @@ export abstract class AzureAuth implements vscode.Disposable {
 		return undefined;
 	}
 
-
-
 	protected abstract loginAdal(tenant: Tenant, resource: Resource): Promise<{ response: OAuthTokenResponse | undefined, authComplete: Deferred<void, Error> }>;
 
 	protected abstract loginMsal(tenant: Tenant, resource: Resource): Promise<{ response: AuthenticationResult | null, authComplete: Deferred<void, Error> }>;
@@ -323,6 +321,9 @@ export abstract class AzureAuth implements vscode.Disposable {
 			Logger.error(`Error: Could not fetch the azure resource ${azureResource} `);
 			return null;
 		}
+		// Resource endpoint must end with '/' to form a valid scope for MSAL token request.
+		const endpoint = resource.endpoint.endsWith('/') ? resource.endpoint : resource.endpoint + '/';
+
 		let account: AccountInfo | null = await this.getAccountFromMsalCache(accountId);
 		if (!account) {
 			Logger.error('Error: Could not fetch account when acquiring token');
@@ -330,9 +331,9 @@ export abstract class AzureAuth implements vscode.Disposable {
 		}
 		let newScope;
 		if (resource.azureResourceId === azdata.AzureResource.ResourceManagement) {
-			newScope = [`${resource?.endpoint}user_impersonation`];
+			newScope = [`${endpoint}user_impersonation`];
 		} else {
-			newScope = [`${resource?.endpoint}.default`];
+			newScope = [`${endpoint}.default`];
 		}
 
 		// construct request

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -39,7 +39,7 @@ const publicAzureSettings: ProviderSettings = {
 			},
 			graphResource: {
 				id: SettingIds.graph,
-				endpoint: 'https://graph.windows.net',
+				endpoint: 'https://graph.windows.net/',
 				azureResourceId: AzureResource.Graph
 			},
 			msGraphResource: {
@@ -59,38 +59,38 @@ const publicAzureSettings: ProviderSettings = {
 			},
 			ossRdbmsResource: {
 				id: SettingIds.ossrdbms,
-				endpoint: 'https://ossrdbms-aad.database.windows.net',
+				endpoint: 'https://ossrdbms-aad.database.windows.net/',
 				azureResourceId: AzureResource.OssRdbms
 			},
 			azureKeyVaultResource: {
 				id: SettingIds.vault,
-				endpoint: 'https://vault.azure.net',
+				endpoint: 'https://vault.azure.net/',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
 			azureDevOpsResource: {
 				id: SettingIds.ado,
-				endpoint: '499b84ac-1321-427f-aa17-267ca6975798',
+				endpoint: '499b84ac-1321-427f-aa17-267ca6975798/',
 				azureResourceId: AzureResource.AzureDevOps,
 			},
 			azureLogAnalyticsResource: {
 				id: SettingIds.ala,
-				endpoint: 'https://api.loganalytics.io',
+				endpoint: 'https://api.loganalytics.io/',
 				azureResourceId: AzureResource.AzureLogAnalytics,
 			},
 			azureStorageResource: {
 				id: SettingIds.storage,
 				endpoint: '',
-				endpointSuffix: '.core.windows.net',
+				endpointSuffix: '.core.windows.net/',
 				azureResourceId: AzureResource.AzureStorage
 			},
 			azureKustoResource: {
 				id: SettingIds.kusto,
-				endpoint: 'https://kusto.kusto.windows.net',
+				endpoint: 'https://kusto.kusto.windows.net/',
 				azureResourceId: AzureResource.AzureKusto,
 			},
 			powerBiResource: {
 				id: SettingIds.powerbi,
-				endpoint: 'https://analysis.windows.net/powerbi/api',
+				endpoint: 'https://analysis.windows.net/powerbi/api/',
 				azureResourceId: AzureResource.PowerBi
 			},
 			redirectUri: 'http://localhost',
@@ -119,12 +119,12 @@ const usGovAzureSettings: ProviderSettings = {
 			},
 			graphResource: {
 				id: SettingIds.graph,
-				endpoint: 'https://graph.windows.net',
+				endpoint: 'https://graph.windows.net/',
 				azureResourceId: AzureResource.Graph
 			},
 			armResource: {
 				id: SettingIds.arm,
-				endpoint: 'https://management.usgovcloudapi.net',
+				endpoint: 'https://management.usgovcloudapi.net/',
 				azureResourceId: AzureResource.ResourceManagement
 			},
 			sqlResource: {
@@ -134,28 +134,28 @@ const usGovAzureSettings: ProviderSettings = {
 			},
 			ossRdbmsResource: {
 				id: SettingIds.ossrdbms,
-				endpoint: 'https://ossrdbms-aad.database.usgovcloudapi.net',
+				endpoint: 'https://ossrdbms-aad.database.usgovcloudapi.net/',
 				azureResourceId: AzureResource.OssRdbms
 			},
 			azureKeyVaultResource: {
 				id: SettingIds.vault,
-				endpoint: 'https://vault.usgovcloudapi.net',
+				endpoint: 'https://vault.usgovcloudapi.net/',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
 			azureLogAnalyticsResource: {
 				id: SettingIds.ala,
-				endpoint: 'https://api.loganalytics.us',
+				endpoint: 'https://api.loganalytics.us/',
 				azureResourceId: AzureResource.AzureLogAnalytics,
 			},
 			azureStorageResource: {
 				id: SettingIds.storage,
 				endpoint: '',
-				endpointSuffix: '.core.usgovcloudapi.net',
+				endpointSuffix: '.core.usgovcloudapi.net/',
 				azureResourceId: AzureResource.AzureStorage
 			},
 			powerBiResource: {
 				id: SettingIds.powerbi,
-				endpoint: 'https://analysis.windows.net/powerbi/api',
+				endpoint: 'https://analysis.windows.net/powerbi/api/',
 				azureResourceId: AzureResource.PowerBi
 			},
 			redirectUri: 'http://localhost',
@@ -183,7 +183,7 @@ const usNatAzureSettings: ProviderSettings = {
 			},
 			graphResource: {
 				id: SettingIds.graph,
-				endpoint: 'https://graph.eaglex.ic.gov',
+				endpoint: 'https://graph.eaglex.ic.gov/',
 				azureResourceId: AzureResource.Graph
 			},
 			armResource: {
@@ -198,23 +198,23 @@ const usNatAzureSettings: ProviderSettings = {
 			},
 			ossRdbmsResource: {
 				id: SettingIds.ossrdbms,
-				endpoint: 'https://ossrdbms-aad.database.cloudapi.eaglex.ic.gov',
+				endpoint: 'https://ossrdbms-aad.database.cloudapi.eaglex.ic.gov/',
 				azureResourceId: AzureResource.OssRdbms
 			},
 			azureKeyVaultResource: {
 				id: SettingIds.vault,
-				endpoint: 'https://vault.cloudapi.eaglex.ic.gov',
+				endpoint: 'https://vault.cloudapi.eaglex.ic.gov/',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
 			azureLogAnalyticsResource: {
 				id: SettingIds.ala,
-				endpoint: 'https://api.loganalytics.azure.eaglex.ic.gov',
+				endpoint: 'https://api.loganalytics.azure.eaglex.ic.gov/',
 				azureResourceId: AzureResource.AzureLogAnalytics,
 			},
 			azureStorageResource: {
 				id: SettingIds.storage,
 				endpoint: '',
-				endpointSuffix: '.core.eaglex.ic.gov',
+				endpointSuffix: '.core.eaglex.ic.gov/',
 				azureResourceId: AzureResource.AzureStorage
 			},
 			redirectUri: 'http://localhost',
@@ -238,33 +238,33 @@ const germanyAzureSettings: ProviderSettings = {
 			clientId: 'a69788c6-1d43-44ed-9ca3-b83e194da255',
 			graphResource: {
 				id: SettingIds.graph,
-				endpoint: 'https://graph.cloudapi.de',
+				endpoint: 'https://graph.cloudapi.de/',
 				azureResourceId: AzureResource.Graph
 			},
 			msGraphResource: {
 				id: SettingIds.msgraph,
-				endpoint: 'https://graph.microsoft.de',
+				endpoint: 'https://graph.microsoft.de/',
 				azureResourceId: AzureResource.MsGraph
 			},
 			armResource: {
 				id: SettingIds.arm,
-				endpoint: 'https://management.microsoftazure.de',
+				endpoint: 'https://management.microsoftazure.de/',
 				azureResourceId: AzureResource.ResourceManagement
 			},
 			azureKeyVaultResource: {
 				id: SettingIds.vault,
-				endpoint: 'https://vault.microsoftazure.de',
+				endpoint: 'https://vault.microsoftazure.de/',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
 			azureStorageResource: {
 				id: SettingIds.storage,
 				endpoint: '',
-				endpointSuffix: '.core.cloudapi.de',
+				endpointSuffix: '.core.cloudapi.de/',
 				azureResourceId: AzureResource.AzureStorage
 			},
 			powerBiResource: {
 				id: SettingIds.powerbi,
-				endpoint: 'https://analysis.windows.net/powerbi/api',
+				endpoint: 'https://analysis.windows.net/powerbi/api/',
 				azureResourceId: AzureResource.PowerBi
 			},
 			redirectUri: 'http://localhost',


### PR DESCRIPTION
This PR fixes #21536

Resource endpoints are appended to scope when request is made to MSAL, therefore they need to end with slash (`/`)
This change is backwards compatible with ADAL.