### PR TITLE
update the default json cell style and allow user to disable special handling for JSON cells

### DIFF
--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -70,7 +70,6 @@ export function hyperLinkFormatter(row: number | undefined, cell: any | undefine
 	if (DBCellValue.isDBCellValue(value)) {
 		valueToDisplay = 'NULL';
 		if (!value.isNull) {
-			cellClasses += ' xmlLink';
 			valueToDisplay = getCellDisplayValue(value.displayValue);
 			return `<a class="${cellClasses}">${valueToDisplay}</a>`;
 		} else {

--- a/src/sql/base/browser/ui/table/media/slickColorTheme.css
+++ b/src/sql/base/browser/ui/table/media/slickColorTheme.css
@@ -17,18 +17,24 @@
 }
 
 .slick-cell a,
-.slick-cell a:link,
-.resultsMessageValue a,
-.resultsMessageValue a:link {
+.resultsMessageValue a {
 	color: var(--color-grid-link);
-	text-decoration: underline;
 	cursor: pointer;
 	white-space: inherit;
+}
+
+.resultsMessageValue a {
+	text-decoration: underline;
+}
+
+.slick-cell a {
+	text-decoration: none;
 }
 
 .slick-cell a:hover,
 .resultsMessageValue a:hover {
 	color: var(--color-grid-link-hover);
+	text-decoration: underline;
 }
 
 /*

--- a/src/sql/platform/query/common/query.ts
+++ b/src/sql/platform/query/common/query.ts
@@ -6,40 +6,52 @@
 export interface IQueryEditorConfiguration {
 	readonly results: {
 		readonly saveAsCsv: {
-			readonly includeHeaders: boolean,
-			readonly delimiter: string,
-			readonly lineSeperator: string,
-			readonly textIdentifier: string,
-			readonly encoding: string
-		},
+			readonly includeHeaders: boolean;
+			readonly delimiter: string;
+			readonly lineSeperator: string;
+			readonly textIdentifier: string;
+			readonly encoding: string;
+		};
 		readonly saveAsExcel: {
-			readonly includeHeaders: boolean,
-		},
+			readonly includeHeaders: boolean;
+		};
 		readonly saveAsMarkdown: {
-			readonly encoding: string,
-			readonly includeHeaders: boolean,
-			readonly lineSeparator: string,
-		}
+			readonly encoding: string;
+			readonly includeHeaders: boolean;
+			readonly lineSeparator: string;
+		};
 		readonly saveAsXml: {
-			readonly formatted: boolean,
-			readonly encoding: string
-		},
-		readonly streaming: boolean,
-		readonly copyIncludeHeaders: boolean,
-		readonly copyRemoveNewLine: boolean,
-		readonly optimizedTable: boolean,
-		readonly inMemoryDataProcessingThreshold: number,
-		readonly openAfterSave: boolean
+			readonly formatted: boolean;
+			readonly encoding: string;
+		};
+		readonly streaming: boolean;
+		readonly copyIncludeHeaders: boolean;
+		readonly copyRemoveNewLine: boolean;
+		readonly optimizedTable: boolean;
+		readonly inMemoryDataProcessingThreshold: number;
+		readonly openAfterSave: boolean;
 		readonly showActionBar: boolean;
 	},
 	readonly messages: {
-		readonly showBatchTime: boolean,
-		readonly wordwrap: boolean
-	},
+		readonly showBatchTime: boolean;
+		readonly wordwrap: boolean;
+	};
 	readonly chart: {
 		readonly defaultChartType: 'bar' | 'doughnut' | 'horizontalBar' | 'line' | 'pie' | 'scatter' | 'timeSeries',
-	},
-	readonly tabColorMode: 'off' | 'border' | 'fill',
+	};
+	readonly tabColorMode: 'off' | 'border' | 'fill';
 	readonly showConnectionInfoInTitle: boolean;
 	readonly promptToSaveGeneratedFiles: boolean;
+}
+
+export interface IResultGridConfiguration {
+	fontFamily: string;
+	fontWeight: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
+	fontSize: number;
+	letterSpacing: number;
+	rowHeight: number;
+	cellPadding: number | number[];
+	autoSizeColumns: boolean;
+	maxColumnWidth: number;
+	showJsonAsLink: boolean;
 }

--- a/src/sql/workbench/contrib/query/browser/queryResultsEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsEditor.ts
@@ -21,19 +21,13 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { RESULTS_GRID_DEFAULTS } from 'sql/workbench/common/constants';
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
+import { IResultGridConfiguration } from 'sql/platform/query/common/query';
 
 export const TextCompareEditorVisible = new RawContextKey<boolean>('textCompareEditorVisible', false);
 
 export class BareResultsGridInfo extends BareFontInfo {
 
-	public static override createFromRawSettings(opts: {
-		fontFamily?: string;
-		fontWeight?: string;
-		fontSize?: number;
-		lineHeight?: number;
-		letterSpacing?: number;
-		cellPadding?: number | number[];
-	}, zoomLevel: number): BareResultsGridInfo {
+	public static override createFromRawSettings(opts: IResultGridConfiguration, zoomLevel: number): BareResultsGridInfo {
 		let cellPadding = !types.isUndefinedOrNull(opts.cellPadding) ? opts.cellPadding : RESULTS_GRID_DEFAULTS.cellPadding;
 		return new BareResultsGridInfo(BareFontInfo.createFromRawSettings(opts, PixelRatio.value, false), { cellPadding });
 	}

--- a/src/sql/workbench/contrib/query/common/resultsGrid.contribution.ts
+++ b/src/sql/workbench/contrib/query/common/resultsGrid.contribution.ts
@@ -67,6 +67,11 @@ const resultsGridConfiguration: IConfigurationNode = {
 			type: 'number',
 			default: 212,
 			description: nls.localize('maxColumnWidth', "The maximum width in pixels for auto-sized columns")
+		},
+		'resultsGrid.showJsonAsLink': {
+			'type': 'boolean',
+			'description': nls.localize('resultsGrid.showJsonAsLink', "Whether to show cells with JSON formatted string as hyperlink. When enabled, upon click the JSON value will be opened in another tab. The default value is true."),
+			'default': true
 		}
 	}
 };


### PR DESCRIPTION
This PR fixes #21908

1. The underline decoration only shows on hover.
3. add a setting to control whether we treat JSON cells differently.


Before:
![image](https://user-images.githubusercontent.com/13777222/218223923-5e61743d-950b-4d3c-b62a-53de98d219d5.png)

After:
With the setting on (default)
![default-link](https://user-images.githubusercontent.com/13777222/218223807-8560aa0c-f5b5-44f1-9a59-189a859b29da.gif)

With the setting off
![json-link-off](https://user-images.githubusercontent.com/13777222/218223822-f32a62f2-27fb-4d26-814c-d3a1dc40a1a4.gif)
