### PR TITLE
Improvements for Change password dialog + logs added

### DIFF
--- a/extensions/mssql/src/errorDiagnostics/errorDiagnosticsProvider.ts
+++ b/extensions/mssql/src/errorDiagnostics/errorDiagnosticsProvider.ts
@@ -57,7 +57,7 @@ export class ErrorDiagnosticsProvider extends SqlOpsFeature<any> {
 						logDebug(`Error Code ${errorCode} requires user to change their password, launching change password dialog.`)
 						return await this.handleChangePassword(restoredProfile);
 					}
-          logDebug(`No error handler found for errorCode ${errorCode}.`);
+					logDebug(`No error handler found for errorCode ${errorCode}.`);
 					return { handled: false };
 				}
 
@@ -72,15 +72,15 @@ export class ErrorDiagnosticsProvider extends SqlOpsFeature<any> {
 				try {
 					const result = await azdata.connection.openChangePasswordDialog(connection);
 					// MSSQL uses 'password' as the option key for connection profile.
-          if(result) {
-            connection.options['password'] = result;
-            return { handled: true, options: connection.options };
-          }
+					if (result) {
+						connection.options['password'] = result;
+						return { handled: true, options: connection.options };
+					}
 				}
 				catch (e) {
 					console.error(`Change password failed unexpectedly with error: ${e}`);
 				}
-        return { handled: false };
+				return { handled: false };
 			}
 		}
 	}

--- a/extensions/mssql/src/errorDiagnostics/errorDiagnosticsProvider.ts
+++ b/extensions/mssql/src/errorDiagnostics/errorDiagnosticsProvider.ts
@@ -71,8 +71,9 @@ export class ErrorDiagnosticsProvider extends SqlOpsFeature<any> {
 			private async handleChangePassword(connection: azdata.IConnectionProfile): Promise<azdata.diagnostics.ConnectionDiagnosticsResult> {
 				try {
 					const result = await azdata.connection.openChangePasswordDialog(connection);
-					// MSSQL uses 'password' as the option key for connection profile.
+					// result will be undefined if password change was closed or cancelled.
 					if (result) {
+						// MSSQL uses 'password' as the option key for connection profile.
 						connection.options['password'] = result;
 						return { handled: true, options: connection.options };
 					}

--- a/src/sql/workbench/services/connection/browser/media/passwordDialog.css
+++ b/src/sql/workbench/services/connection/browser/media/passwordDialog.css
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 .change-password-dialog {
-	width: 100%;
+	padding: 30px;
 	height: 100%;
 	overflow: hidden;
 	display: flex;
@@ -15,8 +15,9 @@
 	overflow-y: auto;
 }
 
-.change-password-dialog .component-label {
-	vertical-align: middle;
+.change-password-dialog .component-label-bold {
+	font-weight: 600;
+	padding-bottom: 30px;
 }
 
 .change-password-dialog .components-grid {
@@ -25,7 +26,7 @@
 	grid-template-columns: max-content 1fr;
 	grid-template-rows: max-content;
 	grid-gap: 10px;
-	padding: 5px;
+	padding: 30px 0px 10px;
 	align-content: start;
 	box-sizing: border-box;
 }

--- a/src/sql/workbench/services/connection/browser/passwordChangeDialog.ts
+++ b/src/sql/workbench/services/connection/browser/passwordChangeDialog.ts
@@ -93,7 +93,7 @@ export class PasswordChangeDialog extends Modal {
 	protected renderBody(container: HTMLElement) {
 		const body = container.appendChild(DOM.$('.change-password-dialog'));
 		body.appendChild(DOM.$('span.component-label-bold')).innerText = localize('passwordChangeDialog.Message1',
-			`Password must be changed for '{0}'.`, this._profile?.userName);
+			`Password must be changed for '{0}' to continue logging into '{1}'.`, this._profile?.userName, this._profile?.serverName);
 		body.appendChild(DOM.$('span.component-label')).innerText = localize('passwordChangeDialog.Message2',
 			`Please enter a new password below:`);
 

--- a/src/sql/workbench/services/connection/browser/passwordChangeDialog.ts
+++ b/src/sql/workbench/services/connection/browser/passwordChangeDialog.ts
@@ -78,13 +78,11 @@ export class PasswordChangeDialog extends Modal {
 		return promise;
 	}
 
-	public override dispose(): void {
-
-	}
+	public override dispose(): void { }
 
 	public override render() {
 		super.render();
-		this.title = localize('passwordChangeDialog.title', "Password expired for: '{0}'\non the server: '{1}'\n\nPlease enter a new password below:", this._profile?.userName, this._profile?.serverName);
+		this.title = localize('passwordChangeDialog.title', 'Change Password');
 		this._register(attachModalDialogStyler(this, this._themeService));
 		this._okButton = this.addFooterButton(okText, async () => { await this.handleOkButtonClick(); });
 		this._cancelButton = this.addFooterButton(cancelText, () => { this.handleCancelButtonClick(); }, 'right', true);
@@ -94,6 +92,11 @@ export class PasswordChangeDialog extends Modal {
 
 	protected renderBody(container: HTMLElement) {
 		const body = container.appendChild(DOM.$('.change-password-dialog'));
+		body.appendChild(DOM.$('span.component-label-bold')).innerText = localize('passwordChangeDialog.Message1',
+			`Password must be changed for '{0}'.`, this._profile?.userName);
+		body.appendChild(DOM.$('span.component-label')).innerText = localize('passwordChangeDialog.Message2',
+			`Please enter a new password below:`);
+
 		const contentElement = body.appendChild(DOM.$('.properties-content.components-grid'));
 		contentElement.appendChild(DOM.$('')).appendChild(DOM.$('span.component-label')).innerText = newPasswordText;
 		const passwordInputContainer = contentElement.appendChild(DOM.$(''));


### PR DESCRIPTION
Hi @smartguest 

Adding some improvements with logging, styling for the change password dialog.
Please take a look.

Thanks :)

Attaching screenshot of updated dialog for reference:

<img src="https://user-images.githubusercontent.com/13396919/215871149-24c4ce99-e897-4f31-85e0-3d57c0fb7bfb.png" width=500 />

_Note: undefined profile properties seems related to RPC conversion, which Alex is working on._