### PR TITLE
Fix connecting to MI login bug

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -194,10 +194,6 @@ export interface AzureSqlDatabaseServer {
 	},
 }
 
-export function isAzureSqlDatabaseServer(instance: any): instance is AzureSqlDatabaseServer {
-	return (instance as AzureSqlDatabaseServer) !== undefined;
-}
-
 export type SqlVMServer = {
 	properties: {
 		virtualMachineResourceId: string,
@@ -214,10 +210,6 @@ export type SqlVMServer = {
 	subscriptionId: string,
 	networkInterfaces: Map<string, NetworkInterface>,
 };
-
-export function isSqlVMServer(instance: any): instance is SqlVMServer {
-	return (instance as SqlVMServer) !== undefined;
-}
 
 export type VirtualMachineInstanceView = {
 	computerName: string,

--- a/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
@@ -153,7 +153,6 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 		}
 
 		const isSqlDbTarget = this.migrationStateModel._targetType === MigrationTargetType.SQLDB;
-		console.log(isSqlDbTarget);
 
 		if (this._targetUserNameInputBox) {
 			await this._targetUserNameInputBox.updateProperty('required', true);
@@ -174,6 +173,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 			this._targetPasswordInputBox.value = '';
 			this.migrationStateModel._sqlMigrationServices = undefined!;
 			this.migrationStateModel._targetServerInstance = undefined!;
+			this.migrationStateModel._targetServerName = undefined!;
 			this.migrationStateModel._resourceGroup = undefined!;
 			this.migrationStateModel._location = undefined!;
 			await this.populateLocationDropdown();
@@ -337,7 +337,6 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 				this.migrationStateModel.isWindowsAuthMigrationSupported));
 			this.migrationStateModel._loginMigrationModel.collectedSourceLogins = true;
 			this.migrationStateModel._loginMigrationModel.loginsOnSource = sourceLogins;
-			console.log(this.migrationStateModel._targetType);
 		}));
 
 		const flexContainer = this._view.modelBuilder.flexContainer()
@@ -616,7 +615,8 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 						this.wizard.nextButton.enabled = false;
 						loginsOnTarget.push(
 							...await collectTargetLogins(
-								targetDatabaseServer,
+								this.migrationStateModel.targetServerName,
+								targetDatabaseServer.id,
 								userName,
 								password,
 								this.migrationStateModel.isWindowsAuthMigrationSupported));
@@ -750,6 +750,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 									this.migrationStateModel._azureAccount,
 									this.migrationStateModel._targetSubscription,
 									this.migrationStateModel._targetServerInstance);
+								this.migrationStateModel.setTargetServerName();
 
 								this.wizard.message = { text: '' };
 
@@ -779,6 +780,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 
 							if (selectedMi) {
 								this.migrationStateModel._targetServerInstance = utils.deepClone(selectedMi)! as azureResource.AzureSqlManagedInstance;
+								this.migrationStateModel.setTargetServerName();
 
 								this.wizard.message = { text: '' };
 								if (this.migrationStateModel._targetServerInstance.properties.state !== 'Ready') {
@@ -797,6 +799,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 
 							if (sqlDatabaseServer) {
 								this.migrationStateModel._targetServerInstance = utils.deepClone(sqlDatabaseServer)! as AzureSqlDatabaseServer;
+								this.migrationStateModel.setTargetServerName();
 								this.wizard.message = { text: '' };
 								if (this.migrationStateModel._targetServerInstance.properties.state === 'Ready') {
 									this._targetUserNameInputBox.value = this.migrationStateModel._targetServerInstance.properties.administratorLogin;
@@ -813,6 +816,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 					}
 				} else {
 					this.migrationStateModel._targetServerInstance = undefined!;
+					this.migrationStateModel._targetServerName = undefined!;
 					if (isSqlDbTarget) {
 						this._targetUserNameInputBox.value = '';
 					}
@@ -989,14 +993,6 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 						this.migrationStateModel._location,
 						this.migrationStateModel._resourceGroup?.name,
 						constants.NO_VIRTUAL_MACHINE_FOUND);
-
-					let response = await utils.getVirtualMachinesDropdownValues(
-						this.migrationStateModel._targetSqlVirtualMachines,
-						this.migrationStateModel._location,
-						this.migrationStateModel._resourceGroup,
-						this.migrationStateModel._azureAccount,
-						this.migrationStateModel._targetSubscription);
-					console.log(response);
 
 					break;
 				case MigrationTargetType.SQLDB:

--- a/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
@@ -152,8 +152,6 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 				break;
 		}
 
-		const isSqlDbTarget = this.migrationStateModel._targetType === MigrationTargetType.SQLDB;
-
 		if (this._targetUserNameInputBox) {
 			await this._targetUserNameInputBox.updateProperty('required', true);
 		}

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -11,7 +11,6 @@ import * as constants from '../constants/strings';
 import { debounce, getLoginStatusImage, getLoginStatusMessage } from '../api/utils';
 import * as styles from '../constants/styles';
 import { collectSourceLogins, collectTargetLogins, LoginTableInfo } from '../api/sqlUtils';
-import { AzureSqlDatabaseServer } from '../api/azure';
 import { IconPathHelper } from '../constants/iconPathHelper';
 import * as utils from '../api/utils';
 import { LoginType } from '../models/loginMigrationModel';
@@ -377,7 +376,8 @@ export class LoginSelectorPage extends MigrationWizardPage {
 		try {
 			if (this.isTargetInstanceSet()) {
 				targetLogins.push(...await collectTargetLogins(
-					stateMachine._targetServerInstance as AzureSqlDatabaseServer,
+					stateMachine.targetServerName,
+					stateMachine._targetServerInstance.id,
 					stateMachine._targetUserName,
 					stateMachine._targetPassword,
 					stateMachine.isWindowsAuthMigrationSupported));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes a regression for migration login for MI instances that was introduced in https://github.com/microsoft/azuredatastudio/pull/21776/files#diff-93c1a62583fa32d99f775b71ad27922cf31f660d10717ecc6966784306de1b6f. 

After that change, support for MI would fail as MI server types were going into the Sql VM path in sqlutils because the underlying logic for isSqlServerVM() was returning wrong results. 

The new approach uses the targetType set in StateMachine to extract the correct serverName for connection string based on the targetType.

Testing:

- Tested SQL VM login migration end to end
- Tested SQL MI login migration end to end

This change also bumps the version to 1.3.0
