### PR TITLE
Fixing nvda scan mode on execution plans 

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
     "applicationinsights": "1.4.2",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.57",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.58",
     "chart.js": "^2.9.4",
     "chokidar": "3.5.1",
     "graceful-fs": "4.2.8",

--- a/remote/package.json
+++ b/remote/package.json
@@ -21,7 +21,7 @@
     "applicationinsights": "1.4.2",
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.57",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.58",
     "chart.js": "^2.9.4",
     "cookie": "^0.4.0",
     "graceful-fs": "4.2.8",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -18,7 +18,7 @@
 		"@vscode/vscode-languagedetection": "1.0.21",
 		"angular2-grid": "2.0.6",
 		"ansi_up": "^5.1.0",
-		"azdataGraph": "github:Microsoft/azdataGraph#0.0.57",
+		"azdataGraph": "github:Microsoft/azdataGraph#0.0.58",
 		"chart.js": "^2.9.4",
 		"gridstack": "^3.1.3",
 		"kburtram-query-plan": "2.6.1",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -181,9 +181,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.57":
-  version "0.0.57"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/911884b2b347fcdc1d69a17207cec18940c6fb47"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.58":
+  version "0.0.58"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/45c88554e98ed3b41cd283a672bd497af08c7ac3"
 
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -246,9 +246,9 @@ async-listener@^0.6.0:
     semver "^5.3.0"
     shimmer "^1.1.0"
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.57":
-  version "0.0.57"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/911884b2b347fcdc1d69a17207cec18940c6fb47"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.58":
+  version "0.0.58"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/45c88554e98ed3b41cd283a672bd497af08c7ac3"
 
 base64-js@^1.3.1:
   version "1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,9 +2090,9 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.57":
-  version "0.0.57"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/911884b2b347fcdc1d69a17207cec18940c6fb47"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.58":
+  version "0.0.58"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/45c88554e98ed3b41cd283a672bd497af08c7ac3"
 
 bach@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
Previously, user was not able to enter the scan mode as the graph was consuming the event. I have fixed azdata graph to let the user enter scan mode.


Issue #20777 