### PR TITLE
Fix OE tree hang issue

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -584,15 +584,15 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		return this.expandOrRefreshTreeNode(session, parentTree, needsRefresh);
 	}
 
-	public refreshTreeNode(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
-		return this.expandOrRefreshTreeNode(session, parentTree, true);
+	public async refreshTreeNode(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
+		return await this.expandOrRefreshTreeNode(session, parentTree, true);
 	}
 
-	private callExpandOrRefreshFromService(providerId: string, session: azdata.ObjectExplorerSession, node: TreeNode, refresh: boolean = false): Promise<azdata.ObjectExplorerExpandInfo | undefined> {
+	private async callExpandOrRefreshFromService(providerId: string, session: azdata.ObjectExplorerSession, node: TreeNode, refresh: boolean = false): Promise<azdata.ObjectExplorerExpandInfo | undefined> {
 		if (refresh) {
-			return this.refreshNode(providerId, session, node);
+			return await this.refreshNode(providerId, session, node);
 		} else {
-			return this.expandNode(providerId, session, node);
+			return await this.expandNode(providerId, session, node);
 		}
 	}
 

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -378,9 +378,9 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 	private async callExpandOrRefreshFromProvider(provider: azdata.ObjectExplorerProviderBase, nodeInfo: azdata.ExpandNodeInfo, refresh: boolean = false): Promise<boolean> {
 		if (refresh) {
-			return provider.refreshNode(nodeInfo);
+			return await provider.refreshNode(nodeInfo);
 		} else {
-			return provider.expandNode(nodeInfo);
+			return await provider.expandNode(nodeInfo);
 		}
 	}
 
@@ -514,7 +514,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		return finalResult;
 	}
 
-	public refreshNode(providerId: string, session: azdata.ObjectExplorerSession, node: TreeNode): Promise<azdata.ObjectExplorerExpandInfo | undefined> {
+	public async refreshNode(providerId: string, session: azdata.ObjectExplorerSession, node: TreeNode): Promise<azdata.ObjectExplorerExpandInfo | undefined> {
 		let provider = this._providers[providerId];
 		if (provider) {
 			this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.TelemetryAction.ObjectExplorerExpand)
@@ -522,7 +522,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 					refresh: true,
 					provider: providerId
 				}).send();
-			return this.expandOrRefreshNode(providerId, session, node, true);
+			return await this.expandOrRefreshNode(providerId, session, node, true);
 		}
 		return Promise.resolve(undefined);
 	}
@@ -578,10 +578,10 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		this._nodeProviders[nodeProvider.supportedProviderId] = nodeProviders;
 	}
 
