### PR TITLE
[SQL-Migration] Release v1.4.0 to Stable

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.3.0",
-							"lastUpdated": "02/06/2023",
+							"version": "1.4.0",
+							"lastUpdated": "02/15/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.3.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the insiders extension gallery to the latest version of the SQL Migration extension. The main change here is the decoupling of the migration extension from STS, where we instead now use our own dedicated Migration service - see https://github.com/microsoft/azuredatastudio/pull/21781



Link to Azure Data Studio - Extensions pipeline run off main containing vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=189857&view=results