### PR TITLE
Remove unused SqlDatabaseProjectTreeViewProvider functions

### DIFF
--- a/extensions/sql-database-projects/src/controllers/databaseProjectTreeViewProvider.ts
+++ b/extensions/sql-database-projects/src/controllers/databaseProjectTreeViewProvider.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as constants from '../common/constants';
 
 import { BaseProjectTreeItem, SpacerTreeItem } from '../models/tree/baseTreeItem';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
@@ -44,13 +43,6 @@ export class SqlDatabaseProjectTreeViewProvider implements vscode.TreeDataProvid
 		return element.children;
 	}
 
-	public getParent(element: BaseProjectTreeItem): BaseProjectTreeItem {
-		if (!element.parent) {
-			throw new Error(constants.parentTreeItemUnknown);
-		}
-		return element.parent;
-	}
-
 	/**
 	 * Constructs a new set of root nodes from a list of Projects
 	 * @param projects List of Projects
@@ -77,13 +69,5 @@ export class SqlDatabaseProjectTreeViewProvider implements vscode.TreeDataProvid
 		}
 
 		this.treeView = value;
-	}
-
-	public async focus(project: Project): Promise<void> {
-		const projNode = this.roots.find(x => x instanceof ProjectRootTreeItem ? (<ProjectRootTreeItem>x).project === project : false);
-
-		if (projNode) {
-			await this.treeView?.reveal(projNode, { focus: true, expand: true });
-		}
 	}
 }


### PR DESCRIPTION
Removing these functions since they aren't being used so that they don't need to be updated with the changes needed for adding drag and drop support.

`getParent` is an optional function to implement of `TreeDataProvider`. The way we had it implemented uses a circular reference that child parents had to the parent, which is something I'm getting rid of later which is necessary for drag and drop support.

`focus` was added before the Data Workspace extension was introduced to display tree views, and this function was no longer used after that change.