### PR TITLE
Bump sql-migration insiders to 1.3.1

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.3.0",
-							"lastUpdated": "02/03/2023",
+							"version": "1.3.1",
+							"lastUpdated": "02/08/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.3.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.3.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the Insiders extension gallery to the latest release candidate version of the SQL Migration extension. This change includes hot fixes for encrypt / trust sever certificate error and update databases query. 

Link to Azure Data Studio - Extensions pipeline run containing vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=189284&view=results