### PR TITLE
Normalize resources when checking valid roots (#163327) (#21700)

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
+++ b/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
@@ -7,7 +7,7 @@ import { VSBufferReadableStream } from 'vs/base/common/buffer';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { isUNC } from 'vs/base/common/extpath';
 import { Schemas } from 'vs/base/common/network';
-import { sep } from 'vs/base/common/path';
+import { normalize, sep } from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
 import { FileOperationError, FileOperationResult, IFileService } from 'vs/platform/files/common/files';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -103,8 +103,8 @@ function containsResource(root: URI, resource: URI): boolean {
 		return false;
 	}
 
-	let rootPath = root.fsPath + (root.fsPath.endsWith(sep) ? '' : sep);
-	let resourceFsPath = resource.fsPath;
+	let resourceFsPath = normalize(resource.fsPath);
+	let rootPath = normalize(root.fsPath + (root.fsPath.endsWith(sep) ? '' : sep));
 
 	if (isUNC(root.fsPath) && isUNC(resource.fsPath)) {
 		rootPath = rootPath.toLowerCase();


### PR DESCRIPTION
Port...
Fix MSCR 74267

Fix https://github.com/microsoft/vscode-internalbacklog/issues/3140

Remove extra indexOf check

This could cause failures for files such as `img..png`

Co-authored-by: Matt Bierner <matb@microsoft.com>
