### PR TITLE
Swap create new project api for sql projects

### DIFF
--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -603,6 +603,10 @@ export namespace SavePublishProfileRequest {
 
 // ------------------------------- < Sql Projects > ------------------------------------
 
+export namespace NewSqlProjectRequest {
+	export const type = new RequestType<NewSqlProjectParams, azdata.ResultStatus, void, void>('sqlProjects/newProject');
+}
+
 export namespace OpenSqlProjectRequest {
 	export const type = new RequestType<SqlProjectParams, azdata.ResultStatus, void, void>('sqlProjects/openProject');
 }
@@ -613,6 +617,12 @@ export namespace GetCrossPlatformCompatiblityRequest {
 
 export interface SqlProjectParams {
 	projectUri: string;
+}
+
+export interface NewSqlProjectParams extends SqlProjectParams {
+	sqlProjectType: mssql.ProjectType,
+	databaseSchemaProvider: string,
+	buildSdkVersion?: string
 }
 
 // ------------------------------- </ Sql Projects > -----------------------------------

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -319,8 +319,14 @@ declare module 'mssql' {
 	//#region --- Sql Projects
 
 	export interface ISqlProjectsService {
+		newProject(projectUri: string, sqlProjectType: ProjectType, databaseSchemaProvider: string, buildSdkVersion?: string): Promise<azdata.ResultStatus>;
 		openProject(projectUri: string): Promise<azdata.ResultStatus>;
 		getCrossPlatformCompatiblityRequest(projectUri: string): Promise<GetCrossPlatformCompatiblityResult>;
+	}
+
+	export const enum ProjectType {
+		SdkStyle = 0,
+		LegacyStyle = 1
 	}
 
 	export interface GetCrossPlatformCompatiblityResult extends azdata.ResultStatus {

--- a/extensions/mssql/src/sqlProjects/sqlProjectsService.ts
+++ b/extensions/mssql/src/sqlProjects/sqlProjectsService.ts
@@ -32,6 +32,16 @@ export class SqlProjectsService implements mssql.ISqlProjectsService {
 		context.registerService(constants.SqlProjectsService, this);
 	}
 
+	public async newProject(projectUri: string, sqlProjectType: mssql.ProjectType, databaseSchemaProvider: string, buildSdkVersion?: string): Promise<azdata.ResultStatus> {
+		const params: contracts.NewSqlProjectParams = { projectUri, sqlProjectType, databaseSchemaProvider, buildSdkVersion };
+		try {
+			const result = await this.client.sendRequest(contracts.NewSqlProjectRequest.type, params);
+			return result;
+		} catch (e) {
+			this.client.logFailedRequest(contracts.NewSqlProjectRequest.type, e);
+			throw e;
+		}
+	}
 
 	public async openProject(projectUri: string): Promise<azdata.ResultStatus> {
 		const params: contracts.SqlProjectParams = { projectUri };

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -183,14 +183,7 @@ export class ProjectsController {
 		}
 
 		const targetPlatform = creationParams.targetPlatform ? constants.targetPlatformToVersion.get(creationParams.targetPlatform)! : constants.defaultDSP;
-
-		const macroDict: Record<string, string> = {
-			'PROJECT_NAME': creationParams.newProjName,
-			'PROJECT_GUID': creationParams.projectGuid ?? UUID.generateUuid().toUpperCase(),
-			'PROJECT_DSP': targetPlatform
-		};
-
-		let newProjFileContents = creationParams.sdkStyle ? templates.macroExpansion(templates.newSdkSqlProjectTemplate, macroDict) : templates.macroExpansion(templates.newSqlProjectTemplate, macroDict);
+		const sdkStyle = creationParams.sdkStyle ? mssql.ProjectType.SdkStyle : mssql.ProjectType.LegacyStyle;
 
 		let newProjFileName = creationParams.newProjName;
 
@@ -204,9 +197,8 @@ export class ProjectsController {
 			throw new Error(constants.projectAlreadyExists(newProjFileName, path.parse(newProjFilePath).dir));
 		}
 
-		const projectFolderPath = path.dirname(newProjFilePath);
-		await fs.mkdir(projectFolderPath, { recursive: true });
-		await fs.writeFile(newProjFilePath, newProjFileContents);
+		const sqlProjectsService = await utils.getSqlProjectsService();
+		await sqlProjectsService.newProject(newProjFilePath, sdkStyle, targetPlatform);
 
 		await this.addTemplateFiles(newProjFilePath, creationParams.projectTypeId);
 

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -54,23 +54,6 @@ describe('ProjectsController', function (): void {
 
 	describe('project controller operations', function (): void {
 		describe('Project file operations and prompting', function (): void {
-			it('Should create new sqlproj file with correct values', async function (): Promise<void> {
-				const projController = new ProjectsController(testContext.outputChannel);
-				const projFileDir = path.join(testUtils.generateBaseFolderName(), `TestProject_${new Date().getTime()}`);
-
-				const projFilePath = await projController.createNewProject({
-					newProjName: 'TestProjectName',
-					folderUri: vscode.Uri.file(projFileDir),
-					projectTypeId: constants.emptySqlDatabaseProjectTypeId,
-					projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575',
-					sdkStyle: false
-				});
-
-				let projFileText = (await fs.readFile(projFilePath)).toString();
-
-				should(projFileText).equal(baselines.newProjectFileBaseline);
-			});
-
 			it('Should create new sqlproj file with correct specified target platform', async function (): Promise<void> {
 				const projController = new ProjectsController(testContext.outputChannel);
 				const projFileDir = path.join(testUtils.generateBaseFolderName(), `TestProject_${new Date().getTime()}`);


### PR DESCRIPTION
Exposing the `newProject` api from STS and swapping the sql projects extension to use it for creating new projects