### PR TITLE
Add horizontal scrollbar to Kqlmagic table and remove plotly graph max width

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.css
@@ -20,3 +20,7 @@ output-area-component .notebook-output {
 	white-space: pre-wrap;
 	word-wrap: break-word;
 }
+
+.output-userselect {
+	overflow: scroll;
+}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.css
@@ -21,6 +21,6 @@ output-area-component .notebook-output {
 	word-wrap: break-word;
 }
 
-.output-userselect {
+output-area-component .notebook-output .output-userselect {
 	overflow: scroll;
 }

--- a/src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component.ts
@@ -78,7 +78,6 @@ export class PlotlyOutputComponent extends AngularDisposable implements IMimeCom
 			PlotlyOutputComponent.Plotly = import('plotly.js-dist-min');
 		}
 		this._plotDiv = this.output.nativeElement;
-		this._plotDiv.style.maxWidth = '700px';
 		this._plotDiv.style.width = '100%';
 		this.renderPlotly();
 		this._initialized = true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/21859
## Horizontal scrollbar:
<img width="1351" alt="Screenshot 2023-02-13 at 1 01 03 PM" src="https://user-images.githubusercontent.com/23462877/218779953-6cd05aa8-10e8-4b0c-a70f-ef6d827fa6a4.png">

## plotly graph
### before
![Screenshot 2023-02-14 at 7 29 40 AM](https://user-images.githubusercontent.com/23462877/218783044-bf1feb3f-7843-4228-8d81-a2f03c254729.png)


### after:
![Screenshot 2023-02-14 at 7 06 21 AM](https://user-images.githubusercontent.com/23462877/218780183-e52b37d2-986e-4fb6-b781-4e4f01107908.png)

