### PR TITLE
Add profile section in Publish project UI

### DIFF
--- a/extensions/dacpac/src/test/testDacFxService.ts
+++ b/extensions/dacpac/src/test/testDacFxService.ts
@@ -90,7 +90,7 @@ export class DacFxTestService implements mssql.IDacFxService {
 		return Promise.resolve({ containsCreateTableStatement: true });
 	}
 
-	savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>): Thenable<mssql.SavePublishProfileResult> {
+	savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>): Thenable<azdata.ResultStatus> {
 		return Promise.resolve(this.dacfxResult);
 	}
 }

--- a/extensions/dacpac/src/test/testDacFxService.ts
+++ b/extensions/dacpac/src/test/testDacFxService.ts
@@ -89,4 +89,8 @@ export class DacFxTestService implements mssql.IDacFxService {
 	parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<mssql.ParseTSqlScriptResult> {
 		return Promise.resolve({ containsCreateTableStatement: true });
 	}
+
+	savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>): Thenable<mssql.SavePublishProfileResult> {
+		return Promise.resolve(this.dacfxResult);
+	}
 }

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -551,6 +551,14 @@ export interface ParseTSqlScriptParams {
 	databaseSchemaProvider: string;
 }
 
+export interface SavePublishProfileParams {
+	profilePath: string;
+	databaseName: string;
+	connectionString: string;
+	sqlCommandVariableValues?: Record<string, string>;
+	deploymentOptions?: mssql.DeploymentOptions;
+}
+
 export namespace ExportRequest {
 	export const type = new RequestType<ExportParams, mssql.DacFxResult, void, void>('dacfx/export');
 }
@@ -585,6 +593,10 @@ export namespace ValidateStreamingJobRequest {
 
 export namespace ParseTSqlScriptRequest {
 	export const type = new RequestType<ParseTSqlScriptParams, mssql.ParseTSqlScriptResult, void, void>('dacfx/parseTSqlScript');
+}
+
+export namespace SavePublishProfileRequest {
+	export const type = new RequestType<SavePublishProfileParams, mssql.ParseTSqlScriptResult, void, void>('dacfx/savePublishProfile');
 }
 
 // ------------------------------- </ DacFx > ------------------------------------

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -596,7 +596,7 @@ export namespace ParseTSqlScriptRequest {
 }
 
 export namespace SavePublishProfileRequest {
-	export const type = new RequestType<SavePublishProfileParams, mssql.SavePublishProfileResult, void, void>('dacfx/savePublishProfile');
+	export const type = new RequestType<SavePublishProfileParams, azdata.ResultStatus, void, void>('dacfx/savePublishProfile');
 }
 
 // ------------------------------- </ DacFx > ------------------------------------

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -596,7 +596,7 @@ export namespace ParseTSqlScriptRequest {
 }
 
 export namespace SavePublishProfileRequest {
-	export const type = new RequestType<SavePublishProfileParams, mssql.ParseTSqlScriptResult, void, void>('dacfx/savePublishProfile');
+	export const type = new RequestType<SavePublishProfileParams, mssql.SavePublishProfileResult, void, void>('dacfx/savePublishProfile');
 }
 
 // ------------------------------- </ DacFx > ------------------------------------

--- a/extensions/mssql/src/dacfx/dacFxService.ts
+++ b/extensions/mssql/src/dacfx/dacFxService.ts
@@ -141,4 +141,15 @@ export class DacFxService implements mssql.IDacFxService {
 			throw e;
 		}
 	}
+
+	public async savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: mssql.DeploymentOptions): Promise<mssql.ParseTSqlScriptResult> {
+		const params: contracts.SavePublishProfileParams = { profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions };
+		try {
+			const result = await this.client.sendRequest(contracts.SavePublishProfileRequest.type, params);
+			return result;
+		} catch (e) {
+			this.client.logFailedRequest(contracts.SavePublishProfileRequest.type, e);
+			throw e;
+		}
+	}
 }