-	public resolveTreeNodeChildren(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
+	public async resolveTreeNodeChildren(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
 		// Always refresh the node if it has an error, otherwise expand it normally
 		let needsRefresh = !!parentTree.errorStateMessage;
-		return this.expandOrRefreshTreeNode(session, parentTree, needsRefresh);
+		return await this.expandOrRefreshTreeNode(session, parentTree, needsRefresh);
 	}
 
 	public async refreshTreeNode(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
@@ -774,7 +774,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		if (expandedState === TreeItemCollapsibleState.Expanded) {
 			await this._serverTreeView?.reveal(expandNode);
 		}
-		return this._serverTreeView?.setExpandedState(expandNode, expandedState);
+		return await this._serverTreeView?.setExpandedState(expandNode, expandedState);
 	}
 
 	private async setNodeSelected(treeNode?: TreeNode, selected?: boolean, clearOtherSelections?: boolean): Promise<void> {
@@ -789,7 +789,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		if (selected) {
 			await this._serverTreeView?.reveal(selectNode);
 		}
-		return this._serverTreeView?.setSelected(selectNode, selected, clearOtherSelections);
+		return await this._serverTreeView?.setSelected(selectNode, selected, clearOtherSelections);
 	}
 
 	private async getChildren(treeNode?: TreeNode): Promise<TreeNode[]> {

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -214,7 +214,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 	public async updateObjectExplorerNodes(connection: IConnectionProfile, requestStatus?: ObjectExplorerRequestStatus | undefined): Promise<void> {
 		const withPassword = await this._connectionManagementService.addSavedPassword(connection);
 		const connectionProfile = ConnectionProfile.fromIConnectionProfile(this._capabilitiesService, withPassword);
-		return await this.updateNewObjectExplorerNode(connectionProfile, requestStatus);
+		return this.updateNewObjectExplorerNode(connectionProfile, requestStatus);
 	}
 
 	public async deleteObjectExplorerNode(connection: IConnectionProfile): Promise<void> {
@@ -390,9 +390,9 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 	private async callExpandOrRefreshFromProvider(provider: azdata.ObjectExplorerProviderBase, nodeInfo: azdata.ExpandNodeInfo, refresh: boolean = false): Promise<boolean> {
 		if (refresh) {
-			return await provider.refreshNode(nodeInfo);
+			return provider.refreshNode(nodeInfo);
 		} else {
-			return await provider.expandNode(nodeInfo);
+			return provider.expandNode(nodeInfo);
 		}
 	}
 
@@ -607,21 +607,21 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		this._nodeProviders[nodeProvider.supportedProviderId] = nodeProviders;
 	}
 
-	public async resolveTreeNodeChildren(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
+	public resolveTreeNodeChildren(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
 		// Always refresh the node if it has an error, otherwise expand it normally
 		let needsRefresh = !!parentTree.errorStateMessage;
-		return await this.expandOrRefreshTreeNode(session, parentTree, needsRefresh);
+		return this.expandOrRefreshTreeNode(session, parentTree, needsRefresh);
 	}
 
-	public async refreshTreeNode(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
-		return await this.expandOrRefreshTreeNode(session, parentTree, true);
+	public refreshTreeNode(session: azdata.ObjectExplorerSession, parentTree: TreeNode): Promise<TreeNode[]> {
+		return this.expandOrRefreshTreeNode(session, parentTree, true);
 	}
 
-	private async callExpandOrRefreshFromService(providerId: string, session: azdata.ObjectExplorerSession, node: TreeNode, refresh: boolean = false): Promise<azdata.ObjectExplorerExpandInfo | undefined> {
+	private callExpandOrRefreshFromService(providerId: string, session: azdata.ObjectExplorerSession, node: TreeNode, refresh: boolean = false): Promise<azdata.ObjectExplorerExpandInfo | undefined> {
 		if (refresh) {
-			return await this.refreshNode(providerId, session, node);
+			return this.refreshNode(providerId, session, node);
 		} else {
-			return await this.expandNode(providerId, session, node);
+			return this.expandNode(providerId, session, node);
 		}
 	}
 
@@ -808,7 +808,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		if (expandedState === TreeItemCollapsibleState.Expanded) {
 			await this._serverTreeView?.reveal(expandNode);
 		}
-		return await this._serverTreeView?.setExpandedState(expandNode, expandedState);
+		return this._serverTreeView?.setExpandedState(expandNode, expandedState);
 	}
 
 	private async setNodeSelected(treeNode?: TreeNode, selected?: boolean, clearOtherSelections?: boolean): Promise<void> {
@@ -823,7 +823,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		if (selected) {
 			await this._serverTreeView?.reveal(selectNode);
 		}
-		return await this._serverTreeView?.setSelected(selectNode, selected, clearOtherSelections);
+		return this._serverTreeView?.setSelected(selectNode, selected, clearOtherSelections);
 	}
 
 	private async getChildren(treeNode?: TreeNode): Promise<TreeNode[]> {


### PR DESCRIPTION
This PR fixes issues #21578 #21500

Continuing https://github.com/microsoft/azuredatastudio/issues/21578#issuecomment-1381269392, it seems that the Node Provider implementation when executed 'expandNode()', was able to complete expansion by firing event synchronously, whereas OEService was missing awaits on async APIs - that was likely causing this hang when OE nodes were opened.

https://github.com/microsoft/azuredatastudio/blob/bb1f5bfffe60156d4b4407fb450a4b466e66ed95/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts#L59-L67

**To reproduce the original issue:**
1. Make 4-5 diff connections including Azure servers/dbs
2. Reload window/restart ADS
3. Open all 5 OE connections at the same time. 
(repeat if it doesn't reproduce). 
With issue, atleast 1-2 nodes will be stuck and won't expand.

**Edit:** On further investigation we found when the node does not expand, the session does not have any nodes (rare case) - which led to node emitter event not being triggered - as that was responsible for returning merged results from `allProviders`. Adding an event emitter for no nodes usecase fixed the issue.

Thanks @corivera for supporting with testing and validation!