### PR TITLE
[SQL Migration][Hotfix] Remove parameter from IR validation

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.2.4",
+  "version": "1.2.6",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -736,8 +736,8 @@ export async function validateIrDatabaseMigrationSettings(
 			dataSource: sourceServerName,
 			userName: migration._sqlServerUsername,
 			password: migration._sqlServerPassword,
+			// to-do: use correct value of encryptConnection and trustServerCertificate
 			trustServerCertificate: trustServerCertificate,
-			encryptConnection: true,
 			authentication: migration._authenticationType,
 		}
 	};

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -1141,6 +1141,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 					authentication: this._authenticationType,
 					userName: this._sqlServerUsername,
 					password: this._sqlServerPassword,
+					// to-do: use correct value of encryptConnection and trustServerCertificate
 					trustServerCertificate: currentConnection?.options.trustServerCertificate ?? false
 				},
 				scope: this._targetServerInstance.id,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR removes the `encryptConnection` property from the IR validation request body, which was breaking certain customer migration workflows (e.g. see https://github.com/microsoft/azuredatastudio/issues/21769) when it was being hardcoded to `true`. A longer term fix is in the works to properly respect the user's provided values for `encryptConnection` as well as `trustServerCertificate`, which requires backend RP changes.

This PR also vbumps the extension, as discussed internally, we are looking to release this ASAP to unblock stuck customers who cannot proceed past IR validation (along with an ongoing RP hotfix deployment).