### PR TITLE
Bump sql-migration version to 1.2.2

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/src/dashboard/dashboardTab.ts
+++ b/extensions/sql-migration/src/dashboard/dashboardTab.ts
@@ -141,7 +141,6 @@ export class DashboardTab extends TabBase<DashboardTab> {
 		const toolbar = view.modelBuilder.toolbarContainer();
 		toolbar.addToolbarItems([
 			<azdata.ToolbarComponent>{ component: this.createNewMigrationButton() },
-			<azdata.ToolbarComponent>{ component: this.createNewLoginMigrationButton() },
 			<azdata.ToolbarComponent>{ component: this.createNewSupportRequestButton() },
 			<azdata.ToolbarComponent>{ component: this.createFeedbackButton() },
 		]);

--- a/extensions/sql-migration/src/dashboard/migrationsListTab.ts
+++ b/extensions/sql-migration/src/dashboard/migrationsListTab.ts
@@ -144,7 +144,6 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 
 		toolbar.addToolbarItems([
 			<azdata.ToolbarComponent>{ component: this.createNewMigrationButton(), toolbarSeparatorAfter: true },
-			<azdata.ToolbarComponent>{ component: this.createNewLoginMigrationButton(), toolbarSeparatorAfter: true },
 			<azdata.ToolbarComponent>{ component: this.createNewSupportRequestButton() },
 			<azdata.ToolbarComponent>{ component: this.createFeedbackButton(), toolbarSeparatorAfter: true },
 			<azdata.ToolbarComponent>{ component: this._refreshLoader },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR bumps sql-migration version to 1.2.2 in order to release to insider's gallery. This also disables the LoginMigration button as we do not want to release it to public yet. 