### PR TITLE
Adding better handling for checkbox column based row selection

### DIFF
--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -286,6 +286,9 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 			this._register(this._table);
 			this._register(attachTableStyler(this._table, this.themeService));
 			this._register(this._table.onSelectedRowsChanged((e, data) => {
+				if (this.isCheckboxColumnsUsedForSelection()) {
+					return;
+				}
 				this.selectedRows = data.rows;
 				this.fireEvent({
 					eventType: ComponentEventType.onSelectedRowChanged,
@@ -445,6 +448,8 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 			}, index));
 
 			this._register(this._checkboxColumns.get(col.value).onChange((state) => {
+				this.data[state.row][state.column] = state.checked;
+				this.setPropertyFromUI<any[][]>((props, value) => props.data = value, this.data);
 				this.fireEvent({
 					eventType: ComponentEventType.onCellAction,
 					args: {
@@ -454,6 +459,34 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 						name: name
 					}
 				});
+				if (checkboxAction === ActionOnCheck.selectRow) {
+					const selectedRows: number[] = [];
+					this.data.forEach((row, index) => {
+						if (row[state.column]) {
+							selectedRows.push(index);
+						}
+					});
+					this.selectedRows = selectedRows;
+					this.fireEvent({
+						eventType: ComponentEventType.onSelectedRowChanged,
+						args: selectedRows
+					});
+				}
+			}));
+
+			this._register(this._checkboxColumns.get(col.value).onCheckAllChange((state) => {
+				this.data.forEach((row, index) => {
+					row[state.column] = state.checked;
+				});
+				this.setPropertyFromUI<any[][]>((props, value) => props.data = value, this.data);
+				if (checkboxAction === ActionOnCheck.selectRow) {
+
+					this.selectedRows = state.checked ? this.data.map((v, i) => i) : [];
+					this.fireEvent({
+						eventType: ComponentEventType.onSelectedRowChanged,
+						args: this.selectedRows
+					});
+				}
 			}));
 		}
 	}
@@ -619,6 +652,16 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 			}
 			this._table.grid.getActiveCellNode().focus();
 		}
+	}
+
+	/**
+	 * Returns true if the checkbox column is used for row selection in the table
+	 */
+	private isCheckboxColumnsUsedForSelection(): boolean {
+		return this.columns.some(c => {
+			const checkboxAction = <ActionOnCheck>(c.options ? (<any>c.options).actionOnCheckbox : c.action);
+			return checkboxAction === ActionOnCheck.selectRow
+		});
 	}
 
 	// CSS-bound properties

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -659,7 +659,7 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 	 */
 	private isCheckboxColumnsUsedForSelection(): boolean {
 		return this.columns.some(c => {
-			const checkboxAction = <ActionOnCheck>(c.options ? (<any>c.options).actionOnCheckbox : c.action);
+			const checkboxAction = <ActionOnCheck>(c.options ? (<azdata.CheckboxColumnOption>c.options).actionOnCheckbox : c.action);
 			return checkboxAction === ActionOnCheck.selectRow
 		});
 	}


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/21491

There were a couple of rowSelectionEvents fired whenever a checkbox state was changed in slickgrid.
First there was rowSelectionEvent fired for row whose value was just changed by the RowSelectionModel plugin and then there was a second rowSelectionEvent fired for all the checked rows by CheckboxSelectColumn plugin.

This PR fixes that issue. Now, if a checkbox column is used for row selection, the duplicate event is not fired anymore.

Previously, the table data was not updated when the value of the checkbox was updated. This PR also fixes that issue. Now, the value of the table is always updated before the checkbox action event is fired so it truly reflects what is seen in the UI.

This change should be completely back compatible with the existing behavior of the API. I have tested it out in migration extension and the schema compare extension. However, given how big the change is I will take it for March 2023 release instead of Jan 2023. 