### PR TITLE
SQL migration extension - fix target selection bug

### DIFF
--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -266,16 +266,12 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			this.migrationStateModel._resourceGroup = undefined!;
 			this.migrationStateModel._targetServerInstance = undefined!;
 
-			const clearDropDown = async (dropDown: azdata.DropDownComponent): Promise<void> => {
-				dropDown.values = [];
-				dropDown.value = undefined;
-			};
-			await clearDropDown(this._azureAccountsDropdown);
-			await clearDropDown(this._accountTenantDropdown);
-			await clearDropDown(this._azureSubscriptionDropdown);
-			await clearDropDown(this._azureLocationDropdown);
-			await clearDropDown(this._azureResourceGroupDropdown);
-			await clearDropDown(this._azureResourceDropdown);
+			this._clearDropDown(this._azureAccountsDropdown);
+			this._clearDropDown(this._accountTenantDropdown);
+			this._clearDropDown(this._azureSubscriptionDropdown);
+			this._clearDropDown(this._azureLocationDropdown);
+			this._clearDropDown(this._azureResourceGroupDropdown);
+			this._clearDropDown(this._azureResourceDropdown);
 		}
 
 		await this.populateAzureAccountsDropdown();
@@ -416,6 +412,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 						: undefined!;
 					this.migrationStateModel.refreshDatabaseBackupPage = true;
 				}
+				this._clearDropDown(this._azureLocationDropdown);
 				await this.populateLocationDropdown();
 			}));
 
@@ -446,6 +443,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 						: undefined!;
 				}
 				this.migrationStateModel.refreshDatabaseBackupPage = true;
+				this._clearDropDown(this._azureResourceGroupDropdown);
 				await this.populateResourceGroupDropdown();
 			}));
 
@@ -672,6 +670,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 						? utils.deepClone(selectedResourceGroup)!
 						: undefined!;
 				}
+				this._clearDropDown(this._azureResourceDropdown);
 				await this.populateResourceInstanceDropdown();
 			}));
 
@@ -1207,5 +1206,10 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			targetDatabaseCollation !== undefined &&
 			targetDatabaseCollation.length > 0 &&
 			sourceDatabaseCollation.toLocaleLowerCase() === targetDatabaseCollation.toLocaleLowerCase();
+	}
+
+	private _clearDropDown(dropDown: azdata.DropDownComponent): void {
+		dropDown.values = [];
+		dropDown.value = undefined;
 	}
 }


### PR DESCRIPTION
this code fixes a bug in the target selection wizard step that would not correctly auto-populate child dropdown selections when a new target value does not change... resulting in un-triggered value change event resulting in uninitialized or stale components.

Tested with the following settings targeting SQL MI by toggling between the two locations:
![image](https://user-images.githubusercontent.com/61598682/219752118-736643c6-8644-44fc-be36-003315802d94.png)

and:
![image](https://user-images.githubusercontent.com/61598682/219752226-5ec42529-548c-4871-aa16-5f3a397c982c.png)

