### PR TITLE
Stops Azure connection with the "Do not save" server group option from being stored in the default server group list.

### DIFF
--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -169,8 +169,6 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 		} : undefined;
 
 		if (connectionCompletionOptions && connectionCompletionOptions.saveConnection) {
-			// Somehow, connectionProfile.saveProfile is false even if initialConnectionProfile.saveProfile is true, reset the flag here.
-			connectionProfile.saveProfile = initialConnectionProfile.saveProfile;
 			await this._connectionManagementService.connectAndSaveProfile(connectionProfile, undefined, {
 				saveTheConnection: isUndefinedOrNull(connectionCompletionOptions.saveConnection) ? true : connectionCompletionOptions.saveConnection,
 				showDashboard: isUndefinedOrNull(connectionCompletionOptions.showDashboard) ? false : connectionCompletionOptions.showDashboard,

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -257,7 +257,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			return;
 		}
 		let fromEditor = params && params.connectionType === ConnectionType.editor;
-		let isTemporaryConnection = params && params.connectionType === ConnectionType.temporary;
+		let isTemporaryConnection = params && (params.connectionType === ConnectionType.temporary || !connection.saveProfile); // When the server group is "<default>" or named their saveProfile flag will be true, but not for "<Do not save>"
 		let uri: string = undefined;
 		if (fromEditor && params && params.input) {
 			uri = params.input.uri;

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -257,7 +257,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			return;
 		}
 		let fromEditor = params && params.connectionType === ConnectionType.editor;
-		let isTemporaryConnection = params && (params.connectionType === ConnectionType.temporary || !connection.saveProfile); // When the server group is "<default>" or named their saveProfile flag will be true, but not for "<Do not save>"
+		let isTemporaryConnection = params && params.connectionType === ConnectionType.temporary;
 		let uri: string = undefined;
 		if (fromEditor && params && params.input) {
 			uri = params.input.uri;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21835

This PR will stop Azure connections with the "< Do not save >" server group option selected from appearing in the default server group list in the "Servers" pane.
