### PR TITLE
Remove references to root in sql projects

### DIFF
--- a/extensions/sql-database-projects/src/models/tree/baseTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/baseTreeItem.ts
@@ -25,14 +25,4 @@ export abstract class BaseProjectTreeItem {
 	public get friendlyName(): string {
 		return path.parse(this.relativeProjectUri.path).base;
 	}
-
-	public get root() {
-		let node: BaseProjectTreeItem = this;
-
-		while (node.parent !== undefined) {
-			node = node.parent;
-		}
-
-		return node;
-	}
 }

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -127,10 +127,11 @@ describe('ProjectsController', function (): void {
 				sinon.stub(vscode.window, 'showInputBox').resolves(tableName);
 				const spy = sinon.spy(vscode.window, 'showErrorMessage');
 				const projController = new ProjectsController(testContext.outputChannel);
-				const project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
+				let project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
 
 				should(project.files.length).equal(0, 'There should be no files');
 				await projController.addItemPrompt(project, '', { itemType: ItemType.script });
+
 				should(project.files.length).equal(1, 'File should be successfully added');
 				await projController.addItemPrompt(project, '', { itemType: ItemType.script });
 				const msg = constants.fileAlreadyExists(tableName);
@@ -155,7 +156,7 @@ describe('ProjectsController', function (): void {
 				sinon.stub(vscode.window, 'showInputBox').resolves(tableName);
 				const spy = sinon.spy(vscode.window, 'showErrorMessage');
 				const projController = new ProjectsController(testContext.outputChannel);
-				const project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
+				let project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
 
 				should(project.files.length).equal(0, 'There should be no files');
 				await projController.addItemPrompt(project, '', { itemType: ItemType.script });
@@ -164,12 +165,18 @@ describe('ProjectsController', function (): void {
 				// exclude item
 				const projTreeRoot = new ProjectRootTreeItem(project);
 				await projController.exclude(createWorkspaceTreeItem(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'table1.sql')!));
+
+				// reload project
+				project = await Project.openProject(project.projectFilePath);
 				should(project.files.length).equal(0, 'File should be successfully excluded');
 				should(spy.called).be.false(`showErrorMessage not called with expected message. Actual '${spy.getCall(0)?.args[0]}'`);
 
 				// add item back
 				sinon.stub(vscode.window, 'showOpenDialog').resolves([vscode.Uri.file(path.join(project.projectFolderPath, 'table1.sql'))]);
 				await projController.addExistingItemPrompt(createWorkspaceTreeItem(projTreeRoot));
+
+				// reload project
+				project = await Project.openProject(project.projectFilePath);
 				should(project.files.length).equal(1, 'File should be successfully re-added');
 			});
 
@@ -178,11 +185,15 @@ describe('ProjectsController', function (): void {
 				const stub = sinon.stub(vscode.window, 'showInputBox').resolves(folderName);
 
 				const projController = new ProjectsController(testContext.outputChannel);
-				const project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
+				let project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
 				const projectRoot = new ProjectRootTreeItem(project);
 
 				should(project.files.length).equal(0, 'There should be no other folders');
 				await projController.addFolderPrompt(createWorkspaceTreeItem(projectRoot));
+
+				// reload project
+				project = await Project.openProject(project.projectFilePath);
+
 				should(project.files.length).equal(1, 'Folder should be successfully added');
 				stub.restore();
 				await verifyFolderNotAdded(folderName, projController, project, projectRoot);
@@ -198,22 +209,28 @@ describe('ProjectsController', function (): void {
 				const stub = sinon.stub(vscode.window, 'showInputBox').resolves(folderName);
 
 				const projController = new ProjectsController(testContext.outputChannel);
-				const project = await testUtils.createTestProject(baselines.openProjectFileBaseline);
+				let project = await testUtils.createTestProject(baselines.openProjectFileBaseline);
 				const projectRoot = new ProjectRootTreeItem(project);
 
 				// make sure it's ok to add these folders if they aren't where the reserved folders are at the root of the project
 				let node = projectRoot.children.find(c => c.friendlyName === 'Tables');
 				stub.restore();
 				for (let i in reservedProjectFolders) {
+					// reload project
+					project = await Project.openProject(project.projectFilePath);
 					await verifyFolderAdded(reservedProjectFolders[i], projController, project, <BaseProjectTreeItem>node);
 				}
 			});
 
 			async function verifyFolderAdded(folderName: string, projController: ProjectsController, project: Project, node: BaseProjectTreeItem): Promise<void> {
 				const beforeFileCount = project.files.length;
+				let beforeFiles = project.files.map(f => f.relativePath);
 				const stub = sinon.stub(vscode.window, 'showInputBox').resolves(folderName);
 				await projController.addFolderPrompt(createWorkspaceTreeItem(node));
-				should(project.files.length).equal(beforeFileCount + 1, `File count should be increased by one after adding the folder ${folderName}`);
+
+				// reload project
+				project = await Project.openProject(project.projectFilePath);
+				should(project.files.length).equal(beforeFileCount + 1, `File count should be increased by one after adding the folder ${folderName}. before files: ${JSON.stringify(beforeFiles)}/n after files: ${JSON.stringify(project.files.map(f => f.relativePath))}`);
 				stub.restore();
 			}
 
@@ -261,7 +278,7 @@ describe('ProjectsController', function (): void {
 
 			it('Should delete database references', async function (): Promise<void> {
 				// setup - openProject baseline has a system db reference to master
-				const proj = await testUtils.createTestProject(baselines.openProjectFileBaseline);
+				let proj = await testUtils.createTestProject(baselines.openProjectFileBaseline);
 				const projController = new ProjectsController(testContext.outputChannel);
 				sinon.stub(vscode.window, 'showWarningMessage').returns(<any>Promise.resolve(constants.yesString));
 
@@ -281,6 +298,8 @@ describe('ProjectsController', function (): void {
 				});
 
 				const projTreeRoot = new ProjectRootTreeItem(proj);
+				// reload project
+				proj = await Project.openProject(proj.projectFilePath);
 				should(proj.databaseReferences.length).equal(3, 'Should start with 3 database references');
 
 				const databaseReferenceNodeChildren = projTreeRoot.children.find(x => x.friendlyName === constants.databaseReferencesNodeName)?.children;
@@ -289,6 +308,8 @@ describe('ProjectsController', function (): void {
 				await projController.delete(createWorkspaceTreeItem(databaseReferenceNodeChildren?.find(x => x.friendlyName === 'project1')!)); // project reference
 
 				// confirm result
+				// reload project
+				proj = await Project.openProject(proj.projectFilePath);
 				should(proj.databaseReferences.length).equal(0, 'All database references should have been deleted');
 			});
 
@@ -353,7 +374,7 @@ describe('ProjectsController', function (): void {
 				const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.newProjectFileBaseline, folderPath);
 				const treeProvider = new SqlDatabaseProjectTreeViewProvider();
 				const projController = new ProjectsController(testContext.outputChannel);
-				const project = await Project.openProject(vscode.Uri.file(sqlProjPath).fsPath);
+				let project = await Project.openProject(vscode.Uri.file(sqlProjPath).fsPath);
 				treeProvider.load([project]);
 
 				// change the sql project file
@@ -361,9 +382,12 @@ describe('ProjectsController', function (): void {
 				should(project.files.length).equal(0);
 
 				// call reload project
-				await projController.reloadProject({ treeDataProvider: treeProvider, element: { root: { project: project } } });
+				const projTreeRoot = new ProjectRootTreeItem(project);
+				await projController.reloadProject(createWorkspaceTreeItem(projTreeRoot));
 				// calling this because this gets called in the projectProvider.getProjectTreeDataProvider(), which is called by workspaceTreeDataProvider
 				// when notifyTreeDataChanged() happens
+				// reload project
+				project = await Project.openProject(sqlProjPath);
 				treeProvider.load([project]);
 
 				// check that the new project is in the tree
@@ -421,7 +445,7 @@ describe('ProjectsController', function (): void {
 				projController.setup(x => x.getPublishDialog(TypeMoq.It.isAny())).returns(() => publishDialog.object);
 				const proj = new Project('FakePath');
 				sinon.stub(proj, 'getProjectTargetVersion').returns('150');
-				void projController.object.publishProject(proj);
+				await projController.object.publishProject(proj);
 				should(opened).equal(true);
 			});
 


### PR DESCRIPTION
Part 2 of removing the circular references in the sql projects tree. Part 1 was https://github.com/microsoft/azuredatastudio/pull/21901

This PR removes all the references to the `root` of sql project tree items, which is what the circular reference was being used to access the project stored at the root `ProjectRootTreeItem`. All those places using the root for that purpose are now opening the project using the sqlproj uri. I tried passing the `Project` to each `BaseProjectTreeItem`, but that also resulted in circular reference errors from drag and drop because of the project xml that's stored in the `projFileXmlDoc` of a `Project`, which is why I had to go down this route.

Several tests had to be updated to reopen the project now that the same project object that was previously stored in the tree isn't being used. With lots of upcoming changes coming when we swap to using the DacFx project parsing, I wasn't too concerned about having to update the tests to do this. The actual projects tree reloads and reopens the projects whenever there's a change (ex: a file is added), so there isn't the same problem as the tests where a different project instance gets updated than the one being used in the test.

Next PR will be removing the parent being passed into the constructors of sql project tree items, then after that the drag and drop changes can finally be started!