### PR TITLE
[SQL-Migration] Bump sql-migration version to 1.3.0

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.2.2",
-							"lastUpdated": "1/26/2023",
+							"version": "1.3.0",
+							"lastUpdated": "02/06/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.2.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.3.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the stable extension gallery to the latest release candidate version of the SQL Migration extension. This change includes bug fixes for login migrations, removing parameter that was blocking customers in in validate IR, and improved error messages for collation violations.

Link to Azure Data Studio - Extensions pipeline run containing vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=188884&view=results

Note: We are releasing this version to insiders on 02/03 and to stable on 02/06. I'm creating a draft PR just to have it ready, but we will merge this PR on 2/6.
