### PR TITLE
Don't check insiders gallery on RC1 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
         node-version: 14.17.3
     - run: yarn install --frozen-lockfile
       name: Install dependencies
-    - run: node scripts/validateGalleries.js ${GITHUB_REF##*/}
+    - run: node scripts/validateGalleries.js ${GITHUB_BASE_REF}
       name: Validate Extension Galleries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
         node-version: 14.17.3
     - run: yarn install --frozen-lockfile
       name: Install dependencies
-    - run: node scripts/validateGalleries.js
+    - run: node scripts/validateGalleries.js ${GITHUB_REF##*/}
       name: Validate Extension Galleries

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -611,7 +611,7 @@ const validationPromises = [
 // argv[2] is the branch name
 // RC1 branch only needs to check the stable gallery since the insiders gallery won't be updated there.
 const isRC1 = process.argv[2] === 'extensions/rc1';
-
+console.log(process.argv[2]);
 if (!isRC1) {
     validationPromises.push(validateExtensionGallery(INSIDERS_GALLERY_PATH, INSIDERS_GALLERY_JSON));
 }

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -604,7 +604,15 @@ async function cleanDownloadedExtensionFolder(downloadedExtDir) {
 await cleanDownloadedExtensionFolder(STABLE_DOWNLOADED_EXT_DIR);
 await cleanDownloadedExtensionFolder(INSIDERS_DOWNLOADED_EXT_DIR);
 
-await Promise.all([
+const validationPromises = [
     validateExtensionGallery(STABLE_GALLERY_PATH, STABLE_GALLERY_JSON),
-    validateExtensionGallery(INSIDERS_GALLERY_PATH, INSIDERS_GALLERY_JSON)
-]);
+]
+
+// argv[2] is the branch name
+// RC1 branch only needs to check the stable gallery since the insiders gallery won't be updated there.
+const isRC1 = process.argv[2] === 'extensions/rc1';
+
+if (!isRC1) {
+    validationPromises.push(validateExtensionGallery(INSIDERS_GALLERY_PATH, INSIDERS_GALLERY_JSON));
+}
+await Promise.all(validationPromises);

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -608,10 +608,10 @@ const validationPromises = [
     validateExtensionGallery(STABLE_GALLERY_PATH, STABLE_GALLERY_JSON),
 ]
 
-// argv[2] is the branch name
+// argv[2] is the target branch name
 // RC1 branch only needs to check the stable gallery since the insiders gallery won't be updated there.
 const isRC1 = process.argv[2] === 'extensions/rc1';
-console.log(process.argv[2]);
+
 if (!isRC1) {
     validationPromises.push(validateExtensionGallery(INSIDERS_GALLERY_PATH, INSIDERS_GALLERY_JSON));
 }


### PR DESCRIPTION
Skip checking insiders gallery since otherwise we'll have to keep updating whenever insiders updates are made or the checks will fail (since rc1 branch will have outdated values).

When we eventually merge the rc1 branch into release/extensions then it'll check both and verify everything is matching between the two.