### PR TITLE
[Port] Add back missing big-data-cluster extension rebuild

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -282,6 +282,7 @@ exports.vscodeExternalExtensions = [
 ];
 // extensions that require a rebuild since they have native parts
 const rebuildExtensions = [
+    'big-data-cluster',
     'mssql'
 ];
 const marketplaceWebExtensionsExclude = new Set([


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/21634

The BDC removal commit that was reverted updated build/lib/extensions.ts but didn't rebuild the build folder - which means the checked in js was never updated in that commit.

Recently a separate PR then also made changes to that file and rebuilt it - which meant that the js file then finally had the bdc extension removed. 

https://github.com/microsoft/azuredatastudio/pull/21594/files#diff-66f0c65d9f46c3d32db2a94bd8b71c9f14fa0a0b6833a9daa018895f5436ef0dL284

But with the revert that part was missed, so it never rebuilt the native node modules the extension requires.