### PR TITLE
Fix set authenticationType of undefined error in connection dialog

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -670,14 +670,17 @@ export class ConnectionWidget extends lifecycle.Disposable {
 			this._passwordInputBox.enable();
 			this._rememberPasswordCheckBox.enabled = true;
 
-			this._initialConnectionInfo.authenticationType = AuthenticationType.SqlLogin;
-			if (this._initialConnectionInfo && this._initialConnectionInfo.userName) {
-				const setPasswordInputBox = (profile: IConnectionProfile) => {
-					this._passwordInputBox.value = profile.password;
-				};
+			if (this._initialConnectionInfo) {
+				this._initialConnectionInfo.authenticationType = AuthenticationType.SqlLogin;
 
-				this._rememberPasswordCheckBox.checked = this._initialConnectionInfo.savePassword;
-				this._connectionManagementService.addSavedPassword(this._initialConnectionInfo, true).then(setPasswordInputBox)
+				if (this._initialConnectionInfo.userName) {
+					const setPasswordInputBox = (profile: IConnectionProfile) => {
+						this._passwordInputBox.value = profile.password;
+					};
+
+					this._rememberPasswordCheckBox.checked = this._initialConnectionInfo.savePassword;
+					this._connectionManagementService.addSavedPassword(this._initialConnectionInfo, true).then(setPasswordInputBox)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21979

The error was occurring because the `_initialConnectionInfo` property was undefined when the auth type was being set. This PR fixes that by ensuring that `_initialConnectionInfo` is set to a value before the auth type is set to SQL Login. The auth type needs to be set because the `addSavedPassword` call checks for the auth type to be SQL Login so it can retrieve the password from the credential service.