### PR TITLE
fix undefined error in dacpac extension when sending telemetry

### DIFF
--- a/extensions/dacpac/src/wizard/api/models.ts
+++ b/extensions/dacpac/src/wizard/api/models.ts
@@ -16,5 +16,5 @@ export interface DacFxDataModel {
 	filePath: string;
 	version: string;
 	upgradeExisting: boolean;
-	potentialDataLoss: boolean;
+	potentialDataLoss?: boolean;
 }

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -335,7 +335,7 @@ export class DataTierApplicationWizard {
 		additionalMeasurements.totalDurationMs = (new Date().getTime() - deployStartTime);
 		additionalMeasurements.deployDacpacFileSizeBytes = await utils.tryGetFileSize(this.model.filePath);
 		additionalProps.upgradeExistingDatabase = this.model.upgradeExisting.toString();
-		additionalProps.potentialDataLoss = this.model.potentialDataLoss.toString();
+		additionalProps.potentialDataLoss = this.model.potentialDataLoss?.toString();
 
 		this.sendDacFxOperationTelemetryEvent(result, TelemetryAction.DeployDacpac, additionalProps, additionalMeasurements);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21626. The error was because `potentialDataLoss` doesn't get set for deploy to new db, only for deploy to existing db. 
