### PR TITLE
ADS: Make select all tables by default instead of having to click edit and do select all

### DIFF
--- a/extensions/sql-migration/src/dialog/tableMigrationSelection/tableMigrationSelectionDialog.ts
+++ b/extensions/sql-migration/src/dialog/tableMigrationSelection/tableMigrationSelectionDialog.ts
@@ -51,7 +51,8 @@ export class TableMigrationSelectionDialog {
 				this._tableSelectionMap = new Map();
 				sourceTableList.forEach(table => {
 					const sourceTable = targetDatabaseInfo.sourceTables.get(table.tableName);
-					const isSelected = sourceTable?.selectedForMigration === true;
+					// Tables are selected by default at the first time going to the table selection page
+					const isSelected = sourceTable === null || sourceTable === undefined ? true : sourceTable?.selectedForMigration === true;
 					const tableInfo: TableInfo = {
 						databaseName: table.databaseName,
 						rowCount: table.rowCount,
@@ -97,7 +98,9 @@ export class TableMigrationSelectionDialog {
 		let tableRow = 0;
 		this._missingTableCount = 0;
 		this._tableSelectionMap.forEach(sourceTable => {
-			if (filterText?.length === 0 || sourceTable.tableName.indexOf(filterText) > -1) {
+			const tableName = sourceTable.tableName.toLocaleLowerCase();
+			const searchText = filterText.toLocaleLowerCase();
+			if (filterText?.length === 0 || tableName.indexOf(searchText) > -1) {
 				const targetTable = this._targetTableMap.get(sourceTable.tableName);
 				if (targetTable) {
 					const targetTableRowCount = targetTable?.rowCount ?? 0;

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -76,6 +76,15 @@ export class TargetSelectionPage extends MigrationWizardPage {
 				this._disposables.forEach(
 					d => { try { d.dispose(); } catch { } });
 			}));
+
+		if (this.migrationStateModel.resumeAssessment) {
+			await this.populateAzureAccountsDropdown();
+			//await this.populateSubscriptionDropdown();
+			//await this.populateResourceGroupDropdown();
+			//await this.populateLocationDropdown();
+			//await this.populateResourceInstanceDropdown();
+		}
+
 		await this._view.initializeModel(form);
 	}
 

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -79,10 +79,6 @@ export class TargetSelectionPage extends MigrationWizardPage {
 
 		if (this.migrationStateModel.resumeAssessment) {
 			await this.populateAzureAccountsDropdown();
-			//await this.populateSubscriptionDropdown();
-			//await this.populateResourceGroupDropdown();
-			//await this.populateLocationDropdown();
-			//await this.populateResourceInstanceDropdown();
 		}
 
 		await this._view.initializeModel(form);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Make select all tables by default instead of having to click edit and do select all
Changes included:
1. Mark all mapped tables are selected as default
2. Table search function allows case insensitive

Tests:
1. Click 'Edit' in table selection wizard at the first time
![image](https://user-images.githubusercontent.com/48336822/214107904-2af3721d-b474-4dc3-8131-f4bf9e377b3f.png)
2. The previous behaviors are not changed and work as before

