### PR TITLE
Read server options from publish profile

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -546,6 +546,9 @@ export const authenticationSetting = 'Authentication';
 export const activeDirectoryInteractive = 'active directory interactive';
 export const userIdSetting = 'User ID';
 export const passwordSetting = 'Password';
+export const encryptSetting = 'Encrypt';
+export const trustServerCertificateSetting = 'Trust Server Certificate';
+export const hostnameInCertificateSetting = 'Host Name in Certificate';
 
 export const azureAddAccount = localize('azureAddAccount', "Add an Account...");
 

--- a/extensions/sql-database-projects/src/models/dataSources/sqlConnectionStringSource.ts
+++ b/extensions/sql-database-projects/src/models/dataSources/sqlConnectionStringSource.ts
@@ -114,7 +114,8 @@ export class SqlConnectionDataSource extends DataSource {
 			id: this.name + '-dataSource',
 			options: {
 				'encrypt': this.encrypt,
-				'trustServerCertificate': this.trustServerCertificate
+				'trustServerCertificate': this.trustServerCertificate,
+				'hostnameInCertificate': this.hostnameInCertificate
 			}
 		};
 

--- a/extensions/sql-database-projects/src/models/dataSources/sqlConnectionStringSource.ts
+++ b/extensions/sql-database-projects/src/models/dataSources/sqlConnectionStringSource.ts
@@ -62,6 +62,18 @@ export class SqlConnectionDataSource extends DataSource {
 		return this.getSetting(constants.passwordSetting);
 	}
 
+	public get encrypt(): string {
+		return this.getSetting(constants.encryptSetting);
+	}
+
+	public get trustServerCertificate(): string {
+		return this.getSetting(constants.trustServerCertificateSetting);
+	}
+
+	public get hostnameInCertificate(): string {
+		return this.getSetting(constants.hostnameInCertificateSetting);
+	}
+
 	constructor(name: string, connectionString: string) {
 		super(name);
 
@@ -100,7 +112,10 @@ export class SqlConnectionDataSource extends DataSource {
 			providerName: 'MSSQL',
 			saveProfile: true,
 			id: this.name + '-dataSource',
-			options: []
+			options: {
+				'encrypt': this.encrypt,
+				'trustServerCertificate': this.trustServerCertificate
+			}
 		};
 
 		return connProfile;

--- a/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
+++ b/extensions/sql-database-projects/src/models/publishProfile/publishProfile.ts
@@ -89,8 +89,12 @@ async function readConnectionString(xmlDoc: any): Promise<{ connectionId: string
 			if (dataSource.integratedSecurity) {
 				if (azdataApi) {
 					const connectionResult = await utils.getAzdataApi()!.connection.connect(connectionProfile, false, false);
-					utils.throwIfNotConnected(connectionResult);
-					connId = connectionResult.connectionId!;
+					if (!connectionResult.connected) {
+						const connection = await utils.getAzdataApi()!.connection.openConnectionDialog(undefined, connectionProfile);
+						connId = connection.connectionId;
+					} else {
+						connId = connectionResult.connectionId!;
+					}
 				} else {
 					// TODO@chgagnon - hook up VS Code MSSQL
 				}


### PR DESCRIPTION
This PR fixes #21927.
Prior changes did not read Encrypt and Trust Server Certificate value, hence doesn't load the connection properly and throws an error. The changes here reads it and uses these values to create a connection profile with proper options.
