### PR TITLE
Bump sql migration version to 1.2.4

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",


### PR DESCRIPTION
This PR bumps sql-migration version to 1.2.4 in order to release to insider's gallery. This version now supports login migration for SQL VM as a target. 