### PR TITLE
Add a check for an undefined model when creating the connection dialog model.

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -415,7 +415,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		}
 
 		let newProfile = new ConnectionProfile(this._capabilitiesService, model || providerName);
-		if (!model.password) {
+		if (model && !model.password) {
 			try {
 				await this._connectionManagementService.addSavedPassword(newProfile);
 			}


### PR DESCRIPTION
Opening the connection dialog was failing because this model reference was undefined. Introduced by this change: https://github.com/microsoft/azuredatastudio/commit/d9b24522e5c5ab11301ebc9c3addbcedf8e9229b#diff-1c35cfd3000efef5f2127a369f5c49e1c5c6c8d83e12582d42b78326a1605f76R418
