### PR TITLE
Minor improvements in notebook edit mode handling

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -298,8 +298,8 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			}
 			this._layoutEmitter.fire();
 		}));
-		this._register(this.cellModel.onCellModeChanged((isEditMode) => {
-			this.onCellModeChanged(isEditMode);
+		this._register(this.cellModel.onCellEditModeChanged((isEditMode) => {
+			this.onCellEditModeChanged(isEditMode);
 		}));
 
 		this.layout();
@@ -453,7 +453,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		this._editor.setHeightToScrollHeight(false, isCollapsed);
 	}
 
-	private onCellModeChanged(isEditMode: boolean): void {
+	private onCellEditModeChanged(isEditMode: boolean): void {
 		if (this.cellModel.id === this._activeCellId || this._activeCellId === '') {
 			if (isEditMode) {
 				this._editor.getControl().focus();

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/codeCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/codeCell.component.ts
@@ -53,7 +53,7 @@ export class CodeCellComponent extends CellView implements OnInit, OnChanges {
 			this._register(this.cellModel.onOutputsChanged(() => {
 				this._changeRef.detectChanges();
 			}));
-			this._register(this.cellModel.onCellModeChanged(mode => {
+			this._register(this.cellModel.onCellEditModeChanged(mode => {
 				if (mode !== this.cellModel.isEditMode) {
 					this._changeRef.detectChanges();
 				}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -209,11 +209,10 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this._register(this.cellModel.onOutputsChanged(e => {
 			this.updatePreview();
 		}));
-		this._register(this.cellModel.onCellModeChanged(mode => {
+		this._register(this.cellModel.onCellEditModeChanged(mode => {
 			if (mode !== this.isEditMode) {
 				this.toggleEditMode(mode);
 			}
-			this._changeRef.detectChanges();
 		}));
 		this._register(this.cellModel.onCurrentEditModeChanged(editMode => {
 			let markdown: boolean = editMode !== CellEditModes.WYSIWYG;
@@ -268,11 +267,6 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 				let changedProp = changes[propName];
 				this._activeCellId = changedProp.currentValue;
 				this.toggleUserSelect(this.isActive());
-				// If the activeCellId is undefined (i.e. in an active cell update), don't unnecessarily set editMode to false;
-				// it will be set to true in a subsequent call to toggleEditMode()
-				if (changedProp.previousValue !== undefined) {
-					this.toggleEditMode(false);
-				}
 				break;
 			}
 		}

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -374,8 +374,8 @@ export class NotebookEditor extends EditorPane implements IFindNotebookControlle
 			filters: false
 		};
 		this._notebookModel.cells?.forEach(cell => {
-			this._register(cell.onCellModeChanged((state) => {
-				if (state) {
+			this._register(cell.onCellEditModeChanged((isEditMode) => {
+				if (isEditMode) {
 					this._onFindStateChange(changeEvent).catch(onUnexpectedError);
 				}
 			}));

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
@@ -463,7 +463,7 @@ suite('Test class NotebookEditor:', () => {
 		const notebookModel = <NotebookModelStub>await notebookEditor.getNotebookModel();
 		notebookModel['_cells'] = [new CellModel({ cell_type: 'code', source: '' }, { isTrusted: true, notebook: notebookModel })];
 		notebookEditor['registerModelChanges']();
-		notebookModel.cells[0]['_onCellModeChanged'].fire(true); //fire cellModeChanged event on the first sell of our test notebookModel
+		notebookModel.cells[0]['_onCellEditModeChanged'].fire(true); //fire cellEditModeChanged event on the first sell of our test notebookModel
 		notebookModel.contentChangedEmitter.fire({ changeType: NotebookChangeType.Saved });
 		(<NotebookService>notebookService)['_onNotebookEditorAdd'].fire(<INotebookEditor>{});
 		notebookFindModelMock.verify(x => x.find(

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -998,7 +998,7 @@ suite('Cell Model', function (): void {
 		let createCellModePromise = () => {
 			return new Promise((resolve, reject) => {
 				setTimeout((error) => reject(error), 2000);
-				model.onCellModeChanged(isEditMode => {
+				model.onCellEditModeChanged(isEditMode => {
 					resolve(isEditMode);
 				});
 			});

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -241,19 +241,21 @@ export class CellModel extends Disposable implements ICellModel {
 	}
 
 	public set isEditMode(isEditMode: boolean) {
-		this._isEditMode = isEditMode;
-		if (this._isEditMode) {
-			const newEditMode = this._lastEditMode ?? this._defaultTextEditMode;
-			this.showPreview = newEditMode !== TextCellEditModes.Markdown;
-			this.showMarkdown = newEditMode !== TextCellEditModes.RichText;
-		} else {
-			// when not in edit mode, default the values since they are only valid when editing.
-			// And to return the correct currentMode value.
-			this._showMarkdown = false;
-			this._showPreview = true;
+		if (this._isEditMode !== isEditMode) {
+			this._isEditMode = isEditMode;
+			if (this._isEditMode) {
+				const newEditMode = this._lastEditMode ?? this._defaultTextEditMode;
+				this.showPreview = newEditMode !== TextCellEditModes.Markdown;
+				this.showMarkdown = newEditMode !== TextCellEditModes.RichText;
+			} else {
+				// when not in edit mode, default the values since they are only valid when editing.
+				// And to return the correct currentMode value.
+				this._showMarkdown = false;
+				this._showPreview = true;
+			}
+			this._onCellEditModeChanged.fire(this._isEditMode);
+			// Note: this does not require a notebook update as it does not change overall state
 		}
-		this._onCellEditModeChanged.fire(this._isEditMode);
-		// Note: this does not require a notebook update as it does not change overall state
 	}
 
 	public get trustedMode(): boolean {

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -60,7 +60,7 @@ export class CellModel extends Disposable implements ICellModel {
 	private _isEditMode: boolean;
 	private _onOutputsChanged = new Emitter<IOutputChangedEvent>();
 	private _onTableUpdated = new Emitter<ITableUpdatedEvent>();
-	private _onCellModeChanged = new Emitter<boolean>();
+	private _onCellEditModeChanged = new Emitter<boolean>();
 	private _onExecutionStateChanged = new Emitter<CellExecutionState>();
 	private _onCurrentEditModeChanged = new Emitter<CellEditModes>();
 	private _isTrusted: boolean;
@@ -149,8 +149,8 @@ export class CellModel extends Disposable implements ICellModel {
 		return this._onTableUpdated.event;
 	}
 
-	public get onCellModeChanged(): Event<boolean> {
-		return this._onCellModeChanged.event;
+	public get onCellEditModeChanged(): Event<boolean> {
+		return this._onCellEditModeChanged.event;
 	}
 
 	public set metadata(data: any) {
@@ -252,7 +252,7 @@ export class CellModel extends Disposable implements ICellModel {
 			this._showMarkdown = false;
 			this._showPreview = true;
 		}
-		this._onCellModeChanged.fire(this._isEditMode);
+		this._onCellEditModeChanged.fire(this._isEditMode);
 		// Note: this does not require a notebook update as it does not change overall state
 	}
 

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -455,7 +455,7 @@ export interface ICellModel {
 	readonly onLanguageChanged: Event<string>;
 	readonly onCollapseStateChanged: Event<boolean>;
 	readonly onParameterStateChanged: Event<boolean>;
-	readonly onCellModeChanged: Event<boolean>;
+	readonly onCellEditModeChanged: Event<boolean>;
 	modelContentChangedEvent: IModelContentChangedEvent;
 	isEditMode: boolean;
 	showPreview: boolean;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -862,12 +862,16 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		if (this._activeCell !== cell) {
 			if (this._activeCell) {
 				this._activeCell.active = false;
-				this._activeCell.isEditMode = false;
+				if (this._activeCell.isEditMode) {
+					this._activeCell.isEditMode = false;
+				}
 			}
 			this._activeCell = cell;
 			if (this._activeCell) {
 				this._activeCell.active = true;
-				this._activeCell.isEditMode = isEditMode;
+				if (this._activeCell.isEditMode !== isEditMode) {
+					this._activeCell.isEditMode = isEditMode;
+				}
 			}
 			this._onActiveCellChanged.fire(cell);
 		}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -862,16 +862,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		if (this._activeCell !== cell) {
 			if (this._activeCell) {
 				this._activeCell.active = false;
-				if (this._activeCell.isEditMode) {
-					this._activeCell.isEditMode = false;
-				}
+				this._activeCell.isEditMode = false;
 			}
 			this._activeCell = cell;
 			if (this._activeCell) {
 				this._activeCell.active = true;
-				if (this._activeCell.isEditMode !== isEditMode) {
-					this._activeCell.isEditMode = isEditMode;
-				}
+				this._activeCell.isEditMode = isEditMode;
 			}
 			this._onActiveCellChanged.fire(cell);
 		}


### PR DESCRIPTION
This PR
- renames onCellModechanged to onCellEditModeChanged
- removes some duplicate detectChanges and toggleEditMode calls