### PR TITLE
Fix Account Dialog with Multiple Providers

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -297,7 +297,7 @@ export class AccountDialog extends Modal {
 		if (Iterable.consume(this._providerViewsMap.values()).length > 0) {
 			const firstView = this._providerViewsMap.values().next().value;
 			if (firstView && firstView.view instanceof AccountPanel) {
-				// This causes an issue with public cloud when it has 1 entry
+				// Handle index error with length 0
 				if (firstView.view.length > 0) {
 					firstView.view.setSelection([0]);
 				}

--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -384,6 +384,13 @@ export class AccountDialog extends Modal {
 
 		// Append the list view to the split view
 		this._splitView!.addView(providerView, Sizing.Distribute, insertIndex);
+		// Increment index for each provider
+		this._providerViewsMap.forEach((provider) => {
+			if (provider.view.index > providerView.index) {
+				provider.view.index++;
+			}
+		})
+
 		providerView.index = insertIndex;
 
 		this._splitView!.layout(DOM.getContentHeight(this._container!));
@@ -417,11 +424,13 @@ export class AccountDialog extends Modal {
 		}
 
 		// Remove the list view from the split view
-		try {
-			this._splitView!.removeView(providerView.view.index!);
-		} catch (error) {
-			this.logService.debug(error);
-		}
+		this._splitView!.removeView(providerView.view.index!);
+		// Decrement index for each provider
+		this._providerViewsMap.forEach((provider) => {
+			if (provider.view.index > providerView.view.index) {
+				provider.view.index--;
+			}
+		})
 		this._splitView!.layout(DOM.getContentHeight(this._container!));
 
 		// Remove the list view from our internal map

--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -364,16 +364,12 @@ export class AccountDialog extends Modal {
 
 		// Check if view is registered, if it isn't, register the view
 		if (!Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).getView(newProvider.addedProvider.id)) {
-			try {
-				Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([{
-					id: newProvider.addedProvider.id,
-					name: newProvider.addedProvider.displayName,
-					ctorDescriptor: new SyncDescriptor(AccountPanel),
-				}], ACCOUNT_VIEW_CONTAINER);
-				this.registerActions(newProvider.addedProvider.id);
-			} catch (error) {
-				this.logService.debug(error);
-			}
+			Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([{
+				id: newProvider.addedProvider.id,
+				name: newProvider.addedProvider.displayName,
+				ctorDescriptor: new SyncDescriptor(AccountPanel),
+			}], ACCOUNT_VIEW_CONTAINER);
+			this.registerActions(newProvider.addedProvider.id);
 		}
 
 
@@ -432,12 +428,11 @@ export class AccountDialog extends Modal {
 			}
 		})
 		this._splitView!.layout(DOM.getContentHeight(this._container!));
-
 		// Remove the list view from our internal map
 		this._providerViewsMap.delete(removedProvider.id);
 		this.logService.debug(`Provider ${removedProvider.id} removed`);
 		// Update view after removing provider
-		if (this._splitViewContainer!.hidden || this._providerViewsMap.size > 1) {
+		if (this._splitViewContainer!.hidden) {
 			this.showSplitView();
 		}
 		this.layout();

--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -295,7 +295,10 @@ export class AccountDialog extends Modal {
 		if (Iterable.consume(this._providerViewsMap.values()).length > 0) {
 			const firstView = this._providerViewsMap.values().next().value;
 			if (firstView && firstView.view instanceof AccountPanel) {
-				firstView.view.setSelection([0]);
+				// This causes an issue with public cloud when it has 1 entry
+				if (firstView.view.length > 0) {
+					firstView.view.setSelection([0]);
+				}
 				firstView.view.focus();
 			}
 		}
@@ -404,6 +407,13 @@ export class AccountDialog extends Modal {
 			return;
 		}
 
+		// Remove from the views registry
+		Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).deregisterViews([{
+			id: removedProvider.id,
+			name: removedProvider.displayName,
+			ctorDescriptor: new SyncDescriptor(AccountPanel),
+		}], ACCOUNT_VIEW_CONTAINER);
+
 		// Remove the list view from the split view
 		this._splitView!.removeView(providerView.view.index!);
 		this._splitView!.layout(DOM.getContentHeight(this._container!));
@@ -430,7 +440,7 @@ export class AccountDialog extends Modal {
 			this.showSplitView();
 		}
 
-		if (this.isEmptyLinkedAccount() && this._noaccountViewContainer!.hidden) {
+		if (this.isEmptyLinkedAccount() && this._noaccountViewContainer!.hidden && this._providerViewsMap.size === 1) {
 			this.showNoAccountContainer();
 		}
 

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -465,6 +465,8 @@ export class AccountManagementService implements IAccountManagementService {
 	}
 
 	public unregisterProvider(providerMetadata: azdata.AccountProviderMetadata): void {
+		const p = this._providers[providerMetadata.id];
+		this.fireAccountListUpdate(p, false);
 		// Delete this account provider
 		delete this._providers[providerMetadata.id];
 

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -536,7 +536,6 @@ class ViewsRegistry extends Disposable implements IViewsRegistry {
 		}
 		const viewsToDeregister: IViewDescriptor[] = [];
 		const remaningViews: IViewDescriptor[] = [];
-		// something doesn't match up here when removing azure china view
 		for (const view of views) {
 			if (!viewDescriptors.includes(view)) {
 				remaningViews.push(view);

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -536,6 +536,7 @@ class ViewsRegistry extends Disposable implements IViewsRegistry {
 		}
 		const viewsToDeregister: IViewDescriptor[] = [];
 		const remaningViews: IViewDescriptor[] = [];
+		// something doesn't match up here when removing azure china view
 		for (const view of views) {
 			if (!viewDescriptors.includes(view)) {
 				remaningViews.push(view);


### PR DESCRIPTION
Fixes a few bugs in the Account Dialog relating to having multiple providers:
Old Behavior:

1. `setSelection([0])` caused an index error on an empty list, and as a result `_providerViewsMap` was not updated.
2. After removing a provider, re-adding it caused this error:
<img width="1904" alt="Screenshot 2023-02-02 at 3 59 01 PM" src="https://user-images.githubusercontent.com/18150417/216714237-fc031cd3-8073-4323-8d7f-efe43d911144.png">

3. When two providers (for example China & US Gov) were selected but none of them contained any accounts, only one "Add an Account" option was shown when there should be two, one for each provider.

4. There was an index out of bounds error because we weren't correctly incrementing/decrementing the index stored in providerView when we add/remove elements to the splitView  

New Behavior:

1. Check the length of firstView.view before calling `setSelection([0])
2. Check if a provider has been added already
3. Check how many providers are active before displaying the noAccountContainer.
4. Correctly increment/decrement providerView index.

Adding / removing too many providers with these unhandled errors also caused the `You have no clouds enabled` message to show up for me, this is fixed now. (although I'm not sure if that's enough to close #11260)
