### PR TITLE
Fix missing password in Connection pane for Server connections with remembered passwords

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -365,12 +365,11 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	}
 
 	private handleFillInConnectionInputs(connectionInfo: IConnectionProfile): void {
-		this._connectionManagementService.addSavedPassword(connectionInfo).then(async connectionWithPassword => {
+		this.createModel(connectionInfo).then(connectionWithPassword => {
 			if (this._model) {
 				this._model.dispose();
 			}
-			this._model = await this.createModel(connectionWithPassword);
-
+			this._model = connectionWithPassword;
 			this.uiController.fillInConnectionInputs(this._model);
 		}).catch(err => onUnexpectedError(err));
 		this._connectionDialog.updateProvider(this._providerNameToDisplayNameMap[connectionInfo.providerName]);

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -431,7 +431,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	}
 
 	private async showDialogWithModel(): Promise<void> {
-		this.updateModelServerCapabilities(this._inputModel);
+		await this.updateModelServerCapabilities(this._inputModel);
 		await this.doShowDialog(this._params);
 	}
 
@@ -470,7 +470,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		this._params = params;
 		this._inputModel = model;
 
-		this.updateModelServerCapabilities(model);
+		await this.updateModelServerCapabilities(model);
 
 		// If connecting from a query editor set "save connection" to false
 		if (params && (params.input && params.connectionType === ConnectionType.editor ||

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -375,7 +375,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			this.uiController.fillInConnectionInputs(this._model);
 		}
 		catch (err) {
-			onUnexpectedError(err);
+			onUnexpectedError(new Error(`Error filling in connection inputs with password. Original error message: ${err.message}`));
 		}
 
 		this._connectionDialog.updateProvider(this._providerNameToDisplayNameMap[connectionInfo.providerName]);
@@ -423,7 +423,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 				await this._connectionManagementService.addSavedPassword(newProfile);
 			}
 			catch (err) {
-				onUnexpectedError(new Error('Error filling in password for connection dialog model.'));
+				onUnexpectedError(new Error(`Error filling in password for connection dialog model. Original error message: ${err.message}`));
 			}
 		}
 		newProfile.saveProfile = true;

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -413,7 +413,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		}
 
 		let newProfile = new ConnectionProfile(this._capabilitiesService, model || providerName);
-		if (!model.password && defaultAuthenticationType === AuthenticationType.SqlLogin && authenticationTypeName === defaultAuthenticationType) {
+		if (!model.password && defaultAuthenticationType === AuthenticationType.SqlLogin && authenticationTypeName === AuthenticationType.SqlLogin) {
 			try {
 				await this._connectionManagementService.addSavedPassword(newProfile, true);
 			}

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -414,7 +414,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		let newProfile = new ConnectionProfile(this._capabilitiesService, model || providerName);
 		if (!model.password && defaultAuthenticationType === AuthenticationType.SqlLogin && authenticationTypeName === AuthenticationType.SqlLogin) {
 			try {
-				await this._connectionManagementService.addSavedPassword(newProfile, true);
+				await this._connectionManagementService.addSavedPassword(newProfile);
 			}
 			catch (err) {
 				onUnexpectedError(err);

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -375,7 +375,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			this.uiController.fillInConnectionInputs(this._model);
 		}
 		catch (err) {
-			onUnexpectedError(new Error(`Error filling in connection inputs with password. Original error message: ${err.message}`));
+			onUnexpectedError(new Error(`Error filling in connection inputs with password. Original error message: ${err}`));
 		}
 
 		this._connectionDialog.updateProvider(this._providerNameToDisplayNameMap[connectionInfo.providerName]);

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -375,7 +375,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			this.uiController.fillInConnectionInputs(this._model);
 		}
 		catch (err) {
-			onUnexpectedError(new Error(`Error filling in connection inputs with password. Original error message: ${err}`));
+			this._logService.error(`Error filling in connection inputs with password. Original error message: ${err}`);
 		}
 
 		this._connectionDialog.updateProvider(this._providerNameToDisplayNameMap[connectionInfo.providerName]);
@@ -418,12 +418,12 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		}
 
 		let newProfile = new ConnectionProfile(this._capabilitiesService, model || providerName);
-		if (!model.password && defaultAuthenticationType === AuthenticationType.SqlLogin && authenticationTypeName === AuthenticationType.SqlLogin) {
+		if (!model.password) {
 			try {
 				await this._connectionManagementService.addSavedPassword(newProfile);
 			}
 			catch (err) {
-				onUnexpectedError(new Error(`Error filling in password for connection dialog model. Original error message: ${err.message}`));
+				this._logService.error(`Error filling in password for connection dialog model. Original error message: ${err}`);
 			}
 		}
 		newProfile.saveProfile = true;

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -364,14 +364,20 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		this.uiController.initDialog(this._params && this._params.providers, this._model);
 	}
 
-	private handleFillInConnectionInputs(connectionInfo: IConnectionProfile): void {
-		this.createModel(connectionInfo).then(connectionWithPassword => {
+	private async handleFillInConnectionInputs(connectionInfo: IConnectionProfile): Promise<void> {
+		try {
+			const connectionWithPassword = await this.createModel(connectionInfo);
+
 			if (this._model) {
 				this._model.dispose();
 			}
 			this._model = connectionWithPassword;
 			this.uiController.fillInConnectionInputs(this._model);
-		}).catch(err => onUnexpectedError(err));
+		}
+		catch (err) {
+			onUnexpectedError(err);
+		}
+
 		this._connectionDialog.updateProvider(this._providerNameToDisplayNameMap[connectionInfo.providerName]);
 	}
 
@@ -417,7 +423,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 				await this._connectionManagementService.addSavedPassword(newProfile);
 			}
 			catch (err) {
-				onUnexpectedError(err);
+				onUnexpectedError(new Error('Error filling in password for connection dialog model.'));
 			}
 		}
 		newProfile.saveProfile = true;
