### PR TITLE
Set current connection as the selected connection in schema compare dialog

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -88,7 +88,7 @@ export class SchemaCompareDialog {
 		// connection to use if schema compare wasn't launched from a database or no previous source/target
 		let connection = await azdata.connection.getCurrentConnection();
 		if (connection) {
-			this.connectionId = connection.connectionId;
+			this.connectionId = connection.connectionId;	// current active connection
 		}
 
 		this.dialog = azdata.window.createModelViewDialog(loc.SchemaCompareLabel);
@@ -875,12 +875,11 @@ export class SchemaCompareDialog {
 			}
 
 			// use current connection else use previously selected server if there is one
-			if (c.connectionId === this.connectionId) {
-				idx = count;
-			} else if (endpointInfo && !isNullOrUndefined(endpointInfo.serverName) && !isNullOrUndefined(endpointInfo.serverDisplayName)
-				&& c.options.server.toLowerCase() === endpointInfo.serverName.toLowerCase()
-				&& finalName.toLowerCase() === endpointInfo.serverDisplayName.toLowerCase()
-				&& idx === -1) {	// select previous server only if current connection hasn't been set already
+			if ((c.connectionId === this.connectionId) ||
+				(endpointInfo && !isNullOrUndefined(endpointInfo.serverName) && !isNullOrUndefined(endpointInfo.serverDisplayName)
+					&& c.options.server.toLowerCase() === endpointInfo.serverName.toLowerCase()
+					&& finalName.toLowerCase() === endpointInfo.serverDisplayName.toLowerCase()
+					&& idx === -1)) { // select previous server only if current connection hasn't been set already
 				idx = count;
 			}
 

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -874,13 +874,13 @@ export class SchemaCompareDialog {
 				finalName = c.options.connectionName;
 			}
 
-			// use previously selected server or current connection if there is one
-			if (endpointInfo && !isNullOrUndefined(endpointInfo.serverName) && !isNullOrUndefined(endpointInfo.serverDisplayName)
-				&& c.options.server.toLowerCase() === endpointInfo.serverName.toLowerCase()
-				&& finalName.toLowerCase() === endpointInfo.serverDisplayName.toLowerCase()) {
+			// use current connection else use previously selected server if there is one
+			if (c.connectionId === this.connectionId) {
 				idx = count;
-			}
-			else if (c.connectionId === this.connectionId) {
+			} else if (endpointInfo && !isNullOrUndefined(endpointInfo.serverName) && !isNullOrUndefined(endpointInfo.serverDisplayName)
+				&& c.options.server.toLowerCase() === endpointInfo.serverName.toLowerCase()
+				&& finalName.toLowerCase() === endpointInfo.serverDisplayName.toLowerCase()
+				&& idx === -1) {	// select previous server only if current connection hasn't been set already
 				idx = count;
 			}
 


### PR DESCRIPTION
This PR fixes #21210.
Currently while creating a list of servers in the schema compare dialog (for database comparison), the code will either pick the newly added connection or the one with which schema compare extension was started from, to set as the selected server- whichever came later. It should rather follow the hierarchy of picking the newly added connection first, if it doesn't exist then pick the one where SC context was launched from. This PR made the change to select newly added connection first; if not, then select contextual server from the SC was launched.

Before the changes:
![scConnectIssue](https://user-images.githubusercontent.com/57200045/213816144-b93cd68a-6484-4253-9592-4d5f0376304f.gif)

After the changes:
![scIssueFix](https://user-images.githubusercontent.com/57200045/213816427-cbe35ed0-980e-4a2c-bd03-218d86bffd47.gif)

Tested other scenarios as well (adding/selecting other servers in the server list).
