### PR TITLE
Skip fetching access token when opening context menu in OE

### DIFF
--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -202,7 +202,7 @@ export interface IConnectionManagementService {
 
 	disconnect(ownerUri: string): Promise<void>;
 
-	addSavedPassword(connectionProfile: IConnectionProfile): Promise<IConnectionProfile>;
+	addSavedPassword(connectionProfile: IConnectionProfile, skipAccessToken?: boolean): Promise<IConnectionProfile>;
 
 	listDatabases(connectionUri: string): Thenable<azdata.ListDatabasesResult | undefined>;
 

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -255,8 +255,10 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 * Load the password for the profile
 	 * @param connectionProfile Connection Profile
 	 */
-	public async addSavedPassword(connectionProfile: interfaces.IConnectionProfile): Promise<interfaces.IConnectionProfile> {
-		await this.fillInOrClearToken(connectionProfile);
+	public async addSavedPassword(connectionProfile: interfaces.IConnectionProfile, skipAccessToken: boolean = false): Promise<interfaces.IConnectionProfile> {
+		if (!skipAccessToken) {
+			await this.fillInOrClearToken(connectionProfile);
+		}
 		return this._connectionStore.addSavedPassword(connectionProfile).then(result => result.profile);
 	}
 

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
@@ -70,7 +70,8 @@ export class ServerTreeActionProvider {
 	 */
 	private getConnectionActions(tree: AsyncServerTree | ITree, profile: ConnectionProfile): IAction[] {
 		let node = new TreeNode(NodeType.Server, NodeType.Server, '', false, '', '', '', undefined, undefined, undefined, undefined);
-		this._connectionManagementService.addSavedPassword(profile);
+		// Only update password and not access tokens to avoid login prompts when opening context menu.
+		this._connectionManagementService.addSavedPassword(profile, true);
 		node.connection = profile;
 		return this.getAllActions({
 			tree: tree,


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/21363

Call to fetch access token can be safely skipped when opening context menu, as it will eventually be fetched when any action is taken on server tree node or its expanded.