### PR TITLE
Remove data workspace * activationEvent

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -13,7 +13,9 @@
     "azdata": ">=1.25.0"
   },
   "activationEvents": [
-    "*"
+    "onView:dataworkspace.views.main",
+    "onCommand:projects.openExisting",
+    "onCommand:projects.new"
   ],
   "main": "./out/main",
   "repository": {
@@ -158,8 +160,7 @@
           "id": "dataworkspace.views.main",
           "name": "%main-view-name%",
           "contextualTitle": "%data-workspace-view-container-name%",
-          "icon": "images/data-workspace.svg",
-          "when": "isProjectProviderAvailable"
+          "icon": "images/data-workspace.svg"
         }
       ]
     },

--- a/extensions/data-workspace/src/common/interfaces.ts
+++ b/extensions/data-workspace/src/common/interfaces.ts
@@ -85,8 +85,6 @@ export interface IWorkspaceService {
 	 */
 	gitCloneProject(url: string, localClonePath: string): Promise<void>;
 
-	readonly isProjectProviderAvailable: boolean;
-
 	/**
 	 * Event fires when projects in workspace changes
 	 */

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -10,7 +10,6 @@ import { WorkspaceTreeItem, IExtension } from 'dataworkspace';
 import { DataWorkspaceExtension } from './common/dataWorkspaceExtension';
 import { NewProjectDialog } from './dialogs/newProjectDialog';
 import { browseForProject, OpenExistingDialog } from './dialogs/openExistingDialog';
-import { IWorkspaceService } from './common/interfaces';
 import { IconPathHelper } from './common/iconHelper';
 import { ProjectDashboard } from './dialogs/projectDashboard';
 import { getAzdataApi } from './common/utils';
@@ -45,13 +44,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	const registerTreeDataProvidertartTime = new Date().getTime();
 	context.subscriptions.push(vscode.window.registerTreeDataProvider('dataworkspace.views.main', workspaceTreeDataProvider));
 	Logger.log(`registerTreeDataProvider took ${new Date().getTime() - registerTreeDataProvidertartTime}ms`);
-
-	const settingProjectProviderContextStartTime = new Date().getTime();
-	context.subscriptions.push(vscode.extensions.onDidChange(() => {
-		setProjectProviderContextValue(workspaceService);
-	}));
-	setProjectProviderContextValue(workspaceService);
-	Logger.log(`setProjectProviderContextValue took ${new Date().getTime() - settingProjectProviderContextStartTime}ms`);
 
 	const registerCommandStartTime = new Date().getTime();
 	context.subscriptions.push(vscode.commands.registerCommand('projects.new', async () => {
@@ -107,10 +99,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	context.subscriptions.push(TelemetryReporter);
 	Logger.log(`Finished activating Data Workspace extension. Total time = ${new Date().getTime() - startTime}ms`);
 	return Promise.resolve(dataWorkspaceExtension);
-}
-
-function setProjectProviderContextValue(workspaceService: IWorkspaceService): void {
-	void vscode.commands.executeCommand('setContext', 'isProjectProviderAvailable', workspaceService.isProjectProviderAvailable);
 }
 
 export function deactivate(): void {

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -31,21 +31,6 @@ export class WorkspaceService implements IWorkspaceService {
 		this.getProjectsInWorkspace(undefined, true).catch(err => Logger.error(`Error initializing projects in workspace ${err}`));
 	}
 
-	get isProjectProviderAvailable(): boolean {
-		Logger.log(`Checking ${vscode.extensions.all.length} extensions to see if there is a project provider is available`);
-		const startTime = new Date().getTime();
-		for (const extension of vscode.extensions.all) {
-			const projectTypes = extension.packageJSON.contributes && extension.packageJSON.contributes.projects as string[];
-			if (projectTypes && projectTypes.length > 0) {
-				Logger.log(`Project provider found. Total time = ${new Date().getTime() - startTime}ms`);
-				return true;
-			}
-		}
-
-		Logger.log(`No project providers found. Total time = ${new Date().getTime() - startTime}ms`);
-		return false;
-	}
-
 	/**
 	 * Verify that a workspace is open or that if one isn't and we're running in ADS, it's ok to create a workspace and restart ADS
 	 */

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -26,7 +26,8 @@
   },
   "extensionDependencies": [
     "Microsoft.mssql",
-    "Microsoft.schema-compare"
+    "Microsoft.schema-compare",
+    "Microsoft.data-workspace"
   ],
   "capabilities": {
     "virtualWorkspaces": false,

--- a/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseDialog.test.ts
@@ -7,6 +7,9 @@ import * as should from 'should';
 import * as azdata from 'azdata';
 import * as mssql from 'mssql';
 import * as sinon from 'sinon';
+import * as utils from '../../common/utils'
+import * as newProjectTool from '../../tools/newProjectTool';
+
 import { CreateProjectFromDatabaseDialog } from '../../dialogs/createProjectFromDatabaseDialog';
 import { mockConnectionProfile } from '../testContext';
 import { ImportDataModel } from '../../models/api/import';
@@ -18,7 +21,7 @@ describe('Create Project From Database Dialog', () => {
 
 	it('Should open dialog successfully', async function (): Promise<void> {
 		sinon.stub(azdata.connection, 'getConnections').resolves([]);
-		sinon.stub(azdata.connection, 'connect').resolves({ connected: true, connectionId: '0', errorMessage: '', errorCode: 0});
+		sinon.stub(azdata.connection, 'connect').resolves({ connected: true, connectionId: '0', errorMessage: '', errorCode: 0 });
 		sinon.stub(azdata.connection, 'listDatabases').resolves([]);
 		const dialog = new CreateProjectFromDatabaseDialog(mockConnectionProfile);
 		await dialog.openDialog();
@@ -27,7 +30,7 @@ describe('Create Project From Database Dialog', () => {
 
 	it('Should enable ok button correctly with a connection profile', async function (): Promise<void> {
 		sinon.stub(azdata.connection, 'getConnections').resolves([]);
-		sinon.stub(azdata.connection, 'connect').resolves({ connected: true, connectionId: '0', errorMessage: '', errorCode: 0});
+		sinon.stub(azdata.connection, 'connect').resolves({ connected: true, connectionId: '0', errorMessage: '', errorCode: 0 });
 		sinon.stub(azdata.connection, 'listDatabases').resolves([]);
 		const dialog = new CreateProjectFromDatabaseDialog(mockConnectionProfile);
 		await dialog.openDialog();		// should set connection details
@@ -79,8 +82,10 @@ describe('Create Project From Database Dialog', () => {
 
 	it('Should create default project name correctly when database information is populated', async function (): Promise<void> {
 		sinon.stub(azdata.connection, 'getConnections').resolves([]);
-		sinon.stub(azdata.connection, 'connect').resolves({ connected: true, connectionId: '0', errorMessage: '', errorCode: 0});
+		sinon.stub(azdata.connection, 'connect').resolves({ connected: true, connectionId: '0', errorMessage: '', errorCode: 0 });
 		sinon.stub(azdata.connection, 'listDatabases').resolves(['My Database']);
+		sinon.stub(utils, 'sanitizeStringForFilename').returns('My Database');
+		sinon.stub(newProjectTool, 'defaultProjectNameFromDb').returns('DatabaseProjectMy Database');
 		const dialog = new CreateProjectFromDatabaseDialog(mockConnectionProfile);
 		await dialog.openDialog();
 		dialog.setProjectName();
@@ -92,7 +97,7 @@ describe('Create Project From Database Dialog', () => {
 		const stubUri = 'My URI';
 		const dialog = new CreateProjectFromDatabaseDialog(mockConnectionProfile);
 		sinon.stub(azdata.connection, 'getConnections').resolves([]);
-		sinon.stub(azdata.connection, 'connect').resolves({ connected: true, connectionId: '0', errorMessage: '', errorCode: 0});
+		sinon.stub(azdata.connection, 'connect').resolves({ connected: true, connectionId: '0', errorMessage: '', errorCode: 0 });
 		sinon.stub(azdata.connection, 'listDatabases').resolves(['My Database']);
 		sinon.stub(azdata.connection, 'getUriForConnection').resolves(stubUri);
 		await dialog.openDialog();

--- a/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseQuickpick.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseQuickpick.test.ts
@@ -12,6 +12,7 @@ import * as constants from '../../common/constants';
 import * as utils from '../../common/utils'
 import * as quickpickHelper from '../../dialogs/quickpickHelper'
 import * as createProjectFromDatabaseQuickpick from '../../dialogs/createProjectFromDatabaseQuickpick';
+import * as newProjectTool from '../../tools/newProjectTool';
 import { createTestUtils, mockConnectionInfo, TestUtils } from './testUtils';
 import { promises as fs } from 'fs';
 import { ImportDataModel } from '../../models/api/import';
@@ -25,6 +26,9 @@ describe('Create Project From Database Quickpick', () => {
 	beforeEach(function (): void {
 		testUtils = createTestUtils();
 		sinon.stub(utils, 'getVscodeMssqlApi').resolves(testUtils.vscodeMssqlIExtension.object);	//set vscode mssql extension api
+		sinon.stub(newProjectTool, 'defaultProjectSaveLocation').returns(undefined);
+		sinon.stub(newProjectTool, 'defaultProjectNameFromDb').returns('DatabaseProjectTestProject');
+		sinon.stub(utils, 'sanitizeStringForFilename').returns('TestProject');
 	});
 
 	afterEach(async function (): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21978. This removes the * activationEvent for the data workspace extension. This was originally added because in ADS, we didn't want the projects view to show unless the sql projects extension was also installed. With this change, the projects view will always show on the Activity Bar in ADS and vscode, but it will only be activated when the view is opened, the projects new or open command is run, or if the sql projects extension is activated by one of its activation events.
