### PR TITLE
[Port request] vbump sqltoolsservice in release/1.41

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.4.1.1",
+	"version": "4.4.1.2",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net6.0.zip",
 		"Windows_64": "win-x64-net6.0.zip",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR bumps the version of sqltoolsservice in mssql from 4.4.1.1 to 4.4.1.2, which includes the latest changes from SQL Migration. Discussed internally in ADS Shiproom.

See https://github.com/microsoft/sqltoolsservice/pull/1814 and https://github.com/microsoft/azuredatastudio/issues/21629 for more details.