### PR TITLE
Update extensionsGallery for Arc and Azcli 1.8.0

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.7.0",
-							"lastUpdated": "11/8/2022",
+							"version": "1.8.0",
+							"lastUpdated": "1/25/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.7.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.8.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4211,14 +4211,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.7.0",
-							"lastUpdated": "11/8/2022",
+							"version": "1.8.0",
+							"lastUpdated": "1/25/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.7.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.8.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3316,14 +3316,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.7.0",
-							"lastUpdated": "11/8/2022",
+							"version": "1.8.0",
+							"lastUpdated": "1/25/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.7.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-1.8.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4211,14 +4211,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.7.0",
-							"lastUpdated": "11/8/2022",
+							"version": "1.8.0",
+							"lastUpdated": "1/25/2022",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.7.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/azcli/azcli-1.8.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Updating arc and azcli extensionGalleries to 1.8.0.
PR containing version bump: https://github.com/microsoft/azuredatastudio/pull/21725
VSIX files to be used are drop/extensions/arc-1.8.0.vsix and drop/extensions/azcli-1.8.0.vsix from this link: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=187482&view=artifacts&pathAsName=false&type=publishedArtifacts