### PR TITLE
[SQL Migration] Add info boxes for VM existing database names  

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -518,6 +518,7 @@ export const DUPLICATE_NAME_ERROR = localize('sql.migration.unique.name', "Selec
 export function DATABASE_ALREADY_EXISTS_MI(dbName: string, targetName: string): string {
 	return localize('sql.migration.database.already.exists', "Database '{0}' already exists on the target managed instance '{1}'.", dbName, targetName);
 }
+export const DATABASE_ALREADY_EXISTS_VM_INFO = localize('sql.migration.database.already.exists.vm.info', "Ensure that the provided database name(s) do not already exist on the target SQL Server on Azure Virtual Machine.");
 export const DATABASE_BACKUP_BLOB_STORAGE_HEADER_TEXT = localize('sql.migration.blob.storage.header.text', "Azure Storage Blob Container details");
 export const DATABASE_BACKUP_BLOB_STORAGE_HELP_TEXT = localize('sql.migration.blob.storage.help.text', "Provide the Azure Storage Blob Container that contains the backups.");
 export const DATABASE_BACKUP_BLOB_STORAGE_TABLE_HELP_TEXT = localize('sql.migration.blob.storage.table.help', "Enter target database name and select resource group, storage account and container for the selected source databases.");

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -45,6 +45,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 	private _blobContainerStorageAccountDropdowns!: azdata.DropDownComponent[];
 	private _blobContainerDropdowns!: azdata.DropDownComponent[];
 	private _blobContainerLastBackupFileDropdowns!: azdata.DropDownComponent[];
+	private _blobContainerVmDatabaseAlreadyExistsInfoBox!: azdata.TextComponent;
 
 	private _networkShareStorageAccountDetails!: azdata.FlexContainer;
 	private _networkShareContainerSubscription!: azdata.TextComponent;
@@ -52,6 +53,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 	private _networkShareStorageAccountResourceGroupDropdown!: azdata.DropDownComponent;
 	private _networkShareContainerStorageAccountDropdown!: azdata.DropDownComponent;
 	private _networkShareContainerStorageAccountRefreshButton!: azdata.ButtonComponent;
+	private _networkShareVmDatabaseAlreadyExistsInfoBox!: azdata.TextComponent;
 
 	private _targetDatabaseContainer!: azdata.FlexContainer;
 	private _networkShareTargetDatabaseNamesTable!: azdata.DeclarativeTableComponent;
@@ -454,9 +456,18 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 				]
 			}).component();
 
+		this._networkShareVmDatabaseAlreadyExistsInfoBox = this._view.modelBuilder.infoBox()
+			.withProps({
+				text: constants.DATABASE_ALREADY_EXISTS_VM_INFO,
+				style: 'information',
+				width: WIZARD_INPUT_COMPONENT_WIDTH,
+				CSSStyles: { ...styles.BODY_CSS, 'display': 'none' }
+			}).component();
+
 		this._networkTableContainer = this._view.modelBuilder.flexContainer()
 			.withItems([
 				networkShareTableText,
+				this._networkShareVmDatabaseAlreadyExistsInfoBox,
 				this._networkShareTargetDatabaseNamesTable])
 			.withProps({ CSSStyles: { 'display': 'none', } })
 			.component();
@@ -467,10 +478,19 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 				CSSStyles: { ...styles.BODY_CSS }
 			}).component();
 
+		this._blobContainerVmDatabaseAlreadyExistsInfoBox = this._view.modelBuilder.infoBox()
+			.withProps({
+				text: constants.DATABASE_ALREADY_EXISTS_VM_INFO,
+				style: 'information',
+				width: WIZARD_INPUT_COMPONENT_WIDTH,
+				CSSStyles: { ...styles.BODY_CSS, 'display': 'none' }
+			}).component();
+
 		this._blobTableContainer = this._view.modelBuilder.flexContainer()
 			.withItems([
 				blobTableText,
 				allFieldsRequiredLabel,
+				this._blobContainerVmDatabaseAlreadyExistsInfoBox,
 				this._blobContainerTargetDatabaseNamesTable])
 			.withProps({ CSSStyles: { 'display': 'none', } })
 			.component();
@@ -627,6 +647,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 
 	private async _updatePageControlsVisibility(): Promise<void> {
 		const isSqlDbTarget = this.migrationStateModel.isSqlDbTarget;
+		const isSqlVmTarget = this.migrationStateModel.isSqlVmTarget;
 		const isNetworkShare = this.migrationStateModel.isBackupContainerNetworkShare;
 		const isBlobContainer = this.migrationStateModel.isBackupContainerBlobContainer;
 
@@ -634,12 +655,13 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		await utils.updateControlDisplay(this._migrationTableSection, isSqlDbTarget);
 		await utils.updateControlDisplay(this._networkDetailsContainer, !isSqlDbTarget);
 		await utils.updateControlDisplay(this._targetDatabaseContainer, !isSqlDbTarget);
-		await utils.updateControlDisplay(this._networkShareStorageAccountDetails, !isSqlDbTarget);
 
 		await utils.updateControlDisplay(this._networkShareContainer, isNetworkShare && !isSqlDbTarget);
 		await utils.updateControlDisplay(this._networkShareStorageAccountDetails, isNetworkShare && !isSqlDbTarget);
+		await utils.updateControlDisplay(this._networkShareVmDatabaseAlreadyExistsInfoBox, isSqlVmTarget);
 		await utils.updateControlDisplay(this._networkTableContainer, isNetworkShare && !isSqlDbTarget);
 		await utils.updateControlDisplay(this._blobContainer, isBlobContainer && !isSqlDbTarget);
+		await utils.updateControlDisplay(this._blobContainerVmDatabaseAlreadyExistsInfoBox, isSqlVmTarget);
 		await utils.updateControlDisplay(this._blobTableContainer, isBlobContainer && !isSqlDbTarget);
 
 		await this._windowsUserAccountText.updateProperties({ required: isNetworkShare && !isSqlDbTarget });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds an info box to step 5 of the wizard for VM migrations which informs the user to ensure that provided database names don't already exist on the target VM, which will hopefully reduce these types of failures. This is a temporary measure until a proper validation experience is supported.

![image](https://user-images.githubusercontent.com/11844501/211694207-c1b3ceb6-c28d-4f10-9663-694aaa7df2aa.png)
