### PR TITLE
Handle undefined error when opening connection dialog

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -936,7 +936,11 @@ export class ConnectionWidget extends lifecycle.Disposable {
 						// If account was not filled in from received configuration, select the first account.
 						this._azureAccountDropdown.select(0);
 						account = this._azureAccountList[0];
-						accountName = account.key.accountId;
+						if (this._azureAccountList.length > 0) {
+							accountName = account.key.accountId;
+						} else {
+							this._logService.info('No accounts available');
+						}
 					}
 					await this.onAzureAccountSelected();
 
@@ -957,7 +961,9 @@ export class ConnectionWidget extends lifecycle.Disposable {
 						this.onAzureTenantSelected(0);
 					}
 					else {
-						this._logService.error(`fillInConnectionInputs : Could not find any tenants for account ${accountName}`);
+						if (accountName) {
+							this._logService.error(`fillInConnectionInputs : Could not find any tenants for account ${accountName}`);
+						}
 					}
 				}).catch(err => this._logService.error(`Unexpected error populating initial Azure Account options : ${err}`));
 			}

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -960,10 +960,8 @@ export class ConnectionWidget extends lifecycle.Disposable {
 						this._azureTenantId = account.properties.tenants[0].id;
 						this.onAzureTenantSelected(0);
 					}
-					else {
-						if (accountName) {
-							this._logService.error(`fillInConnectionInputs : Could not find any tenants for account ${accountName}`);
-						}
+					else if (accountName) {
+						this._logService.error(`fillInConnectionInputs : Could not find any tenants for account ${accountName}`);
 					}
 				}).catch(err => this._logService.error(`Unexpected error populating initial Azure Account options : ${err}`));
 			}

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -939,7 +939,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 						if (this._azureAccountList.length > 0) {
 							accountName = account.key.accountId;
 						} else {
-							this._logService.info('No accounts available');
+							this._logService.debug('No accounts available');
 						}
 					}
 					await this.onAzureAccountSelected();

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -939,7 +939,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 						if (this._azureAccountList.length > 0) {
 							accountName = account.key.accountId;
 						} else {
-							this._logService.debug('No accounts available');
+							this._logService.debug('fillInConnectionInputs: No accounts available');
 						}
 					}
 					await this.onAzureAccountSelected();


### PR DESCRIPTION
Current behavior:
1. Remove all registered Azure accounts
2. Open connection dialog
3. If AzureMFA isn't selected select it, then close and reopen connection dialog
4. See error in console   ERR Unexpected error populating initial Azure Account options : TypeError: Cannot read properties of undefined (reading 'key')

New Behavior:
- No error message displayed 

This PR fixes #21642
