### PR TITLE
Rename file support in sql projects

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -437,7 +437,7 @@
         },
         {
           "command": "sqlDatabaseProjects.rename",
-          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/",
+          "when": "view == dataworkspace.views.main && viewItem =~ /^databaseProject.itemType.file/",
           "group": "9_dbProjectsLast@3"
         },
         {

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -206,6 +206,11 @@
         "command": "sqlDatabaseProjects.addSqlCmdVariable",
         "title": "%sqlDatabaseProjects.addSqlCmdVariable%",
         "category": "%sqlDatabaseProjects.displayName%"
+      },
+      {
+        "command": "sqlDatabaseProjects.rename",
+        "title": "%sqlDatabaseProjects.rename%",
+        "category": "%sqlDatabaseProjects.displayName%"
       }
     ],
     "menus": {
@@ -333,6 +338,10 @@
         {
           "command": "sqlDatabaseProjects.addSqlCmdVariable",
           "when": "false"
+        },
+        {
+          "command": "sqlDatabaseProjects.rename",
+          "when": "false"
         }
       ],
       "view/item/context": [
@@ -425,6 +434,11 @@
           "command": "sqlDatabaseProjects.delete",
           "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/ || viewItem == databaseProject.itemType.reference || viewItem == databaseProject.itemType.sqlcmdVariable",
           "group": "9_dbProjectsLast@2"
+        },
+        {
+          "command": "sqlDatabaseProjects.rename",
+          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/",
+          "group": "9_dbProjectsLast@3"
         },
         {
           "command": "sqlDatabaseProjects.changeTargetPlatform",

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -15,6 +15,7 @@
 	"sqlDatabaseProjects.delete": "Delete",
 	"sqlDatabaseProjects.exclude": "Exclude from project",
 	"sqlDatabaseProjects.edit": "Edit",
+	"sqlDatabaseProjects.rename": "Rename",
 	"sqlDatabaseProjects.validateExternalStreamingJob": "Validate External Streaming Job",
 
 	"sqlDatabaseProjects.newScript": "Add Script",

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -111,6 +111,7 @@ export function currentTargetPlatform(projectName: string, currentTargetPlatform
 export function projectUpdatedToSdkStyle(projectName: string) { return localize('projectUpdatedToSdkStyle', "The project {0} has been updated to be an SDK-style project. Click 'Learn More' for details on the Microsoft.Build.Sql SDK and ways to simplify the project file.", projectName); }
 export function convertToSdkStyleConfirmation(projectName: string) { return localize('convertToSdkStyleConfirmation', "The project '{0}' will not be fully compatible with SSDT after conversion. A backup copy of the project file will be created in the project folder prior to conversion. More information is available at https://aka.ms/sqlprojsdk. Continue with converting to SDK-style project?", projectName); }
 export function updatedToSdkStyleError(projectName: string) { return localize('updatedToSdkStyleError', "Converting the project {0} to SDK-style was unsuccessful. Changes to the .sqlproj have been rolled back.", projectName); }
+export const enterNewName = localize('enterNewName', "Enter new name");
 
 // Publish dialog strings
 export const publishDialogName = localize('publishDialogName', "Publish project");

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -85,6 +85,7 @@ export default class MainController implements vscode.Disposable {
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.convertToSdkStyleProject', async (node: WorkspaceTreeItem) => { return this.projectsController.convertToSdkStyleProject(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.delete', async (node: WorkspaceTreeItem) => { return this.projectsController.delete(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.exclude', async (node: WorkspaceTreeItem) => { return this.projectsController.exclude(node); }));
+		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.rename', async (node: WorkspaceTreeItem) => { return this.projectsController.rename(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.editSqlCmdVariable', async (node: WorkspaceTreeItem) => { return this.projectsController.editSqlCmdVariable(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.addSqlCmdVariable', async (node: WorkspaceTreeItem) => { return this.projectsController.addSqlCmdVariable(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.changeTargetPlatform', async (node: WorkspaceTreeItem) => { return this.projectsController.changeTargetPlatform(node); }));

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -839,6 +839,26 @@ export class ProjectsController {
 		}
 	}
 
+	public async rename(context: dataworkspace.WorkspaceTreeItem): Promise<void> {
+		const node = context.element as BaseProjectTreeItem;
+		const project = this.getProjectFromContext(node);
+
+		const newFileName = await vscode.window.showInputBox(
+			{
+				title: constants.enterNewName,
+				value: node.friendlyName,
+				ignoreFocusOut: true
+			});
+
+		if (!newFileName) {
+			return;
+		}
+
+		// TODO: hookup to "Move" file/folder api
+
+		this.refreshProjectsTree(context);
+	}
+
 	/**
 	 * Opens a quickpick to edit the value of the SQLCMD variable launched from
 	 * @param context

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -850,7 +850,10 @@ export class ProjectsController {
 			{
 				title: constants.enterNewName,
 				value: path.basename(node.friendlyName, constants.sqlFileExtension),
-				ignoreFocusOut: true
+				ignoreFocusOut: true,
+				validateInput: async (value) => {
+					return await this.fileAlreadyExists(value, file?.fsUri.fsPath!) ? constants.fileAlreadyExists(value) : undefined;
+				}
 			});
 
 		if (!newFileName) {
@@ -865,6 +868,10 @@ export class ProjectsController {
 		await project.addExistingItem(newFilePath);
 
 		this.refreshProjectsTree(context);
+	}
+
+	private fileAlreadyExists(newFileName: string, previousFilePath: string): Promise<boolean> {
+		return utils.exists(path.join(path.dirname(previousFilePath), `${newFileName}.sql`));
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -843,6 +843,8 @@ export class ProjectsController {
 		const node = context.element as BaseProjectTreeItem;
 		const project = this.getProjectFromContext(node);
 
+		// need to use quickpick because input box isn't supported in treeviews
+		// https://github.com/microsoft/vscode/issues/117502 and https://github.com/microsoft/vscode/issues/97190
 		const newFileName = await vscode.window.showInputBox(
 			{
 				title: constants.enterNewName,


### PR DESCRIPTION
This PR fixes #15312. This adds support for renaming files in a sql project. This will swap over to using the Move api in the DacFx projects when we move to use those apis.

Input boxes in treeviews aren't currently supported, which is why a quickpick is used for entering the new file name.
 
![fileRename](https://user-images.githubusercontent.com/31145923/217066975-f57359b7-dd6d-429b-b6d0-fd81e3643aa3.gif)

error when a file with the same name at that location already exists:
![image](https://user-images.githubusercontent.com/31145923/217096470-0d305931-8b5c-4248-a8c6-5d11e82d95b5.png)
