### PR TITLE
[SQL-Migration] Enable login migrations to SQL VM

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -299,48 +299,22 @@ export async function getVMInstanceView(sqlVm: SqlVMServer, account: azdata.Acco
 	return response.response.data;
 }
 
+export async function getAzureResourceGivenId(account: azdata.Account, subscription: Subscription, id: string, apiVersion: string): Promise<any> {
+	const api = await getAzureCoreAPI();
+	const path = encodeURI(`${id}?api-version=${apiVersion}`);
+	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
+	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
+
+	if (response.errors.length > 0) {
+		throw new Error(response.errors.toString());
+	}
+
+	return response.response.data;
+}
+
 export async function getComputeVM(sqlVm: SqlVMServer, account: azdata.Account, subscription: Subscription): Promise<any> {
-	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${getResourceGroupFromId(sqlVm.id)}/providers/Microsoft.Compute/virtualMachines/${sqlVm.name}?api-version=2022-08-01`);
-	// /instanceView
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
-
-	if (response.errors.length > 0) {
-		throw new Error(response.errors.toString());
-	}
-
-	return response.response.data;
-}
-
-export async function getNetworkInterface(account: azdata.Account, subscription: Subscription, nicId: string): Promise<NetworkInterface> {
-	const api = await getAzureCoreAPI();
-	const path = encodeURI(`${nicId}?api-version=2022-09-01`);
-	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
-
-	if (response.errors.length > 0) {
-		throw new Error(response.errors.toString());
-	}
-
-	return response.response.data;
-}
-
-export async function getVmNetworkInterfaces(account: azdata.Account, subscription: Subscription, sqlVm: SqlVMServer): Promise<Map<string, NetworkInterface>> {
-	const computeVMs = await getComputeVM(sqlVm, account, subscription);
-	const networkInterfaces = new Map<string, any>();
-
-	if (!computeVMs?.properties?.networkProfile?.networkInterfaces) {
-		return networkInterfaces;
-	}
-
-	for (const nic of computeVMs.properties.networkProfile.networkInterfaces) {
-		const nicId = nic.id;
-		const nicData = await getNetworkInterface(account, subscription, nicId);
-		networkInterfaces.set(nicId, nicData);
-	}
-
-	return networkInterfaces;
+	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${getResourceGroupFromId(sqlVm.id)}/providers/Microsoft.Compute/virtualMachines/${sqlVm.name}`);
+	return getAzureResourceGivenId(account, subscription, path, "2022-08-01");
 }
 
 export type StorageAccount = AzureProduct;
@@ -376,13 +350,13 @@ export async function getBlobs(account: azdata.Account, subscription: Subscripti
 }
 
 export async function getSqlMigrationService(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string): Promise<SqlMigrationService> {
-	const sqlMigrationServiceId = `/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}`;
+	const sqlMigrationServiceId = `/ subscriptions / ${subscription.id} /resourceGroups/${resourceGroupName} /providers/Microsoft.DataMigration / sqlMigrationServices / ${sqlMigrationServiceName} `;
 	return await getSqlMigrationServiceById(account, subscription, sqlMigrationServiceId);
 }
 
 export async function getSqlMigrationServiceById(account: azdata.Account, subscription: Subscription, sqlMigrationServiceId: string): Promise<SqlMigrationService> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`${sqlMigrationServiceId}?api-version=${DMSV2_API_VERSION}`);
+	const path = encodeURI(`${sqlMigrationServiceId}?api - version=${DMSV2_API_VERSION} `);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
@@ -397,7 +371,7 @@ export async function getSqlMigrationServiceById(account: azdata.Account, subscr
 
 export async function getSqlMigrationServicesByResourceGroup(account: azdata.Account, subscription: Subscription, resouceGroupName: string): Promise<SqlMigrationService[]> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resouceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=${DMSV2_API_VERSION}`);
+	const path = encodeURI(`/ subscriptions / ${subscription.id} /resourceGroups/${resouceGroupName} /providers/Microsoft.DataMigration / sqlMigrationServices ? api - version=${DMSV2_API_VERSION} `);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
@@ -415,7 +389,7 @@ export async function getSqlMigrationServicesByResourceGroup(account: azdata.Acc
 
 export async function getSqlMigrationServices(account: azdata.Account, subscription: Subscription): Promise<SqlMigrationService[]> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/subscriptions/${subscription.id}/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=${DMSV2_API_VERSION}`);
