### PR TITLE
Change sqlprojUri to projectFileUri in sql project tree

### DIFF
--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -95,7 +95,7 @@ export default class MainController implements vscode.Disposable {
 			if (node?.element instanceof TableFileNode) {
 				const tableFileNode = node.element as TableFileNode;
 
-				const projectPath = tableFileNode.sqlprojUri.fsPath;
+				const projectPath = tableFileNode.projectFileUri.fsPath;
 				const project = await Project.openProject(projectPath);
 				const targetVersion = project.getProjectTargetVersion();
 				const filePath = tableFileNode.fileSystemUri.fsPath;

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -623,7 +623,7 @@ export class ProjectsController {
 
 	public async addFolderPrompt(treeNode: dataworkspace.WorkspaceTreeItem): Promise<void> {
 		const project = await this.getProjectFromContext(treeNode);
-		const projectRelativeUri = vscode.Uri.file(path.basename((treeNode.element as BaseProjectTreeItem).sqlprojUri.fsPath, constants.sqlprojExtension));
+		const projectRelativeUri = vscode.Uri.file(path.basename((treeNode.element as BaseProjectTreeItem).projectFileUri.fsPath, constants.sqlprojExtension));
 		const relativePathToParent = this.getRelativePath(projectRelativeUri, treeNode.element);
 		const absolutePathToParent = path.join(project.projectFolderPath, relativePathToParent);
 		const newFolderName = await this.promptForNewObjectName(new templates.ProjectScriptType(ItemType.folder, constants.folderFriendlyName, ''),
@@ -679,7 +679,7 @@ export class ProjectsController {
 	}
 
 	public async addItemPromptFromNode(treeNode: dataworkspace.WorkspaceTreeItem, itemTypeName?: string): Promise<void> {
-		const projectRelativeUri = vscode.Uri.file(path.basename((treeNode.element as BaseProjectTreeItem).sqlprojUri.fsPath, constants.sqlprojExtension));
+		const projectRelativeUri = vscode.Uri.file(path.basename((treeNode.element as BaseProjectTreeItem).projectFileUri.fsPath, constants.sqlprojExtension));
 		await this.addItemPrompt(await this.getProjectFromContext(treeNode), this.getRelativePath(projectRelativeUri, treeNode.element), { itemType: itemTypeName }, treeNode.treeDataProvider as SqlDatabaseProjectTreeViewProvider);
 	}
 
@@ -1004,7 +1004,7 @@ export class ProjectsController {
 	 */
 	public async openFileWithWatcher(fileSystemUri: vscode.Uri, node: FileNode): Promise<void> {
 		await vscode.commands.executeCommand(constants.vscodeOpenCommand, fileSystemUri);
-		const project = await Project.openProject(node.sqlprojUri.fsPath);
+		const project = await Project.openProject(node.projectFileUri.fsPath);
 		const projectTargetVersion = project.getProjectTargetVersion();
 		const initiallyContainsCreateTableStatement = await utils.fileContainsCreateTableStatement(fileSystemUri.fsPath, projectTargetVersion);
 
@@ -1452,10 +1452,10 @@ export class ProjectsController {
 			const allFileEntries = project.files.concat(project.preDeployScripts).concat(project.postDeployScripts).concat(project.noneDeployScripts);
 
 			// trim trailing slash since folders with and without a trailing slash are allowed in a sqlproj
-			const trimmedUri = utils.trimChars(utils.getPlatformSafeFileEntryPath(utils.trimUri(fileOrFolder.sqlprojUri, fileOrFolder.fileSystemUri)), '/');
+			const trimmedUri = utils.trimChars(utils.getPlatformSafeFileEntryPath(utils.trimUri(fileOrFolder.projectFileUri, fileOrFolder.fileSystemUri)), '/');
 			return allFileEntries.find(x => utils.trimChars(utils.getPlatformSafeFileEntryPath(x.relativePath), '/') === trimmedUri);
 		}
-		const projectRelativeUri = vscode.Uri.file(path.basename(context.sqlprojUri.fsPath, constants.sqlprojExtension));
+		const projectRelativeUri = vscode.Uri.file(path.basename(context.projectFileUri.fsPath, constants.sqlprojExtension));
 		return project.files.find(x => utils.getPlatformSafeFileEntryPath(x.relativePath) === utils.getPlatformSafeFileEntryPath(utils.trimUri(projectRelativeUri, context.relativeProjectUri)));
 	}
 
@@ -1469,7 +1469,7 @@ export class ProjectsController {
 		}
 
 		if (context instanceof BaseProjectTreeItem) {
-			return Project.openProject(context.sqlprojUri.fsPath);
+			return Project.openProject(context.projectFileUri.fsPath);
 		} else {
 			throw new Error(constants.unexpectedProjectContext(JSON.stringify(context)));
 		}

--- a/extensions/sql-database-projects/src/models/tree/baseTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/baseTreeItem.ts
@@ -13,10 +13,10 @@ export abstract class BaseProjectTreeItem {
 	/**
 	 * Constructor
 	 * @param relativeProjectUri Project-relative URI that's compatible with the project tree
-	 * @param sqlprojUri Full URI to the .sqlproj of this project
+	 * @param projectFileUri Full URI to the .sqlproj of this project
 	 * @param parent parent tree item
 	 */
-	constructor(public relativeProjectUri: vscode.Uri, public sqlprojUri: vscode.Uri, public parent?: BaseProjectTreeItem) { }
+	constructor(public relativeProjectUri: vscode.Uri, public projectFileUri: vscode.Uri, public parent?: BaseProjectTreeItem) { }
 
 	abstract get children(): BaseProjectTreeItem[];
 

--- a/extensions/sql-database-projects/src/models/tree/databaseReferencesTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/databaseReferencesTreeItem.ts
@@ -37,7 +37,7 @@ export class DatabaseReferencesTreeItem extends BaseProjectTreeItem {
 		}
 
 		for (const reference of databaseReferences) {
-			this.references.push(new DatabaseReferenceTreeItem(reference, this.relativeProjectUri, this.sqlprojUri, this));
+			this.references.push(new DatabaseReferenceTreeItem(reference, this.relativeProjectUri, this.projectFileUri, this));
 		}
 	}
 

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -35,8 +35,8 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 		this.fileSystemUri = vscode.Uri.file(project.projectFilePath);
 		this.projectNodeName = path.basename(project.projectFilePath, sqlprojExtension);
 
-		this.databaseReferencesNode = new DatabaseReferencesTreeItem(this.projectNodeName, this.sqlprojUri, project.databaseReferences, this);
-		this.sqlCmdVariablesNode = new SqlCmdVariablesTreeItem(this.projectNodeName, this.sqlprojUri, project.sqlCmdVariables, this);
+		this.databaseReferencesNode = new DatabaseReferencesTreeItem(this.projectNodeName, this.projectFileUri, project.databaseReferences, this);
+		this.sqlCmdVariablesNode = new SqlCmdVariablesTreeItem(this.projectNodeName, this.projectFileUri, project.sqlCmdVariables, this);
 		this.construct();
 	}
 
@@ -83,17 +83,17 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 			switch (entry.type) {
 				case EntryType.File:
 					if (entry.sqlObjectType === ExternalStreamingJob) {
-						newNode = new fileTree.ExternalStreamingJobFileNode(entry.fsUri, this.sqlprojUri, parentNode);
+						newNode = new fileTree.ExternalStreamingJobFileNode(entry.fsUri, this.projectFileUri, parentNode);
 					} else if (entry.containsCreateTableStatement) {
-						newNode = new fileTree.TableFileNode(entry.fsUri, this.sqlprojUri, parentNode);
+						newNode = new fileTree.TableFileNode(entry.fsUri, this.projectFileUri, parentNode);
 					}
 					else {
-						newNode = new fileTree.FileNode(entry.fsUri, this.sqlprojUri, parentNode);
+						newNode = new fileTree.FileNode(entry.fsUri, this.projectFileUri, parentNode);
 					}
 
 					break;
 				case EntryType.Folder:
-					newNode = new fileTree.FolderNode(entry.fsUri, this.sqlprojUri, parentNode);
+					newNode = new fileTree.FolderNode(entry.fsUri, this.projectFileUri, parentNode);
 					break;
 				default:
 					throw new Error(`Unknown EntryType: '${entry.type}'`);
@@ -107,7 +107,7 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 	 * Gets the immediate parent tree node for an entry in a project file
 	 */
 	private getEntryParentNode(entry: FileProjectEntry): fileTree.FolderNode | ProjectRootTreeItem {
-		const relativePathParts = utils.trimChars(utils.trimUri(this.sqlprojUri, entry.fsUri), '/').split('/').slice(0, -1); // remove the last part because we only care about the parent
+		const relativePathParts = utils.trimChars(utils.trimUri(this.projectFileUri, entry.fsUri), '/').split('/').slice(0, -1); // remove the last part because we only care about the parent
 
 		if (relativePathParts.length === 0) {
 			return this; // if nothing left after trimming the entry itself, must been root
@@ -122,7 +122,7 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 		for (const part of relativePathParts) {
 			if (current.fileChildren[part] === undefined) {
 				const parentPath = current instanceof ProjectRootTreeItem ? path.dirname(current.fileSystemUri.fsPath) : current.fileSystemUri.fsPath;
-				current.fileChildren[part] = new fileTree.FolderNode(vscode.Uri.file(path.join(parentPath, part)), this.sqlprojUri, current);
+				current.fileChildren[part] = new fileTree.FolderNode(vscode.Uri.file(path.join(parentPath, part)), this.projectFileUri, current);
 			}
 
 			if (current.fileChildren[part] instanceof fileTree.FileNode) {

--- a/extensions/sql-database-projects/src/models/tree/sqlcmdVariableTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/sqlcmdVariableTreeItem.ts
@@ -37,7 +37,7 @@ export class SqlCmdVariablesTreeItem extends BaseProjectTreeItem {
 
 		for (const sqlCmdVariable of Object.keys(sqlCmdVariables)) {
 			if (sqlCmdVariable) {
-				this.sqlcmdVariableTreeItems.push(new SqlCmdVariableTreeItem(sqlCmdVariable, this.relativeProjectUri, this.sqlprojUri, this));
+				this.sqlcmdVariableTreeItems.push(new SqlCmdVariableTreeItem(sqlCmdVariable, this.relativeProjectUri, this.projectFileUri, this));
 			}
 		}
 	}


### PR DESCRIPTION
Updating this name to not be sql projects specific for when this is used in the data workspace tree for drag and drop (support for that will be added in a separate PR).