### PR TITLE
completely hide the hidden widget

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
@@ -251,12 +251,15 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 	}
 
 	private _onFindStateChange(e: FindReplaceStateChangedEvent): void {
+		const node = this._finder.getDomNode();
 		if (e.isRevealed) {
 			if (this._findState.isRevealed) {
-				this._finder.getDomNode().style.top = '0px';
+				node.style.top = '0px';
+				node.style.display = '';
 				this._updateFinderMatchState();
 			} else {
-				this._finder.getDomNode().style.top = '';
+				node.style.top = '';
+				node.style.display = 'none';
 			}
 		}
 


### PR DESCRIPTION
https://msdata.visualstudio.com/Data%20Studio/_workitems/edit/1613458

when hidden, the elements are still in the DOM, we need to set display to none so that keyboard focus won't go into it.