### PR TITLE
Bump sql-migration insiders to 1.2.4

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,8 +4036,8 @@
 					},
 					"versions": [
 						{
-							"version": "1.2.3",
-							"lastUpdated": "01/25/2023",
+							"version": "1.2.4",
+							"lastUpdated": "01/31/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4043,7 +4043,7 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.2.3.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.2.4.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the Insiders extension gallery to the latest release candidate version of the SQL Migration extension. This change includes login migrations support for SQL VM.

Link to Azure Data Studio - Extensions pipeline run containing vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=188220&view=results 
