### PR TITLE
Fix publish profile telemetry for ADS

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -897,6 +897,8 @@ export class PublishDatabaseDialog {
 				// show file path in text box and hover text
 				this.loadProfileTextBox!.value = fileUris[0].fsPath;
 				await this.loadProfileTextBox!.updateProperty('title', fileUris[0].fsPath);
+
+				this.profileUsed = true;
 			}
 		});
 


### PR DESCRIPTION
`profileUsed` was getting initialized to false here https://github.com/microsoft/azuredatastudio/blob/985a30d7730b00812eadb905ae50708c9deb791f/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts#L59

but never got set to true when a publish profile was loaded in ADS, so it made it seem like no one was using publish profiles in ADS. The publish quickpick for vscode was correctly `profileUsed`.