### PR TITLE
[SQL Migration] Ensure SqlVM14 servers use page blob backups

### DIFF
--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -13,6 +13,7 @@ import * as constants from '../constants/strings';
 import { logError, TelemetryViews } from '../telemtery';
 import { AdsMigrationStatus } from '../dashboard/tabBase';
 import { getMigrationMode, getMigrationStatus, getMigrationTargetType, hasRestoreBlockingReason, PipelineStatusCodes } from '../constants/helper';
+import { ServerInfo } from 'azdata';
 
 export type TargetServerType = azure.SqlVMServer | azureResource.AzureSqlManagedInstance | azure.AzureSqlDatabaseServer;
 
@@ -34,6 +35,12 @@ export const MenuCommands = {
 	NewSupportRequest: 'sqlmigration.newsupportrequest',
 	SendFeedback: 'sqlmigration.sendfeedback',
 };
+
+export enum BlobType {
+	BlockBlob = "BlockBlob",
+	PageBlob = "PageBlob",
+	AppendBlob = "AppendBlob",
+}
 
 export function deepClone<T>(obj: T): T {
 	if (!obj || typeof obj !== 'object') {
@@ -71,6 +78,10 @@ export function getSqlServerName(majorVersion: number): string | undefined {
 		default:
 			return undefined;
 	}
+}
+
+export function isSqlServerVersion2014OrBelow(serverInfo: ServerInfo): boolean {
+	return serverInfo.serverMajorVersion! <= 12;
 }
 
 export interface IPackageInfo {

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -581,6 +581,9 @@ export function INVALID_BLOB_CONTAINER_ERROR(sourceDb: string): string {
 export function INVALID_BLOB_LAST_BACKUP_FILE_ERROR(sourceDb: string): string {
 	return localize('sql.migration.invalid.blob.lastBackupFile.error', "To continue, select a valid last backup file for source database '{0}'.", sourceDb);
 }
+export function INVALID_NON_PAGE_BLOB_BACKUP_FILE_ERROR(sourceDb: string): string {
+	return localize('sql.migration.invalid.non.page.blob.backupFile.error', "To continue, select a blob container where all the backup files are page blobs for source database '{0}'. Backups to block blobs are supported only in SQL Server 2016 or later. Learn more: https://learn.microsoft.com/azure/dms/known-issues-azure-sql-migration-azure-data-studio#azure-sql-managed-instance-and-sql-server-on-azure-virtual-machine-known-issues-and-limitations", sourceDb);
+}
 export const INVALID_NETWORK_SHARE_LOCATION = localize('sql.migration.invalid.network.share.location', "Invalid network share location format. Example: {0}", NETWORK_SHARE_PATH_FORMAT);
 export const INVALID_USER_ACCOUNT = localize('sql.migration.invalid.user.account', "Invalid user account format. Example: {0}", WINDOWS_USER_ACCOUNT);
 export const INVALID_TARGET_NAME_ERROR = localize('sql.migration.invalid.target.name.error', "Enter a valid name for the target database.");

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -12,7 +12,7 @@ import * as constants from '../constants/strings';
 import * as nls from 'vscode-nls';
 import { v4 as uuidv4 } from 'uuid';
 import { sendSqlMigrationActionEvent, TelemetryAction, TelemetryViews, logError } from '../telemtery';
-import { hashString, deepClone } from '../api/utils';
+import { hashString, deepClone, isSqlServerVersion2014OrBelow } from '../api/utils';
 import { SKURecommendationPage } from '../wizard/skuRecommendationPage';
 import { excludeDatabases, getConnectionProfile, LoginTableInfo, TargetDatabaseInfo } from '../api/sqlUtils';
 const localize = nls.loadMessageBundle();
@@ -1402,6 +1402,11 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 				return constants.LOGIN_MIGRATIONS_DB_TEXT;
 		}
 		return "";
+	}
+
+	public async isSqlVM2014OrBelow(): Promise<boolean> {
+		const sqlServerInfo = await azdata.connection.getServerInfo((await azdata.connection.getCurrentConnection()).connectionId);
+		return this._targetType === MigrationTargetType.SQLVM && isSqlServerVersion2014OrBelow(sqlServerInfo);
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR validates blob time for type SQL VM migrations with source servers running SQL Server 2014 or below, due to a [known limitation](https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/2093980).

For any SQL VM migrations with source version <= 2014, we check all backups in the blob container. If not all the backups are page blob, we display an error explaining the limitation along with a link to [known issues](https://learn.microsoft.com/en-us/azure/dms/known-issues-azure-sql-migration-azure-data-studio#azure-sql-managed-instance-and-sql-server-on-azure-virtual-machine-known-issues-and-limitations) documentation.

(Technically speaking, since this check is performed by assessing the source version of the current connection in ADS, this wouldn't prevent a user from launching the wizard from a >2014 source instance but still provide backups from a <=2014 source, but since this is a temporary limitation, this edge case can be ignored for now.)

(I will add a screenshot of error message shortly)