### PR TITLE
revert the language clent channel change

### DIFF
--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -196,6 +196,28 @@ function getClientOptions(context: AppContext): ClientOptions {
 			ExecutionPlanServiceFeature,
 			TdeMigrationService.asFeature(context),
 		],
-		outputChannel: outputChannel
+		outputChannel: new CustomOutputChannel()
 	};
+}
+
+class CustomOutputChannel implements vscode.OutputChannel {
+	name: string;
+	append(value: string): void {
+		console.log(value);
+	}
+	appendLine(value: string): void {
+		console.log(value);
+	}
+	clear(): void {
+	}
+	show(preserveFocus?: boolean): void;
+	show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
+	show(column?: any, preserveFocus?: any) {
+	}
+	hide(): void {
+	}
+	dispose(): void {
+	}
+	replace(_value: string): void {
+	}
 }


### PR DESCRIPTION
For #21851

The PR: https://github.com/microsoft/azuredatastudio/pull/21591 hooked up the 'SQL Tools Service' output channel with the Data Protocol Client and the errors started show up in there in a very noticeable way. The particular error in the issue has always been there but caught the user's attention because of the different output locations.

for 1.41 release, I am reverting the output channel change so that users won't be annoyed, and, in the meanwhile, I will fix the actual problem in main branch.