### PR TITLE
Fixes/cleanup for datavirtualization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /extensions/azcli/ @Charles-Gagnon @swells @candiceye
 /extensions/azurecore/ @cssuh @cheenamalhotra
 /extensions/dacpac/ @kisantia
+/extensions/datavirtualization @Charles-Gagnon
 /extensions/notebook @azure-data-studio-notebook-devs
 /extensions/query-history/ @Charles-Gagnon
 /extensions/resource-deployment/ @Charles-Gagnon

--- a/extensions/datavirtualization/config.json
+++ b/extensions/datavirtualization/config.json
@@ -5,16 +5,7 @@
 		"Windows_64": "win-x64.zip",
 		"Windows_86": "win-x86.zip",
 		"OSX": "osx-x64.tar.gz",
-		"Linux_64": "linux-x64.tar.gz",
-		"CentOS_7": "linux-x64.tar.gz",
-		"Debian_8": "linux-x64.tar.gz",
-		"Fedora_23": "linux-x64.tar.gz",
-		"OpenSUSE_13_2": "linux-x64.tar.gz",
-		"RHEL_7": "linux-x64.tar.gz",
-		"SLES_12_2": "linux-x64.tar.gz",
-		"Ubuntu_14": "linux-x64.tar.gz",
-		"Ubuntu_16": "linux-x64.tar.gz",
-		"Ubuntu_18": "linux-x64.tar.gz"
+		"Linux": "linux-x64.tar.gz"
 	},
 	"installDirectory": "scaleoutdataservice/{#platform#}/{#version#}",
 	"executableFiles": [

--- a/extensions/datavirtualization/src/services/serviceClient.ts
+++ b/extensions/datavirtualization/src/services/serviceClient.ts
@@ -47,7 +47,7 @@ export class ServiceClient {
 				const processStart = Date.now();
 				client.onReady().then(() => {
 					const processEnd = Date.now();
-					this.statusView.text = localize('serviceStarted', 'Service Started');
+					this.statusView.text = localize('serviceStarted', '{0} started', Constants.serviceName);
 					setTimeout(() => {
 						this.statusView.hide();
 					}, 1500);
@@ -59,13 +59,13 @@ export class ServiceClient {
 					});
 				});
 				this.statusView.show();
-				this.statusView.text = localize('serviceStarting', 'Starting service');
+				this.statusView.text = localize('serviceStarting', 'Starting {0}...', Constants.serviceName);
 				let disposable = client.start();
 				context.subscriptions.push(disposable);
 				resolve();
 			}, e => {
 				Telemetry.sendTelemetryEvent('ServiceInitializingFailed');
-				this.apiWrapper.showErrorMessage(localize('serviceStartFailed', 'Failed to start Scale Out Data service:{0}', e));
+				this.apiWrapper.showErrorMessage(localize('serviceStartFailed', 'Failed to start {0}: {1}', Constants.serviceName, e));
 				// Just resolve to avoid unhandled promise. We show the error to the user.
 				resolve();
 			});

--- a/extensions/datavirtualization/src/wizards/wizardCommands.ts
+++ b/extensions/datavirtualization/src/wizards/wizardCommands.ts
@@ -96,24 +96,7 @@ export class OpenMssqlHdfsTableFromFileWizardCommand extends Command {
 }
 
 function convertIConnectionProfile(profile: azdata.IConnectionProfile): azdata.connection.ConnectionProfile {
-	let connection: azdata.connection.ConnectionProfile;
-	if (profile) {
-		connection = {
-			providerId: profile.providerName,
-			connectionId: profile.id,
-			connectionName: profile.connectionName,
-			serverName: profile.serverName,
-			databaseName: profile.databaseName,
-			userName: profile.userName,
-			password: profile.password,
-			authenticationType: profile.authenticationType,
-			savePassword: profile.savePassword,
-			groupFullName: profile.groupFullName,
-			groupId: profile.groupId,
-			saveProfile: profile.saveProfile,
-			azureTenantId: profile.azureTenantId,
-			options: {}
-		};
-	}
+	const connection = azdata.connection.ConnectionProfile.createFrom(profile.options);
+	connection.providerId = profile.providerName;
 	return connection;
 }


### PR DESCRIPTION
1. Fix issue where the connection profile being sent to the service was missing properties such as Encrypt (they just weren't coded into the helper method). The fix there was to use out extensibility API to do the conversion. A longer term task is to go through this whole ConnectionProfile vs IConnectionProfile mess we have now and at the very least provide easy methods to convert between the two, but for now this will at least fix the immediate issue and prevent future regressions (as long as we keep the API function up to date)
2. Add service name to status bar messages so it's clear which service is starting
3. Update to latest version of backing service with a bunch of fixes so it actually starts up and works.
4. Add myself as owner for the code in the extension folder

Did quick smoke test run through of main scenarios and things seem to be back to normal - will do more thorough test pass this week.