### PR TITLE
Initial SQL 4 CDS extension listing

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4828,6 +4828,71 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+				{
+					"extensionId": "96",
+					"extensionName": "mark carrington.azuredatastudio-sql4cds",
+					"displayName": "SQL 4 CDS",
+					"shortDescription": "Query and modify data in Microsoft Dataverse/Dynamics 365/CRM using standard SQL queries.",
+					"publisher": {
+						"displayName": "Mark Carrington",
+						"publisherId": "mark carrington",
+						"publisherName": "Mark Carrington"
+					},
+					"versions": [
+						{
+							"version": "7.1.0",
+							"lastUpdated": "02/01/2023",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.SQLOps.DownloadPage",
+									"source": "https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.1.0"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/master/MarkMpn.Sql4Cds/Images/SQL4CDS%20Icon.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/v7.1.0/AzureDataStudioExtension/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
+									"source": "https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.1.0"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/v7.1.0/AzureDataStudioExtension/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/v7.1.0/LICENSE"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": "^1.65.2"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/MarkMpn/Sql4Cds"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": ""
 				}
 			],
 			"resultMetadata": [
@@ -4836,7 +4901,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 79
+							"count": 80
 						}
 					]
 				}

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4860,7 +4860,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.1.0"
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/master/AzureDataStudioExtension/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4828,6 +4828,75 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+				{
+					"extensionId": "96",
+					"extensionName": "mark carrington.azuredatastudio-sql4cds",
+					"displayName": "SQL 4 CDS",
+					"shortDescription": "Query and modify data in Microsoft Dataverse/Dynamics 365/CRM using standard SQL queries.",
+					"publisher": {
+						"displayName": "Mark Carrington",
+						"publisherId": "mark carrington",
+						"publisherName": "Mark Carrington"
+					},
+					"versions": [
+						{
+							"version": "7.1.0",
+							"lastUpdated": "02/01/2023",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"source": "https://github.com/MarkMpn/Sql4Cds/releases/download/v7.1.0/azuredatastudio-sql4cds-7.1.0.vsix"
+								},
+								{
+									"assetType": "Microsoft.SQLOps.DownloadPage",
+									"source": "https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.1.0"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://markcarrington.dev/wp-content/uploads/2019/10/SQL4CDS-Icon.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/v7.1.0/AzureDataStudioExtension/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
+									"source": "https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.1.0"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/v7.1.0/AzureDataStudioExtension/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/v7.1.0/LICENSE"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": "^1.65.2"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/mongodb-js/vscode"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": ""
 				}
 			],
 			"resultMetadata": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4847,16 +4847,12 @@
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://github.com/MarkMpn/Sql4Cds/releases/download/v7.1.0/azuredatastudio-sql4cds-7.1.0.vsix"
-								},
-								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
 									"source": "https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.1.0"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://markcarrington.dev/wp-content/uploads/2019/10/SQL4CDS-Icon.png"
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/master/MarkMpn.Sql4Cds/Images/SQL4CDS%20Icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
@@ -4890,7 +4886,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/mongodb-js/vscode"
+									"value": "https://github.com/MarkMpn/Sql4Cds"
 								}
 							]
 						}
@@ -4905,7 +4901,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 79
+							"count": 80
 						}
 					]
 				}

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4860,7 +4860,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.1.0"
+									"source": "https://raw.githubusercontent.com/MarkMpn/Sql4Cds/master/AzureDataStudioExtension/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",


### PR DESCRIPTION
Added listing for SQL 4 CDS extension to let users query data in Microsoft Dataverse/Dynamics 365 instances from Azure Data Studio.

I've included both a direct link to the vsix file and to the GitHub release page for the downloads, please let me know if I need to remove one of them.

More information about the extension is available at https://markcarrington.dev/2023/01/31/sql-4-cds-v7-1-released/#azure_data_studio