+	const path = encodeURI(`/ subscriptions / ${subscription.id} /providers/Microsoft.DataMigration / sqlMigrationServices ? api - version=${DMSV2_API_VERSION} `);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
@@ -433,7 +407,7 @@ export async function getSqlMigrationServices(account: azdata.Account, subscript
 
 export async function createSqlMigrationService(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string, sessionId: string): Promise<SqlMigrationService> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}?api-version=${DMSV2_API_VERSION}`);
+	const path = encodeURI(`/ subscriptions / ${subscription.id} /resourceGroups/${resourceGroupName} /providers/Microsoft.DataMigration / sqlMigrationServices / ${sqlMigrationServiceName}?api - version=${DMSV2_API_VERSION} `);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const requestBody = {
 		'location': regionName
@@ -468,7 +442,7 @@ export async function createSqlMigrationService(account: azdata.Account, subscri
 
 export async function getSqlMigrationServiceAuthKeys(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string): Promise<SqlMigrationServiceAuthenticationKeys> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}/ListAuthKeys?api-version=${DMSV2_API_VERSION}`);
+	const path = encodeURI(`/ subscriptions / ${subscription.id} /resourceGroups/${resourceGroupName} /providers/Microsoft.DataMigration / sqlMigrationServices / ${sqlMigrationServiceName} /ListAuthKeys?api-version=${DMSV2_API_VERSION}`);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, undefined, true, host);
 	if (response.errors.length > 0) {

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -17,6 +17,7 @@ const SQL_VM_API_VERSION = '2021-11-01-preview';
 const SQL_MI_API_VERSION = '2021-11-01-preview';
 const SQL_SQLDB_API_VERSION = '2021-11-01-preview';
 const DMSV2_API_VERSION = '2022-03-30-preview';
+const COMPUTE_VM_API_VERSION = '2022-08-01';
 
 async function getAzureCoreAPI(): Promise<azurecore.IExtension> {
 	const api = (await vscode.extensions.getExtension(azurecore.extension.name)?.activate()) as azurecore.IExtension;
@@ -288,7 +289,7 @@ export async function getAvailableSqlVMs(account: azdata.Account, subscription: 
 
 export async function getVMInstanceView(sqlVm: SqlVMServer, account: azdata.Account, subscription: Subscription): Promise<VirtualMachineInstanceView> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${getResourceGroupFromId(sqlVm.id)}/providers/Microsoft.Compute/virtualMachines/${sqlVm.name}/instanceView?api-version=2022-08-01`);
+	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${getResourceGroupFromId(sqlVm.id)}/providers/Microsoft.Compute/virtualMachines/${sqlVm.name}/instanceView?api-version=${COMPUTE_VM_API_VERSION}`);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 
@@ -314,7 +315,7 @@ export async function getAzureResourceGivenId(account: azdata.Account, subscript
 
 export async function getComputeVM(sqlVm: SqlVMServer, account: azdata.Account, subscription: Subscription): Promise<any> {
 	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${getResourceGroupFromId(sqlVm.id)}/providers/Microsoft.Compute/virtualMachines/${sqlVm.name}`);
-	return getAzureResourceGivenId(account, subscription, path, "2022-08-01");
+	return getAzureResourceGivenId(account, subscription, path, COMPUTE_VM_API_VERSION);
 }
 
 export type StorageAccount = AzureProduct;

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -350,13 +350,13 @@ export async function getBlobs(account: azdata.Account, subscription: Subscripti
 }
 
 export async function getSqlMigrationService(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string): Promise<SqlMigrationService> {
-	const sqlMigrationServiceId = `/ subscriptions / ${subscription.id} /resourceGroups/${resourceGroupName} /providers/Microsoft.DataMigration / sqlMigrationServices / ${sqlMigrationServiceName} `;
+	const sqlMigrationServiceId = `/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}`;
 	return await getSqlMigrationServiceById(account, subscription, sqlMigrationServiceId);
 }
 
 export async function getSqlMigrationServiceById(account: azdata.Account, subscription: Subscription, sqlMigrationServiceId: string): Promise<SqlMigrationService> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`${sqlMigrationServiceId}?api - version=${DMSV2_API_VERSION} `);
+	const path = encodeURI(`${sqlMigrationServiceId}?api-version=${DMSV2_API_VERSION} `);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
@@ -371,7 +371,7 @@ export async function getSqlMigrationServiceById(account: azdata.Account, subscr
 
 export async function getSqlMigrationServicesByResourceGroup(account: azdata.Account, subscription: Subscription, resouceGroupName: string): Promise<SqlMigrationService[]> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/ subscriptions / ${subscription.id} /resourceGroups/${resouceGroupName} /providers/Microsoft.DataMigration / sqlMigrationServices ? api - version=${DMSV2_API_VERSION} `);
+	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resouceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=${DMSV2_API_VERSION}`);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
@@ -389,7 +389,7 @@ export async function getSqlMigrationServicesByResourceGroup(account: azdata.Acc
 
 export async function getSqlMigrationServices(account: azdata.Account, subscription: Subscription): Promise<SqlMigrationService[]> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/ subscriptions / ${subscription.id} /providers/Microsoft.DataMigration / sqlMigrationServices ? api - version=${DMSV2_API_VERSION} `);
+	const path = encodeURI(`/subscriptions/${subscription.id}/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=${DMSV2_API_VERSION}`);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {
@@ -407,7 +407,7 @@ export async function getSqlMigrationServices(account: azdata.Account, subscript
 
 export async function createSqlMigrationService(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string, sessionId: string): Promise<SqlMigrationService> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/ subscriptions / ${subscription.id} /resourceGroups/${resourceGroupName} /providers/Microsoft.DataMigration / sqlMigrationServices / ${sqlMigrationServiceName}?api - version=${DMSV2_API_VERSION} `);
+	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}?api-version=${DMSV2_API_VERSION}`);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const requestBody = {
 		'location': regionName
@@ -442,7 +442,7 @@ export async function createSqlMigrationService(account: azdata.Account, subscri
 
 export async function getSqlMigrationServiceAuthKeys(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationServiceName: string): Promise<SqlMigrationServiceAuthenticationKeys> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`/ subscriptions / ${subscription.id} /resourceGroups/${resourceGroupName} /providers/Microsoft.DataMigration / sqlMigrationServices / ${sqlMigrationServiceName} /ListAuthKeys?api-version=${DMSV2_API_VERSION}`);
+	const path = encodeURI(`/subscriptions/${subscription.id}/resourceGroups/${resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/${sqlMigrationServiceName}/ListAuthKeys?api-version=${DMSV2_API_VERSION}`);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.POST, undefined, true, host);
 	if (response.errors.length > 0) {

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -356,7 +356,7 @@ export async function getSqlMigrationService(account: azdata.Account, subscripti
 
 export async function getSqlMigrationServiceById(account: azdata.Account, subscription: Subscription, sqlMigrationServiceId: string): Promise<SqlMigrationService> {
 	const api = await getAzureCoreAPI();
-	const path = encodeURI(`${sqlMigrationServiceId}?api-version=${DMSV2_API_VERSION} `);
+	const path = encodeURI(`${sqlMigrationServiceId}?api-version=${DMSV2_API_VERSION}`);
 	const host = api.getProviderMetadataForAccount(account).settings.armResource?.endpoint;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, host);
 	if (response.errors.length > 0) {

--- a/extensions/sql-migration/src/api/dataModels/azure/networkInterfaceModel.ts
+++ b/extensions/sql-migration/src/api/dataModels/azure/networkInterfaceModel.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface NetworkResource {
+	id: string,
+	name: string,
+	type: string,
+	location: string,
+	properties: any
+}
+
+export interface NetworkInterface extends NetworkResource {
+	properties: {
+		ipConfigurations: NetworkInterfaceIpConfiguration[],
+		primary: boolean,
+		provisioningState: string,
+		resourceGuid: string,
+		virtualMachine: {
+			id: string,
+		},
+	},
+}
+
+export interface NetworkInterfaceIpConfiguration extends NetworkResource {
+	properties: {
+		primary: boolean,
+		privateIPAddress: string,
+		privateIPAddressVersion: string,
+		provisioningState: string,
+		publicIPAddress: NetworkResource
+	}
+}
+
+export class NetworkInterfaceModel {
+	public static IPv4VersionType = "IPv4".toLocaleLowerCase();
+
+	public static getPrimaryNetworkInterface(networkInterfaces: NetworkInterface[]): NetworkInterface | undefined {
+		if (networkInterfaces && networkInterfaces.length > 0) {
+			const primaryNetworkInterface = networkInterfaces.find(nic => nic.properties.primary === true);
+			if (primaryNetworkInterface) {
+				return primaryNetworkInterface;
+			}
+		}
+
+		return undefined;
+	}
+
+	public static getPrimaryNetworkInterfaceIpConfiguration(networkInterface: NetworkInterface): NetworkInterfaceIpConfiguration | undefined {
+		const hasIpConfigurations = networkInterface?.properties?.ipConfigurations && networkInterface.properties.ipConfigurations?.length > 0;
+		if (!hasIpConfigurations) {
+			return undefined;
+		}
+
+		// If the primary property exists, return the primary, otherwise, return the first ip configuration
+		let primaryIpConfig = networkInterface.properties.ipConfigurations.find((ipConfig: NetworkInterfaceIpConfiguration) => ipConfig.properties.primary);
+		if (primaryIpConfig) {
+			return primaryIpConfig;
+		}
+
+		// Otherwise, find the first configuration with a public ip address.
+		primaryIpConfig = networkInterface.properties.ipConfigurations.find(ipConfiguration => ipConfiguration.properties.publicIPAddress !== undefined);
+		if (primaryIpConfig) {
+			return primaryIpConfig;
+		}
+
+		// Otherwise, return the first ipv4 configuration
+		primaryIpConfig = networkInterface.properties.ipConfigurations.find(ipConfiguration => ipConfiguration.properties.privateIPAddressVersion.toLocaleLowerCase() === NetworkInterfaceModel.IPv4VersionType);
+		return primaryIpConfig;
+	}
+
+	public static getPublicIpAddressFromId(publicIpAddressId: string): string {
+		// TODO AKMA: will need to use this ip address id to get the public ip address
+		return publicIpAddressId;
+	}
+
+	public static getIpAddress(networkInterfaces: NetworkInterface[]): string {
+		const primaryNetworkInterface = NetworkInterfaceModel.getPrimaryNetworkInterface(networkInterfaces);
+
+		if (!primaryNetworkInterface) {
+			return "";
+		}
+
+		const ipConfig = NetworkInterfaceModel.getPrimaryNetworkInterfaceIpConfiguration(primaryNetworkInterface);
+		if (ipConfig && ipConfig.properties.publicIPAddress) {
+			return NetworkInterfaceModel.getPublicIpAddressFromId(ipConfig.properties.publicIPAddress.id);
+		}
+
+		if (ipConfig && ipConfig.properties.privateIPAddress) {
+			return ipConfig.properties.privateIPAddress;
+		}
+
+		return "";
+	}
+}

--- a/extensions/sql-migration/src/api/dataModels/azure/networkInterfaceModel.ts
+++ b/extensions/sql-migration/src/api/dataModels/azure/networkInterfaceModel.ts
@@ -44,6 +44,7 @@ export interface PublicIpAddress extends NetworkResource {
 
 export class NetworkInterfaceModel {
 	public static IPv4VersionType = "IPv4".toLocaleLowerCase();
+	private static NETWORK_API_VERSION = '2022-09-01';
 
 	public static getPrimaryNetworkInterface(networkInterfaces: NetworkInterface[]): NetworkInterface | undefined {
 		if (networkInterfaces && networkInterfaces.length > 0) {
@@ -114,11 +115,11 @@ export class NetworkInterfaceModel {
 	}
 
 	public static async getNetworkInterfaces(account: azdata.Account, subscription: Subscription, nicId: string): Promise<NetworkInterface> {
-		return getAzureResourceGivenId(account, subscription, nicId, "2022-09-01");
+		return getAzureResourceGivenId(account, subscription, nicId, this.NETWORK_API_VERSION);
 	}
 
 	public static async getPublicIpAddress(account: azdata.Account, subscription: Subscription, publicIpAddressId: string): Promise<PublicIpAddress> {
-		return getAzureResourceGivenId(account, subscription, publicIpAddressId, "2022-09-01");
+		return getAzureResourceGivenId(account, subscription, publicIpAddressId, this.NETWORK_API_VERSION);
 	}
 
 	public static async getVmNetworkInterfaces(account: azdata.Account, subscription: Subscription, sqlVm: SqlVMServer): Promise<Map<string, NetworkInterface>> {

--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -205,7 +205,7 @@ export function getConnectionProfile(
 	};
 }
 
-export function extractNameFromServer(
+function extractNameFromServer(
 	server: string | SqlManagedInstance | SqlVMServer | AzureSqlDatabaseServer): string {
 
 	// No need to extract name if the server is a string

--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -5,10 +5,11 @@
 
 import * as azdata from 'azdata';
 import { azureResource } from 'azurecore';
-import { AzureSqlDatabase, AzureSqlDatabaseServer } from './azure';
+import { AzureSqlDatabase, AzureSqlDatabaseServer, isAzureSqlDatabaseServer, isSqlManagedInstance, isSqlVMServer, SqlManagedInstance, SqlVMServer } from './azure';
 import { generateGuid } from './utils';
 import * as utils from '../api/utils';
 import { TelemetryAction, TelemetryViews, logError } from '../telemetry';
+import { NetworkInterfaceModel } from './dataModels/azure/networkInterfaceModel';
 
 const query_database_tables_sql = `
 	SELECT
@@ -166,12 +167,14 @@ function getSqlDbConnectionProfile(
 }
 
 export function getConnectionProfile(
-	serverName: string,
+	server: string | SqlManagedInstance | SqlVMServer | AzureSqlDatabaseServer,
 	azureResourceId: string,
 	userName: string,
-	password: string): azdata.IConnectionProfile {
+	password: string,
+	trustServerCert: boolean = false): azdata.IConnectionProfile {
 
 	const connectId = generateGuid();
+	const serverName = extractNameFromServer(server);
 	return {
 		serverName: serverName,
 		id: connectId,
@@ -194,12 +197,35 @@ export function getConnectionProfile(
 			connectionTimeout: 60,
 			columnEncryptionSetting: 'Enabled',
 			encrypt: true,
-			trustServerCertificate: false,
+			trustServerCertificate: trustServerCert,
 			connectRetryCount: '1',
 			connectRetryInterval: '10',
 			applicationName: 'azdata',
 		},
 	};
+}
+
+export function extractNameFromServer(
+	server: string | SqlManagedInstance | SqlVMServer | AzureSqlDatabaseServer): string {
+
+	// No need to extract name if the server is a string
+	if (typeof server === 'string') {
+		return server
+	}
+
+	if (isSqlVMServer(server)) {
+		// For sqlvm, we need to use ip address from the network interface to connect to the server
+		const sqlVm = server as SqlVMServer;
+		const networkInterfaces = Array.from(sqlVm.networkInterfaces.values());
+		return NetworkInterfaceModel.getIpAddress(networkInterfaces);
+	}
+
+	// check if the target server is a managed instance or a VM
+	if (isSqlManagedInstance(server) || isAzureSqlDatabaseServer(server)) {
+		return server.properties.fullyQualifiedDomainName;
+	}
+
+	return "";
 }
 
 export async function collectSourceDatabaseTableInfo(sourceConnectionId: string, sourceDatabase: string): Promise<TableInfo[]> {
@@ -387,16 +413,17 @@ export async function collectSourceLogins(
 }
 
 export async function collectTargetLogins(
-	targetServer: AzureSqlDatabaseServer,
+	targetServer: SqlManagedInstance | SqlVMServer | AzureSqlDatabaseServer,
 	userName: string,
 	password: string,
 	includeWindowsAuth: boolean = true): Promise<string[]> {
 
 	const connectionProfile = getConnectionProfile(
-		targetServer.properties.fullyQualifiedDomainName,
+		targetServer,
 		targetServer.id,
 		userName,
-		password);
+		password,
+		true /* trustServerCertificate */);
 
 	const result = await azdata.connection.connect(connectionProfile, false, false);
 	if (result.connected && result.connectionId) {

--- a/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
@@ -754,7 +754,8 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 								this.wizard.message = { text: '' };
 
 								// validate power state from VM instance view
-								if (!this.migrationStateModel._vmInstanceView.statuses.some(status => status.code.toLowerCase() === 'PowerState/running'.toLowerCase())) {
+								const runningState = 'PowerState/running'.toLowerCase();
+								if (!this.migrationStateModel._vmInstanceView.statuses.some(status => status.code.toLowerCase() === runningState)) {
 									this.wizard.message = {
 										text: constants.VM_NOT_READY_POWER_STATE_ERROR(this.migrationStateModel._targetServerInstance.name),
 										level: azdata.window.MessageLevel.Warning
@@ -762,7 +763,8 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 								}
 
 								// validate IaaS extension mode
-								if (this.migrationStateModel._targetServerInstance.properties.sqlManagement.toLowerCase() !== 'Full'.toLowerCase()) {
+								const fullMode = 'Full'.toLowerCase();
+								if (this.migrationStateModel._targetServerInstance.properties.sqlManagement.toLowerCase() !== fullMode) {
 									this.wizard.message = {
 										text: constants.VM_NOT_READY_IAAS_EXTENSION_ERROR(this.migrationStateModel._targetServerInstance.name, this.migrationStateModel._targetServerInstance.properties.sqlManagement),
 										level: azdata.window.MessageLevel.Warning

--- a/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
@@ -13,8 +13,9 @@ import * as styles from '../constants/styles';
 import { WIZARD_INPUT_COMPONENT_WIDTH } from './wizardController';
 import * as utils from '../api/utils';
 import { azureResource } from 'azurecore';
-import { AzureSqlDatabaseServer, getVMInstanceView, getVmNetworkInterfaces, SqlVMServer } from '../api/azure';
+import { AzureSqlDatabaseServer, getVMInstanceView, SqlVMServer } from '../api/azure';
 import { collectSourceLogins, collectTargetLogins, isSysAdmin, LoginTableInfo } from '../api/sqlUtils';
+import { NetworkInterfaceModel } from '../api/dataModels/azure/networkInterfaceModel';
 
 export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 	private _view!: azdata.ModelView;
@@ -745,10 +746,10 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 							if (selectedVm) {
 								this.migrationStateModel._targetServerInstance = utils.deepClone(selectedVm)! as SqlVMServer;
 								this.migrationStateModel._vmInstanceView = await getVMInstanceView(this.migrationStateModel._targetServerInstance, this.migrationStateModel._azureAccount, this.migrationStateModel._targetSubscription);
-
-								let networkInterface = await getVmNetworkInterfaces(this.migrationStateModel._azureAccount, this.migrationStateModel._targetSubscription, this.migrationStateModel._targetServerInstance);
-								console.log("network interfaces: ", networkInterface)
-								this.migrationStateModel._targetServerInstance.networkInterfaces = networkInterface;
+								this.migrationStateModel._targetServerInstance.networkInterfaces = await NetworkInterfaceModel.getVmNetworkInterfaces(
+									this.migrationStateModel._azureAccount,
+									this.migrationStateModel._targetSubscription,
+									this.migrationStateModel._targetServerInstance);
 
 								this.wizard.message = { text: '' };
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds support for migrating logins to SQL VM. Adding support for 2 scenarios supported here: VMs with private IP and public IP.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/9324681/215642816-0cb1fca1-08f4-4a15-94aa-ef2b512c5219.png">


- I've successfuly tested the private IP code path end to end.
- I haven't been able to test public IP path end to end due to network configuration issues inherited from MSFT subs (tried baston + ER routes), however i have stepped through debugger to confirm the values sent to connection string are as expected. The public IP address is extremely rare for customers and the only way to test is with a non msft subscription. After syncing with Sreraman, the approach I took and testing I did for this scenario should be sufficient. 