### PR TITLE
Add publish profile to sql proj and tree

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -486,7 +486,7 @@ export const ImportElements = localize('importElements', "Import Elements");
 export const ProjectReferenceNameElement = localize('projectReferenceNameElement', "Project reference name element");
 export const ProjectReferenceElement = localize('projectReferenceElement', "Project reference");
 export const DacpacReferenceElement = localize('dacpacReferenceElement', "Dacpac reference");
-export const PublishProfileElements = localize('publishProfileElements', "Publish profile Elements");
+export const PublishProfileElements = localize('publishProfileElements', "Publish profile elements");
 
 /** Name of the property item in the project file that defines default database collation. */
 export const DefaultCollationProperty = 'DefaultCollation';

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -14,6 +14,7 @@ const localize = nls.loadMessageBundle();
 export const dataSourcesFileName = 'datasources.json';
 export const sqlprojExtension = '.sqlproj';
 export const sqlFileExtension = '.sql';
+export const publishProfileExtension = '.publish.xml';
 export const openApiSpecFileExtensions = ['yaml', 'yml', 'json'];
 export const schemaCompareExtensionId = 'microsoft.schema-compare';
 export const master = 'master';
@@ -485,6 +486,7 @@ export const ImportElements = localize('importElements', "Import Elements");
 export const ProjectReferenceNameElement = localize('projectReferenceNameElement', "Project reference name element");
 export const ProjectReferenceElement = localize('projectReferenceElement', "Project reference");
 export const DacpacReferenceElement = localize('dacpacReferenceElement', "Dacpac reference");
