### PR TITLE
Remove Germany and US National clouds

### DIFF
--- a/extensions/azurecore/package.disabled.json
+++ b/extensions/azurecore/package.disabled.json
@@ -4,19 +4,9 @@
 		"default": false,
 		"description": "%config.enableUsGovCloudDescription%"
 	},
-	"accounts.azure.enableUsNatCloud": {
-		"type": "boolean",
-		"default": false,
-		"description": "%config.enableUsNatCloudDescription%"
-	},
 	"accounts.azure.enableChinaCloud": {
 		"type": "boolean",
 		"default": false,
 		"description": "%config.enableChinaCloudDescription%"
-	},
-	"accounts.azure.enableGermanyCloud": {
-		"type": "boolean",
-		"default": false,
-		"description": "%config.enableGermanyCloudDescription%"
 	}
 }

--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -63,16 +63,6 @@
             "default": false,
             "description": "%config.enableUsGovCloudDescription%"
           },
-          "accounts.azure.cloud.enableUsNatCloud": {
-            "type": "boolean",
-            "default": false,
-            "description": "%config.enableUsNatCloudDescription%"
-          },
-          "accounts.azure.cloud.enableGermanyCloud": {
-            "type": "boolean",
-            "default": false,
-            "description": "%config.enableGermanyCloudDescription%"
-          },
           "accounts.azure.cloud.enableChinaCloud": {
             "type": "boolean",
             "default": false,

--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -144,7 +144,8 @@ export class AzureAccountProviderService implements vscode.Disposable {
 		const isSaw: boolean = vscode.env.appName.toLowerCase().indexOf(Constants.Saw) > 0;
 		const noSystemKeychain = vscode.workspace.getConfiguration(Constants.AzureSection).get<boolean>(Constants.NoSystemKeyChainSection);
 		const tokenCacheKey = `azureTokenCache-${provider.metadata.id}`;
-		const tokenCacheKeyMsal = `azureTokenCacheMsal-${provider.metadata.id}`;
+		// Hardcode the MSAL Cache Key so there is only one cache location
+		const tokenCacheKeyMsal = `azureTokenCacheMsal-azure_publicCloud`;
 		try {
 			if (!this._credentialProvider) {
 				throw new Error('Credential provider not registered');

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -168,115 +168,6 @@ const usGovAzureSettings: ProviderSettings = {
 	}
 };
 
-const usNatAzureSettings: ProviderSettings = {
-	configKey: 'enableUsNatCloud',
-	metadata: {
-		displayName: localize('usNatCloudDisplayName', "Azure (US National)"),
-		id: 'azure_usNatCloud',
-		settings: {
-			host: 'https://login.microsoftonline.eaglex.ic.gov/',
-			clientId: 'a69788c6-1d43-44ed-9ca3-b83e194da255',
-			microsoftResource: {
-				id: SettingIds.marm,
-				endpoint: 'https://management.azure.eaglex.ic.gov/',
-				azureResourceId: AzureResource.MicrosoftResourceManagement
-			},
-			graphResource: {
-				id: SettingIds.graph,
-				endpoint: 'https://graph.eaglex.ic.gov/',
-				azureResourceId: AzureResource.Graph
-			},
-			armResource: {
-				id: SettingIds.arm,
-				endpoint: 'https://management.core.eaglex.ic.gov/',
-				azureResourceId: AzureResource.ResourceManagement
-			},
-			sqlResource: {
-				id: SettingIds.sql,
-				endpoint: 'https://database.cloudapi.eaglex.ic.gov/',
-				azureResourceId: AzureResource.Sql
-			},
-			ossRdbmsResource: {
-				id: SettingIds.ossrdbms,
-				endpoint: 'https://ossrdbms-aad.database.cloudapi.eaglex.ic.gov/',
-				azureResourceId: AzureResource.OssRdbms
-			},
-			azureKeyVaultResource: {
-				id: SettingIds.vault,
-				endpoint: 'https://vault.cloudapi.eaglex.ic.gov/',
-				azureResourceId: AzureResource.AzureKeyVault
-			},
-			azureLogAnalyticsResource: {
-				id: SettingIds.ala,
-				endpoint: 'https://api.loganalytics.azure.eaglex.ic.gov/',
-				azureResourceId: AzureResource.AzureLogAnalytics,
-			},
-			azureStorageResource: {
-				id: SettingIds.storage,
-				endpoint: '',
-				endpointSuffix: '.core.eaglex.ic.gov/',
-				azureResourceId: AzureResource.AzureStorage
-			},
-			redirectUri: 'http://localhost',
-			scopes: [
-				'openid', 'email', 'profile', 'offline_access',
-				'https://management.core.eaglex.ic.gov/user_impersonation'
-			],
-			portalEndpoint: 'https://portal.azure.eaglex.ic.gov/'
-		}
-	}
-};
-
-
-const germanyAzureSettings: ProviderSettings = {
-	configKey: 'enableGermanyCloud',
-	metadata: {
-		displayName: localize('germanyCloud', "Azure (Germany)"),
-		id: 'azure_germanyCloud',
-		settings: {
-			host: 'https://login.microsoftazure.de/',
-			clientId: 'a69788c6-1d43-44ed-9ca3-b83e194da255',
-			graphResource: {
-				id: SettingIds.graph,
-				endpoint: 'https://graph.cloudapi.de/',
-				azureResourceId: AzureResource.Graph
-			},
-			msGraphResource: {
-				id: SettingIds.msgraph,
-				endpoint: 'https://graph.microsoft.de/',
-				azureResourceId: AzureResource.MsGraph
-			},
-			armResource: {
-				id: SettingIds.arm,
-				endpoint: 'https://management.microsoftazure.de/',
-				azureResourceId: AzureResource.ResourceManagement
-			},
-			azureKeyVaultResource: {
-				id: SettingIds.vault,
-				endpoint: 'https://vault.microsoftazure.de/',
-				azureResourceId: AzureResource.AzureKeyVault
-			},
-			azureStorageResource: {
-				id: SettingIds.storage,
-				endpoint: '',
-				endpointSuffix: '.core.cloudapi.de/',
-				azureResourceId: AzureResource.AzureStorage
-			},
-			powerBiResource: {
-				id: SettingIds.powerbi,
-				endpoint: 'https://analysis.windows.net/powerbi/api/',
-				azureResourceId: AzureResource.PowerBi
-			},
-			redirectUri: 'http://localhost',
-			scopes: [
-				'openid', 'email', 'profile', 'offline_access',
-				'https://management.microsoftazure.de/user_impersonation'
-			],
-			portalEndpoint: 'https://portal.microsoftazure.de/'
-		}
-	}
-};
-
 const chinaAzureSettings: ProviderSettings = {
 	configKey: 'enableChinaCloud',
 	metadata: {
@@ -340,5 +231,5 @@ const chinaAzureSettings: ProviderSettings = {
 		}
 	}
 };
-const allSettings = [publicAzureSettings, usGovAzureSettings, usNatAzureSettings, germanyAzureSettings, chinaAzureSettings];
+const allSettings = [publicAzureSettings, usGovAzureSettings, chinaAzureSettings];
 export default allSettings;


### PR DESCRIPTION
The only clouds listed [here](https://learn.microsoft.com/en-us/azure/active-directory/develop/authentication-national-cloud) are: 
- Azure China
- Azure US Government
- Azure Public Cloud

It seems like the Germany cloud was decommissioned, so removing that one along with the US National Cloud (which seems to also have been removed).

Additionally, in an effort to consolidate the Token Cache for MSAL to share easily with STS, changed to a hardcoded token cache key.