### PR TITLE
Update dacpac, schema compare and sql database projects extensions for January release (Insiders)

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1230,14 +1230,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.11.0",
-							"lastUpdated": "11/7/2022",
+							"version": "1.12.0",
+							"lastUpdated": "1/20/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.11.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.12.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1474,14 +1474,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.17.0",
-							"lastUpdated": "11/7/2022",
+							"version": "1.18.0",
+							"lastUpdated": "1/20/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.17.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.18.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3434,14 +3434,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.20.0",
-							"lastUpdated": "11/7/2022",
+							"version": "0.21.0",
+							"lastUpdated": "1/20/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.20.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.21.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Updating these extensions for the January ADS release in insiders:

- dacpac
- schema compare
- sql database projects
Build with vsixs: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=186852&view=artifacts&pathAsName=false&type=publishedArtifacts
