### PR TITLE
Adds functionality to copy table column headers

### DIFF
--- a/src/sql/workbench/contrib/query/browser/actions.ts
+++ b/src/sql/workbench/contrib/query/browser/actions.ts
@@ -111,7 +111,7 @@ export class CopyResultAction extends Action {
 		id: string,
 		label: string,
 		private copyHeader: boolean,
-		@IConfigurationService private configurationService: IConfigurationService,
+		@IConfigurationService private configurationService: IConfigurationService
 	) {
 		super(id, label);
 	}

--- a/src/sql/workbench/contrib/query/browser/actions.ts
+++ b/src/sql/workbench/contrib/query/browser/actions.ts
@@ -107,34 +107,39 @@ export class CopyResultAction extends Action {
 	public static COPYWITHHEADERS_ID = 'grid.copyWithHeaders';
 	public static COPYWITHHEADERS_LABEL = localize('copyWithHeaders', "Copy With Headers");
 
-	public static COPYHEADERS_ID = 'grid.copyHeaders';
-	public static COPYHEADERS_LABEL = localize('copyHeaders', 'Copy Headers');
-
 	constructor(
 		id: string,
 		label: string,
 		private copyHeader: boolean,
-		private onlyCopyHeaders: boolean,
 		@IConfigurationService private configurationService: IConfigurationService,
-		@IClipboardService private clipboardService: IClipboardService
 	) {
 		super(id, label);
 	}
 
 	public override async run(context: IGridActionContext): Promise<void> {
-		if (this.onlyCopyHeaders) {
-			// Starting at index 1 to ignore the first column of row numbers
-			const columnHeaders = context.table.columns.slice(1, context.table.columns.length)
-				.map(c => c.name ? c.name : '')
-				.join(', ');
-
-			await this.clipboardService.writeText(columnHeaders);
-			return;
-		}
-
 		const selection = mapForNumberColumn(context.selection);
 		const includeHeader = this.configurationService.getValue<boolean>('queryEditor.results.copyIncludeHeaders') || this.copyHeader;
 		await context.gridDataProvider.copyResults(selection, includeHeader, context.table.getData());
+	}
+}
+
+export class CopyHeadersAction extends Action {
+	private static ID = 'grid.copyHeaders';
+	private static LABEL = localize('copyHeaders', 'Copy Headers');
+
+	constructor(
+		@IClipboardService private clipboardService: IClipboardService
+	) {
+		super(CopyHeadersAction.ID, CopyHeadersAction.LABEL);
+	}
+
+	public override async run(context: IGridActionContext): Promise<void> {
+		// Starting at index 1 to ignore the first column of row numbers
+		const columnHeaders = context.table.columns.slice(1, context.table.columns.length)
+			.map(c => c.name ? c.name : '')
+			.join(',');
+
+		await this.clipboardService.writeText(columnHeaders);
 	}
 }
 

