### PR TITLE
[SQL Migration] Update mssql contracts to support XEvents assessment

### DIFF
--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1101,6 +1101,7 @@ export namespace ProfilerSessionCreatedNotification {
 export interface SqlMigrationAssessmentParams {
 	ownerUri: string;
 	databases: string[];
+	xEventsFilesFolderPath: string;
 }
 
 export namespace GetSqlMigrationAssessmentItemsRequest {

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -701,7 +701,7 @@ declare module 'mssql' {
 	}
 
 	export interface ISqlMigrationService {
-		getAssessments(ownerUri: string, databases: string[]): Promise<AssessmentResult | undefined>;
+		getAssessments(ownerUri: string, databases: string[], xEventsFilesFolderPath: string): Promise<AssessmentResult | undefined>;
 		getSkuRecommendations(dataFolder: string, perfQueryIntervalInSec: number, targetPlatforms: string[], targetSqlInstance: string, targetPercentile: number, scalingFactor: number, startTime: string, endTime: string, includePreviewSkus: boolean, databaseAllowList: string[]): Promise<SkuRecommendationResult | undefined>;
 		startPerfDataCollection(ownerUri: string, dataFolder: string, perfQueryIntervalInSec: number, staticQueryIntervalInSec: number, numberOfIterations: number): Promise<StartPerfDataCollectionResult | undefined>;
 		stopPerfDataCollection(): Promise<StopPerfDataCollectionResult | undefined>;
@@ -797,10 +797,6 @@ declare module 'mssql' {
 		rawAssessmentResult: any;
 		errors: ErrorModel[];
 		assessmentReportPath: string;
-	}
-
-	export interface ISqlMigrationService {
-		getAssessments(ownerUri: string, databases: string[]): Promise<AssessmentResult | undefined>;
 	}
 
 	export interface CreateSasResponse {

--- a/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
+++ b/extensions/mssql/src/sqlMigration/sqlMigrationService.ts
@@ -29,8 +29,8 @@ export class SqlMigrationService implements mssql.ISqlMigrationService {
 		context.registerService(constants.SqlMigrationService, this);
 	}
 
-	async getAssessments(ownerUri: string, databases: string[]): Promise<mssql.AssessmentResult | undefined> {
-		let params: contracts.SqlMigrationAssessmentParams = { ownerUri: ownerUri, databases: databases };
+	async getAssessments(ownerUri: string, databases: string[], xEventsFilesFolderPath: string): Promise<mssql.AssessmentResult | undefined> {
+		let params: contracts.SqlMigrationAssessmentParams = { ownerUri: ownerUri, databases: databases, xEventsFilesFolderPath: xEventsFilesFolderPath };
 		try {
 			return this.client.sendRequest(contracts.GetSqlMigrationAssessmentItemsRequest.type, params);
 		}

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -389,7 +389,8 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 	public async getDatabaseAssessments(targetType: MigrationTargetType[]): Promise<ServerAssessment> {
 		const ownerUri = await azdata.connection.getUriForConnection(this.sourceConnectionId);
 		try {
-			const response = (await this.migrationService.getAssessments(ownerUri, this._databasesForAssessment))!;
+			const xEventsFilesFolderPath = '';		// to-do: collect by prompting the user in the UI - for now, blank = disabled
+			const response = (await this.migrationService.getAssessments(ownerUri, this._databasesForAssessment, xEventsFilesFolderPath))!;
 			this._assessmentApiResponse = response;
 			this._assessedDatabaseList = this._databasesForAssessment.slice();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In a previous PR (https://github.com/microsoft/sqltoolsservice/pull/1734), the assessments NuGet was updated to support XEvents assessments, and in the backend sqltoolsservice the appropriate contracts were updated. However, on the ADS side, these corresponding contracts in mssql were not updated, which made us unable to consume these changes. 

This PR updates those contracts. Currently there is no user-facing change, but this will unblock us and allow us to build the UI for this feature as long as these contracts make it into the next release of ADS (which is happening soon). 