### PR TITLE
databases query updated to prevent error when casting large numbers.

### DIFF
--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -49,7 +49,7 @@ const query_databases_with_size = `
 		db_size
 		AS
 		(
-			SELECT database_id, CAST(SUM(size) * 8.0 / 1024 AS INTEGER) size
+			SELECT database_id, CAST(SUM(size) / 128 AS bigint) size
 			FROM sys.master_files with (nolock)
 			GROUP BY database_id
 		)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Issue:
Fixes an error that occurs when there are databases with very large sizes, which can't fit in the integer value.
![image](https://user-images.githubusercontent.com/109680247/217040214-c528b9a5-2ad0-4e98-8483-d143b8842ff5.png)

Action
 Updated the query to bigint and validated the query with a client experiencing the issue. 
![image](https://user-images.githubusercontent.com/109680247/217043558-ad39ce21-0821-4ec5-89bd-4d8df952deb9.png)