--- a/extensions/mssql/src/dacfx/dacFxService.ts
+++ b/extensions/mssql/src/dacfx/dacFxService.ts
@@ -142,7 +142,7 @@ export class DacFxService implements mssql.IDacFxService {
 		}
 	}
 
-	public async savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: mssql.DeploymentOptions): Promise<mssql.SavePublishProfileResult> {
+	public async savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: mssql.DeploymentOptions): Promise<azdata.ResultStatus> {
 		const params: contracts.SavePublishProfileParams = { profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions };
 		try {
 			const result = await this.client.sendRequest(contracts.SavePublishProfileRequest.type, params);

--- a/extensions/mssql/src/dacfx/dacFxService.ts
+++ b/extensions/mssql/src/dacfx/dacFxService.ts
@@ -142,7 +142,7 @@ export class DacFxService implements mssql.IDacFxService {
 		}
 	}
 
-	public async savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: mssql.DeploymentOptions): Promise<mssql.ParseTSqlScriptResult> {
+	public async savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: mssql.DeploymentOptions): Promise<mssql.SavePublishProfileResult> {
 		const params: contracts.SavePublishProfileParams = { profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions };
 		try {
 			const result = await this.client.sendRequest(contracts.SavePublishProfileRequest.type, params);

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -244,7 +244,7 @@ declare module 'mssql' {
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
 		parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<ParseTSqlScriptResult>;
-		savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<SavePublishProfileResult>;
+		savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<azdata.ResultStatus>;
 	}
 
 	export interface DacFxResult extends azdata.ResultStatus {
@@ -264,9 +264,6 @@ declare module 'mssql' {
 
 	export interface ParseTSqlScriptResult {
 		containsCreateTableStatement: boolean;
-	}
-
-	export interface SavePublishProfileResult extends azdata.ResultStatus {
 	}
 
 	export interface ExportParams {

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -244,6 +244,7 @@ declare module 'mssql' {
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
 		parseTSqlScript(filePath: string, databaseSchemaProvider: string): Thenable<ParseTSqlScriptResult>;
+		savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<SavePublishProfileResult>;
 	}
 
 	export interface DacFxResult extends azdata.ResultStatus {
@@ -263,6 +264,9 @@ declare module 'mssql' {
 
 	export interface ParseTSqlScriptResult {
 		containsCreateTableStatement: boolean;
+	}
+
+	export interface SavePublishProfileResult extends azdata.ResultStatus {
 	}
 
 	export interface ExportParams {

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -134,6 +134,7 @@ export const server = localize('server', "Server");
 export const defaultUser = localize('default', "default");
 export const selectProfileToUse = localize('selectProfileToUse', "Select publish profile to load");
 export const selectProfile = localize('selectProfile', "Select Profile");
+export const saveProfileAsButtonText = localize('saveProfileAsButtonText', "Save Profile As...");
 export const dontUseProfile = localize('dontUseProfile', "Don't use profile");
 export const browseForProfileWithIcon = `$(folder) ${localize('browseForProfile', "Browse for profile")}`;
 export const chooseAction = localize('chooseAction', "Choose action");

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -135,6 +135,7 @@ export const defaultUser = localize('default', "default");
 export const selectProfileToUse = localize('selectProfileToUse', "Select publish profile to load");
 export const selectProfile = localize('selectProfile', "Select Profile");
 export const saveProfileAsButtonText = localize('saveProfileAsButtonText', "Save Profile As...");
+export const save = localize('save', "Save");
 export const dontUseProfile = localize('dontUseProfile', "Don't use profile");
 export const browseForProfileWithIcon = `$(folder) ${localize('browseForProfile', "Browse for profile")}`;
 export const chooseAction = localize('chooseAction', "Choose action");

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -26,7 +26,7 @@ import { ImportDataModel } from '../models/api/import';
 import { NetCoreTool, DotNetError } from '../tools/netcoreTool';
 import { ShellCommandOptions } from '../tools/shellExecutionHelper';
 import { BuildHelper } from '../tools/buildHelper';
-import { readPublishProfile } from '../models/publishProfile/publishProfile';
+import { readPublishProfile, savePublishProfile } from '../models/publishProfile/publishProfile';
 import { AddDatabaseReferenceDialog } from '../dialogs/addDatabaseReferenceDialog';
 import { ISystemDatabaseReferenceSettings, IDacpacReferenceSettings, IProjectReferenceSettings } from '../models/IDatabaseReferenceSettings';
 import { DatabaseReferenceTreeItem } from '../models/tree/databaseReferencesTreeItem';
@@ -419,6 +419,7 @@ export class ProjectsController {
 			publishDatabaseDialog.publishToContainer = async (proj, prof) => this.publishToDockerContainer(proj, prof);
 			publishDatabaseDialog.generateScript = async (proj, prof) => this.publishOrScriptProject(proj, prof, false);
 			publishDatabaseDialog.readPublishProfile = async (profileUri) => readPublishProfile(profileUri);
+			publishDatabaseDialog.savePublishProfile = async (profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions) => savePublishProfile(profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions);
 
 			publishDatabaseDialog.openDialog();
 

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -941,7 +941,7 @@ export class PublishDatabaseDialog {
 			}
 
 			if (this.savePublishProfile) {
-				const targetConnectionString = this.targetConnectionTextBox?.value ?? '';
+				const targetConnectionString = this.connectionId ? await utils.getAzdataApi()!.connection.getConnectionString(this.connectionId, false) : '';
 				const targetDatabaseName = this.targetDatabaseName ?? '';
 				const deploymentOptions = await this.getDeploymentOptions();
 				await this.savePublishProfile(filePath.fsPath, targetDatabaseName, targetConnectionString, this.getSqlCmdVariablesForPublish(), deploymentOptions);

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -946,9 +946,11 @@ export class PublishDatabaseDialog {
 			if (!filePath) {
 				return;
 			}
-
+			console.error('----------------------------------------------In save');
 			if (this.savePublishProfile) {
-				await this.savePublishProfile(filePath.fsPath);
+				const targetConnectionString = this.targetConnectionTextBox?.value ?? '';
+				const deploymentOptions = await this.getDeploymentOptions();
+				await this.savePublishProfile(filePath.fsPath, this.targetDatabaseName, targetConnectionString, this.getSqlCmdVariablesForPublish(), deploymentOptions);
 			}
 
 		});

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -143,13 +143,24 @@ export class PublishDatabaseDialog {
 			const options = await this.getDefaultDeploymentOptions();
 			this.setDeploymentOptions(options);
 
-			const profileRow = this.createProfileRow(view);
+			const profileRow = this.createProfileSection(view);
+
+			let publishProfileFormComponentGroup: azdataType.FormComponentGroup = {
+				components: [
+					{
+						title: '',
+						component: profileRow
+					}
+				],
+				title: constants.profile
+			};
+
 			this.connectionRow = this.createConnectionRow(view);
 			this.databaseRow = this.createDatabaseRow(view);
 			const displayOptionsButton = this.createOptionsButton(view);
 
 			const horizontalFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
-			horizontalFormSection.addItems([profileRow, this.databaseRow]);
+			horizontalFormSection.addItems([this.databaseRow]);
 
 			this.formBuilder = <azdataType.FormBuilder>view.modelBuilder.formContainer()
 				.withFormItems([
@@ -186,6 +197,8 @@ export class PublishDatabaseDialog {
 				.withLayout({
 					width: '100%'
 				});
+
+			this.formBuilder.insertFormItem(publishProfileFormComponentGroup, 1);
 
 			// add SQLCMD variables table if the project has any
 			if (Object.keys(this.project.sqlCmdVariables).length > 0) {
@@ -523,8 +536,10 @@ export class PublishDatabaseDialog {
 		}
 	}
 
-	private createProfileRow(view: azdataType.ModelView): azdataType.FlexContainer {
-		const loadProfileButton = this.createLoadProfileButton(view);
+	private createProfileSection(view: azdataType.ModelView): azdataType.FlexContainer {
+		const selectProfileButton = this.createSelectProfileButton(view);
+		const saveProfileAsButton = this.createSaveProfileAsButton(view);
+
 		this.loadProfileTextBox = view.modelBuilder.inputBox().withProps({
 			placeHolder: constants.loadProfilePlaceholderText,
 			ariaLabel: constants.profile,
@@ -532,13 +547,7 @@ export class PublishDatabaseDialog {
 			enabled: false
 		}).component();
 
-		const profileLabel = view.modelBuilder.text().withProps({
-			value: constants.profile,
-			width: cssStyles.publishDialogLabelWidth
-		}).component();
-
-		const profileRow = view.modelBuilder.flexContainer().withItems([profileLabel, this.loadProfileTextBox], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
-		profileRow.insertItem(loadProfileButton, 2, { CSSStyles: { 'margin-right': '0px' } });
+		const profileRow = view.modelBuilder.flexContainer().withItems([this.loadProfileTextBox, selectProfileButton, saveProfileAsButton], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
 
 		return profileRow;
 	}
@@ -842,12 +851,14 @@ export class PublishDatabaseDialog {
 		}
 	}
 
-	private createLoadProfileButton(view: azdataType.ModelView): azdataType.ButtonComponent {
+	private createSelectProfileButton(view: azdataType.ModelView): azdataType.ButtonComponent {
 		let loadProfileButton: azdataType.ButtonComponent = view.modelBuilder.button().withProps({
-			ariaLabel: constants.loadProfilePlaceholderText,
-			iconPath: IconPathHelper.folder_blue,
-			height: '18px',
-			width: '18px'
+			label: constants.selectProfile,
+			title: constants.selectProfile,
+			ariaLabel: constants.selectProfile,
+			width: cssStyles.PublishingOptionsButtonWidth,
+			height: '25px',
+			secondary: true,
 		}).component();
 
 		loadProfileButton.onDidClick(async () => {
@@ -903,6 +914,23 @@ export class PublishDatabaseDialog {
 		});
 
 		return loadProfileButton;
+	}
+
+	private createSaveProfileAsButton(view: azdataType.ModelView): azdataType.ButtonComponent {
+		let saveProfileAsButton: azdataType.ButtonComponent = view.modelBuilder.button().withProps({
+			label: constants.saveProfileAsButtonText,
+			title: constants.saveProfileAsButtonText,
+			ariaLabel: constants.saveProfileAsButtonText,
+			width: cssStyles.PublishingOptionsButtonWidth,
+			height: '25px',
+			secondary: true
+		}).component();
+
+		saveProfileAsButton.onDidClick(async () => {
+			// TODO: Handle button click
+		});
+
+		return saveProfileAsButton;
 	}
 
 	private convertSqlCmdVarsToTableFormat(sqlCmdVars: Record<string, string>): azdataType.DeclarativeTableCellValue[][] {

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -147,16 +147,6 @@ export class PublishDatabaseDialog {
 
 			const profileRow = this.createProfileSection(view);
 
-			let publishProfileFormComponentGroup: azdataType.FormComponentGroup = {
-				components: [
-					{
-						title: '',
-						component: profileRow
-					}
-				],
-				title: constants.profile
-			};
-
 			this.connectionRow = this.createConnectionRow(view);
 			this.databaseRow = this.createDatabaseRow(view);
 			const displayOptionsButton = this.createOptionsButton(view);
@@ -173,10 +163,10 @@ export class PublishDatabaseDialog {
 								component: flexRadioButtonsModel,
 								title: ''
 							},
-							/*{
-								component: publishProfileFormComponentGroup,
-								title: ''
-							},*/
+							{
+								component: profileRow,
+								title: constants.profile
+							},
 							{
 								component: this.connectionRow,
 								title: ''
@@ -203,8 +193,6 @@ export class PublishDatabaseDialog {
 				.withLayout({
 					width: '100%'
 				});
-
-			this.formBuilder.insertFormItem(publishProfileFormComponentGroup, 2);
 
 			// add SQLCMD variables table if the project has any
 			if (Object.keys(this.project.sqlCmdVariables).length > 0) {
@@ -450,18 +438,19 @@ export class PublishDatabaseDialog {
 		this.createDatabaseRow(view);
 		this.tryEnableGenerateScriptAndOkButtons();
 		if (existingServer) {
-			if (this.connectionRow) {
-				this.formBuilder!.insertFormItem({
-					title: '',
-					component: this.connectionRow
-				}, 2);
-			}
 			if (this.localDbSection) {
 				this.formBuilder!.removeFormItem({
 					title: '',
 					component: this.localDbSection
 				});
 			}
+			if (this.connectionRow) {
+				this.formBuilder!.insertFormItem({
+					title: '',
+					component: this.connectionRow
+				}, 3);
+			}
+
 		} else {
 			if (this.connectionRow) {
 				this.formBuilder!.removeFormItem({
@@ -946,7 +935,7 @@ export class PublishDatabaseDialog {
 			if (!filePath) {
 				return;
 			}
-			console.error('----------------------------------------------In save');
+
 			if (this.savePublishProfile) {
 				const targetConnectionString = this.targetConnectionTextBox?.value ?? '';
 				const deploymentOptions = await this.getDeploymentOptions();

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -71,6 +71,7 @@ export class PublishDatabaseDialog {
 	public publishToContainer: ((proj: Project, profile: IPublishToDockerSettings) => any) | undefined;
 	public generateScript: ((proj: Project, profile: ISqlProjectPublishSettings) => any) | undefined;
 	public readPublishProfile: ((profileUri: vscode.Uri) => any) | undefined;
+	public savePublishProfile: ((profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions) => any) | undefined;
 
 	constructor(private project: Project) {
 		this.dialog = utils.getAzdataApi()!.window.createModelViewDialog(constants.publishDialogName, 'sqlProjectPublishDialog');
@@ -944,6 +945,10 @@ export class PublishDatabaseDialog {
 
 			if (!filePath) {
 				return;
+			}
+
+			if (this.savePublishProfile) {
+				await this.savePublishProfile(filePath.fsPath);
 			}
 
 		});

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -198,7 +198,7 @@ export class PublishDatabaseDialog {
 					width: '100%'
 				});
 
-			this.formBuilder.insertFormItem(publishProfileFormComponentGroup, 1);
+			this.formBuilder.insertFormItem(publishProfileFormComponentGroup, 2);
 
 			// add SQLCMD variables table if the project has any
 			if (Object.keys(this.project.sqlCmdVariables).length > 0) {

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as constants from '../common/constants';
 import * as utils from '../common/utils';
 import * as uiUtils from './utils';
+import * as path from 'path';
 
 import { Project } from '../models/project';
 import { SqlConnectionDataSource } from '../models/dataSources/sqlConnectionStringSource';
@@ -171,6 +172,10 @@ export class PublishDatabaseDialog {
 								component: flexRadioButtonsModel,
 								title: ''
 							},
+							/*{
+								component: publishProfileFormComponentGroup,
+								title: ''
+							},*/
 							{
 								component: this.connectionRow,
 								title: ''
@@ -927,7 +932,20 @@ export class PublishDatabaseDialog {
 		}).component();
 
 		saveProfileAsButton.onDidClick(async () => {
-			// TODO: Handle button click
+			const filePath = await vscode.window.showSaveDialog(
+				{
+					defaultUri: vscode.Uri.file(path.join(this.project.projectFolderPath, `${this.project.projectFileName}_1`)),
+					saveLabel: constants.save,
+					filters: {
+						'Publish Settings Files': ['publish.xml'],
+					}
+				}
+			);
+
+			if (!filePath) {
+				return;
+			}
+
 		});
 
 		return saveProfileAsButton;

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -62,6 +62,7 @@ export class PublishDatabaseDialog {
 	protected optionsButton: azdataType.ButtonComponent | undefined;
 	private publishOptionsDialog: PublishOptionsDialog | undefined;
 	public publishOptionsModified: boolean = false;
+	private publishProfileUri: vscode.Uri | undefined;
 
 	private completionPromise: Deferred = new Deferred();
 
@@ -444,6 +445,7 @@ export class PublishDatabaseDialog {
 					component: this.localDbSection
 				});
 			}
+
 			if (this.connectionRow) {
 				this.formBuilder!.insertFormItem({
 					title: '',
@@ -458,6 +460,7 @@ export class PublishDatabaseDialog {
 					component: this.connectionRow
 				});
 			}
+
 			if (this.localDbSection) {
 				this.formBuilder!.insertFormItem({
 					title: '',
@@ -905,6 +908,7 @@ export class PublishDatabaseDialog {
 				await this.loadProfileTextBox!.updateProperty('title', fileUris[0].fsPath);
 
 				this.profileUsed = true;
+				this.publishProfileUri = fileUris[0];
 			}
 		});
 
@@ -924,7 +928,7 @@ export class PublishDatabaseDialog {
 		saveProfileAsButton.onDidClick(async () => {
 			const filePath = await vscode.window.showSaveDialog(
 				{
-					defaultUri: vscode.Uri.file(path.join(this.project.projectFolderPath, `${this.project.projectFileName}_1`)),
+					defaultUri: this.publishProfileUri ?? vscode.Uri.file(path.join(this.project.projectFolderPath, `${this.project.projectFileName}_1`)),
 					saveLabel: constants.save,
 					filters: {
 						'Publish Settings Files': ['publish.xml'],
@@ -938,10 +942,13 @@ export class PublishDatabaseDialog {
 
 			if (this.savePublishProfile) {
 				const targetConnectionString = this.targetConnectionTextBox?.value ?? '';
+				const targetDatabaseName = this.targetDatabaseName ?? '';
 				const deploymentOptions = await this.getDeploymentOptions();
-				await this.savePublishProfile(filePath.fsPath, this.targetDatabaseName, targetConnectionString, this.getSqlCmdVariablesForPublish(), deploymentOptions);
+				await this.savePublishProfile(filePath.fsPath, targetDatabaseName, targetConnectionString, this.getSqlCmdVariablesForPublish(), deploymentOptions);
 			}
 
+			this.profileUsed = true;
+			this.publishProfileUri = filePath;
 		});
 
 		return saveProfileAsButton;

--- a/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
+++ b/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
@@ -123,9 +123,9 @@ async function readConnectionString(xmlDoc: any): Promise<{ connectionId: string
 }
 
 /**
- * saves publish settings to the specified file
+ * saves publish settings to the specified profile file
  */
-export async function savePublishProfile(profilePath: vscode.Uri): Promise<void> {
+export async function savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: mssql.DeploymentOptions): Promise<void> {
 	const dacFxService = await utils.getDacFxService();
-	await dacFxService.savePublishProfile(profilePath.fsPath);
+	await dacFxService.savePublishProfile(profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions);
 }

--- a/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
+++ b/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
@@ -127,5 +127,7 @@ async function readConnectionString(xmlDoc: any): Promise<{ connectionId: string
  */
 export async function savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: mssql.DeploymentOptions): Promise<void> {
 	const dacFxService = await utils.getDacFxService();
+	console.error('-In method-----------------------------------------------------------------------method');
 	await dacFxService.savePublishProfile(profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions);
+	console.error('------------------------------------------------------------------------Here');
 }

--- a/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
+++ b/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
@@ -127,7 +127,5 @@ async function readConnectionString(xmlDoc: any): Promise<{ connectionId: string
  */
 export async function savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: mssql.DeploymentOptions): Promise<void> {
 	const dacFxService = await utils.getDacFxService();
-	console.error('-In method-----------------------------------------------------------------------method');
 	await dacFxService.savePublishProfile(profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions);
-	console.error('------------------------------------------------------------------------Here');
 }

--- a/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
+++ b/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
@@ -121,3 +121,11 @@ async function readConnectionString(xmlDoc: any): Promise<{ connectionId: string
 		server: server
 	};
 }
+
+/**
+ * saves publish settings to the specified file
+ */
+export async function savePublishProfile(profilePath: vscode.Uri): Promise<void> {
+	const dacFxService = await utils.getDacFxService();
+	await dacFxService.savePublishProfile(profilePath.fsPath);
+}

--- a/extensions/sql-database-projects/src/test/testContext.ts
+++ b/extensions/sql-database-projects/src/test/testContext.ts
@@ -24,8 +24,7 @@ export const mockDacFxResult = {
 
 export const mockSavePublishResult = {
 	success: true,
-	errorMessage: '',
-	report: ''
+	errorMessage: ''
 };
 
 /* Get the deployment options sample model */

--- a/extensions/sql-database-projects/src/test/testContext.ts
+++ b/extensions/sql-database-projects/src/test/testContext.ts
@@ -22,6 +22,12 @@ export const mockDacFxResult = {
 	report: ''
 };
 
+export const mockSavePublishResult = {
+	success: true,
+	errorMessage: '',
+	report: ''
+};
+
 /* Get the deployment options sample model */
 export function getDeploymentOptions(): mssql.DeploymentOptions {
 	const sampleDesc = 'Sample Description text';
@@ -57,6 +63,7 @@ export class MockDacFxService implements mssql.IDacFxService {
 	public getOptionsFromProfile(_: string): Thenable<mssql.DacFxOptionsResult> { return Promise.resolve(mockDacFxOptionsResult); }
 	public validateStreamingJob(_: string, __: string): Thenable<mssql.ValidateStreamingJobResult> { return Promise.resolve(mockDacFxResult); }
 	public parseTSqlScript(_: string, __: string): Thenable<mssql.ParseTSqlScriptResult> { return Promise.resolve({ containsCreateTableStatement: true }); }
+	public savePublishProfile(_: string, __: string, ___: string, ______?: Record<string, string>): Thenable<mssql.SavePublishProfileResult> { return Promise.resolve(mockSavePublishResult); }
 }
 
 export function createContext(): TestContext {

--- a/extensions/sql-database-projects/src/test/testContext.ts
+++ b/extensions/sql-database-projects/src/test/testContext.ts
@@ -63,7 +63,7 @@ export class MockDacFxService implements mssql.IDacFxService {
 	public getOptionsFromProfile(_: string): Thenable<mssql.DacFxOptionsResult> { return Promise.resolve(mockDacFxOptionsResult); }
 	public validateStreamingJob(_: string, __: string): Thenable<mssql.ValidateStreamingJobResult> { return Promise.resolve(mockDacFxResult); }
 	public parseTSqlScript(_: string, __: string): Thenable<mssql.ParseTSqlScriptResult> { return Promise.resolve({ containsCreateTableStatement: true }); }
-	public savePublishProfile(_: string, __: string, ___: string, ______?: Record<string, string>): Thenable<mssql.SavePublishProfileResult> { return Promise.resolve(mockSavePublishResult); }
+	public savePublishProfile(_: string, __: string, ___: string, ______?: Record<string, string>): Thenable<azdata.ResultStatus> { return Promise.resolve(mockSavePublishResult); }
 }
 
 export function createContext(): TestContext {

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -426,7 +426,7 @@ declare module 'vscode-mssql' {
 		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
-		//savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<SavePublishProfileResult>;
+		savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<ResultStatus>;
 	}
 
 	/**
@@ -656,8 +656,6 @@ declare module 'vscode-mssql' {
 
 	export interface ValidateStreamingJobResult extends ResultStatus { }
 
-	//export interface SavePublishProfileResult extends ResultStatus { }
-
 	export interface ExportParams {
 		databaseName: string;
 		packageFilePath: string;
@@ -724,13 +722,13 @@ declare module 'vscode-mssql' {
 		defaultDeploymentOptions: DeploymentOptions;
 	}
 
-	/*export interface SavePublishProfileParams {
+	export interface SavePublishProfileParams {
 		profilePath: string;
 		databaseName: string;
 		connectionString: string;
 		sqlCommandVariableValues?: Record<string, string>;
 		deploymentOptions?: DeploymentOptions;
-	}*/
+	}
 
 	export interface ITreeNodeInfo extends vscode.TreeItem {
 		readonly connectionInfo: IConnectionInfo;

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -426,6 +426,7 @@ declare module 'vscode-mssql' {
 		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
+		savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<SavePublishProfileResult>;
 	}
 
 	/**
@@ -655,6 +656,8 @@ declare module 'vscode-mssql' {
 
 	export interface ValidateStreamingJobResult extends ResultStatus { }
 
+	export interface SavePublishProfileResult extends ResultStatus { }
+
 	export interface ExportParams {
 		databaseName: string;
 		packageFilePath: string;
@@ -719,6 +722,14 @@ declare module 'vscode-mssql' {
 
 	export interface SchemaCompareOptionsResult extends ResultStatus {
 		defaultDeploymentOptions: DeploymentOptions;
+	}
+
+	export interface SavePublishProfileParams {
+		profilePath: string;
+		databaseName: string;
+		connectionString: string;
+		sqlCommandVariableValues?: Record<string, string>;
+		deploymentOptions?: DeploymentOptions;
 	}
 
 	export interface ITreeNodeInfo extends vscode.TreeItem {

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -426,7 +426,7 @@ declare module 'vscode-mssql' {
 		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
-		savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<SavePublishProfileResult>;
+		//savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<SavePublishProfileResult>;
 	}
 
 	/**
@@ -656,7 +656,7 @@ declare module 'vscode-mssql' {
 
 	export interface ValidateStreamingJobResult extends ResultStatus { }
 
-	export interface SavePublishProfileResult extends ResultStatus { }
+	//export interface SavePublishProfileResult extends ResultStatus { }
 
 	export interface ExportParams {
 		databaseName: string;
@@ -724,13 +724,13 @@ declare module 'vscode-mssql' {
 		defaultDeploymentOptions: DeploymentOptions;
 	}
 
-	export interface SavePublishProfileParams {
+	/*export interface SavePublishProfileParams {
 		profilePath: string;
 		databaseName: string;
 		connectionString: string;
 		sqlCommandVariableValues?: Record<string, string>;
 		deploymentOptions?: DeploymentOptions;
-	}
+	}*/
 
 	export interface ITreeNodeInfo extends vscode.TreeItem {
 		readonly connectionInfo: IConnectionInfo;


### PR DESCRIPTION
This PR is the first part for saving publish profile (https://github.com/microsoft/azuredatastudio/issues/12185).
The missing functionality in PR:
- present profile in tree and add context menu to it
- add publish profile information to sqlproj.

Before changes:
![image](https://user-images.githubusercontent.com/57200045/218141916-e9758223-db46-4861-87a3-19ca172a9a2a.png)

After changes:

Publish to existing server:
![image](https://user-images.githubusercontent.com/57200045/218502835-e9e1a0de-f505-4a8c-9e97-3683a26ac9b8.png)

Publish to new SQL container
![image](https://user-images.githubusercontent.com/57200045/218503147-eadec357-a932-4c28-9ae7-3e19b29e44ad.png)