+export const PublishProfileElements = localize('publishProfileElements', "Publish profile Elements");
 
 /** Name of the property item in the project file that defines default database collation. */
 export const DefaultCollationProperty = 'DefaultCollation';

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -763,3 +763,13 @@ export function isValidBasename(name?: string): boolean {
 export function isValidBasenameErrorMessage(name?: string): string {
 	return getDataWorkspaceExtensionApi().isValidBasenameErrorMessage(name);
 }
+
+/**
+ * Checks if the provided file is a publish profile
+ * @param fileName filename to check
+ * @returns True if it is a publish profile, otherwise false
+ */
+export function isPublishProfile(fileName: string): boolean {
+	const hasPublishExtension = fileName.trim().toLowerCase().endsWith(constants.publishProfileExtension);
+	return hasPublishExtension;
+}

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -422,11 +422,7 @@ export class ProjectsController {
 
 			publishDatabaseDialog.openDialog();
 
-			await publishDatabaseDialog.waitForClose();
-
-			if (publishDatabaseDialog.profileSaved) {
-				this.refreshProjectsTree(context as dataworkspace.WorkspaceTreeItem);
-			}
+			return publishDatabaseDialog.waitForClose();
 		} else {
 			return this.publishDatabase(project);
 		}

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -422,7 +422,11 @@ export class ProjectsController {
 
 			publishDatabaseDialog.openDialog();
 
-			return publishDatabaseDialog.waitForClose();
+			await publishDatabaseDialog.waitForClose();
+
+			if (publishDatabaseDialog.profileSaved) {
+				this.refreshProjectsTree(context as dataworkspace.WorkspaceTreeItem);
+			}
 		} else {
 			return this.publishDatabase(project);
 		}

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1453,7 +1453,7 @@ export class ProjectsController {
 
 		if (fileOrFolder) {
 			// use relative path and not tree paths for files and folder
-			const allFileEntries = project.files.concat(project.preDeployScripts).concat(project.postDeployScripts).concat(project.noneDeployScripts);
+			const allFileEntries = project.files.concat(project.preDeployScripts).concat(project.postDeployScripts).concat(project.noneDeployScripts).concat(project.publishProfiles);
 
 			// trim trailing slash since folders with and without a trailing slash are allowed in a sqlproj
 			const trimmedUri = utils.trimChars(utils.getPlatformSafeFileEntryPath(utils.trimUri(fileOrFolder.projectFileUri, fileOrFolder.fileSystemUri)), '/');

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -63,7 +63,6 @@ export class PublishDatabaseDialog {
 	private publishOptionsDialog: PublishOptionsDialog | undefined;
 	public publishOptionsModified: boolean = false;
 	private publishProfileUri: vscode.Uri | undefined;
-	public profileSaved: boolean = false;
 
 	private completionPromise: Deferred = new Deferred();
 
@@ -95,8 +94,6 @@ export class PublishDatabaseDialog {
 
 		this.dialog.customButtons = [];
 		this.dialog.customButtons.push(generateScriptButton);
-
-		this.profileSaved = false;		// Reset
 
 		utils.getAzdataApi()!.window.openDialog(this.dialog);
 	}
@@ -953,9 +950,8 @@ export class PublishDatabaseDialog {
 			this.profileUsed = true;
 			this.publishProfileUri = filePath;
 
-			this.profileSaved = true;
-
-			void this.project.addPublishProfileToProjFile(filePath.fsPath);		//add profile to the sqlproj in background
+			await this.project.addPublishProfileToProjFile(filePath.fsPath);
+			void vscode.commands.executeCommand(constants.refreshDataWorkspaceCommand);		//refresh data workspace to load the newly added profile to the tree
 		});
 
 		return saveProfileAsButton;

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -63,6 +63,7 @@ export class PublishDatabaseDialog {
 	private publishOptionsDialog: PublishOptionsDialog | undefined;
 	public publishOptionsModified: boolean = false;
 	private publishProfileUri: vscode.Uri | undefined;
+	public profileSaved: boolean = false;
 
 	private completionPromise: Deferred = new Deferred();
 
@@ -94,6 +95,8 @@ export class PublishDatabaseDialog {
 
 		this.dialog.customButtons = [];
 		this.dialog.customButtons.push(generateScriptButton);
+
+		this.profileSaved = false;		// Reset
 
 		utils.getAzdataApi()!.window.openDialog(this.dialog);
 	}
@@ -949,6 +952,10 @@ export class PublishDatabaseDialog {
 
 			this.profileUsed = true;
 			this.publishProfileUri = filePath;
+
+			this.profileSaved = true;
+
+			void this.project.addPublishProfileToProjFile(filePath.fsPath);		//add profile to the sqlproj in background
 		});
 
 		return saveProfileAsButton;

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -1247,7 +1247,7 @@ export class Project implements ISqlProject {
 		}
 
 		// if none already exist, make a new ItemGroup for it
-		if (!outputItemGroup) {
+		if (outputItemGroup.length === 0) {
 			returnItemGroup = this.projFileXmlDoc!.createElement(constants.ItemGroup);
 			this.projFileXmlDoc!.documentElement.appendChild(returnItemGroup);
 
@@ -1259,7 +1259,7 @@ export class Project implements ISqlProject {
 				for (let ig = 0; ig < outputItemGroup.length; ig++) {
 					const itemGroup = outputItemGroup[ig];
 
-					// find all none remove scripts to specified in the sqlproj
+					// find all none include scripts specified in the sqlproj
 					const noneItems = itemGroup.getElementsByTagName(constants.None);
 					for (let n = 0; n < noneItems.length; n++) {
 						let noneIncludeItem = noneItems[n].getAttribute(constants.Include);

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -984,19 +984,20 @@ export class Project implements ISqlProject {
 		return fileEntry;
 	}
 
-	public async exclude(entry: FileProjectEntry): Promise<void> {//TODO: Check publish profile to be added
-		const toExclude: FileProjectEntry[] = this._files.concat(this._preDeployScripts).concat(this._postDeployScripts).concat(this._noneDeployScripts).filter(x => x.fsUri.fsPath.startsWith(entry.fsUri.fsPath));
+	public async exclude(entry: FileProjectEntry): Promise<void> {
+		const toExclude: FileProjectEntry[] = this._files.concat(this._preDeployScripts).concat(this._postDeployScripts).concat(this._noneDeployScripts).concat(this._publishProfiles).filter(x => x.fsUri.fsPath.startsWith(entry.fsUri.fsPath));
 		await this.removeFromProjFile(toExclude);
 
 		this._files = this._files.filter(x => !x.fsUri.fsPath.startsWith(entry.fsUri.fsPath));
 		this._preDeployScripts = this._preDeployScripts.filter(x => !x.fsUri.fsPath.startsWith(entry.fsUri.fsPath));
 		this._postDeployScripts = this._postDeployScripts.filter(x => !x.fsUri.fsPath.startsWith(entry.fsUri.fsPath));
 		this._noneDeployScripts = this._noneDeployScripts.filter(x => !x.fsUri.fsPath.startsWith(entry.fsUri.fsPath));
+		this._publishProfiles = this._publishProfiles.filter(x => !x.fsUri.fsPath.startsWith(entry.fsUri.fsPath));
 	}
 
 	public async deleteFileFolder(entry: FileProjectEntry): Promise<void> {
-		// compile a list of folder contents to delete; if entry is a file, contents will contain only itself//TODO: Check publishProfile to be added
-		const toDeleteFiles: FileProjectEntry[] = this._files.concat(this._preDeployScripts).concat(this._postDeployScripts).concat(this._noneDeployScripts).filter(x => x.fsUri.fsPath.startsWith(entry.fsUri.fsPath) && x.type === EntryType.File);
+		// compile a list of folder contents to delete; if entry is a file, contents will contain only itself
+		const toDeleteFiles: FileProjectEntry[] = this._files.concat(this._preDeployScripts).concat(this._postDeployScripts).concat(this._noneDeployScripts).concat(this._publishProfiles).filter(x => x.fsUri.fsPath.startsWith(entry.fsUri.fsPath) && x.type === EntryType.File);
 		const toDeleteFolders: FileProjectEntry[] = this._files.filter(x => x.fsUri.fsPath.startsWith(entry.fsUri.fsPath) && x.type === EntryType.Folder);
 
 		await Promise.all(toDeleteFiles.map(x => fs.unlink(x.fsUri.fsPath)));
@@ -1396,7 +1397,7 @@ export class Project implements ISqlProject {
 	 * @returns True when a node has been removed, false otherwise.
 	 */
 	private removeNode(includeString: string, nodes: HTMLCollectionOf<Element>, undoRemove: boolean = false): boolean {
-		// Default function behavior removes nodes like <Compile Include="..." />//TODO: publish profile
+		// Default function behavior removes nodes like <Compile Include="..." />
 		// However when undoRemove is true, this function removes <Compile Remove="..." />
 		const xmlAttribute = undoRemove ? constants.Remove : constants.Include;
 		for (let i = 0; i < nodes.length; i++) {
@@ -1779,7 +1780,7 @@ export class Project implements ISqlProject {
 		await this.serializeToProjFile(this.projFileXmlDoc!);
 	}
 
-	private async removeFromProjFile(entries: IProjectEntry | IProjectEntry[]): Promise<void> {//TODO: publish profile
+	private async removeFromProjFile(entries: IProjectEntry | IProjectEntry[]): Promise<void> {
 		if (!Array.isArray(entries)) {
 			entries = [entries];
 		}

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -65,7 +65,8 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 		let treeItemList = this.project.files
 			.concat(this.project.preDeployScripts)
 			.concat(this.project.postDeployScripts)
-			.concat(this.project.noneDeployScripts);
+			.concat(this.project.noneDeployScripts)
+			.concat(this.project.publishProfiles);
 
 		for (const entry of treeItemList) {
 			if (entry.type !== EntryType.File && entry.relativePath.startsWith(RelativeOuterPath)) {

--- a/extensions/sql-database-projects/src/test/baselines/baselines.ts
+++ b/extensions/sql-database-projects/src/test/baselines/baselines.ts
@@ -40,6 +40,7 @@ export let openSdkStyleSqlProjectWithFilesSpecifiedBaseline: string;
 export let openSdkStyleSqlProjectWithGlobsSpecifiedBaseline: string;
 export let openSdkStyleSqlProjectWithBuildRemoveBaseline: string;
 export let openSdkStyleSqlProjectNoProjectGuidBaseline: string;
+export let openSqlProjectWithAdditionalPublishProfileBaseline: string;
 
 const baselineFolderPath = __dirname;
 
@@ -77,6 +78,7 @@ export async function loadBaselines() {
 	openSdkStyleSqlProjectWithGlobsSpecifiedBaseline = await loadBaseline(baselineFolderPath, 'openSdkStyleSqlProjectWithGlobsSpecifiedBaseline.xml');
 	openSdkStyleSqlProjectWithBuildRemoveBaseline = await loadBaseline(baselineFolderPath, 'openSdkStyleSqlProjectWithBuildRemoveBaseline.xml');
 	openSdkStyleSqlProjectNoProjectGuidBaseline = await loadBaseline(baselineFolderPath, 'openSdkStyleSqlProjectNoProjectGuidBaseline.xml');
+	openSqlProjectWithAdditionalPublishProfileBaseline = await loadBaseline(baselineFolderPath, 'openSqlProjectWithAdditionalPublishProfileBaseline.xml');
 }
 
 async function loadBaseline(baselineFolderPath: string, fileName: string): Promise<string> {

--- a/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithAdditionalPublishProfileBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithAdditionalPublishProfileBaseline.xml
@@ -52,7 +52,7 @@
     <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
     <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
   </PropertyGroup>
-  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
@@ -109,6 +109,7 @@
     <None Include="TestProjectName_1.publish.xml" />
     <None Include="TestProjectName_2.publish.xml" />
     <None Include="TestProjectName_3.publish.xml" />
+    <None Include="TestProjectName_4.publish.xml" />
   </ItemGroup>
   <Target Name="BeforeBuild">
     <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />

--- a/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithAdditionalSqlCmdVariablesBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithAdditionalSqlCmdVariablesBaseline.xml
@@ -109,6 +109,11 @@
     <PostDeploy Include="Script.PostDeployment1.sql" />
     <None Include="Tables\Script.PostDeployment1.sql" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="TestProjectName_1.publish.xml" />
+    <None Include="TestProjectName_2.publish.xml" />
+    <None Include="TestProjectName_3.publish.xml" />
+  </ItemGroup>
   <Target Name="BeforeBuild">
     <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -66,6 +66,12 @@ describe('Project: sqlproj content operations', function (): void {
 		should(project.postDeployScripts.find(f => f.type === EntryType.File && f.relativePath === 'Script.PostDeployment1.sql')).not.equal(undefined, 'File Script.PostDeployment1.sql not read');
 		should(project.noneDeployScripts.find(f => f.type === EntryType.File && f.relativePath === 'Script.PreDeployment2.sql')).not.equal(undefined, 'File Script.PostDeployment2.sql not read');
 		should(project.noneDeployScripts.find(f => f.type === EntryType.File && f.relativePath === 'Tables\\Script.PostDeployment1.sql')).not.equal(undefined, 'File Tables\\Script.PostDeployment1.sql not read');
+
+		// Publish profiles
+		should(project.publishProfiles.length).equal(3);
+		should(project.publishProfiles.find(f => f.type === EntryType.File && f.relativePath === 'TestProjectName_1.publish.xml')).not.equal(undefined, 'Profile TestProjectName_1.publish.xml not read');
+		should(project.publishProfiles.find(f => f.type === EntryType.File && f.relativePath === 'TestProjectName_2.publish.xml')).not.equal(undefined, 'Profile TestProjectName_2.publish.xml not read');
+		should(project.publishProfiles.find(f => f.type === EntryType.File && f.relativePath === 'TestProjectName_3.publish.xml')).not.equal(undefined, 'Profile TestProjectName_3.publish.xml not read');
 	});
 
 	it('Should read Project with Project reference from sqlproj', async function (): Promise<void> {
@@ -1589,6 +1595,30 @@ describe('Project: add SQLCMD Variables', function (): void {
 
 		const projFileText = (await fs.readFile(projFilePath)).toString();
 		should(projFileText).equal(baselines.openSqlProjectWithAdditionalSqlCmdVariablesBaseline.trim());
+	});
+});
+
+describe('Project: add publish profiles', function (): void {
+	before(async function (): Promise<void> {
+		await baselines.loadBaselines();
+	});
+
+	after(async function (): Promise<void> {
+		await testUtils.deleteGeneratedTestFolder();
+	});
+
+	it('Should update .sqlproj with new publish profiles', async function (): Promise<void> {
+		projFilePath = await testUtils.createTestSqlProjFile(baselines.openProjectFileBaseline);
+		const project = await Project.openProject(projFilePath);
+		should(Object.keys(project.publishProfiles).length).equal(3);
+
+		// add a new publish profile
+		await project.addPublishProfileToProjFile(path.join(projFilePath, 'TestProjectName_4.publish.xml'));
+
+		should(Object.keys(project.publishProfiles).length).equal(4);
+
+		const projFileText = (await fs.readFile(projFilePath)).toString();
+		should(projFileText).equal(baselines.openSqlProjectWithAdditionalPublishProfileBaseline.trim());
 	});
 });
 


### PR DESCRIPTION
This PR is the second part for saving publish profile (https://github.com/microsoft/azuredatastudio/issues/12185) and it completes the UI functionality. It adds the ability to present created profiles in the project tree and add it to the sqlproj file. 
The only remaining piece for finalizing the profile work is to add the upstream functionality to read deployment options appropriately.

![publishProfile](https://user-images.githubusercontent.com/57200045/220482080-6ca068ef-db37-4072-999e-4fd9106e9bf6.gif)
