### PR TITLE
[SQL Migration] Release v1.2.2 to worldwide

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4037,7 +4037,7 @@
 					"versions": [
 						{
 							"version": "1.2.2",
-							"lastUpdated": "1/25/2023",
+							"lastUpdated": "1/26/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.2.0",
-							"lastUpdated": "1/5/2023",
+							"version": "1.2.2",
+							"lastUpdated": "1/25/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.2.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.2.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4073,7 +4073,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.40.0"
+									"value": ">=1.41.0"
 								}
 							]
 						}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the worldwide extension gallery to the latest version of the SQL Migration extension. It also bumps the dependent version of ADS to 1.41, matching the extension definition.

Link to `Azure Data Studio - Extensions` pipeline run containing vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=187362&view=results

~~(This version has not gone to insiders (and probably won't) because it's basically identical to the 1.2.1 version currently in insiders, with a one line change to disable a preview feature that was intended only for insiders and not public consumption. We will do another follow up insiders release soon to add more stuff anyways)~~