### PR TITLE
Azure core | Include alternate library accounts if found

### DIFF
--- a/extensions/azurecore/src/azureResource/commands.ts
+++ b/extensions/azurecore/src/azureResource/commands.ts
@@ -17,7 +17,7 @@ import { AzureResourceServiceNames } from './constants';
 import { AzureAccount, Tenant, azureResource } from 'azurecore';
 import { FlatAccountTreeNode } from './tree/flatAccountTreeNode';
 import { ConnectionDialogTreeProvider } from './tree/connectionDialogTreeProvider';
-import { AzureResourceErrorMessageUtil } from './utils';
+import { AzureResourceErrorMessageUtil, filterAccounts } from './utils';
 
 export function registerAzureResourceCommands(appContext: AppContext, azureViewTree: AzureResourceTreeProvider, connectionDialogTree: ConnectionDialogTreeProvider, authLibrary: string): void {
 	const trees = [azureViewTree, connectionDialogTree];
@@ -33,7 +33,7 @@ export function registerAzureResourceCommands(appContext: AppContext, azureViewT
 			if (node instanceof AzureResourceAccountTreeNode) {
 				azureAccount = node.account;
 			} else {
-				let accounts = await azdata.accounts.getAllAccounts();
+				let accounts = filterAccounts(await azdata.accounts.getAllAccounts(), authLibrary);
 				accounts = accounts.filter(a => a.key.providerId.startsWith('azure'));
 				if (accounts.length === 0) {
 					const signin = localize('azure.signIn', "Sign in");

--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -51,10 +51,10 @@ import { IAccountManagementService } from 'sql/platform/accounts/common/interfac
 
 export const VIEWLET_ID = 'workbench.view.accountpanel';
 export type AuthLibrary = 'ADAL' | 'MSAL';
+export const MSAL_AUTH_LIBRARY: AuthLibrary = 'MSAL'; // default
+export const ADAL_AUTH_LIBRARY: AuthLibrary = 'ADAL';
 
-export class AccountPaneContainer extends ViewPaneContainer {
-
-}
+export class AccountPaneContainer extends ViewPaneContainer { }
 
 export const ACCOUNT_VIEW_CONTAINER = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
 	id: VIEWLET_ID,
@@ -499,19 +499,10 @@ export class AccountDialog extends Modal {
 export function filterAccounts(accounts: azdata.Account[], authLibrary: AuthLibrary): azdata.Account[] {
 	let filteredAccounts = accounts.filter(account => {
 		if (account.key.authLibrary) {
-			if (account.key.authLibrary === authLibrary) {
-				return true;
-			} else {
-				return false;
-			}
+			return account.key.authLibrary === authLibrary;
 		} else {
-			if (authLibrary === 'ADAL') {
-				return true;
-			} else {
-				return false;
-			}
+			return authLibrary === ADAL_AUTH_LIBRARY;
 		}
 	});
-
 	return filteredAccounts;
 }

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -554,13 +554,13 @@ export class AccountManagementService implements IAccountManagementService {
 	}
 
 	// Filters and merges accounts from both authentication libraries
-	private async filterAndMergeAccounts(accounts: azdata.Account[], currenAuthLibrary: AuthLibrary): Promise<azdata.Account[]> {
+	private async filterAndMergeAccounts(accounts: azdata.Account[], currentAuthLibrary: AuthLibrary): Promise<azdata.Account[]> {
 		// Fetch accounts for alternate authenticationLibrary
-		const altLibrary = currenAuthLibrary === MSAL_AUTH_LIBRARY ? ADAL_AUTH_LIBRARY : MSAL_AUTH_LIBRARY;
+		const altLibrary = currentAuthLibrary === MSAL_AUTH_LIBRARY ? ADAL_AUTH_LIBRARY : MSAL_AUTH_LIBRARY;
 		const altLibraryAccounts = filterAccounts(accounts, altLibrary);
 
 		// Fetch accounts for current authenticationLibrary
-		const currentLibraryAccounts = filterAccounts(accounts, currenAuthLibrary);
+		const currentLibraryAccounts = filterAccounts(accounts, currentAuthLibrary);
 
 		// In the list of alternate accounts, check if the accounts are present in the current library cache,
 		// if not, add the account and mark it stale. The original account is marked as taken so its not picked again.
@@ -571,8 +571,7 @@ export class AccountManagementService implements IAccountManagementService {
 			} else {
 				// TODO: Refresh access token for the account if feasible.
 				account.isStale = true;
-				account.key.accountVersion = currenAuthLibrary === MSAL_AUTH_LIBRARY ? '2.0' : '1.0'; // toggle account version
-				account.key.authLibrary = currenAuthLibrary;
+				account.key.authLibrary = currentAuthLibrary;
 				currentLibraryAccounts.push(account);
 				await this.addAccountWithoutPrompt(account);
 			}


### PR DESCRIPTION
This PR brings first set of changes to append accounts from alternate authentication library if absent from current library account list and cache. The accounts are added and marked as 'stale' so their credentials can be refreshed by user.

**Current behavior:**
When users switch authentication library from ADAL to MSAL, accounts are not transitioned and align with only 1 library. Users need to add accounts again after switching authentication library.

**New behavior (with PR changes):**
User accounts will be combined from both libraries such that when users transition from one library to another, and reload ADS, their Azure account list stays the same.

**Validations:**
- Validated accounts for both toggles: ADAL > MSAL and MSAL > ADAL
- Accounts are merged and marked stale if missing from current library.

**Future to do:**
- (Optional) Retrieve access tokens for alternate library accounts transparently so users need not re-authenticate.