### PR TITLE
Replacing select with focus to prevent second create session

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
@@ -137,7 +137,7 @@ export class TreeUpdateUtils {
 							await tree.expandAll(targetsToExpand);
 						}
 						if (selectedElement) {
-							tree.select(selectedElement);
+							tree.setFocus(selectedElement);
 						}
 						tree.getFocus();
 					}, onUnexpectedError);


### PR DESCRIPTION
The current code leads to the redrawing of the entire OE every time a new session is initiated, resulting in the loss of the previously focused connection in the tree. The code attempted to refocus the element using `tree. Select()`, but this function caused the creation of two sessions if the session was not already created. To resolve this, the code has been changed to use `tree.Focus()` instead, which prevents the creation of two sessions and maintains the focus on the desired element.

However, there are still frequent tree redraws which is not ideal, so a more comprehensive solution may be necessary to prevent UI-related errors in the future.