### PR TITLE
Fix connect icon for Arc extension

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -54,7 +54,7 @@
       {
         "command": "arc.connectToController",
         "title": "%command.connectToController.title%",
-        "icon": "$(disconnect)"
+        "icon": "$(plug)"
       },
       {
         "command": "arc.removeController",


### PR DESCRIPTION
VS Code renamed this to `debug-disconnect` at some point. Changing to just use the plug icon since that better aligns with the "connect" action being taken. 

Before : 
![image](https://user-images.githubusercontent.com/28519865/213543099-64a4a611-19c9-4f43-9bf0-28ba6ad61d33.png)

After : 
![image](https://user-images.githubusercontent.com/28519865/213542963-1dda48ba-1e12-4cbc-b892-b9851b5cb41c.png)
