### PR TITLE
Fix empty connection name in delete connection prompt

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -290,7 +290,7 @@ export class DeleteConnectionAction extends Action {
 		const deleteConnectionConfirmationNo = localize('deleteConnectionConfirmationNo', "No");
 
 		if (this.element instanceof ConnectionProfile) {
-			const name = this.element.connectionName ? this.element.connectionName : this.element.serverName;
+			const name = this.element.connectionName || this.element.serverName;
 			const modalResult = await this._dialogService.show(Severity.Warning, localize('deleteConnectionConfirmation', "Are you sure you want to delete connection '{0}'?", name),
 				[deleteConnectionConfirmationYes, deleteConnectionConfirmationNo]);
 			if (modalResult.choice === 0) {

--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -290,7 +290,8 @@ export class DeleteConnectionAction extends Action {
 		const deleteConnectionConfirmationNo = localize('deleteConnectionConfirmationNo', "No");
 
 		if (this.element instanceof ConnectionProfile) {
-			const modalResult = await this._dialogService.show(Severity.Warning, localize('deleteConnectionConfirmation', "Are you sure you want to delete connection '{0}'?", this.element.connectionName),
+			const name = this.element.connectionName ? this.element.connectionName : this.element.serverName;
+			const modalResult = await this._dialogService.show(Severity.Warning, localize('deleteConnectionConfirmation', "Are you sure you want to delete connection '{0}'?", name),
 				[deleteConnectionConfirmationYes, deleteConnectionConfirmationNo]);
 			if (modalResult.choice === 0) {
 				await this._connectionManagementService.deleteConnection(this.element);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21935

The PR fixes the connection delete prompt by showing the server name when the optional connection name isn't provided.
![image](https://user-images.githubusercontent.com/87730006/220488870-74af6d99-19f9-44d2-957d-3398aa5f1b7d.png)