--- a/src/sql/workbench/contrib/query/browser/actions.ts
+++ b/src/sql/workbench/contrib/query/browser/actions.ts
@@ -114,7 +114,7 @@ export class CopyResultAction extends Action {
 		id: string,
 		label: string,
 		private copyHeader: boolean,
-		private copyHeadersOnly: boolean,
+		private onlyCopyHeaders: boolean,
 		@IConfigurationService private configurationService: IConfigurationService,
 		@IClipboardService private clipboardService: IClipboardService
 	) {
@@ -122,9 +122,9 @@ export class CopyResultAction extends Action {
 	}
 
 	public override async run(context: IGridActionContext): Promise<void> {
-		if (this.copyHeadersOnly) {
+		if (this.onlyCopyHeaders) {
 			// Starting at index 1 to ignore the first column of row numbers
-			let columnHeaders = context.table.columns.slice(1, context.table.columns.length)
+			const columnHeaders = context.table.columns.slice(1, context.table.columns.length)
 				.map(c => c.name ? c.name : '')
 				.join(', ');
 

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -13,7 +13,7 @@ import { VirtualizedCollection } from 'sql/base/browser/ui/table/asyncDataView';
 import { Table } from 'sql/base/browser/ui/table/table';
 import { MouseWheelSupport } from 'sql/base/browser/ui/table/plugins/mousewheelTableScroll.plugin';
 import { AutoColumnSize } from 'sql/base/browser/ui/table/plugins/autoSizeColumns.plugin';
-import { IGridActionContext, SaveResultAction, CopyResultAction, SelectAllGridAction, MaximizeTableAction, RestoreTableAction, ChartDataAction, VisualizerDataAction } from 'sql/workbench/contrib/query/browser/actions';
+import { IGridActionContext, SaveResultAction, CopyResultAction, SelectAllGridAction, MaximizeTableAction, RestoreTableAction, ChartDataAction, VisualizerDataAction, CopyHeadersAction } from 'sql/workbench/contrib/query/browser/actions';
 import { CellSelectionModel } from 'sql/base/browser/ui/table/plugins/cellSelectionModel.plugin';
 import { RowNumberColumn } from 'sql/base/browser/ui/table/plugins/rowNumberColumn.plugin';
 import { escape } from 'sql/base/common/strings';
@@ -621,7 +621,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 			const selectedRanges = this.table.getSelectedRanges();
 			// Only do copy if the grid is the current active grid.
 			if (this.container.contains(document.activeElement) && selectedRanges && selectedRanges.length !== 0) {
-				this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPY_ID, CopyResultAction.COPY_LABEL, false, false).run(this.generateContext());
+				this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPY_ID, CopyResultAction.COPY_LABEL, false).run(this.generateContext());
 				return true;
 			}
 			return false;
@@ -853,9 +853,9 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 					actions.push(new Separator());
 				}
 				actions.push(
-					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPY_ID, CopyResultAction.COPY_LABEL, false, false),
-					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPYWITHHEADERS_ID, CopyResultAction.COPYWITHHEADERS_LABEL, true, false),
-					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPYHEADERS_ID, CopyResultAction.COPYHEADERS_LABEL, false, true)
+					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPY_ID, CopyResultAction.COPY_LABEL, false),
+					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPYWITHHEADERS_ID, CopyResultAction.COPYWITHHEADERS_LABEL, true),
+					this.instantiationService.createInstance(CopyHeadersAction)
 				);
 
 				if (this.state.canBeMaximized) {

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -621,7 +621,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 			const selectedRanges = this.table.getSelectedRanges();
 			// Only do copy if the grid is the current active grid.
 			if (this.container.contains(document.activeElement) && selectedRanges && selectedRanges.length !== 0) {
-				this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPY_ID, CopyResultAction.COPY_LABEL, false).run(this.generateContext());
+				this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPY_ID, CopyResultAction.COPY_LABEL, false, false).run(this.generateContext());
 				return true;
 			}
 			return false;
@@ -853,8 +853,9 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 					actions.push(new Separator());
 				}
 				actions.push(
-					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPY_ID, CopyResultAction.COPY_LABEL, false),
-					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPYWITHHEADERS_ID, CopyResultAction.COPYWITHHEADERS_LABEL, true)
+					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPY_ID, CopyResultAction.COPY_LABEL, false, false),
+					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPYWITHHEADERS_ID, CopyResultAction.COPYWITHHEADERS_LABEL, true, false),
+					this.instantiationService.createInstance(CopyResultAction, CopyResultAction.COPYHEADERS_ID, CopyResultAction.COPYHEADERS_LABEL, false, true)
 				);
 
 				if (this.state.canBeMaximized) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #2119

The PR adds functionality to copy all column headers as a comma separated list.
![Query Editor - Copy Column Headers](https://user-images.githubusercontent.com/87730006/211696180-5cdaac18-3307-438c-8676-3d125b8c9d19.gif)
