### PR TITLE
Add Azure Resource 'Sql' to MSSQL extension.

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -589,6 +589,7 @@
       "providerId": "MSSQL",
       "displayName": "%mssql.provider.displayName%",
       "isExecutionPlanProvider": true,
+      "azureResource": "Sql",
       "supportedExecutionPlanFileExtensions": [
         "sqlplan"
       ],

--- a/src/sql/platform/capabilities/common/capabilitiesService.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesService.ts
@@ -48,16 +48,65 @@ export interface ConnectionStringOptions {
 	isDefault?: boolean;
 }
 
+/**
+ * The connection provider properties.
+ */
 export interface ConnectionProviderProperties {
+	/**
+	 * The connection provider id, e.g. MSSQL, LOGANALYTICS
+	 */
 	providerId: string;
+
+	/**
+	 * Path to the connection provider's icon
+	 */
 	iconPath?: URI | IconPath | { id: string, path: IconPath, default?: boolean }[]
+
+	/**
+	 * The display name of the connection provider, e.g. Microsoft SQL Server, Azure Monitor Logs
+	 */
 	displayName: string;
+
+	/**
+	 * Alias to be used for the kernel in notebooks
+	 */
 	notebookKernelAlias?: string;
+
+	/**
+	 * Azure resource endpoint to be used by the connection provider.
+	 *
+	 * Accepted values are determined from azdata.AzureResource enum:
+	 * ResourceManagement, Sql, OssRdbms, AzureKeyVault, Graph, MicrosoftResourceManagement,
+	 * AzureDevOps, MsGraph, AzureLogAnalytics, AzureStorage, AzureKusto, PowerBi
+	 *
+	 * Defaults to 'Sql' if not specified.
+	 */
 	azureResource?: string;
+
+	/**
+	 * List of all connection properties for the connection provider.
+	 */
 	connectionOptions: azdata.ConnectionOption[];
+
+	/**
+	 * Boolean indicating whether the connection provider supports queries.
+	 * The default value is true.
+	 */
 	isQueryProvider?: boolean;
+
+	/**
+	 * Boolean indicating whether the connection provider supports execution plan.
+	 */
 	isExecutionPlanProvider?: boolean;
+
+	/**
+	 * List of file extensions supported by the execution plan provider, if execution plan is supported.
+	 */
 	supportedExecutionPlanFileExtensions?: string[];
+
+	/**
+	 * Connection string options for the connection provider
+	 */
 	connectionStringOptions?: ConnectionStringOptions;
 }
 

--- a/src/sql/workbench/contrib/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/contrib/connection/common/connectionProviderExtension.ts
@@ -26,6 +26,10 @@ const ConnectionProviderContrib: IJSONSchema = {
 			type: 'string',
 			description: localize('schema.displayName', "Display Name for the provider")
 		},
+		azureResource: {
+			type: 'string',
+			description: localize('schema.azureResource', "Azure resource endpoint for the provider.")
+		},
 		notebookKernelAlias: {
 			type: 'string',
 			description: localize('schema.notebookKernelAlias', "Notebook Kernel Alias for the provider")

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -833,7 +833,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		// default to SQL if there are no provides or registered resources
 		let provider = this._providers.get(connection.providerName);
 		if (!provider || !provider.properties || !provider.properties.azureResource) {
-			this._logService.warn('Connection providers incorrectly registered. Defaulting to SQL Azure resource,');
+			this._logService.warn(`Connection provider '${connection.providerName}' is incorrectly registered, defaulting to 'SQL' Azure resource. Provider must specify applicable 'azureResource' in 'connectionProvider' configuration.`);
 			return AzureResource.Sql;
 		}
 


### PR DESCRIPTION
This PR fixes #21587.

MSSQL provider was not registering 'azureResource' in it's 'connectionProvider' configuration, hence it lead to warning when 'provider.properties.azureResource' was not found.
