### PR TITLE
Added provider-based handling for change password/generic error handling.

### DIFF
--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1251,25 +1251,6 @@ export namespace ExecutionPlanComparisonRequest {
 
 // ------------------------------- < Execution Plan > ------------------------------------
 
-// ------------------------------- < Error Diagnostics > ------------------------------------
-
-export interface ErrorDiagnosticsParameters {
-	/**
-	 * The code of the error we want to check.
-	 */
-	errorCode: number;
-	/**
-	 * The accompanying error message.
-	 */
-	errorMessage: string;
-}
-
-export namespace DiagnosticsRequest {
-	export const type = new RequestType<ErrorDiagnosticsParameters, azdata.diagnostics.ErrorDiagnosticsResponse, void, void>('diagnostics/errorHandler');
-}
-
-// ------------------------------- < Error Diagnostics > ------------------------------------
-
 // ------------------------------- < Tde Migration > ------------------------------------
 
 export namespace TdeMigrateRequest {

--- a/extensions/mssql/src/errorDiagnostics/errorDiagnosticsConstants.ts
+++ b/extensions/mssql/src/errorDiagnostics/errorDiagnosticsConstants.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const MssqlPasswordResetCode: number = 18488;
+

--- a/extensions/mssql/src/errorDiagnostics/errorDiagnosticsService.ts
+++ b/extensions/mssql/src/errorDiagnostics/errorDiagnosticsService.ts
@@ -34,13 +34,32 @@ export class ErrorDiagnosticsService extends SqlOpsFeature<any> {
 				});
 			}
 
