### PR TITLE
[RC1] Fix missing BDC connect icon

### DIFF
--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -134,7 +134,7 @@
       {
         "command": "bigDataClusters.command.connectController",
         "title": "%command.connectController.title%",
-        "icon": "$(disconnect)"
+        "icon": "$(plug)"
       },
       {
         "command": "bigDataClusters.command.removeController",


### PR DESCRIPTION
VS Code changed this at some point - it's now `debug-disconnect` (https://code.visualstudio.com/api/references/icons-in-labels)

Switching to just use the plug icon instead to better match the "connect" action being done here. 

![image](https://user-images.githubusercontent.com/28519865/213542018-249bfef7-c34f-4550-8655-813619e3e2f5.png)
