### PR TITLE
Save sql plan no longer uses the exact same name as the default

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanView.ts
@@ -446,24 +446,31 @@ export class SavePlanFile extends Action {
 	public override async run(context: ExecutionPlanView): Promise<void> {
 		const workspaceFolders = context.workspaceContextService.getWorkspace().folders;
 		const defaultFileName = 'plan';
+		const fileExtension = 'sqlplan'; //TODO: Get this extension from provider
 		let defaultUri: URI;
 
 		const lastUsedSavePath = this.storageService.get(SavePlanFile.LAST_USED_EXECUTION_PLAN_SAVE_PATH_STORAGE_KEY, StorageScope.GLOBAL);
 
 		if (lastUsedSavePath) {
-			defaultUri = joinPath(URI.file(lastUsedSavePath), defaultFileName);
+			defaultUri = joinPath(URI.file(lastUsedSavePath), `${defaultFileName}.${fileExtension}`);
 		} else {
 			if (workspaceFolders.length !== 0) {
-				defaultUri = URI.joinPath(workspaceFolders[0].uri, defaultFileName); // appending default file name to workspace uri
+				defaultUri = URI.joinPath(workspaceFolders[0].uri, `${defaultFileName}.${fileExtension}`); // appending default file name to workspace uri
 			} else {
-				defaultUri = URI.joinPath(await this.fileDialogService.defaultFolderPath(Schemas.file), defaultFileName);
+				defaultUri = URI.joinPath(await this.fileDialogService.defaultFolderPath(Schemas.file), `${defaultFileName}.${fileExtension}`);
 			}
 		}
+
+		let planNumber = 1;
+		while (await context.fileService.exists(defaultUri)) {
+			defaultUri = joinPath(URI.file(lastUsedSavePath), `${defaultFileName}${planNumber}.${fileExtension}`);
+		}
+
 
 		const destination = await this.fileDialogService.showSaveDialog({
 			filters: [
 				{
-					extensions: ['sqlplan'], //TODO: Get this extension from provider
+					extensions: [fileExtension],
 					name: localize('executionPlan.SaveFileDescription', 'Execution Plan Files') //TODO: Get the names from providers.
 				}
 			],

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanView.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanView.ts
@@ -464,8 +464,8 @@ export class SavePlanFile extends Action {
 		let planNumber = 1;
 		while (await context.fileService.exists(defaultUri)) {
 			defaultUri = joinPath(URI.file(lastUsedSavePath), `${defaultFileName}${planNumber}.${fileExtension}`);
+			planNumber++;
 		}
-
 
 		const destination = await this.fileDialogService.showSaveDialog({
 			filters: [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #18385

Previously when you clicked on the "Save Plan File" button. The save file dialog would appear recommending "plan.sqlplan" as the file name, even if there was already a file with that same name in the save folder location. This PR appends a number to the default file name, so any new files being saved with the default name will appear as "plan1.sqlplan", "plan2.sqlplan", and so on.