+			private restoreProfileFormat(profile: azdata.connection.ConnectionProfile): azdata.IConnectionProfile {
+				return {
+					providerName: profile.providerId,
+					id: profile.connectionId,
+					connectionName: profile.connectionName,
+					serverName: profile.serverName,
+					databaseName: profile.databaseName,
+					userName: profile.userName,
+					password: profile.password,
+					authenticationType: profile.authenticationType,
+					savePassword: profile.savePassword,
+					groupFullName: profile.groupFullName,
+					groupId: profile.groupId,
+					saveProfile: profile.savePassword,
+					azureTenantId: profile.azureTenantId,
+					options: profile.options
+				};
+			}
+
 			protected override registerProvider(options: any): Disposable {
-				let handleErrorCode = (errorCode: number, errorMessage: string): Thenable<boolean> => {
+				let handleErrorCode = async (errorCode: number, errorMessage: string): Promise<boolean> => {
 					if (errorCode = ErrorDiagnosticsConstants.MssqlPasswordResetCode) {
-						return azdata.connection.getConnectionProfileFromError().then(profile => {
-							azdata.connection.openChangePasswordDialog(profile);
-							return Promise.resolve(true);
-						});
+						let profile = await azdata.connection.getConnectionProfileFromError();
+						let restoredProfile = this.restoreProfileFormat(profile);
+						azdata.connection.openChangePasswordDialog(restoredProfile);
+						return Promise.resolve(true);
 					}
 					else {
 						return Promise.resolve(false);

--- a/extensions/mssql/src/errorDiagnostics/errorDiagnosticsService.ts
+++ b/extensions/mssql/src/errorDiagnostics/errorDiagnosticsService.ts
@@ -6,7 +6,6 @@
 import * as azdata from 'azdata';
 import { ISqlOpsFeature, SqlOpsDataClient, SqlOpsFeature } from 'dataprotocol-client';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
-//import * as contracts from '../contracts';
 import { AppContext } from '../appContext';
 import { ServerCapabilities, ClientCapabilities, RPCMessageType } from 'vscode-languageclient';
 import { Disposable } from 'vscode';
@@ -57,6 +56,7 @@ export class ErrorDiagnosticsService extends SqlOpsFeature<any> {
 				let handleErrorCode = async (errorCode: number, errorMessage: string): Promise<boolean> => {
 					if (errorCode = ErrorDiagnosticsConstants.MssqlPasswordResetCode) {
 						let profile = await azdata.connection.getConnectionProfileFromError();
+						// Need to convert back to IConnectionProfile.
 						let restoredProfile = this.restoreProfileFormat(profile);
 						azdata.connection.openChangePasswordDialog(restoredProfile);
 						return Promise.resolve(true);

--- a/extensions/mssql/src/errorDiagnostics/errorDiagnosticsService.ts
+++ b/extensions/mssql/src/errorDiagnostics/errorDiagnosticsService.ts
@@ -37,9 +37,10 @@ export class ErrorDiagnosticsService extends SqlOpsFeature<any> {
 			protected override registerProvider(options: any): Disposable {
 				let handleErrorCode = (errorCode: number, errorMessage: string): Thenable<boolean> => {
 					if (errorCode = ErrorDiagnosticsConstants.MssqlPasswordResetCode) {
-
-						//azdata.connection.openChangePasswordDialog(additionalParameters.profile, additionalParameters.options);
-						return Promise.resolve(true);
+						return azdata.connection.getConnectionProfileFromError().then(profile => {
+							azdata.connection.openChangePasswordDialog(profile);
+							return Promise.resolve(true);
+						});
 					}
 					else {
 						return Promise.resolve(false);

--- a/extensions/mssql/src/errorDiagnostics/errorDiagnosticsService.ts
+++ b/extensions/mssql/src/errorDiagnostics/errorDiagnosticsService.ts
@@ -6,18 +6,18 @@
 import * as azdata from 'azdata';
 import { ISqlOpsFeature, SqlOpsDataClient, SqlOpsFeature } from 'dataprotocol-client';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
-import * as contracts from '../contracts';
+//import * as contracts from '../contracts';
 import { AppContext } from '../appContext';
 import { ServerCapabilities, ClientCapabilities, RPCMessageType } from 'vscode-languageclient';
 import { Disposable } from 'vscode';
+import * as ErrorDiagnosticsConstants from './errorDiagnosticsConstants';
 
 export const diagnosticsId = 'azurediagnostics'
 export const serviceName = 'AzureDiagnostics';
 
 export class ErrorDiagnosticsService extends SqlOpsFeature<any> {
-	private static readonly messagesTypes: RPCMessageType[] = [
-		contracts.DiagnosticsRequest.type,
-	];
+	//No contracts for now, but can be added later.
+	private static readonly messagesTypes: RPCMessageType[] = [];
 
 	public static asFeature(context: AppContext): ISqlOpsFeature {
 		return class extends ErrorDiagnosticsService {
@@ -35,16 +35,14 @@ export class ErrorDiagnosticsService extends SqlOpsFeature<any> {
 			}
 
 			protected override registerProvider(options: any): Disposable {
-				const client = this._client;
+				let handleErrorCode = (errorCode: number, errorMessage: string): Thenable<boolean> => {
+					if (errorCode = ErrorDiagnosticsConstants.MssqlPasswordResetCode) {
 
-				let handleErrorCode = (errorCode: number, errorMessage: string): Thenable<azdata.diagnostics.ErrorDiagnosticsResponse> => {
-					const params: contracts.ErrorDiagnosticsParameters = { errorCode, errorMessage };
-					try {
-						return client.sendRequest(contracts.DiagnosticsRequest.type, params);
+						//azdata.connection.openChangePasswordDialog(additionalParameters.profile, additionalParameters.options);
+						return Promise.resolve(true);
 					}
-					catch (e) {
-						client.logFailedRequest(contracts.DiagnosticsRequest.type, e);
-						return Promise.reject(e);
+					else {
+						return Promise.resolve(false);
 					}
 				}
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -486,7 +486,7 @@ declare module 'azdata' {
 		/**
 		 * Gets the connection profile and params from the last error (required to avoid circular dependencies)
 		 */
-		export function getConnectionProfileFromError(): Thenable<IConnectionProfile>;
+		export function getConnectionProfileFromError(): Thenable<ConnectionProfile>;
 	}
 
 	/*

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -435,14 +435,14 @@ declare module 'azdata' {
 
 	export namespace diagnostics {
 		/**
-		 * Diagnostics object for handling error codes.
+		 * Diagnostics object for handling error codes for a provider.
 		 */
 		export interface ErrorDiagnostics {
 			handleErrorCode(errorCode: number, errorMessage: string): Thenable<boolean>;
 		}
 
 		/**
-		 * Registers a Diagnostics object that can support a provider.
+		 * Registers provider with instance of Diagnostics implementation.
 		 */
 		export function registerDiagnostics(providerMetadata: ResourceProviderMetadata, diagnostics: ErrorDiagnostics): vscode.Disposable;
 	}
@@ -486,7 +486,7 @@ declare module 'azdata' {
 		/**
 		 * Gets the connection profile and params from the last error (required to avoid circular dependencies)
 		 */
-		export function getErrorProfile(): IConnectionProfile
+		export function getConnectionProfileFromError(): Thenable<IConnectionProfile>;
 	}
 
 	/*

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -432,22 +432,19 @@ declare module 'azdata' {
 		azurePortalEndpoint?: string;
 	}
 
-	/**
-	 * An interface for receiving diagnostic data from a provider.
-	 */
-	export interface Diagnostics {
-		handleErrorCode(errorCode: number, errorMessage: string): Thenable<diagnostics.ErrorDiagnosticsResponse>;
-	}
 
 	export namespace diagnostics {
-		export interface ErrorDiagnosticsResponse {
-			errorAction: string;
+		/**
+		 * Diagnostics object for handling error codes.
+		 */
+		export interface ErrorDiagnostics {
+			handleErrorCode(errorCode: number, errorMessage: string): Thenable<boolean>;
 		}
 
 		/**
 		 * Registers a Diagnostics object that can support a provider.
 		 */
-		export function registerDiagnostics(providerMetadata: ResourceProviderMetadata, diagnostics: Diagnostics): vscode.Disposable;
+		export function registerDiagnostics(providerMetadata: ResourceProviderMetadata, diagnostics: ErrorDiagnostics): vscode.Disposable;
 	}
 
 	export namespace connection {
@@ -480,6 +477,16 @@ declare module 'azdata' {
 			 */
 			None = 'None'
 		}
+
+		/**
+		 * Opens the change password dialog in connection management service.
+		 */
+		export function openChangePasswordDialog(initialConnectionProfile: IConnectionProfile): void;
+
+		/**
+		 * Gets the connection profile and params from the last error (required to avoid circular dependencies)
+		 */
+		export function getErrorProfile(): IConnectionProfile
 	}
 
 	/*

--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -333,6 +333,13 @@ export interface IConnectionManagementService {
 	 * @returns Promise with a boolean value indicating whether the user has accepted the suggestion.
 	 */
 	handleUnsupportedProvider(providerId: string): Promise<boolean>;
+
+	/**
+	 * Handle the unsupported provider scenario.
+	 * @param providerId The provider ID
+	 * @returns Promise with a boolean value indicating whether the user has accepted the suggestion.
+	 */
+	launchChangePasswordDialog?(profile: IConnectionProfile): void;
 }
 
 export enum RunQueryOnConnectionMode {

--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -335,11 +335,15 @@ export interface IConnectionManagementService {
 	handleUnsupportedProvider(providerId: string): Promise<boolean>;
 
 	/**
-	 * Handle the unsupported provider scenario.
-	 * @param providerId The provider ID
-	 * @returns Promise with a boolean value indicating whether the user has accepted the suggestion.
+	 * Launches the password change dialog.
+	 * @param profile The connection profile to change the password.
 	 */
 	launchChangePasswordDialog?(profile: IConnectionProfile): void;
+
+	/**
+	 * Get the connection profile that caused an error from Connection Management.
+	 */
+	getConnectionProfileFromError?(): IConnectionProfile;
 }
 
 export enum RunQueryOnConnectionMode {

--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -92,7 +92,7 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 	}
 
 	public $getConnections(activeConnectionsOnly?: boolean): Thenable<azdata.connection.ConnectionProfile[]> {
-		return Promise.resolve(this._connectionManagementService.getConnections(activeConnectionsOnly).map(profile => this.convertToConnectionProfile(profile)));
+		return Promise.resolve(this._connectionManagementService.getConnections(activeConnectionsOnly).map(profile => this.convertToConnectionProfile(profile, true, true)));
 	}
 
 	public $getConnection(uri: string): Thenable<azdata.connection.ConnectionProfile> {
@@ -101,22 +101,7 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 			return Promise.resolve(undefined);
 		}
 
-		let connection: azdata.connection.ConnectionProfile = {
-			providerId: profile.providerName,
-			connectionId: profile.id,
-			connectionName: profile.connectionName,
-			serverName: profile.serverName,
-			databaseName: profile.databaseName,
-			userName: profile.userName,
-			password: profile.password,
-			authenticationType: profile.authenticationType,
-			savePassword: profile.savePassword,
-			groupFullName: profile.groupFullName,
-			groupId: profile.groupId,
-			saveProfile: profile.savePassword,
-			azureTenantId: profile.azureTenantId,
-			options: profile.options
-		};
+		let connection = this.convertToConnectionProfile(profile, false, false);
 		return Promise.resolve(connection);
 	}
 
@@ -129,7 +114,7 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 	}
 
 	public $getCurrentConnectionProfile(): Thenable<azdata.connection.ConnectionProfile> {
-		return Promise.resolve(this.convertToConnectionProfile(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, true)));
+		return Promise.resolve(this.convertToConnectionProfile(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, true,), true, true));
 	}
 
 	public $getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {
@@ -195,22 +180,7 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 		}
 
 		// Need to convert profile into azdata friendly format
-		let connection: azdata.connection.ConnectionProfile = {
-			providerId: profile.providerName,
-			connectionId: profile.id,
-			connectionName: profile.connectionName,
-			serverName: profile.serverName,
-			databaseName: profile.databaseName,
-			userName: profile.userName,
-			password: profile.password,
-			authenticationType: profile.authenticationType,
-			savePassword: profile.savePassword,
-			groupFullName: profile.groupFullName,
-			groupId: profile.groupId,
-			saveProfile: profile.savePassword,
-			azureTenantId: profile.azureTenantId,
-			options: profile.options
-		};
+		let connection = this.convertToConnectionProfile(profile, false, false)
 		return Promise.resolve(connection);
 	}
 
@@ -241,16 +211,19 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 		return connection;
 	}
 
-	private convertToConnectionProfile(profile: IConnectionProfile): azdata.connection.ConnectionProfile {
+	private convertToConnectionProfile(profile: IConnectionProfile, removeCredentials: boolean, deepCopyOptions: boolean): azdata.connection.ConnectionProfile {
 		if (!profile) {
 			return undefined;
 		}
 
-		profile = this._connectionManagementService.removeConnectionProfileCredentials(profile);
+		// Need to account for different types of conversion usages.
+		if (removeCredentials) {
+			profile = this._connectionManagementService.removeConnectionProfileCredentials(profile);
+		}
 		let connection: azdata.connection.ConnectionProfile = {
 			providerId: profile.providerName,
 			connectionId: profile.id,
-			options: deepClone(profile.options),
+			options: deepCopyOptions ? deepClone(profile.options) : profile.options,
 			connectionName: profile.connectionName,
 			serverName: profile.serverName,
 			databaseName: profile.databaseName,
@@ -260,6 +233,7 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 			savePassword: profile.savePassword,
 			groupFullName: profile.groupFullName,
 			groupId: profile.groupId,
+			azureTenantId: profile.azureTenantId,
 			saveProfile: profile.saveProfile
 		};
 		return connection;

--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -183,11 +183,33 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 	}
 
 	public $openChangePasswordDialog(initialConnectionProfile: IConnectionProfile): void {
-		this._connectionManagementService.launchChangePasswordDialog(initialConnectionProfile);
+		let profile = new ConnectionProfile(this._capabilitiesService, initialConnectionProfile);
+		this._connectionManagementService.launchChangePasswordDialog(profile);
 	}
 
-	public $getConnectionProfileFromError(): Thenable<IConnectionProfile> {
-		return Promise.resolve(this._connectionManagementService.getConnectionProfileFromError());
+	public $getConnectionProfileFromError(): Thenable<azdata.connection.ConnectionProfile> {
+		let profile = this._connectionManagementService.getConnectionProfileFromError();
+		if (!profile) {
+			return Promise.resolve(undefined);
+		}
+
+		let connection: azdata.connection.ConnectionProfile = {
+			providerId: profile.providerName,
+			connectionId: profile.id,
+			connectionName: profile.connectionName,
+			serverName: profile.serverName,
+			databaseName: profile.databaseName,
+			userName: profile.userName,
+			password: profile.password,
+			authenticationType: profile.authenticationType,
+			savePassword: profile.savePassword,
+			groupFullName: profile.groupFullName,
+			groupId: profile.groupId,
+			saveProfile: profile.savePassword,
+			azureTenantId: profile.azureTenantId,
+			options: profile.options
+		};
+		return Promise.resolve(connection);
 	}
 
 	public async $listDatabases(connectionId: string): Promise<string[]> {

--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -183,6 +183,7 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 	}
 
 	public $openChangePasswordDialog(initialConnectionProfile: IConnectionProfile): void {
+		// Need to have access to getOptionsKey, so recreate profile from details.
 		let profile = new ConnectionProfile(this._capabilitiesService, initialConnectionProfile);
 		this._connectionManagementService.launchChangePasswordDialog(profile);
 	}
@@ -193,6 +194,7 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 			return Promise.resolve(undefined);
 		}
 
+		// Need to convert profile into azdata friendly format
 		let connection: azdata.connection.ConnectionProfile = {
 			providerId: profile.providerName,
 			connectionId: profile.id,

--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -182,6 +182,10 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 		return connection;
 	}
 
+	public $openChangePasswordDialog(initialConnectionProfile: IConnectionProfile): void {
+		this._connectionManagementService.launchChangePasswordDialog(initialConnectionProfile)
+	}
+
 	public async $listDatabases(connectionId: string): Promise<string[]> {
 		let connectionUri = await this.$getUriForConnection(connectionId);
 		let result = await this._connectionManagementService.listDatabases(connectionUri);

--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -183,7 +183,11 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 	}
 
 	public $openChangePasswordDialog(initialConnectionProfile: IConnectionProfile): void {
-		this._connectionManagementService.launchChangePasswordDialog(initialConnectionProfile)
+		this._connectionManagementService.launchChangePasswordDialog(initialConnectionProfile);
+	}
+
+	public $getConnectionProfileFromError(): Thenable<IConnectionProfile> {
+		return Promise.resolve(this._connectionManagementService.getConnectionProfileFromError());
 	}
 
 	public async $listDatabases(connectionId: string): Promise<string[]> {

--- a/src/sql/workbench/api/browser/mainThreadErrorDiagnostics.ts
+++ b/src/sql/workbench/api/browser/mainThreadErrorDiagnostics.ts
@@ -33,8 +33,8 @@ export class MainThreadErrorDiagnostics extends Disposable implements MainThread
 		let self = this;
 
 		//Create the error handler that interfaces with the extension via the proxy and register it
-		let diagnostics: azdata.Diagnostics = {
-			handleErrorCode(errorCode: number, errorMessage: string): Thenable<azdata.diagnostics.ErrorDiagnosticsResponse> {
+		let diagnostics: azdata.diagnostics.ErrorDiagnostics = {
+			handleErrorCode(errorCode: number, errorMessage: string): Thenable<boolean> {
 				return self._proxy.$handleErrorCode(handle, errorCode, errorMessage);
 			}
 		};

--- a/src/sql/workbench/api/common/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/common/extHostConnectionManagement.ts
@@ -78,6 +78,10 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 		return this._proxy.$openChangePasswordDialog(initialConnectionProfile);
 	}
 
+	public $getConnectionProfileFromError(): Thenable<azdata.IConnectionProfile> {
+		return this._proxy.$getConnectionProfileFromError();
+	}
+
 	public $listDatabases(connectionId: string): Thenable<string[]> {
 		return this._proxy.$listDatabases(connectionId);
 	}

--- a/src/sql/workbench/api/common/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/common/extHostConnectionManagement.ts
@@ -78,7 +78,7 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 		return this._proxy.$openChangePasswordDialog(initialConnectionProfile);
 	}
 
-	public $getConnectionProfileFromError(): Thenable<azdata.IConnectionProfile> {
+	public $getConnectionProfileFromError(): Thenable<azdata.connection.ConnectionProfile> {
 		return this._proxy.$getConnectionProfileFromError();
 	}
 

--- a/src/sql/workbench/api/common/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/common/extHostConnectionManagement.ts
@@ -74,6 +74,10 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 		return this._proxy.$openConnectionDialog(providers, initialConnectionProfile, connectionCompletionOptions);
 	}
 
+	public $openChangePasswordDialog(initialConnectionProfile: azdata.IConnectionProfile): void {
+		return this._proxy.$openChangePasswordDialog(initialConnectionProfile);
+	}
+
 	public $listDatabases(connectionId: string): Thenable<string[]> {
 		return this._proxy.$listDatabases(connectionId);
 	}

--- a/src/sql/workbench/api/common/extHostErrorDiagnostics.ts
+++ b/src/sql/workbench/api/common/extHostErrorDiagnostics.ts
@@ -25,12 +25,12 @@ export class ExtHostErrorDiagnostics extends ExtHostErrorDiagnosticsShape {
 
 	// PUBLIC METHODS //////////////////////////////////////////////////////
 	// - MAIN THREAD AVAILABLE METHODS /////////////////////////////////////
-	public override $handleErrorCode(handle: number, errorCode: number, errorMessage: string): Thenable<azdata.diagnostics.ErrorDiagnosticsResponse> {
-		return this._withProvider(handle, (provider: azdata.Diagnostics) => provider.handleErrorCode(errorCode, errorMessage));
+	public override $handleErrorCode(handle: number, errorCode: number, errorMessage: string): Thenable<boolean> {
+		return this._withProvider(handle, (provider: azdata.diagnostics.ErrorDiagnostics) => provider.handleErrorCode(errorCode, errorMessage));
 	}
 
 	// - EXTENSION HOST AVAILABLE METHODS //////////////////////////////////
-	public $registerDiagnostics(providerMetadata: azdata.ResourceProviderMetadata, diagnostics: azdata.Diagnostics): Disposable {
+	public $registerDiagnostics(providerMetadata: azdata.ResourceProviderMetadata, diagnostics: azdata.diagnostics.ErrorDiagnostics): Disposable {
 		let self = this;
 
 		// Look for any account providers that have the same provider ID
@@ -71,7 +71,7 @@ export class ExtHostErrorDiagnostics extends ExtHostErrorDiagnosticsShape {
 		return this._handlePool++;
 	}
 
-	private _withProvider<R>(handle: number, callback: (provider: azdata.Diagnostics) => Thenable<R>): Thenable<R> {
+	private _withProvider<R>(handle: number, callback: (provider: azdata.diagnostics.ErrorDiagnostics) => Thenable<R>): Thenable<R> {
 		let provider = this._providers[handle];
 		if (provider === undefined) {
 			return Promise.reject(new Error(`Provider ${handle} not found.`));
@@ -82,5 +82,5 @@ export class ExtHostErrorDiagnostics extends ExtHostErrorDiagnosticsShape {
 
 interface DiagnosticsWithMetadata {
 	metadata: azdata.ResourceProviderMetadata;
-	provider: azdata.Diagnostics;
+	provider: azdata.diagnostics.ErrorDiagnostics;
 }

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -141,8 +141,8 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				openChangePasswordDialog(initialConnectionProfile: azdata.IConnectionProfile) {
 					return extHostConnectionManagement.$openChangePasswordDialog(initialConnectionProfile)
 				},
-				getErrorProfile() {
-
+				getConnectionProfileFromError(): Thenable<azdata.IConnectionProfile> {
+					return extHostConnectionManagement.$getConnectionProfileFromError();
 				},
 				listDatabases(connectionId: string): Thenable<string[]> {
 					return extHostConnectionManagement.$listDatabases(connectionId);

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -141,7 +141,7 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				openChangePasswordDialog(initialConnectionProfile: azdata.IConnectionProfile) {
 					return extHostConnectionManagement.$openChangePasswordDialog(initialConnectionProfile)
 				},
-				getConnectionProfileFromError(): Thenable<azdata.IConnectionProfile> {
+				getConnectionProfileFromError(): Thenable<azdata.connection.ConnectionProfile> {
 					return extHostConnectionManagement.$getConnectionProfileFromError();
 				},
 				listDatabases(connectionId: string): Thenable<string[]> {

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -138,6 +138,12 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				openConnectionDialog(providers?: string[], initialConnectionProfile?: azdata.IConnectionProfile, connectionCompletionOptions?: azdata.IConnectionCompletionOptions): Thenable<azdata.connection.Connection> {
 					return extHostConnectionManagement.$openConnectionDialog(providers, initialConnectionProfile, connectionCompletionOptions);
 				},
+				openChangePasswordDialog(initialConnectionProfile: azdata.IConnectionProfile) {
+					return extHostConnectionManagement.$openChangePasswordDialog(initialConnectionProfile)
+				},
+				getErrorProfile() {
+
+				},
 				listDatabases(connectionId: string): Thenable<string[]> {
 					return extHostConnectionManagement.$listDatabases(connectionId);
 				},
@@ -220,7 +226,7 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 			// namespace: diagnostics
 			const diagnostics: typeof azdata.diagnostics = {
 				// "azdata" API definition
-				registerDiagnostics: (providerMetadata: azdata.ResourceProviderMetadata, diagnostics: azdata.Diagnostics): vscode.Disposable => {
+				registerDiagnostics: (providerMetadata: azdata.ResourceProviderMetadata, diagnostics: azdata.diagnostics.ErrorDiagnostics): vscode.Disposable => {
 					return extHostErrorDiagnostics.$registerDiagnostics(providerMetadata, diagnostics);
 				}
 			}

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -723,6 +723,7 @@ export interface MainThreadConnectionManagementShape extends IDisposable {
 	$getServerInfo(connectedId: string): Thenable<azdata.ServerInfo>;
 	$openConnectionDialog(providers: string[], initialConnectionProfile?: azdata.IConnectionProfile, connectionCompletionOptions?: azdata.IConnectionCompletionOptions): Thenable<azdata.connection.Connection>;
 	$openChangePasswordDialog(initialConnectionProfile: azdata.IConnectionProfile): void;
+	$getConnectionProfileFromError(): Thenable<azdata.IConnectionProfile>;
 	$listDatabases(connectionId: string): Thenable<string[]>;
 	$getConnectionString(connectionId: string, includePassword: boolean): Thenable<string>;
 	$getUriForConnection(connectionId: string): Thenable<string>;

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -723,7 +723,7 @@ export interface MainThreadConnectionManagementShape extends IDisposable {
 	$getServerInfo(connectedId: string): Thenable<azdata.ServerInfo>;
 	$openConnectionDialog(providers: string[], initialConnectionProfile?: azdata.IConnectionProfile, connectionCompletionOptions?: azdata.IConnectionCompletionOptions): Thenable<azdata.connection.Connection>;
 	$openChangePasswordDialog(initialConnectionProfile: azdata.IConnectionProfile): void;
-	$getConnectionProfileFromError(): Thenable<azdata.IConnectionProfile>;
+	$getConnectionProfileFromError(): Thenable<azdata.connection.ConnectionProfile>;
 	$listDatabases(connectionId: string): Thenable<string[]>;
 	$getConnectionString(connectionId: string, includePassword: boolean): Thenable<string>;
 	$getUriForConnection(connectionId: string): Thenable<string>;

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -613,7 +613,7 @@ export abstract class ExtHostErrorDiagnosticsShape {
 	/**
 	 * Handle other error types
 	 */
-	$handleErrorCode(handle: number, errorCode: number, errorMessage: string): Thenable<azdata.diagnostics.ErrorDiagnosticsResponse> { throw ni(); }
+	$handleErrorCode(handle: number, errorCode: number, errorMessage: string): Thenable<boolean> { throw ni(); }
 }
 
 /**
@@ -722,6 +722,7 @@ export interface MainThreadConnectionManagementShape extends IDisposable {
 	$getCredentials(connectionId: string): Thenable<{ [name: string]: string }>;
 	$getServerInfo(connectedId: string): Thenable<azdata.ServerInfo>;
 	$openConnectionDialog(providers: string[], initialConnectionProfile?: azdata.IConnectionProfile, connectionCompletionOptions?: azdata.IConnectionCompletionOptions): Thenable<azdata.connection.Connection>;
+	$openChangePasswordDialog(initialConnectionProfile: azdata.IConnectionProfile): void;
 	$listDatabases(connectionId: string): Thenable<string[]>;
 	$getConnectionString(connectionId: string, includePassword: boolean): Thenable<string>;
 	$getUriForConnection(connectionId: string): Thenable<string>;

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -1059,15 +1059,6 @@ export namespace executionPlan {
 	}
 }
 
-export namespace diagnostics {
-	/**
-	 * The error codes returned to indicate what kind of error is being thrown.
-	 */
-	export interface ErrorDiagnosticsResponse {
-		errorAction: string;
-	}
-}
-
 export namespace env {
 	/**
 	 * Well-known app quality values

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -563,9 +563,9 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 					options.showFirewallRuleOnError = false;
 					return this.connectWithOptions(connection, uri, options, callbacks);
 				} else {
-					return this.handleOtherError(connection, connectionResult, options).then(success => {
+					return this._errorDiagnosticsService.checkErrorCode(connectionResult.errorCode, connectionResult.errorMessage, connection.providerName).then(success => {
 						if (success) {
-							//For now handle connection errors inside handleOtherError.
+							//For now handle connection errors in provider.
 							connectionResult.errorHandled = true;
 							return connectionResult;
 						}
@@ -597,21 +597,9 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		});
 	}
 
-	private handleOtherError(connection: interfaces.IConnectionProfile, connectionResult: IConnectionResult, options: IConnectionCompletionOptions): Promise<boolean> {
-		return this._errorDiagnosticsService.checkErrorCode(connectionResult.errorCode, connectionResult.errorMessage, connection.providerName).then(response => {
-			if (response.errorAction === Constants.expiredPasswordErrorCode) {
-				this._logService.info(`change password error code returned!`);
-				this.launchChangePasswordDialog(connection, options.params)
-				return true;
-			} else {
-				return false;
-			}
-		});
-	}
-
-	public launchChangePasswordDialog(profile: interfaces.IConnectionProfile, params: INewConnectionParams): void {
+	public launchChangePasswordDialog(profile: interfaces.IConnectionProfile): void {
 		let dialog = this._instantiationService.createInstance(PasswordChangeDialog);
-		dialog.open(profile, params);
+		dialog.open(profile)
 	}
 
 	private doActionsAfterConnectionComplete(uri: string, options: IConnectionCompletionOptions): void {

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -20,7 +20,7 @@ import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
 import { TestConnectionProvider } from 'sql/platform/connection/test/common/testConnectionProvider';
 import { TestResourceProvider } from 'sql/workbench/services/resourceProvider/test/common/testResourceProviderService';
-import { TestErrorDiagnosticsService } from 'sql/platform/diagnostics/common/testErrorDiagnosticsService';
+import { TestErrorDiagnosticsService } from 'sql/workbench/services/connection/test/common/testErrorDiagnosticsService';
 
 import * as azdata from 'azdata';
 

--- a/src/sql/workbench/services/connection/test/common/testErrorDiagnosticsService.ts
+++ b/src/sql/workbench/services/connection/test/common/testErrorDiagnosticsService.ts
@@ -4,22 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
-import { diagnostics } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IErrorDiagnosticsService } from 'sql/workbench/services/diagnostics/common/errorDiagnosticsService';
 
 export class TestErrorDiagnosticsService implements IErrorDiagnosticsService {
 	_serviceBrand: undefined;
 
-	registerDiagnostics(providerId: string, diagnostics: azdata.Diagnostics): void {
+	registerDiagnostics(providerId: string, diagnostics: azdata.diagnostics.ErrorDiagnostics): void {
 	}
 
 	unregisterDiagnostics(ProviderId: string): void {
 	}
 
-	checkErrorCode(errorCode: number, errorMessage: string, providerId: string): Promise<diagnostics.ErrorDiagnosticsResponse> {
-		let response: diagnostics.ErrorDiagnosticsResponse = {
-			errorAction: ""
-		}
-		return Promise.resolve(response);
+	checkErrorCode(errorCode: number, errorMessage: string, providerId: string): Promise<boolean> {
+		return Promise.resolve(false);
 	}
 }

--- a/src/sql/workbench/services/diagnostics/browser/errorDiagnosticsService.ts
+++ b/src/sql/workbench/services/diagnostics/browser/errorDiagnosticsService.ts
@@ -9,21 +9,16 @@ import * as azdata from 'azdata';
 export class ErrorDiagnosticsService implements IErrorDiagnosticsService {
 
 	_serviceBrand: undefined;
-	private _providers: { [handle: string]: azdata.Diagnostics; } = Object.create(null);
+	private _providers: { [handle: string]: azdata.diagnostics.ErrorDiagnostics; } = Object.create(null);
 
 	constructor(
 	) { }
 
-	public async checkErrorCode(errorCode: number, errorMessage: string, providerId: string): Promise<azdata.diagnostics.ErrorDiagnosticsResponse> {
-		let result = { errorAction: "" };
+	public async checkErrorCode(errorCode: number, errorMessage: string, providerId: string): Promise<boolean> {
+		let result = false;
 		let provider = this._providers[providerId]
 		if (provider) {
-			await provider.handleErrorCode(errorCode, errorMessage)
-				.then(response => {
-					if (result.errorAction !== response.errorAction) {
-						result = response;
-					}
-				}, () => { });
+			result = await provider.handleErrorCode(errorCode, errorMessage)
 		}
 		return result;
 	}
@@ -31,7 +26,7 @@ export class ErrorDiagnosticsService implements IErrorDiagnosticsService {
 	/**
 	 * Register a diagnostics object for a provider
 	 */
-	public registerDiagnostics(providerId: string, diagnostics: azdata.Diagnostics): void {
+	public registerDiagnostics(providerId: string, diagnostics: azdata.diagnostics.ErrorDiagnostics): void {
 		this._providers[providerId] = diagnostics;
 	}
 

--- a/src/sql/workbench/services/diagnostics/common/errorDiagnosticsService.ts
+++ b/src/sql/workbench/services/diagnostics/common/errorDiagnosticsService.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { diagnostics } from 'sql/workbench/api/common/sqlExtHostTypes';
 import * as azdata from 'azdata';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
@@ -16,7 +15,7 @@ export interface IErrorDiagnosticsService {
 	/**
 	 * Register a Diagnostics object for a provider
 	 */
-	registerDiagnostics(providerId: string, diagnostics: azdata.Diagnostics): void;
+	registerDiagnostics(providerId: string, diagnostics: azdata.diagnostics.ErrorDiagnostics): void;
 
 	/**
 	 * Unregister a Diagnostics object for a provider
@@ -29,5 +28,5 @@ export interface IErrorDiagnosticsService {
 	 * @param errorMessage Error message that describes the problem in detail.
 	 * @param providerId Identifies what provider the error comes from.
 	 */
-	checkErrorCode(errorCode: number, errorMessage: string, providerId: string): Promise<diagnostics.ErrorDiagnosticsResponse>;
+	checkErrorCode(errorCode: number, errorMessage: string, providerId: string): Promise<boolean>;
 }


### PR DESCRIPTION
This PR now makes it so that when an error code is checked on the provider side, the provider will first have to get the profile that was causing the error via an API call (temporarily stored until error handling is done, and it can be used for all kinds of errors not just password reset, and CMS won't know anything about error codes), then after converting it back and forth from interfaces.IConnectionProfile to azdata.connection.ConnectionProfile, it will then call the existing change password dialog via another API call. 

Additionally, the params for the password change dialog are removed as it's only the default connection type that is passed in this scenario. 

Attempts to include the connection profile and params in one class as part of the error code handling (as an 'any' type) resulted in a circular dependency happening due to the way the RPC calls are generated (it involves the capabilities service), so they would have to be retrieved separately (also helps make the error code check truly generic)