### PR TITLE
Update api to pass more detailed error messaging from azurecore

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -146,7 +146,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 				}
 			} else {
 				if (ex.message) {
-					loginComplete?.reject(new AzureAuthError(`${ex.message}`, `${ex.message}`, undefined));
+					loginComplete?.reject(new AzureAuthError(`${ex.errorMessage || ex.message}`, `${ex.errorMessage || ex.message}`, undefined));
 					return {
 						canceled: false,
 						error: true,

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -147,14 +147,11 @@ export abstract class AzureAuth implements vscode.Disposable {
 			} else {
 				if (ex.message) {
 					loginComplete?.reject(new AzureAuthError(`${ex.message}`, `${ex.message}`, undefined));
-					let error: azdata.ErrorMessage = {
-						errorCode: ex.errorCode,
-						errorMessage: ex.errorMessage || ex.message
-					};
 					return {
 						canceled: false,
 						error: true,
-						message: error
+						errorCode: ex.errorCode,
+						errorMessage: ex.errorMessage || ex.message
 					};
 				}
 				Logger.error(ex);

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -150,7 +150,6 @@ export abstract class AzureAuth implements vscode.Disposable {
 					loginComplete?.reject(new AzureAuthError(message, message, undefined));
 					return {
 						canceled: false,
-						error: true,
 						errorCode: ex.errorCode,
 						errorMessage: message
 					};

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -145,14 +145,24 @@ export abstract class AzureAuth implements vscode.Disposable {
 					Logger.error(ex.originalMessageAndException);
 				}
 			} else {
+				if (ex.message) {
+					loginComplete?.reject(new AzureAuthError(localize('azureAuth.unidentifiedError', `${ex.message}`), `${ex.message}`, undefined));
+					let error: azdata.ErrorMessage = {
+						errorCode: ex.errorCode,
+						errorMessage: ex.errorMessage || ex.message
+					};
+					return {
+						canceled: false,
+						error: true,
+						message: error
+					};
+				}
 				Logger.error(ex);
 
 			}
 			return {
 				canceled: false
 			};
-		} finally {
-			loginComplete?.reject(new AzureAuthError(localize('azureAuth.unidentifiedError', "Unidentified error with azure authentication"), 'Unidentified error with azure auth', undefined));
 		}
 	}
 

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -146,7 +146,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 				}
 			} else {
 				if (ex.message) {
-					loginComplete?.reject(new AzureAuthError(localize('azureAuth.unidentifiedError', `${ex.message}`), `${ex.message}`, undefined));
+					loginComplete?.reject(new AzureAuthError(`${ex.message}`, `${ex.message}`, undefined));
 					let error: azdata.ErrorMessage = {
 						errorCode: ex.errorCode,
 						errorMessage: ex.errorMessage || ex.message

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -145,13 +145,14 @@ export abstract class AzureAuth implements vscode.Disposable {
 					Logger.error(ex.originalMessageAndException);
 				}
 			} else {
-				if (ex.message) {
-					loginComplete?.reject(new AzureAuthError(`${ex.errorMessage || ex.message}`, `${ex.errorMessage || ex.message}`, undefined));
+				const message = ex.errorMessage || ex.message;
+				if (message) {
+					loginComplete?.reject(new AzureAuthError(message, message, undefined));
 					return {
 						canceled: false,
 						error: true,
 						errorCode: ex.errorCode,
-						errorMessage: ex.errorMessage || ex.message
+						errorMessage: message
 					};
 				}
 				Logger.error(ex);

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2520,28 +2520,22 @@ declare module 'azdata' {
 		 * Type guard for differentiating user cancelled sign in errors from other errors
 		 */
 		canceled: boolean;
+
 		/**
 		 * Signals that an error other than the user cancelled sign in error has occurred
 		 */
 		error?: boolean;
+
+		/**
+		 * Error code used for non-user cancelled sign in errors
+		 */
+		errorCode?: string;
+
 		/**
 		 * Error message used for non-user cancelled sign in errors
 		 */
-		message?: ErrorMessage;
+		errorMessage?: string;
 	}
-
-	export interface ErrorMessage {
-		/**
-		 * Error code corresponding to
-		 */
-		errorCode: string;
-
-		/**
-		 * Error message
-		 */
-		errorMessage: string;
-	}
-
 	/**
 	 * Represents a provider of accounts.
 	 */

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2520,21 +2520,6 @@ declare module 'azdata' {
 		 * Type guard for differentiating user cancelled sign in errors from other errors
 		 */
 		canceled: boolean;
-
-		/**
-		 * Signals that an error other than the user cancelled sign in error has occurred
-		 */
-		error?: boolean;
-
-		/**
-		 * Error code used for non-user cancelled sign in errors
-		 */
-		errorCode?: string;
-
-		/**
-		 * Error message used for non-user cancelled sign in errors
-		 */
-		errorMessage?: string;
 	}
 	/**
 	 * Represents a provider of accounts.

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2521,6 +2521,7 @@ declare module 'azdata' {
 		 */
 		canceled: boolean;
 	}
+
 	/**
 	 * Represents a provider of accounts.
 	 */

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2520,6 +2520,26 @@ declare module 'azdata' {
 		 * Type guard for differentiating user cancelled sign in errors from other errors
 		 */
 		canceled: boolean;
+		/**
+		 * Signals that an error other than the user cancelled sign in error has occurred
+		 */
+		error?: boolean;
+		/**
+		 * Error message used for non-user cancelled sign in errors
+		 */
+		message?: ErrorMessage;
+	}
+
+	export interface ErrorMessage {
+		/**
+		 * Error code corresponding to
+		 */
+		errorCode: string;
+
+		/**
+		 * Error message
+		 */
+		errorMessage: string;
 	}
 
 	/**

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -434,11 +434,6 @@ declare module 'azdata' {
 
 	export interface PromptFailedResult {
 		/**
-		 * Signals that an error other than the user cancelled sign in error has occurred
-		 */
-		error?: boolean;
-
-		/**
 		 * Error code used for non-user cancelled sign in errors
 		 */
 		errorCode?: string;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -432,6 +432,23 @@ declare module 'azdata' {
 		azurePortalEndpoint?: string;
 	}
 
+	export interface PromptFailedResult {
+		/**
+		 * Signals that an error other than the user cancelled sign in error has occurred
+		 */
+		error?: boolean;
+
+		/**
+		 * Error code used for non-user cancelled sign in errors
+		 */
+		errorCode?: string;
+
+		/**
+		 * Error message used for non-user cancelled sign in errors
+		 */
+		errorMessage?: string;
+	}
+
 	export namespace diagnostics {
 		/**
 		 * Represents a diagnostics provider of accounts.

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -148,7 +148,7 @@ export class AccountManagementService implements IAccountManagementService {
 					if (accountResult.canceled === true) {
 						return;
 					} else {
-						throw new Error(localize('addAccountFailedMessage', `${accountResult.errorCode} \nError Message: ${accountResult.errorMessage}`));
+						throw new Error(localize('addAccountFailedMessage', `${0} \nError Message: ${1}`, accountResult.errorCode, accountResult.errorMessage));
 					}
 				}
 				let result = await this._accountStore.addOrUpdate(accountResult);

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -147,9 +147,7 @@ export class AccountManagementService implements IAccountManagementService {
 				if (this.isCanceledResult(accountResult)) {
 					return;
 				} else if (this.isErrorResult(accountResult)) {
-					let message = this.getMessage(accountResult);
-					let code = this.getCode(accountResult);
-					throw Error(`\nError Code: ${code}\nError Message: ${message}`);
+					throw Error(localize('error', `Error Code: ${accountResult.errorCode} Error Message: ${accountResult.errorMessage}`));
 				}
 				let result = await this._accountStore.addOrUpdate(accountResult);
 				if (!result) {
@@ -199,13 +197,6 @@ export class AccountManagementService implements IAccountManagementService {
 
 	private isErrorResult(result: azdata.Account | azdata.PromptFailedResult): result is azdata.PromptFailedResult {
 		return (<azdata.PromptFailedResult>result).error;
-	}
-
-	private getMessage(result: azdata.Account | azdata.PromptFailedResult): string {
-		return (<azdata.PromptFailedResult>result).errorMessage;
-	}
-	private getCode(result: azdata.Account | azdata.PromptFailedResult): string {
-		return (<azdata.PromptFailedResult>result).errorCode;
 	}
 
 	/**

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -148,7 +148,7 @@ export class AccountManagementService implements IAccountManagementService {
 					if (accountResult.canceled === true) {
 						return;
 					} else {
-						throw Error(localize('error', `${accountResult.errorCode} \nError Message: ${accountResult.errorMessage}`));
+						throw Error(localize('addAccountFailed', `${accountResult.errorCode} \nError Message: ${accountResult.errorMessage}`));
 					}
 				}
 				let result = await this._accountStore.addOrUpdate(accountResult);
@@ -211,6 +211,8 @@ export class AccountManagementService implements IAccountManagementService {
 				if (refreshedAccount.canceled) {
 					// Pattern here is to throw if this fails. Handled upstream.
 					throw new Error(localize('refreshFailed', "Refresh account was canceled by the user"));
+				} else {
+					throw Error(localize('refreshFailed', `${refreshedAccount.errorCode} \nError Message: ${refreshedAccount.errorMessage}`));
 				}
 			} else {
 				account = refreshedAccount;

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -149,7 +149,7 @@ export class AccountManagementService implements IAccountManagementService {
 					return;
 				} else if (this.isErrorResult(account)) {
 					let message = this.getMessage(account);
-					throw Error(`Code: ${message.errorCode}\n Error Message: ${message.errorMessage}`);
+					throw Error(`\nError Code: ${message.errorCode}\nError Message: ${message.errorMessage}`);
 				}
 				let result = await this._accountStore.addOrUpdate(account);
 				if (!result) {

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -212,7 +212,7 @@ export class AccountManagementService implements IAccountManagementService {
 					// Pattern here is to throw if this fails. Handled upstream.
 					throw new Error(localize('refreshCanceled', "Refresh account was canceled by the user"));
 				} else {
-					throw new Error(localize('refreshFailed', `${refreshedAccount.errorCode} \nError Message: ${refreshedAccount.errorMessage}`));
+					throw new Error(localize('refreshFailed', `${0} \nError Message: ${1}`, refreshedAccount.errorCode, refreshedAccount.errorMessage));
 				}
 			} else {
 				account = refreshedAccount;

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -210,7 +210,7 @@ export class AccountManagementService implements IAccountManagementService {
 			if (self.isPromptFailedResult(refreshedAccount)) {
 				if (refreshedAccount.canceled) {
 					// Pattern here is to throw if this fails. Handled upstream.
-					throw new Error(localize('refreshFailed', "Refresh account was canceled by the user"));
+					throw new Error(localize('refreshCanceled', "Refresh account was canceled by the user"));
 				} else {
 					throw Error(localize('refreshFailed', `${refreshedAccount.errorCode} \nError Message: ${refreshedAccount.errorMessage}`));
 				}

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -148,13 +148,13 @@ export class AccountManagementService implements IAccountManagementService {
 					if (accountResult.canceled === true) {
 						return;
 					} else {
-						throw Error(localize('addAccountFailed', `${accountResult.errorCode} \nError Message: ${accountResult.errorMessage}`));
+						throw new Error(localize('addAccountFailedMessage', `${accountResult.errorCode} \nError Message: ${accountResult.errorMessage}`));
 					}
 				}
 				let result = await this._accountStore.addOrUpdate(accountResult);
 				if (!result) {
 					this._logService.error('adding account failed');
-					throw Error('Adding account failed, check Azure Accounts log for more info.')
+					throw new Error(localize('addAccountFailedGeneric', 'Adding account failed, check Azure Accounts log for more info.'));
 				}
 				if (result.accountAdded) {
 					// Add the account to the list
@@ -212,7 +212,7 @@ export class AccountManagementService implements IAccountManagementService {
 					// Pattern here is to throw if this fails. Handled upstream.
 					throw new Error(localize('refreshCanceled', "Refresh account was canceled by the user"));
 				} else {
-					throw Error(localize('refreshFailed', `${refreshedAccount.errorCode} \nError Message: ${refreshedAccount.errorMessage}`));
+					throw new Error(localize('refreshFailed', `${refreshedAccount.errorCode} \nError Message: ${refreshedAccount.errorMessage}`));
 				}
 			} else {
 				account = refreshedAccount;


### PR DESCRIPTION
Improve Error Messages coming from azurecore extension

Current Behavior:
When adding an account fails due to an MSAL error, we proceed with an undefined account until it hits an undefined error
<img width="930" alt="Screenshot 2023-02-21 at 6 23 49 PM" src="https://user-images.githubusercontent.com/18150417/220504941-25c33ad7-7346-479c-bb09-e5fb69fe93e5.png">


New Behavior:
We capture the error message and throw a more detailed message to the user
<img width="930" alt="Screenshot 2023-02-21 at 6 32 05 PM" src="https://user-images.githubusercontent.com/18150417/220505984-5f81f47c-6f6c-4616-a515-81046c0129c8.png">

