### PR TITLE
Add option to show and hide the action bar in the query results view

### DIFF
--- a/src/sql/platform/query/common/query.ts
+++ b/src/sql/platform/query/common/query.ts
@@ -30,6 +30,7 @@ export interface IQueryEditorConfiguration {
 		readonly optimizedTable: boolean,
 		readonly inMemoryDataProcessingThreshold: number,
 		readonly openAfterSave: boolean
+		readonly showActionBar: boolean;
 	},
 	readonly messages: {
 		readonly showBatchTime: boolean,

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -62,6 +62,7 @@ const HEADER_HEIGHT = 26;
 const MIN_GRID_HEIGHT_ROWS = 8;
 const ESTIMATED_SCROLL_BAR_HEIGHT = 15;
 const BOTTOM_PADDING = 15;
+const NO_ACTIONBAR_ADDITIONAL_PADDING = 75;
 const ACTIONBAR_WIDTH = 36;
 
 // minimum height needed to show the full actionbar
@@ -629,7 +630,8 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		// if the actionsOrientation passed in is "VERTICAL" (or no actionsOrientation is passed in at all), create a vertical actionBar
 		else {
 			actionBarContainer.className = 'grid-panel action-bar vertical';
-			actionBarContainer.style.width = ACTIONBAR_WIDTH + 'px';
+			let actionBarWidth = this.showActionBar ? ACTIONBAR_WIDTH : 0;
+			actionBarContainer.style.width = actionBarWidth + 'px';
 			this.container.appendChild(actionBarContainer);
 		}
 
@@ -820,11 +822,17 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	public get minimumSize(): number {
 		// clamp between ensuring we can show the actionbar, while also making sure we don't take too much space
 		// if there is only one table then allow a minimum size of ROW_HEIGHT
-		return this.isOnlyTable ? ROW_HEIGHT : Math.max(Math.min(this.maxSize, MIN_GRID_HEIGHT), ACTIONBAR_HEIGHT + BOTTOM_PADDING);
+		let actionBarHeight = this.showActionBar ? ACTIONBAR_HEIGHT : 0;
+		let bottomPadding = this.showActionBar ? BOTTOM_PADDING : BOTTOM_PADDING + NO_ACTIONBAR_ADDITIONAL_PADDING;
+
+		return this.isOnlyTable ? ROW_HEIGHT : Math.max(Math.min(this.maxSize, MIN_GRID_HEIGHT), actionBarHeight + bottomPadding);
 	}
 
 	public get maximumSize(): number {
-		return Math.max(this.maxSize, ACTIONBAR_HEIGHT + BOTTOM_PADDING);
+		let actionBarHeight = this.showActionBar ? ACTIONBAR_HEIGHT : 0;
+		let bottomPadding = this.showActionBar ? BOTTOM_PADDING : BOTTOM_PADDING + NO_ACTIONBAR_ADDITIONAL_PADDING;
+
+		return Math.max(this.maxSize, actionBarHeight + bottomPadding);
 	}
 
 	private loadData(offset: number, count: number): Thenable<T[]> {

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -630,8 +630,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		// if the actionsOrientation passed in is "VERTICAL" (or no actionsOrientation is passed in at all), create a vertical actionBar
 		else {
 			actionBarContainer.className = 'grid-panel action-bar vertical';
-			let actionBarWidth = this.showActionBar ? ACTIONBAR_WIDTH : 0;
-			actionBarContainer.style.width = actionBarWidth + 'px';
+			actionBarContainer.style.width = (this.showActionBar ? ACTIONBAR_WIDTH : 0) + 'px';
 			this.container.appendChild(actionBarContainer);
 		}
 

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -442,6 +442,11 @@ const queryEditorConfiguration: IConfigurationNode = {
 			'description': localize('queryEditor.results.openAfterSave', "Whether to open the file in Azure Data Studio after the result is saved."),
 			'default': true
 		},
+		'queryEditor.results.showActionBar': {
+			'type': 'boolean',
+			'description': localize('queryEditor.results.showActionBar', "Configuration options for showing the action bar in the Results View"),
+			'default': true
+		},
 		'queryEditor.messages.showBatchTime': {
 			'type': 'boolean',
 			'description': localize('queryEditor.messages.showBatchTime', "Should execution time be shown for individual batches"),

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -444,7 +444,7 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.showActionBar': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.showActionBar', "Configuration options for showing the action bar in the Results View"),
+			'description': localize('queryEditor.results.showActionBar', "Whether to show the action bar in the query results view"),
 			'default': true
 		},
 		'queryEditor.messages.showBatchTime': {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21538

The PR adds the ability to show and hide the actions bar that appears in the results pane.
![Query Editor - show and hide actions bar](https://user-images.githubusercontent.com/87730006/211618669-d9c248d0-8c06-41e5-9577-78c475d6b2a7.gif)


The space between tables when multiple queries are executed are adjusted accordingly when the action bar isn't present:
Action bar hidden:
![image](https://user-images.githubusercontent.com/87730006/211931507-e436d1ec-d04d-458d-b781-cad2fd254e91.png)

Action bar visible:
![image](https://user-images.githubusercontent.com/87730006/211931590-758d9656-38ab-4312-8885-a8f7fbc2e954.png)