@@ -495,7 +501,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			});
 			this._connectionDialog.onShowUiComponent((input) => this.handleShowUiComponent(input));
 			this._connectionDialog.onInitDialog(() => this.handleInitDialog());
-			this._connectionDialog.onFillinConnectionInputs((input) => this.handleFillInConnectionInputs(input as IConnectionProfile));
+			this._connectionDialog.onFillinConnectionInputs(async (input) => this.handleFillInConnectionInputs(input as IConnectionProfile));
 			this._connectionDialog.onResetConnection(() => this.handleProviderOnResetConnection());
 			this._connectionDialog.render();
 			this._connectionDialog.onClosed(() => {

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -33,7 +33,6 @@ import { CmsConnectionController } from 'sql/workbench/services/connection/brows
 import { entries } from 'sql/base/common/collections';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { ILogService } from 'vs/platform/log/common/log';
-import { AuthenticationType } from 'sql/platform/connection/common/constants';
 
 export interface IConnectionValidateResult {
 	isValid: boolean;

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -500,7 +500,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			});
 			this._connectionDialog.onShowUiComponent((input) => this.handleShowUiComponent(input));
 			this._connectionDialog.onInitDialog(() => this.handleInitDialog());
-			this._connectionDialog.onFillinConnectionInputs(async (input) => this.handleFillInConnectionInputs(input as IConnectionProfile));
+			this._connectionDialog.onFillinConnectionInputs((input) => this.handleFillInConnectionInputs(input as IConnectionProfile));
 			this._connectionDialog.onResetConnection(() => this.handleProviderOnResetConnection());
 			this._connectionDialog.render();
 			this._connectionDialog.onClosed(() => {

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -598,6 +598,16 @@ export class ConnectionWidget extends lifecycle.Disposable {
 			this._userNameInputBox.enable();
 			this._passwordInputBox.enable();
 			this._rememberPasswordCheckBox.enabled = true;
+
+			const recentConnections = this._connectionManagementService.getRecentConnections();
+			if (recentConnections && recentConnections.length > 0) {
+				const self = this;
+				const connectionProfile = recentConnections.find(c => c.serverName === self._serverNameInputBox.value && c.userName === self._userNameInputBox.value);
+				if (connectionProfile) {
+					this._rememberPasswordCheckBox.checked = connectionProfile.savePassword;
+					this._connectionManagementService.addSavedPassword(connectionProfile, true).then(profile => self._passwordInputBox.value = profile.password);
+				}
+			}
 		}
 	}
 

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -543,7 +543,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		this._callbacks.onSetConnectButton(shouldEnableConnectButton);
 	}
 
-	protected onAuthTypeSelected(selectedAuthType: string) {
+	protected async onAuthTypeSelected(selectedAuthType: string): Promise<void> {
 		let currentAuthType = this.getMatchingAuthType(selectedAuthType);
 		if (currentAuthType !== AuthenticationType.SqlLogin) {
 			if (currentAuthType !== AuthenticationType.AzureMFA && currentAuthType !== AuthenticationType.AzureMFAAndUser) {
@@ -602,12 +602,9 @@ export class ConnectionWidget extends lifecycle.Disposable {
 
 			this._initialConnectionInfo.authenticationType = AuthenticationType.SqlLogin;
 			if (this._initialConnectionInfo && this._initialConnectionInfo.userName) {
-				const loadProfileIntoPasswordInputBox = (profile: IConnectionProfile) => {
-					this._passwordInputBox.value = profile.password;
-				};
-
 				this._rememberPasswordCheckBox.checked = this._initialConnectionInfo.savePassword;
-				this._connectionManagementService.addSavedPassword(this._initialConnectionInfo, true).then(loadProfileIntoPasswordInputBox);
+				const profileWithSavedPassword = await this._connectionManagementService.addSavedPassword(this._initialConnectionInfo, true);
+				this._passwordInputBox.value = profileWithSavedPassword.password;
 			}
 		}
 	}

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -42,6 +42,7 @@ import { AuthLibrary, filterAccounts } from 'sql/workbench/services/accountManag
 const ConnectionStringText = localize('connectionWidget.connectionString', "Connection string");
 
 export class ConnectionWidget extends lifecycle.Disposable {
+	private _initialConnectionInfo: IConnectionProfile;
 	private _defaultInputOptionRadioButton: RadioButton;
 	private _connectionStringRadioButton: RadioButton;
 	private _previousGroupOption: string;
@@ -598,6 +599,16 @@ export class ConnectionWidget extends lifecycle.Disposable {
 			this._userNameInputBox.enable();
 			this._passwordInputBox.enable();
 			this._rememberPasswordCheckBox.enabled = true;
+
+			this._initialConnectionInfo.authenticationType = AuthenticationType.SqlLogin;
+			if (this._initialConnectionInfo && this._initialConnectionInfo.userName) {
+				const loadProfileIntoPasswordInputBox = (profile: IConnectionProfile) => {
+					this._passwordInputBox.value = profile.password;
+				};
+
+				this._rememberPasswordCheckBox.checked = this._initialConnectionInfo.savePassword;
+				this._connectionManagementService.addSavedPassword(this._initialConnectionInfo, true).then(loadProfileIntoPasswordInputBox);
+			}
 		}
 	}
 
@@ -752,6 +763,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 	}
 
 	public initDialog(connectionInfo: IConnectionProfile): void {
+		this._initialConnectionInfo = connectionInfo;
 		this.fillInConnectionInputs(connectionInfo);
 	}
 

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -543,7 +543,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		this._callbacks.onSetConnectButton(shouldEnableConnectButton);
 	}
 
-	protected async onAuthTypeSelected(selectedAuthType: string): Promise<void> {
+	protected onAuthTypeSelected(selectedAuthType: string): void {
 		let currentAuthType = this.getMatchingAuthType(selectedAuthType);
 		if (currentAuthType !== AuthenticationType.SqlLogin) {
 			if (currentAuthType !== AuthenticationType.AzureMFA && currentAuthType !== AuthenticationType.AzureMFAAndUser) {
@@ -602,9 +602,12 @@ export class ConnectionWidget extends lifecycle.Disposable {
 
 			this._initialConnectionInfo.authenticationType = AuthenticationType.SqlLogin;
 			if (this._initialConnectionInfo && this._initialConnectionInfo.userName) {
+				const setPasswordInputBox = (profile: IConnectionProfile) => {
+					this._passwordInputBox.value = profile.password;
+				};
+
 				this._rememberPasswordCheckBox.checked = this._initialConnectionInfo.savePassword;
-				const profileWithSavedPassword = await this._connectionManagementService.addSavedPassword(this._initialConnectionInfo, true);
-				this._passwordInputBox.value = profileWithSavedPassword.password;
+				this._connectionManagementService.addSavedPassword(this._initialConnectionInfo, true).then(setPasswordInputBox)
 			}
 		}
 	}

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -598,16 +598,6 @@ export class ConnectionWidget extends lifecycle.Disposable {
 			this._userNameInputBox.enable();
 			this._passwordInputBox.enable();
 			this._rememberPasswordCheckBox.enabled = true;
-
-			const recentConnections = this._connectionManagementService.getRecentConnections();
-			if (recentConnections && recentConnections.length > 0) {
-				const self = this;
-				const connectionProfile = recentConnections.find(c => c.serverName === self._serverNameInputBox.value && c.userName === self._userNameInputBox.value);
-				if (connectionProfile) {
-					this._rememberPasswordCheckBox.checked = connectionProfile.savePassword;
-					this._connectionManagementService.addSavedPassword(connectionProfile, true).then(profile => self._passwordInputBox.value = profile.password);
-				}
-			}
 		}
 	}
 

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -312,7 +312,10 @@ suite('ConnectionDialogService tests', () => {
 		await (connectionDialogService as any).handleFillInConnectionInputs(connectionProfile);
 
 		let connectionControllerMap = (connectionDialogService as any)._connectionControllerMap;
+		assert(!!connectionControllerMap);
+
 		let returnedModel = (connectionControllerMap['MSSQL'] as any)._model;
+		assert(!!returnedModel);
 
 		assert.strictEqual(returnedModel._groupName, 'testGroup');
 		assert(called);

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -308,14 +308,16 @@ suite('ConnectionDialogService tests', () => {
 			called = true;
 		});
 
-		await connectionDialogService.showDialog(mockConnectionManagementService.object, testConnectionParams, connectionProfile).then(() => {
-			((connectionDialogService as any)._connectionControllerMap['MSSQL'] as any)._model = connectionProfile;
-		});
+		await connectionDialogService.showDialog(mockConnectionManagementService.object, testConnectionParams, connectionProfile);
 		await (connectionDialogService as any).handleFillInConnectionInputs(connectionProfile);
 
-		let returnedModel = ((connectionDialogService as any)._connectionControllerMap['MSSQL'] as any)._model;
-		assert.strictEqual(returnedModel._groupName, 'testGroup');
-		assert(called); // lewissanchez TODO why is this losing true?
+		setTimeout(() => {
+			let connectionControllerMap = (connectionDialogService as any)._connectionControllerMap;
+			let returnedModel = (connectionControllerMap['MSSQL'] as any)._model;
+
+			assert.strictEqual(returnedModel._groupName, 'testGroup');
+			assert(called);
+		}, 200)
 	});
 
 	test('handleOnConnect calls connectAndSaveProfile when called with profile', async () => {

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -311,13 +311,11 @@ suite('ConnectionDialogService tests', () => {
 		await connectionDialogService.showDialog(mockConnectionManagementService.object, testConnectionParams, connectionProfile);
 		await (connectionDialogService as any).handleFillInConnectionInputs(connectionProfile);
 
-		setTimeout(() => {
-			let connectionControllerMap = (connectionDialogService as any)._connectionControllerMap;
-			let returnedModel = (connectionControllerMap['MSSQL'] as any)._model;
+		let connectionControllerMap = (connectionDialogService as any)._connectionControllerMap;
+		let returnedModel = (connectionControllerMap['MSSQL'] as any)._model;
 
-			assert.strictEqual(returnedModel._groupName, 'testGroup');
-			assert(called);
-		}, 200);
+		assert.strictEqual(returnedModel._groupName, 'testGroup');
+		assert(called);
 	});
 
 	test('handleOnConnect calls connectAndSaveProfile when called with profile', async () => {

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -317,7 +317,7 @@ suite('ConnectionDialogService tests', () => {
 
 			assert.strictEqual(returnedModel._groupName, 'testGroup');
 			assert(called);
-		}, 200)
+		}, 200);
 	});
 
 	test('handleOnConnect calls connectAndSaveProfile when called with profile', async () => {

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -307,11 +307,15 @@ suite('ConnectionDialogService tests', () => {
 		mockWidget.setup(x => x.fillInConnectionInputs(TypeMoq.It.isAny())).returns(() => {
 			called = true;
 		});
-		await connectionDialogService.showDialog(mockConnectionManagementService.object, testConnectionParams, connectionProfile);
+
+		await connectionDialogService.showDialog(mockConnectionManagementService.object, testConnectionParams, connectionProfile).then(() => {
+			((connectionDialogService as any)._connectionControllerMap['MSSQL'] as any)._model = connectionProfile;
+		});
 		await (connectionDialogService as any).handleFillInConnectionInputs(connectionProfile);
+
 		let returnedModel = ((connectionDialogService as any)._connectionControllerMap['MSSQL'] as any)._model;
 		assert.strictEqual(returnedModel._groupName, 'testGroup');
-		assert(called);
+		assert(called); // lewissanchez TODO why is this losing true?
 	});
 
 	test('handleOnConnect calls connectAndSaveProfile when called with profile', async () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21812

This PR fixes a bug around remembered passwords for connections not appearing in the connection blade. Clicking on the "Connect" button for a server that has previously been connected to and set to have the password remembered will now appear in the connection pane.

1. Click on the "Connect" button (plug icon) on a server node that has previously been connected to.
![image](https://user-images.githubusercontent.com/87730006/216252839-500dda8c-8305-4499-94ad-b6a3aeb37120.png)

   1.1. Switch the authentication type to SQL Login (May not need to do this if default auth type is SQL Login).

2. The user name and password for the connection will be filled in.
![image](https://user-images.githubusercontent.com/87730006/216252641-820e1fd9-f2fb-483b-ad12-cfcfd42dcf3a.png)