### PR TITLE
Update Edit Data column formatter to match Table formatter

### DIFF
--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -126,7 +126,7 @@ export function textFormatter(row: number | undefined, cell: any | undefined, va
 	return `<span title="${titleValue}" style="${cellStyle}" class="${cellClasses}">${valueToDisplay}</span>`;
 }
 
-function getCellDisplayValue(cellValue: string): string {
+export function getCellDisplayValue(cellValue: string): string {
 	// allow-any-unicode-next-line
 	let valueToDisplay = cellValue.replace(/(\r\n|\n|\r)/g, '↵');
 	return escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -1152,9 +1152,13 @@ export class EditDataGridPanel extends GridParentComponent {
 		let cellClasses = 'grid-cell-value-container';
 		/* tslint:disable:no-null-keyword */
 		let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull) || value === 'NULL';
+		let isStringNull = (Services.DBCellValue.isDBCellValue(value) && !value.isNull && value.displayValue === 'NULL');
 		if (valueMissing) {
 			valueToDisplay = 'NULL';
 			cellClasses += ' missing-value';
+		}
+		else if (isStringNull) {
+			valueToDisplay = '\'NULL\'';
 		}
 		else if (Services.DBCellValue.isDBCellValue(value)) {
 			valueToDisplay = getCellDisplayValue(value.displayValue);

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -7,6 +7,7 @@ import 'vs/css!./media/editData';
 
 import { VirtualizedCollection, AsyncDataProvider, ISlickColumn } from 'sql/base/browser/ui/table/asyncDataView';
 import { Table } from 'sql/base/browser/ui/table/table';
+import { getCellDisplayValue } from 'sql/base/browser/ui/table/formatters'
 
 import { IGridDataSet } from 'sql/workbench/contrib/grid/browser/interfaces';
 import * as Services from 'sql/base/browser/ui/table/formatters';
@@ -1151,17 +1152,12 @@ export class EditDataGridPanel extends GridParentComponent {
 		let cellClasses = 'grid-cell-value-container';
 		/* tslint:disable:no-null-keyword */
 		let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull) || value === 'NULL';
-		let isStringNull = (Services.DBCellValue.isDBCellValue(value) && !value.isNull && value.displayValue === 'NULL');
 		if (valueMissing) {
 			valueToDisplay = 'NULL';
 			cellClasses += ' missing-value';
 		}
-		else if (isStringNull) {
-			valueToDisplay = '\'NULL\'';
-		}
 		else if (Services.DBCellValue.isDBCellValue(value)) {
-			valueToDisplay = (value.displayValue + '');
-			valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
+			valueToDisplay = getCellDisplayValue(value.displayValue);
 		}
 		else if (typeof value === 'string' || (value && value.text)) {
 			if (value.text) {
@@ -1169,8 +1165,8 @@ export class EditDataGridPanel extends GridParentComponent {
 			} else {
 				valueToDisplay = value;
 			}
-			valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
+			valueToDisplay = getCellDisplayValue(valueToDisplay);
 		}
-		return '<span title="' + valueToDisplay + '" class="' + cellClasses + '">' + valueToDisplay + '</span>';
+		return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
 	}
 }


### PR DESCRIPTION
Changes the table formatter to match that of the current table formatter (prevents HTML injection and also handles newlines with unicode nextline).

This PR fixes #20881
