### PR TITLE
Revert "[SQL Migration][Hotfix] Remove parameter from IR validation"

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.2.6",
+  "version": "1.2.4",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -736,8 +736,8 @@ export async function validateIrDatabaseMigrationSettings(
 			dataSource: sourceServerName,
 			userName: migration._sqlServerUsername,
 			password: migration._sqlServerPassword,
-			// to-do: use correct value of encryptConnection and trustServerCertificate
 			trustServerCertificate: trustServerCertificate,
+			encryptConnection: true,
 			authentication: migration._authenticationType,
 		}
 	};

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -1141,7 +1141,6 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 					authentication: this._authenticationType,
 					userName: this._sqlServerUsername,
 					password: this._sqlServerPassword,
-					// to-do: use correct value of encryptConnection and trustServerCertificate
 					trustServerCertificate: currentConnection?.options.trustServerCertificate ?? false
 				},
 				scope: this._targetServerInstance.id,


### PR DESCRIPTION
Reverts microsoft/azuredatastudio#21800

RP deployment alone unblocked most customers, and as discussed internally discovery of a new bug means we should pause the release of the hotfixed extension worldwide and rather figure out a way to fix this properly 