### PR TITLE
Fix account and tenant selection behavior

### DIFF
--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -200,10 +200,8 @@ export class SelectBox extends vsSelectBox {
 		}
 		if (option !== undefined) {
 			this.select(option);
-		} else {
-			if (selectFirstByDefault) {
-				this.select(0);
-			}
+		} else if (selectFirstByDefault) {
+			this.select(0);
 		}
 	}
 

--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -193,7 +193,7 @@ export class SelectBox extends vsSelectBox {
 		this.applyStyles();
 	}
 
-	public selectWithOptionName(optionName?: string): void {
+	public selectWithOptionName(optionName?: string, selectFirstByDefault: boolean = true): void {
 		let option: number | undefined;
 		if (optionName !== undefined) {
 			option = this._optionsDictionary.get(optionName);
@@ -201,7 +201,9 @@ export class SelectBox extends vsSelectBox {
 		if (option !== undefined) {
 			this.select(option);
 		} else {
-			this.select(0);
+			if (selectFirstByDefault) {
+				this.select(0);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #21643 and tenant selection issues as well.

I had been intermittently facing this issue and was able to finally debug and root cause it. The issue had been present due to selectBox defaulting to 'first' item by default in `fillInAzureAccountOptions()` which when called without any data always ends up selecting first account in the list. This fires event that populates tenant and we start getting console errors as under:

![image](https://user-images.githubusercontent.com/13396919/215011835-5fed389b-b8f3-4325-ab42-72e09578abd5.png)
_(captured in v1.41.0)_

Which should not be the case as the subscription ID "72f988bf-***" is not applicable to live account. This PR makes sure the correct account is selected after this call completes only in `fillInConnectionInputs(connectionInfo)` when connection Info is available.

Also removed unwanted `_azureTenantId` assignments that were causing incorrect tenant to be selected (started failing since https://github.com/microsoft/azuredatastudio/commit/ec7e754009ef126e60f51fd1c983c16fb974849a#diff-6cbed09935af5348af95a7fe0c504191ac5e2ee347e0325d5d89d6237dd90698R692). This part wasn't necessary in the PR as the fallback to default owning tenant takes care of tenant being available.

Also fixed #21743 with minor changes.

**I would propose we take this change in hotfix as well, to prevent these issues from surfacing.**
cc @kburtram 