### PR TITLE
Extension telemetry feature cleanup

### DIFF
--- a/extensions/admin-tool-ext-win/src/main.ts
+++ b/extensions/admin-tool-ext-win/src/main.ts
@@ -24,6 +24,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		const ssmsMinVer = JSON.parse(rawConfig.toString()).version;
 		exePath = path.join(context.extensionPath, 'ssmsmin', 'Windows', ssmsMinVer, 'ssmsmin.exe');
 		registerCommands(context);
+		context.subscriptions.push(TelemetryReporter);
 	}
 }
 

--- a/extensions/azuremonitor/src/azuremonitorServer.ts
+++ b/extensions/azuremonitor/src/azuremonitorServer.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import * as path from 'path';
 import { getCommonLaunchArgsAndCleanupOldLogFiles } from './utils';
-import { Telemetry, LanguageClientErrorHandler } from './telemetry';
+import { TelemetryReporter, LanguageClientErrorHandler } from './telemetry';
 import { SqlOpsDataClient, ClientOptions } from 'dataprotocol-client';
 import { SerializationFeature } from './features/serializationFeature';
 import { TelemetryFeature } from './features/telemetryFeature';
@@ -48,7 +48,7 @@ export class AzureMonitorServer {
 				vscode.commands.registerCommand('azuremonitor.loadCompletionExtension', (params: CompletionExtensionParams) => {
 					this.client.sendRequest(CompletionExtLoadRequest.type, params);
 				});
-				Telemetry.sendTelemetryEvent('startup/LanguageClientStarted', {
+				TelemetryReporter.sendTelemetryEvent('startup/LanguageClientStarted', {
 					installationTime: String(installationComplete - installationStart),
 					processStartupTime: String(processEnd - processStart),
 					totalTime: String(processEnd - installationStart),
@@ -61,7 +61,7 @@ export class AzureMonitorServer {
 			await Promise.all([clientReadyPromise]);
 			return this.client;
 		} catch (e) {
-			Telemetry.sendTelemetryEvent('ServiceInitializingFailed');
+			TelemetryReporter.sendTelemetryEvent('ServiceInitializingFailed');
 			vscode.window.showErrorMessage(localize('failedToStartServiceErrorMsg', "Failed to start {0}", Constants.serviceName));
 			throw e;
 		}

--- a/extensions/azuremonitor/src/constants.ts
+++ b/extensions/azuremonitor/src/constants.ts
@@ -6,6 +6,7 @@ export const serviceName = 'AzureMonitor Tools Service';
 export const providerId = 'LOGANALYTICS';
 export const serviceCrashLink = 'https://github.com/Microsoft/azuredatastudio/issues';
 export const extensionConfigSectionName = 'azuremonitor';
+export const packageName = 'Microsoft.azuremonitor';
 
 // DATA PROTOCOL VALUES ///////////////////////////////////////////////////////////
 export const azureMonitorClusterProviderName = 'azureMonitorCluster';

--- a/extensions/azuremonitor/src/features/contracts.ts
+++ b/extensions/azuremonitor/src/features/contracts.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { NotificationType, RequestType } from 'vscode-languageclient';
-import { ITelemetryEventProperties, ITelemetryEventMeasures } from '../telemetry';
+import * as telemetry from '@microsoft/ads-extension-telemetry';
 import * as azdata from 'azdata';
 
 // ------------------------------- < Telemetry Sent Event > ------------------------------------
@@ -22,8 +22,8 @@ export namespace TelemetryNotification {
 export class TelemetryParams {
 	public params!: {
 		eventName: string;
-		properties: ITelemetryEventProperties;
-		measures: ITelemetryEventMeasures;
+		properties: telemetry.TelemetryEventProperties;
+		measures: telemetry.TelemetryEventMeasures;
 	};
 }
 

--- a/extensions/azuremonitor/src/features/telemetryFeature.ts
+++ b/extensions/azuremonitor/src/features/telemetryFeature.ts
@@ -5,7 +5,7 @@
 
 import { SqlOpsDataClient } from 'dataprotocol-client';
 import { ClientCapabilities, StaticFeature } from 'vscode-languageclient';
-import { Telemetry } from '../telemetry';
+import { TelemetryReporter } from '../telemetry';
 import * as contracts from './contracts';
 import * as Utils from '../utils';
 
@@ -19,7 +19,7 @@ export class TelemetryFeature implements StaticFeature {
 
 	initialize(): void {
 		this._client.onNotification(contracts.TelemetryNotification.type, e => {
-			Telemetry.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
+			TelemetryReporter.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
 		});
 	}
 }

--- a/extensions/azuremonitor/src/main.ts
+++ b/extensions/azuremonitor/src/main.ts
@@ -19,6 +19,7 @@ import { AzureMonitorIconProvider } from './iconProvider';
 import { createAzureMonitorApi } from './azuremonitorApiFactory';
 import { AzureMonitorServer } from './azuremonitorServer';
 import { promises as fs } from 'fs';
+import { TelemetryReporter } from './telemetry';
 
 const localize = nls.loadMessageBundle();
 
@@ -54,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	const server = new AzureMonitorServer();
 	context.subscriptions.push(server);
 	await server.start(appContext);
-
+	context.subscriptions.push(TelemetryReporter);
 	return createAzureMonitorApi(appContext);
 }
 

--- a/extensions/azuremonitor/src/telemetry.ts
+++ b/extensions/azuremonitor/src/telemetry.ts
@@ -4,118 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as nls from 'vscode-nls';
-import TelemetryReporter from '@microsoft/ads-extension-telemetry';
+import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 import { ErrorAction, ErrorHandler, Message, CloseAction } from 'vscode-languageclient';
 
-import * as Utils from './utils';
 import * as Constants from './constants';
+import * as nls from 'vscode-nls';
+
 
 const localize = nls.loadMessageBundle();
-
-const packageJson = require('../package.json');
 const viewKnownIssuesAction = localize('viewKnownIssuesText', "View Known Issues");
 
-export interface ITelemetryEventProperties {
-	[key: string]: string;
-}
-
-export interface ITelemetryEventMeasures {
-	[key: string]: number;
-}
-
-/**
- * Filters error paths to only include source files. Exported to support testing
- */
-export function FilterErrorPath(line: string): string | undefined {
-	if (line) {
-		let values: string[] = line.split('/out/');
-		if (values.length <= 1) {
-			// Didn't match expected format
-			return line;
-		} else {
-			return values[1];
-		}
-	}
-	return undefined;
-}
-
-export class Telemetry {
-	private static reporter: TelemetryReporter;
-	private static disabled: boolean;
-
-	/**
-	 * Disable telemetry reporting
-	 */
-	public static disable(): void {
-		this.disabled = true;
-	}
-
-	/**
-	 * Initialize the telemetry reporter for use.
-	 */
-	public static initialize(): void {
-		if (typeof this.reporter === 'undefined') {
-			// Check if the user has opted out of telemetry
-			if (!vscode.workspace.getConfiguration('telemetry').get<boolean>('enableTelemetry', true)) {
-				this.disable();
-				return;
-			}
-
-			let packageInfo = Utils.getPackageInfo(packageJson)!;
-			this.reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
-		}
-	}
-
-	/**
-	 * Send a telemetry event for an exception
-	 */
-	public static sendTelemetryEventForException(
-		err: any, methodName: string, _extensionConfigName: string): void {
-		let stackArray: string[];
-		let firstLine: string = '';
-		if (err !== undefined && err.stack !== undefined) {
-			stackArray = err.stack.split('\n');
-			if (stackArray !== undefined && stackArray.length >= 2) {
-				firstLine = stackArray[1]; // The fist line is the error message and we don't want to send that telemetry event
-				firstLine = FilterErrorPath(firstLine)!;
-			}
-		}
-
-		// Only adding the method name and the fist line of the stack trace. We don't add the error message because it might have PII
-		this.sendTelemetryEvent('Exception', { methodName: methodName, errorLine: firstLine });
-	}
-
-	/**
-	 * Send a telemetry event using application insights
-	 */
-	public static sendTelemetryEvent(
-		eventName: string,
-		properties?: ITelemetryEventProperties,
-		measures?: ITelemetryEventMeasures): void {
-
-		if (typeof this.disabled === 'undefined') {
-			this.disabled = false;
-		}
-
-		if (this.disabled || typeof (this.reporter) === 'undefined') {
-			// Don't do anything if telemetry is disabled
-			return;
-		}
-
-		if (!properties || typeof properties === 'undefined') {
-			properties = {};
-		}
-
-		try {
-			this.reporter.sendTelemetryEvent(eventName, properties, measures);
-		} catch (telemetryErr) {
-			// If sending telemetry event fails ignore it so it won't break the extension
-			console.error('Failed to send telemetry event. error: ' + telemetryErr);
-		}
-
-	}
-}
+const packageInfo = vscode.extensions.getExtension(Constants.packageName)?.packageJSON;
+export const TelemetryReporter = new AdsTelemetryReporter<string, string>(packageInfo?.name, packageInfo?.version, packageInfo?.aiKey);
 
 /**
  * Handle Language Service client errors
@@ -127,12 +27,12 @@ export class LanguageClientErrorHandler implements ErrorHandler {
 	 * @memberOf LanguageClientErrorHandler
 	 */
 	showOnErrorPrompt(): void {
-		Telemetry.sendTelemetryEvent(Constants.serviceName + 'Crash');
-		vscode.window.showErrorMessage(
+		TelemetryReporter.sendTelemetryEvent(Constants.serviceName + 'Crash');
+		void vscode.window.showErrorMessage(
 			localize('serviceCrashMessage', "{0} component exited unexpectedly. Please restart Azure Data Studio.", Constants.serviceName),
 			viewKnownIssuesAction).then(action => {
 				if (action && action === viewKnownIssuesAction) {
-					vscode.env.openExternal(vscode.Uri.parse(Constants.serviceCrashLink));
+					void vscode.env.openExternal(vscode.Uri.parse(Constants.serviceCrashLink));
 				}
 			});
 	}
@@ -163,5 +63,3 @@ export class LanguageClientErrorHandler implements ErrorHandler {
 		return CloseAction.DoNotRestart;
 	}
 }
-
-Telemetry.initialize();

--- a/extensions/dacpac/src/extension.ts
+++ b/extensions/dacpac/src/extension.ts
@@ -6,9 +6,11 @@
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import { DataTierApplicationWizard } from './wizard/dataTierApplicationWizard';
+import { TelemetryReporter } from './telemetry';
 
 export async function activate(context: vscode.ExtensionContext) {
 	vscode.commands.registerCommand('dacFx.start', (profile: azdata.IConnectionProfile) => new DataTierApplicationWizard(undefined, context).start(profile));
+	context.subscriptions.push(TelemetryReporter);
 }
 
 export function deactivate(): void {

--- a/extensions/dacpac/src/extension.ts
+++ b/extensions/dacpac/src/extension.ts
@@ -9,7 +9,7 @@ import { DataTierApplicationWizard } from './wizard/dataTierApplicationWizard';
 import { TelemetryReporter } from './telemetry';
 
 export async function activate(context: vscode.ExtensionContext) {
-	vscode.commands.registerCommand('dacFx.start', (profile: azdata.IConnectionProfile) => new DataTierApplicationWizard(undefined, context).start(profile));
+	context.subscriptions.push(vscode.commands.registerCommand('dacFx.start', (profile: azdata.IConnectionProfile) => new DataTierApplicationWizard(undefined, context).start(profile)));
 	context.subscriptions.push(TelemetryReporter);
 }
 

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -16,6 +16,7 @@ import { ProjectDashboard } from './dialogs/projectDashboard';
 import { getAzdataApi } from './common/utils';
 import { createNewProjectWithQuickpick } from './dialogs/newProjectQuickpick';
 import Logger from './common/logger';
+import { TelemetryReporter } from './common/telemetry';
 
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
 	const startTime = new Date().getTime();
@@ -103,6 +104,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	IconPathHelper.setExtensionContext(context);
 	Logger.log(`IconPathHelper took ${new Date().getTime() - iconPathHelperTime}ms`);
 
+	context.subscriptions.push(TelemetryReporter);
 	Logger.log(`Finished activating Data Workspace extension. Total time = ${new Date().getTime() - startTime}ms`);
 	return Promise.resolve(dataWorkspaceExtension);
 }

--- a/extensions/datavirtualization/src/constants.ts
+++ b/extensions/datavirtualization/src/constants.ts
@@ -53,6 +53,7 @@ export const sqlFileExtension = 'sql';
 export const virtualizeDataCommand = 'virtualizedatawizard.cmd.open';
 export const virtualizeDataTask = 'virtualizedatawizard.task.open';
 export const mssqlHdfsTableFromFileCommand = 'mssqlHdfsTableWizard.cmd.open';
+export const packageName = 'Microsoft.datavirtualization';
 
 export const ctp24Version = 'CTP2.4';
 export const ctp25Version = 'CTP2.5';

--- a/extensions/datavirtualization/src/extension.ts
+++ b/extensions/datavirtualization/src/extension.ts
@@ -16,6 +16,7 @@ import { DataSourceWizardService } from './services/contracts';
 import { managerInstance, ApiType } from './services/serviceApiManager';
 import { OpenVirtualizeDataWizardCommand, OpenVirtualizeDataWizardTask, OpenMssqlHdfsTableFromFileWizardCommand } from './wizards/wizardCommands';
 import { ServiceClient } from './services/serviceClient';
+import { TelemetryReporter } from './services/telemetry';
 
 export function activate(extensionContext: vscode.ExtensionContext): void {
 	let apiWrapper = new ApiWrapper();
@@ -38,4 +39,5 @@ export function activate(extensionContext: vscode.ExtensionContext): void {
 	serviceClient.startService(extensionContext).then(success => undefined, err => {
 		apiWrapper.showErrorMessage(utils.getErrorMessage(err));
 	});
+	extensionContext.subscriptions.push(TelemetryReporter);
 }

--- a/extensions/datavirtualization/src/services/contracts.ts
+++ b/extensions/datavirtualization/src/services/contracts.ts
@@ -3,8 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ClientCapabilities as VSClientCapabilities, RequestType, NotificationType } from 'vscode-languageclient';
-import * as types from 'dataprotocol-client/lib/types';
+import { RequestType, NotificationType } from 'vscode-languageclient';
+import * as telemetry from '@microsoft/ads-extension-telemetry';
 import * as azdata from 'azdata';
 
 /**
@@ -29,17 +29,9 @@ export namespace TelemetryNotification {
 export class TelemetryParams {
 	public params: {
 		eventName: string;
-		properties: ITelemetryEventProperties;
-		measures: ITelemetryEventMeasures;
+		properties: telemetry.TelemetryEventProperties;
+		measures: telemetry.TelemetryEventMeasures;
 	};
-}
-
-export interface ITelemetryEventProperties {
-	[key: string]: string;
-}
-
-export interface ITelemetryEventMeasures {
-	[key: string]: number;
 }
 
 

--- a/extensions/datavirtualization/src/services/features.ts
+++ b/extensions/datavirtualization/src/services/features.ts
@@ -9,7 +9,7 @@ import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 import { Disposable } from 'vscode';
 import * as azdata from 'azdata';
 
-import { Telemetry } from './telemetry';
+import { TelemetryReporter } from './telemetry';
 import * as serviceUtils from './serviceUtils';
 import {
 	TelemetryNotification,
@@ -33,7 +33,7 @@ export class TelemetryFeature implements StaticFeature {
 
 	initialize(): void {
 		this._client.onNotification(TelemetryNotification.type, e => {
-			Telemetry.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
+			TelemetryReporter.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
 		});
 	}
 }

--- a/extensions/datavirtualization/src/services/serviceClient.ts
+++ b/extensions/datavirtualization/src/services/serviceClient.ts
@@ -12,7 +12,7 @@ const localize = nls.loadMessageBundle();
 import * as path from 'path';
 import { EventAndListener } from 'eventemitter2';
 
-import { Telemetry, LanguageClientErrorHandler } from './telemetry';
+import { LanguageClientErrorHandler, TelemetryReporter } from './telemetry';
 import { ApiWrapper } from '../apiWrapper';
 import * as Constants from '../constants';
 import { TelemetryFeature, DataSourceWizardFeature } from './features';
@@ -51,7 +51,7 @@ export class ServiceClient {
 					setTimeout(() => {
 						this.statusView.hide();
 					}, 1500);
-					Telemetry.sendTelemetryEvent('startup/LanguageClientStarted', {
+					TelemetryReporter.sendTelemetryEvent('startup/LanguageClientStarted', {
 						installationTime: String(installationComplete - installationStart),
 						processStartupTime: String(processEnd - processStart),
 						totalTime: String(processEnd - installationStart),
@@ -64,7 +64,7 @@ export class ServiceClient {
 				context.subscriptions.push(disposable);
 				resolve();
 			}, e => {
-				Telemetry.sendTelemetryEvent('ServiceInitializingFailed');
+				TelemetryReporter.sendTelemetryEvent('ServiceInitializingFailed');
 				this.apiWrapper.showErrorMessage(localize('serviceStartFailed', 'Failed to start {0}: {1}', Constants.serviceName, e));
 				// Just resolve to avoid unhandled promise. We show the error to the user.
 				resolve();

--- a/extensions/datavirtualization/src/services/telemetry.ts
+++ b/extensions/datavirtualization/src/services/telemetry.ts
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ErrorAction, CloseAction } from 'vscode-languageclient';
-import TelemetryReporter from '@microsoft/ads-extension-telemetry';
-import { PlatformInformation } from '@microsoft/ads-service-downloader/out/platform';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 import { ApiWrapper } from '../apiWrapper';
 import * as constants from '../constants';
-import * as serviceUtils from './serviceUtils';
-import { IMessage, ITelemetryEventProperties, ITelemetryEventMeasures } from './contracts';
+import { IMessage } from './contracts';
+import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 
+const packageInfo = vscode.extensions.getExtension(constants.packageName)?.packageJSON;
+export const TelemetryReporter = new AdsTelemetryReporter<string, string>(packageInfo?.name, packageInfo?.version, packageInfo?.aiKey);
 
 /**
  * Handle Language Service client errors
@@ -36,9 +36,8 @@ export class LanguageClientErrorHandler {
 	 * Show an error message prompt with a link to known issues wiki page
 	 * @memberOf LanguageClientErrorHandler
 	 */
-	showOnErrorPrompt(): void {
-		// TODO add telemetry
-		// Telemetry.sendTelemetryEvent('SqlToolsServiceCrash');
+	public showOnErrorPrompt(): void {
+		TelemetryReporter.sendTelemetryEvent(constants.serviceName + 'Crash');
 		let crashButtonText = localize('serviceCrashButton', 'View Known Issues');
 		this.apiWrapper.showErrorMessage(
 			localize('serviceCrashMessage', 'service component could not start'),
@@ -60,7 +59,7 @@ export class LanguageClientErrorHandler {
 	 *
 	 * @memberOf LanguageClientErrorHandler
 	 */
-	error(error: Error, message: IMessage, count: number): ErrorAction {
+	public error(error: Error, message: IMessage, count: number): ErrorAction {
 		this.showOnErrorPrompt();
 
 		// we don't retry running the service since crashes leave the extension
@@ -75,7 +74,7 @@ export class LanguageClientErrorHandler {
 	 *
 	 * @memberOf LanguageClientErrorHandler
 	 */
-	closed(): CloseAction {
+	public closed(): CloseAction {
 		this.showOnErrorPrompt();
 
 		// we don't retry running the service since crashes leave the extension
@@ -83,134 +82,3 @@ export class LanguageClientErrorHandler {
 		return CloseAction.DoNotRestart;
 	}
 }
-
-/**
- * Filters error paths to only include source files. Exported to support testing
- */
-export function FilterErrorPath(line: string): string {
-	if (line) {
-		let values: string[] = line.split('/out/');
-		if (values.length <= 1) {
-			// Didn't match expected format
-			return line;
-		} else {
-			return values[1];
-		}
-	}
-}
-
-export class Telemetry {
-	private static reporter: TelemetryReporter;
-	private static userId: string;
-	private static platformInformation: PlatformInformation;
-	private static disabled: boolean;
-
-	// Get the unique ID for the current user of the extension
-	public static getUserId(): Promise<string> {
-		return new Promise<string>(resolve => {
-			// Generate the user id if it has not been created already
-			if (typeof this.userId === 'undefined') {
-				let id = serviceUtils.generateUserId();
-				id.then(newId => {
-					this.userId = newId;
-					resolve(this.userId);
-				});
-			} else {
-				resolve(this.userId);
-			}
-		});
-	}
-
-	public static getPlatformInformation(): Promise<PlatformInformation> {
-		if (this.platformInformation) {
-			return Promise.resolve(this.platformInformation);
-		} else {
-			return new Promise<PlatformInformation>(resolve => {
-				PlatformInformation.getCurrent().then(info => {
-					this.platformInformation = info;
-					resolve(this.platformInformation);
-				});
-			});
-		}
-	}
-
-	/**
-	 * Disable telemetry reporting
-	 */
-	public static disable(): void {
-		this.disabled = true;
-	}
-
-	/**
-	 * Initialize the telemetry reporter for use.
-	 */
-	public static initialize(): void {
-		if (typeof this.reporter === 'undefined') {
-			// Check if the user has opted out of telemetry
-			if (!vscode.workspace.getConfiguration('telemetry').get<boolean>('enableTelemetry', true)) {
-				this.disable();
-				return;
-			}
-			let packageInfo = vscode.extensions.getExtension('Microsoft.datavirtualization').packageJSON;
-			this.reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
-		}
-	}
-
-	/**
-	 * Send a telemetry event for an exception
-	 */
-	public static sendTelemetryEventForException(
-		err: any, methodName: string, extensionConfigName: string): void {
-		try {
-			let stackArray: string[];
-			let firstLine: string = '';
-			if (err !== undefined && err.stack !== undefined) {
-				stackArray = err.stack.split('\n');
-				if (stackArray !== undefined && stackArray.length >= 2) {
-					firstLine = stackArray[1]; // The fist line is the error message and we don't want to send that telemetry event
-					firstLine = FilterErrorPath(firstLine);
-				}
-			}
-
-			// Only adding the method name and the fist line of the stack trace. We don't add the error message because it might have PII
-			this.sendTelemetryEvent('Exception', { methodName: methodName, errorLine: firstLine });
-			// Utils.logDebug('Unhandled Exception occurred. error: ' + err + ' method: ' + methodName, extensionConfigName);
-		} catch (telemetryErr) {
-			// If sending telemetry event fails ignore it so it won't break the extension
-			// Utils.logDebug('Failed to send telemetry event. error: ' + telemetryErr, extensionConfigName);
-		}
-	}
-
-	/**
-	 * Send a telemetry event using application insights
-	 */
-	public static sendTelemetryEvent(
-		eventName: string,
-		properties?: ITelemetryEventProperties,
-		measures?: ITelemetryEventMeasures): void {
-
-		if (typeof this.disabled === 'undefined') {
-			this.disabled = false;
-		}
-
-		if (this.disabled || typeof (this.reporter) === 'undefined') {
-			// Don't do anything if telemetry is disabled
-			return;
-		}
-
-		if (!properties || typeof properties === 'undefined') {
-			properties = {};
-		}
-
-		// Augment the properties structure with additional common properties before sending
-		Promise.all([this.getUserId(), this.getPlatformInformation()]).then(() => {
-			properties['userId'] = this.userId;
-			properties['distribution'] = (this.platformInformation && this.platformInformation.distribution) ?
-				`${this.platformInformation.distribution.name}, ${this.platformInformation.distribution.version}` : '';
-
-			this.reporter.sendTelemetryEvent(eventName, properties, measures);
-		});
-	}
-}
-
-Telemetry.initialize();

--- a/extensions/import/src/common/constants.ts
+++ b/extensions/import/src/common/constants.ts
@@ -12,6 +12,7 @@ export const providerId = 'FlatFileImport';
 export const configLogDebugInfo = 'logDebugInfo';
 export const sqlConfigSectionName = 'sql';
 export const mssqlProvider = 'MSSQL';
+export const packageName = 'Microsoft.import';
 
 // allow-any-unicode-next-line
 export const summaryErrorSymbol = '✗ ';

--- a/extensions/import/src/main.ts
+++ b/extensions/import/src/main.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 
 import ControllerBase from './controllers/controllerBase';
 import MainController from './controllers/mainController';
+import { TelemetryReporter } from './services/telemetry';
 
 let controllers: ControllerBase[] = [];
 
@@ -18,6 +19,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(mainController);
 
 	await mainController.activate();
+	context.subscriptions.push(TelemetryReporter);
 }
 
 export function deactivate() {

--- a/extensions/import/src/services/contracts.ts
+++ b/extensions/import/src/services/contracts.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RequestType, NotificationType } from 'vscode-languageclient';
+import * as telemetry from '@microsoft/ads-extension-telemetry';
 
 export interface IMessage {
 	jsonrpc: string;
@@ -24,17 +25,9 @@ export namespace TelemetryNotification {
 export class TelemetryParams {
 	public params: {
 		eventName: string;
-		properties: ITelemetryEventProperties;
-		measures: ITelemetryEventMeasures;
+		properties: telemetry.TelemetryEventProperties;
+		measures: telemetry.TelemetryEventMeasures;
 	};
-}
-
-export interface ITelemetryEventProperties {
-	[key: string]: string;
-}
-
-export interface ITelemetryEventMeasures {
-	[key: string]: number;
 }
 
 /**

--- a/extensions/import/src/services/features.ts
+++ b/extensions/import/src/services/features.ts
@@ -14,7 +14,7 @@ import {
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 import { Disposable } from 'vscode';
 
-import { Telemetry } from './telemetry';
+import { TelemetryReporter } from './telemetry';
 import * as serviceUtils from './serviceUtils';
 import * as Contracts from './contracts';
 import { managerInstance, ApiType } from './serviceApiManager';
@@ -30,7 +30,7 @@ export class TelemetryFeature implements StaticFeature {
 
 	initialize(): void {
 		this._client.onNotification(Contracts.TelemetryNotification.type, e => {
-			Telemetry.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
+			TelemetryReporter.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
 		});
 	}
 }

--- a/extensions/import/src/services/serviceClient.ts
+++ b/extensions/import/src/services/serviceClient.ts
@@ -12,7 +12,7 @@ const localize = nls.loadMessageBundle();
 import * as path from 'path';
 import { EventAndListener } from 'eventemitter2';
 
-import { Telemetry, LanguageClientErrorHandler } from './telemetry';
+import { TelemetryReporter, LanguageClientErrorHandler } from './telemetry';
 import * as Constants from '../common/constants';
 import { TelemetryFeature, FlatFileImportFeature } from './features';
 import { promises as fs } from 'fs';
@@ -43,7 +43,7 @@ export class ServiceClient {
 				setTimeout(() => {
 					this.statusView.hide();
 				}, 1500);
-				Telemetry.sendTelemetryEvent('startup/LanguageClientStarted', {
+				TelemetryReporter.sendTelemetryEvent('startup/LanguageClientStarted', {
 					installationTime: String(installationComplete - installationStart),
 					processStartupTime: String(processEnd - processStart),
 					totalTime: String(processEnd - installationStart),
@@ -57,7 +57,7 @@ export class ServiceClient {
 			return client;
 		}
 		catch (error) {
-			Telemetry.sendTelemetryEvent('ServiceInitializingFailed');
+			TelemetryReporter.sendTelemetryEvent('ServiceInitializingFailed');
 			vscode.window.showErrorMessage(localize('flatFileImport.serviceStartFailed', "Failed to start {0}: {1}", Constants.serviceName, error));
 			// Just resolve to avoid unhandled promise. We show the error to the user.
 			return undefined;

--- a/extensions/import/src/services/telemetry.ts
+++ b/extensions/import/src/services/telemetry.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ErrorAction, CloseAction } from 'vscode-languageclient';
-import TelemetryReporter from '@microsoft/ads-extension-telemetry';
+import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 import * as vscode from 'vscode';
 
 import * as constants from '../common/constants';
-import { IMessage, ITelemetryEventProperties, ITelemetryEventMeasures } from './contracts';
+import { IMessage } from './contracts';
 
+const packageInfo = vscode.extensions.getExtension(constants.packageName)?.packageJSON;
+export const TelemetryReporter = new AdsTelemetryReporter<string, string>(packageInfo?.name, packageInfo?.version, packageInfo?.aiKey);
 
 /**
  * Handle Language Service client errors
@@ -29,8 +31,7 @@ export class LanguageClientErrorHandler {
 	 * @memberOf LanguageClientErrorHandler
 	 */
 	showOnErrorPrompt(): void {
-		// TODO add telemetry
-		// Telemetry.sendTelemetryEvent('SqlToolsServiceCrash');
+		TelemetryReporter.sendTelemetryEvent(constants.serviceName + 'Crash');
 		vscode.window.showErrorMessage(
 			constants.serviceCrashMessageText,
 			constants.crashButtonText
@@ -68,62 +69,3 @@ export class LanguageClientErrorHandler {
 	}
 }
 
-
-
-export class Telemetry {
-	private static reporter: TelemetryReporter;
-	private static disabled: boolean;
-
-	/**
-	 * Disable telemetry reporting
-	 */
-	public static disable(): void {
-		this.disabled = true;
-	}
-
-	/**
-	 * Initialize the telemetry reporter for use.
-	 */
-	public static initialize(): void {
-		if (typeof this.reporter === 'undefined') {
-			// Check if the user has opted out of telemetry
-			if (!vscode.workspace.getConfiguration('telemetry').get<boolean>('enableTelemetry', true)) {
-				this.disable();
-				return;
-			}
-			let packageInfo = vscode.extensions.getExtension('Microsoft.import').packageJSON;
-			this.reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
-		}
-	}
-
-	/**
-	 * Send a telemetry event using application insights
-	 */
-	public static sendTelemetryEvent(
-		eventName: string,
-		properties?: ITelemetryEventProperties,
-		measures?: ITelemetryEventMeasures): void {
-
-		if (typeof this.disabled === 'undefined') {
-			this.disabled = false;
-		}
-
-		if (this.disabled || typeof (this.reporter) === 'undefined') {
-			// Don't do anything if telemetry is disabled
-			return;
-		}
-
-		if (!properties || typeof properties === 'undefined') {
-			properties = {};
-		}
-
-		try {
-			this.reporter.sendTelemetryEvent(eventName, properties, measures);
-		} catch (telemetryErr) {
-			// If sending telemetry event fails ignore it so it won't break the extension
-			console.error('Failed to send telemetry event. error: ' + telemetryErr);
-		}
-	}
-}
-
-Telemetry.initialize();

--- a/extensions/kusto/src/constants.ts
+++ b/extensions/kusto/src/constants.ts
@@ -6,6 +6,7 @@ export const serviceName = 'Kusto Tools Service';
 export const providerId = 'KUSTO';
 export const serviceCrashLink = 'https://github.com/Microsoft/vscode-kusto/wiki/SqlToolsService-Known-Issues';
 export const extensionConfigSectionName = 'kusto';
+export const packageName = 'Microsoft.kusto';
 
 // DATA PROTOCOL VALUES ///////////////////////////////////////////////////////////
 export const kustoClusterProviderName = 'kustoCluster';

--- a/extensions/kusto/src/contracts.ts
+++ b/extensions/kusto/src/contracts.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { NotificationType, RequestType } from 'vscode-languageclient';
-import { ITelemetryEventProperties, ITelemetryEventMeasures } from './telemetry';
+import * as telemetry from '@microsoft/ads-extension-telemetry';
 import * as azdata from 'azdata';
 
 // ------------------------------- < Telemetry Sent Event > ------------------------------------
@@ -22,8 +22,8 @@ export namespace TelemetryNotification {
 export class TelemetryParams {
 	public params!: {
 		eventName: string;
-		properties: ITelemetryEventProperties;
-		measures: ITelemetryEventMeasures;
+		properties: telemetry.TelemetryEventProperties;
+		measures: telemetry.TelemetryEventMeasures;
 	};
 }
 

--- a/extensions/kusto/src/features.ts
+++ b/extensions/kusto/src/features.ts
@@ -7,7 +7,7 @@ import * as nls from 'vscode-nls';
 import { SqlOpsDataClient, SqlOpsFeature } from 'dataprotocol-client';
 import { ClientCapabilities, StaticFeature, RPCMessageType, ServerCapabilities } from 'vscode-languageclient';
 import { Disposable, window } from 'vscode';
-import { Telemetry } from './telemetry';
+import { TelemetryReporter } from './telemetry';
 import * as contracts from './contracts';
 import * as azdata from 'azdata';
 import * as Utils from './utils';
@@ -25,7 +25,7 @@ export class TelemetryFeature implements StaticFeature {
 
 	initialize(): void {
 		this._client.onNotification(contracts.TelemetryNotification.type, e => {
-			Telemetry.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
+			TelemetryReporter.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
 		});
 	}
 }

--- a/extensions/kusto/src/kustoServer.ts
+++ b/extensions/kusto/src/kustoServer.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import * as path from 'path';
 import { getCommonLaunchArgsAndCleanupOldLogFiles } from './utils';
-import { Telemetry, LanguageClientErrorHandler } from './telemetry';
+import { TelemetryReporter, LanguageClientErrorHandler } from './telemetry';
 import { SqlOpsDataClient, ClientOptions } from 'dataprotocol-client';
 import { TelemetryFeature, SerializationFeature, AccountFeature } from './features';
 import { AppContext } from './appContext';
@@ -46,7 +46,7 @@ export class KustoServer {
 				vscode.commands.registerCommand('kusto.loadCompletionExtension', (params: CompletionExtensionParams) => {
 					this.client.sendRequest(CompletionExtLoadRequest.type, params);
 				});
-				Telemetry.sendTelemetryEvent('startup/LanguageClientStarted', {
+				TelemetryReporter.sendTelemetryEvent('startup/LanguageClientStarted', {
 					installationTime: String(installationComplete - installationStart),
 					processStartupTime: String(processEnd - processStart),
 					totalTime: String(processEnd - installationStart),
@@ -59,7 +59,7 @@ export class KustoServer {
 			await Promise.all([clientReadyPromise]);
 			return this.client;
 		} catch (e) {
-			Telemetry.sendTelemetryEvent('ServiceInitializingFailed');
+			TelemetryReporter.sendTelemetryEvent('ServiceInitializingFailed');
 			vscode.window.showErrorMessage(localize('failedToStartServiceErrorMsg', "Failed to start {0}", Constants.serviceName));
 			throw e;
 		}

--- a/extensions/kusto/src/main.ts
+++ b/extensions/kusto/src/main.ts
@@ -19,6 +19,7 @@ import { KustoIconProvider } from './iconProvider';
 import { createKustoApi } from './kustoApiFactory';
 import { KustoServer } from './kustoServer';
 import { promises as fs } from 'fs';
+import { TelemetryReporter } from './telemetry';
 
 const localize = nls.loadMessageBundle();
 
@@ -53,8 +54,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	// initialize client last so we don't have features stuck behind it
 	const server = new KustoServer();
 	context.subscriptions.push(server);
-	await server.start(appContext);		// Commented out until we have Kusto binaries properly setup in Blob location.
-
+	await server.start(appContext);
+	context.subscriptions.push(TelemetryReporter);
 	return createKustoApi(appContext);
 }
 

--- a/extensions/kusto/src/telemetry.ts
+++ b/extensions/kusto/src/telemetry.ts
@@ -4,118 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as nls from 'vscode-nls';
-import TelemetryReporter from '@microsoft/ads-extension-telemetry';
+import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 import { ErrorAction, ErrorHandler, Message, CloseAction } from 'vscode-languageclient';
 
-import * as Utils from './utils';
 import * as Constants from './constants';
+import * as nls from 'vscode-nls';
+
 
 const localize = nls.loadMessageBundle();
-
-const packageJson = require('../package.json');
 const viewKnownIssuesAction = localize('viewKnownIssuesText', "View Known Issues");
 
-export interface ITelemetryEventProperties {
-	[key: string]: string;
-}
-
-export interface ITelemetryEventMeasures {
-	[key: string]: number;
-}
-
-/**
- * Filters error paths to only include source files. Exported to support testing
- */
-export function FilterErrorPath(line: string): string | undefined {
-	if (line) {
-		let values: string[] = line.split('/out/');
-		if (values.length <= 1) {
-			// Didn't match expected format
-			return line;
-		} else {
-			return values[1];
-		}
-	}
-	return undefined;
-}
-
-export class Telemetry {
-	private static reporter: TelemetryReporter;
-	private static disabled: boolean;
-
-	/**
-	 * Disable telemetry reporting
-	 */
-	public static disable(): void {
-		this.disabled = true;
-	}
-
-	/**
-	 * Initialize the telemetry reporter for use.
-	 */
-	public static initialize(): void {
-		if (typeof this.reporter === 'undefined') {
-			// Check if the user has opted out of telemetry
-			if (!vscode.workspace.getConfiguration('telemetry').get<boolean>('enableTelemetry', true)) {
-				this.disable();
-				return;
-			}
-
-			let packageInfo = Utils.getPackageInfo(packageJson)!;
-			this.reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
-		}
-	}
-
-	/**
-	 * Send a telemetry event for an exception
-	 */
-	public static sendTelemetryEventForException(
-		err: any, methodName: string, extensionConfigName: string): void {
-		let stackArray: string[];
-		let firstLine: string = '';
-		if (err !== undefined && err.stack !== undefined) {
-			stackArray = err.stack.split('\n');
-			if (stackArray !== undefined && stackArray.length >= 2) {
-				firstLine = stackArray[1]; // The fist line is the error message and we don't want to send that telemetry event
-				firstLine = FilterErrorPath(firstLine)!;
-			}
-		}
-
-		// Only adding the method name and the fist line of the stack trace. We don't add the error message because it might have PII
-		this.sendTelemetryEvent('Exception', { methodName: methodName, errorLine: firstLine });
-	}
-
-	/**
-	 * Send a telemetry event using application insights
-	 */
-	public static sendTelemetryEvent(
-		eventName: string,
-		properties?: ITelemetryEventProperties,
-		measures?: ITelemetryEventMeasures): void {
-
-		if (typeof this.disabled === 'undefined') {
-			this.disabled = false;
-		}
-
-		if (this.disabled || typeof (this.reporter) === 'undefined') {
-			// Don't do anything if telemetry is disabled
-			return;
-		}
-
-		if (!properties || typeof properties === 'undefined') {
-			properties = {};
-		}
-
-		try {
-			this.reporter.sendTelemetryEvent(eventName, properties, measures);
-		} catch (telemetryErr) {
-			// If sending telemetry event fails ignore it so it won't break the extension
-			console.error('Failed to send telemetry event. error: ' + telemetryErr);
-		}
-
-	}
-}
+const packageInfo = vscode.extensions.getExtension(Constants.packageName)?.packageJSON;
+export const TelemetryReporter = new AdsTelemetryReporter<string, string>(packageInfo?.name, packageInfo?.version, packageInfo?.aiKey);
 
 /**
  * Handle Language Service client errors
@@ -127,12 +27,12 @@ export class LanguageClientErrorHandler implements ErrorHandler {
 	 * @memberOf LanguageClientErrorHandler
 	 */
 	showOnErrorPrompt(): void {
-		Telemetry.sendTelemetryEvent(Constants.serviceName + 'Crash');
-		vscode.window.showErrorMessage(
+		TelemetryReporter.sendTelemetryEvent(Constants.serviceName + 'Crash');
+		void vscode.window.showErrorMessage(
 			localize('serviceCrashMessage', "{0} component exited unexpectedly. Please restart Azure Data Studio.", Constants.serviceName),
 			viewKnownIssuesAction).then(action => {
 				if (action && action === viewKnownIssuesAction) {
-					vscode.env.openExternal(vscode.Uri.parse(Constants.serviceCrashLink));
+					void vscode.env.openExternal(vscode.Uri.parse(Constants.serviceCrashLink));
 				}
 			});
 	}
@@ -142,7 +42,7 @@ export class LanguageClientErrorHandler implements ErrorHandler {
 	 *
 	 * @memberOf LanguageClientErrorHandler
 	 */
-	error(error: Error, message: Message, count: number): ErrorAction {
+	error(_error: Error, _message: Message, _count: number): ErrorAction {
 		this.showOnErrorPrompt();
 
 		// we don't retry running the service since crashes leave the extension
@@ -163,5 +63,3 @@ export class LanguageClientErrorHandler implements ErrorHandler {
 		return CloseAction.DoNotRestart;
 	}
 }
-
-Telemetry.initialize();

--- a/extensions/mssql/src/constants.ts
+++ b/extensions/mssql/src/constants.ts
@@ -7,6 +7,7 @@ export const serviceName = 'SQL Tools Service';
 export const providerId = 'MSSQL';
 export const serviceCrashLink = 'https://github.com/Microsoft/vscode-mssql/wiki/SqlToolsService-Known-Issues';
 export const extensionConfigSectionName = 'mssql';
+export const packageName = 'Microsoft.mssql';
 
 // DATA PROTOCOL VALUES ///////////////////////////////////////////////////////////
 export const sqlProviderName = 'MSSQL';

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { NotificationType, RequestType } from 'vscode-languageclient';
-import { ITelemetryEventProperties, ITelemetryEventMeasures } from './telemetry';
+import * as telemetry from '@microsoft/ads-extension-telemetry';
 import * as azdata from 'azdata';
 import { ConnectParams } from 'dataprotocol-client/lib/protocol';
 import * as mssql from 'mssql';
@@ -24,8 +24,8 @@ export namespace TelemetryNotification {
 export class TelemetryParams {
 	public params: {
 		eventName: string;
-		properties: ITelemetryEventProperties;
-		measures: ITelemetryEventMeasures;
+		properties: telemetry.TelemetryEventProperties;
+		measures: telemetry.TelemetryEventMeasures;
 	};
 }
 

--- a/extensions/mssql/src/features.ts
+++ b/extensions/mssql/src/features.ts
@@ -6,7 +6,7 @@ import * as nls from 'vscode-nls';
 import { SqlOpsDataClient, SqlOpsFeature } from 'dataprotocol-client';
 import { ClientCapabilities, StaticFeature, RPCMessageType, ServerCapabilities } from 'vscode-languageclient';
 import { Disposable, window, QuickPickItem, QuickPickOptions } from 'vscode';
-import { Telemetry } from './telemetry';
+import { TelemetryReporter } from './telemetry';
 import * as contracts from './contracts';
 import * as azdata from 'azdata';
 import * as Utils from './utils';
@@ -27,7 +27,7 @@ export class TelemetryFeature implements StaticFeature {
 
 	initialize(): void {
 		this._client.onNotification(contracts.TelemetryNotification.type, e => {
-			Telemetry.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
+			TelemetryReporter.sendTelemetryEvent(e.params.eventName, e.params.properties, e.params.measures);
 		});
 	}
 }

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -22,6 +22,7 @@ import { IconPathHelper } from './iconHelper';
 import * as nls from 'vscode-nls';
 import { INotebookConvertService } from './notebookConvert/notebookConvertService';
 import { registerTableDesignerCommands } from './tableDesigner/tableDesigner';
+import { TelemetryReporter } from './telemetry';
 
 const localize = nls.loadMessageBundle();
 
@@ -88,6 +89,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 
 	registerTableDesignerCommands(appContext);
 
+	context.subscriptions.push(TelemetryReporter);
 	return createMssqlApi(appContext, server);
 }
 

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -9,7 +9,7 @@ import * as Constants from './constants';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { getCommonLaunchArgsAndCleanupOldLogFiles, getConfigTracingLevel, getOrDownloadServer, getParallelMessageProcessingConfig, TracingLevel } from './utils';
-import { Telemetry, LanguageClientErrorHandler } from './telemetry';
+import { TelemetryReporter, LanguageClientErrorHandler } from './telemetry';
 import { SqlOpsDataClient, ClientOptions } from 'dataprotocol-client';
 import { TelemetryFeature, AgentServicesFeature, SerializationFeature, AccountFeature, SqlAssessmentServicesFeature, ProfilerFeature, TableDesignerFeature, ExecutionPlanServiceFeature } from './features';
 import { CredentialStore } from './credentialstore/credentialstore';
@@ -69,7 +69,7 @@ export class SqlToolsServer {
 				vscode.commands.registerCommand('mssql.loadCompletionExtension', (params: CompletionExtensionParams) => {
 					return this.client.sendRequest(CompletionExtLoadRequest.type, params);
 				});
-				Telemetry.sendTelemetryEvent('startup/LanguageClientStarted', {
+				TelemetryReporter.sendTelemetryEvent('startup/LanguageClientStarted', {
 					installationTime: String(installationComplete - installationStart),
 					processStartupTime: String(processEnd - processStart),
 					totalTime: String(processEnd - installationStart),
@@ -82,7 +82,7 @@ export class SqlToolsServer {
 			await Promise.all([this.activateFeatures(context), clientReadyPromise]);
 			return this.client;
 		} catch (e) {
-			Telemetry.sendTelemetryEvent('ServiceInitializingFailed');
+			TelemetryReporter.sendTelemetryEvent('ServiceInitializingFailed');
 			void vscode.window.showErrorMessage(localize('failedToStartServiceErrorMsg', "Failed to start {0}", Constants.serviceName));
 			throw e;
 		}

--- a/extensions/mssql/src/tableDesigner/tableDesigner.ts
+++ b/extensions/mssql/src/tableDesigner/tableDesigner.ts
@@ -8,7 +8,8 @@ import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import { sqlProviderName } from '../constants';
 import { generateUuid } from 'vscode-languageclient/lib/utils/uuid';
-import { ITelemetryEventProperties, Telemetry } from '../telemetry';
+import { fillServerInfo } from '../telemetry';
+import * as telemetry from '@microsoft/ads-extension-telemetry';
 import * as nls from 'vscode-nls';
 import { getConfigPreloadDatabaseModel, setConfigPreloadDatabaseModel } from '../utils';
 const localize = nls.loadMessageBundle();
@@ -60,11 +61,12 @@ export function registerTableDesignerCommands(appContext: AppContext) {
 	}));
 }
 
-async function getTelemetryInfo(context: azdata.ObjectExplorerContext, tableType: string): Promise<ITelemetryEventProperties> {
+async function getTelemetryInfo(context: azdata.ObjectExplorerContext, tableType: string): Promise<telemetry.TelemetryEventProperties> {
 	const serverInfo = await azdata.connection.getServerInfo(context.connectionProfile.id);
-	const telemetryInfo: ITelemetryEventProperties = {};
-	Telemetry.fillServerInfo(telemetryInfo, serverInfo);
-	telemetryInfo['tableType'] = tableType;
+	const telemetryInfo: telemetry.TelemetryEventProperties = {
+		tableType
+	};
+	fillServerInfo(telemetryInfo, serverInfo);
 	return telemetryInfo;
 }
 

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -21,6 +21,7 @@ import { ExtensionContextHelper } from './common/extensionContextHelper';
 import { BookTreeItem } from './book/bookTreeItem';
 import Logger from './common/logger';
 import { sendNotebookActionEvent, NbTelemetryView, NbTelemetryAction } from './telemetry';
+import { TelemetryReporter } from './telemetry';
 
 const localize = nls.loadMessageBundle();
 
@@ -161,22 +162,23 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	const pinnedBookTreeViewProvider = appContext.pinnedBookTreeViewProvider;
 	await pinnedBookTreeViewProvider.initialized;
 
-	azdata.nb.onDidChangeActiveNotebookEditor(e => {
+	extensionContext.subscriptions.push(azdata.nb.onDidChangeActiveNotebookEditor(e => {
 		if (e.document.uri.scheme === 'untitled') {
 			void providedBookTreeViewProvider.revealDocumentInTreeView(e.document.uri, false, false);
 		} else {
 			void bookTreeViewProvider.revealDocumentInTreeView(e.document.uri, false, false);
 		}
-	});
+	}));
 
-	azdata.nb.onDidOpenNotebookDocument(async e => {
+	extensionContext.subscriptions.push(azdata.nb.onDidOpenNotebookDocument(async e => {
 		if (e.uri.scheme === 'untitled') {
 			await vscode.commands.executeCommand(BuiltInCommands.SetContext, unsavedBooksContextKey, true);
 		} else {
 			await vscode.commands.executeCommand(BuiltInCommands.SetContext, unsavedBooksContextKey, false);
 		}
-	});
+	}));
 
+	extensionContext.subscriptions.push(TelemetryReporter);
 	return {
 		getJupyterController() {
 			return controller;

--- a/extensions/query-history/src/main.ts
+++ b/extensions/query-history/src/main.ts
@@ -104,6 +104,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(vscode.commands.registerCommand('queryHistory.openStorageFolder', async () => {
 		return vscode.env.openExternal(storageUri);
 	}));
+	context.subscriptions.push(TelemetryReporter);
 }
 
 async function openQuery(item: QueryHistoryItem): Promise<void> {

--- a/extensions/resource-deployment/src/main.ts
+++ b/extensions/resource-deployment/src/main.ts
@@ -15,6 +15,7 @@ import { ResourceTypePickerDialog } from './ui/resourceTypePickerDialog';
 import * as rd from 'resource-deployment';
 import { getExtensionApi } from './api';
 import { UriHandlerService } from './services/uriHandlerService';
+import { TelemetryReporter } from './services/telemetryService';
 
 const localize = nls.loadMessageBundle();
 
@@ -46,9 +47,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<rd.IEx
 		}
 	};
 
-	vscode.commands.registerCommand('azdata.resource.sql-image.deploy', () => {
+	context.subscriptions.push(vscode.commands.registerCommand('azdata.resource.sql-image.deploy', () => {
 		openDialog('sql-image');
-	});
+	}));
 
 	/**
 	 * Command to open the Resource Deployment wizard - with options to filter the values shown
@@ -59,7 +60,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<rd.IEx
 	 * @param initialVariableValues - Optional list of initial values to assign to variables. This is an object of key/value pairs in the format
 	 * { "VARIABLE_NAME": "value", "OTHER_VARIABLE_NAME": "value" }
 	 */
-	vscode.commands.registerCommand('azdata.resource.deploy', (defaultResourceTypeName?: string, resourceTypeNameFilters?: string[], optionValuesFilter?: OptionValuesFilter, initialVariableValues?: InitialVariableValues) => {
+	context.subscriptions.push(vscode.commands.registerCommand('azdata.resource.deploy', (defaultResourceTypeName?: string, resourceTypeNameFilters?: string[], optionValuesFilter?: OptionValuesFilter, initialVariableValues?: InitialVariableValues) => {
 		if ((resourceTypeNameFilters && !Array.isArray(resourceTypeNameFilters) ||
 			(resourceTypeNameFilters && resourceTypeNameFilters.length > 0 && typeof resourceTypeNameFilters[0] !== 'string'))) {
 			throw new Error('resourceTypeNameFilters must either be undefined or an array of strings');
@@ -76,11 +77,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<rd.IEx
 			}
 			openDialog(defaultDeploymentType, resourceTypeNameFilters, optionValuesFilter, initialVariableValues);
 		}
-	});
-	vscode.commands.registerCommand('azdata.openNotebookInputDialog', (dialogInfo: NotebookBasedDialogInfo) => {
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('azdata.openNotebookInputDialog', (dialogInfo: NotebookBasedDialogInfo) => {
 		const dialog = new DeploymentInputDialog(notebookService, platformService, toolsService, dialogInfo);
 		dialog.open();
-	});
+	}));
+
+	context.subscriptions.push(TelemetryReporter);
 	return getExtensionApi();
 }
 

--- a/extensions/schema-compare/src/extension.ts
+++ b/extensions/schema-compare/src/extension.ts
@@ -6,11 +6,13 @@
 import * as vscode from 'vscode';
 import * as mssql from 'mssql';
 import { SchemaCompareMainWindow } from './schemaCompareMainWindow';
+import { TelemetryReporter } from './telemetry';
 
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
-	vscode.commands.registerCommand('schemaCompare.start', async (sourceContext: any, targetContext: any = undefined, comparisonResult: any = undefined) => { await new SchemaCompareMainWindow(undefined, extensionContext, undefined).start(sourceContext, targetContext, comparisonResult); });
-	vscode.commands.registerCommand('schemaCompare.runComparison', async (source: mssql.SchemaCompareEndpointInfo | undefined, target: mssql.SchemaCompareEndpointInfo | undefined, runComparison: boolean = false, comparisonResult: mssql.SchemaCompareResult | undefined) => { await new SchemaCompareMainWindow(undefined, extensionContext, undefined).launch(source, target, runComparison, comparisonResult); });
-	vscode.commands.registerCommand('schemaCompare.openInScmp', async (fileUri: vscode.Uri) => { await new SchemaCompareMainWindow(undefined, extensionContext, undefined).openScmpFile(fileUri); });
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('schemaCompare.start', async (sourceContext: any, targetContext: any = undefined, comparisonResult: any = undefined) => { await new SchemaCompareMainWindow(undefined, extensionContext, undefined).start(sourceContext, targetContext, comparisonResult); }));
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('schemaCompare.runComparison', async (source: mssql.SchemaCompareEndpointInfo | undefined, target: mssql.SchemaCompareEndpointInfo | undefined, runComparison: boolean = false, comparisonResult: mssql.SchemaCompareResult | undefined) => { await new SchemaCompareMainWindow(undefined, extensionContext, undefined).launch(source, target, runComparison, comparisonResult); }));
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('schemaCompare.openInScmp', async (fileUri: vscode.Uri) => { await new SchemaCompareMainWindow(undefined, extensionContext, undefined).openScmpFile(fileUri); }));
+	extensionContext.subscriptions.push(TelemetryReporter);
 }
 
 export function deactivate(): void {

--- a/extensions/sql-assessment/src/main.ts
+++ b/extensions/sql-assessment/src/main.ts
@@ -6,12 +6,14 @@
 import * as vscode from 'vscode';
 
 import MainController from './maincontroller';
+import { TelemetryReporter } from './telemetry';
 
 let mainController: MainController;
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
 	mainController = new MainController(context);
-	mainController.activate();
+	await mainController.activate();
+	context.subscriptions.push(TelemetryReporter);
 }
 
 // this method is called when your extension is deactivated

--- a/extensions/sql-bindings/src/extension.ts
+++ b/extensions/sql-bindings/src/extension.ts
@@ -8,6 +8,7 @@ import { IExtension, BindingType, GetAzureFunctionsResult, ResultStatus, IConnec
 import { addSqlBinding, createAzureFunction, getAzureFunctions } from './services/azureFunctionsService';
 import { launchAddSqlBindingQuickpick } from './dialogs/addSqlBindingQuickpick';
 import { promptForBindingType, promptAndUpdateConnectionStringSetting, promptForObjectName, addSqlNugetReferenceToProjectFile } from './common/azureFunctionsUtils';
+import { TelemetryReporter } from './common/telemetry';
 
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
 	// register the add sql binding command
@@ -16,6 +17,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	context.subscriptions.push(vscode.commands.registerCommand('sqlBindings.createAzureFunction', async (node?: ITreeNodeInfo) => {
 		return await createAzureFunction(node);
 	}));
+	context.subscriptions.push(TelemetryReporter);
 	return {
 		addSqlBinding: async (bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Promise<ResultStatus> => {
 			return addSqlBinding(bindingType, filePath, functionName, objectName, connectionStringSetting);

--- a/extensions/sql-database-projects/src/extension.ts
+++ b/extensions/sql-database-projects/src/extension.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { getAzdataApi } from './common/utils';
 import MainController from './controllers/mainController';
 import { SqlDatabaseProjectProvider } from './projectProvider/projectProvider';
+import { TelemetryReporter } from './common/telemetry';
 
 let controllers: MainController[] = [];
 
@@ -16,7 +17,7 @@ export function activate(context: vscode.ExtensionContext): Promise<SqlDatabaseP
 	const mainController = new MainController(context);
 	controllers.push(mainController);
 	context.subscriptions.push(mainController);
-
+	context.subscriptions.push(TelemetryReporter);
 	return mainController.activate();
 }
 

--- a/extensions/sql-migration/src/main.ts
+++ b/extensions/sql-migration/src/main.ts
@@ -5,11 +5,13 @@
 
 import * as vscode from 'vscode';
 import { DashboardWidget } from './dashboard/sqlServerDashboard';
+import { TelemetryReporter } from './telemetry';
 
 let widget: DashboardWidget;
 export async function activate(context: vscode.ExtensionContext): Promise<DashboardWidget> {
 	widget = new DashboardWidget(context);
 	await widget.register();
+	context.subscriptions.push(TelemetryReporter);
 	return widget;
 }
 


### PR DESCRIPTION
Lots of general cleanup to simplify existing code and make a couple small fixes:

- Dispose of the telemetry reporter on deactivation to ensure all events are flushed
- Use properties/measures types from the telemetry package instead of redefining in each extension
- Remove a lot of the telemetry feature code. Much of this wasn't needed since it's already being handled by the telemetry package itself (such as enabling/disabling based on user setting)
- Noticed a few instances of commands not being subscribed so fixed those as well

As with https://github.com/microsoft/azuredatastudio/pull/21778 I'm not planning on updating most of these extensions since it's just general cleanup so is fine to wait until the next release of the extension. 