### PR TITLE
Add config for enabling STS communication logging

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -150,6 +150,17 @@
             "Verbose"
           ]
         },
+        "mssql.trace.server": {
+          "type": "string",
+          "scope": "window",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "%mssql.tracing.desc%"
+        },
         "mssql.logRetentionMinutes": {
           "type": "number",
           "default": 10080,

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -65,7 +65,7 @@
 	"mssql.query.ansiWarnings": "Enable SET ANSI_WARNINGS",
 	"mssql.query.ansiNulls": "Enable SET ANSI_NULLS",
 	"mssql.query.alwaysEncryptedParameterization": "Enable Parameterization for Always Encrypted",
-	"mssql.tracing.desc": "Traces the communication between Azure Data Studio and SQL Tools Service.",
+	"mssql.tracing.desc": "Traces the communication between Azure Data Studio and SQL Tools Service to the SQL Tools Service output channel. WARNING: This may include sensitive information when verbose logging is enabled.",
 	"mssql.ignorePlatformWarning": "[Optional] Do not show unsupported platform warnings",
 
 	"onprem.databaseProperties.recoveryModel": "Recovery Model",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -65,6 +65,7 @@
 	"mssql.query.ansiWarnings": "Enable SET ANSI_WARNINGS",
 	"mssql.query.ansiNulls": "Enable SET ANSI_NULLS",
 	"mssql.query.alwaysEncryptedParameterization": "Enable Parameterization for Always Encrypted",
+	"mssql.tracing.desc": "Traces the communication between Azure Data Studio and SQL Tools Service.",
 	"mssql.ignorePlatformWarning": "[Optional] Do not show unsupported platform warnings",
 
 	"onprem.databaseProperties.recoveryModel": "Recovery Model",

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -57,7 +57,7 @@ export class SqlToolsServer {
 			const installationComplete = Date.now();
 			let serverOptions = await generateServerOptions(context.extensionContext.logPath, serverPath);
 			let clientOptions = getClientOptions(context);
-			this.client = new SqlOpsDataClient(Constants.serviceName, serverOptions, clientOptions);
+			this.client = new SqlOpsDataClient('mssql', Constants.serviceName, serverOptions, clientOptions);
 			const processStart = Date.now();
 			const clientReadyPromise = this.client.onReady().then(() => {
 				const processEnd = Date.now();
@@ -194,28 +194,6 @@ function getClientOptions(context: AppContext): ClientOptions {
 			TableDesignerFeature,
 			ExecutionPlanServiceFeature
 		],
-		outputChannel: new CustomOutputChannel()
+		outputChannel: outputChannel
 	};
-}
-
-class CustomOutputChannel implements vscode.OutputChannel {
-	name: string;
-	append(value: string): void {
-		console.log(value);
-	}
-	appendLine(value: string): void {
-		console.log(value);
-	}
-	clear(): void {
-	}
-	show(preserveFocus?: boolean): void;
-	show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
-	show(column?: any, preserveFocus?: any) {
-	}
-	hide(): void {
-	}
-	dispose(): void {
-	}
-	replace(_value: string): void {
-	}
 }


### PR DESCRIPTION
This will let us easily turn on debug logging for the client side (we already have logging in STS for messages received/sent). Will help with issues such as https://github.com/microsoft/azuredatastudio/issues/21578 to ensure that messages are being received (and examine their contents if needed).

This will be logged to the "SQL Tools Service" output channel. 

Example messages : 

![image](https://user-images.githubusercontent.com/28519865/212409635-40704f33-84b9-4c04-aba0-cfef9c9f2459.png)

Example verbose :

![image](https://user-images.githubusercontent.com/28519865/212409852-53bad6c5-9f2c-4e31-a807-2fe2bfd05895.png)
