### PR TITLE
Hide refresh context menu action on disconnected connections

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
@@ -126,14 +126,15 @@ export class ServerTreeActionProvider {
 	private getBuiltinConnectionActions(context: ObjectExplorerContext): IAction[] {
 		let actions: IAction[] = [];
 
-		if (this._connectionManagementService.isProfileConnected(context.profile)) {
+		const isProfileConnected = this._connectionManagementService.isProfileConnected(context.profile);
+		if (isProfileConnected) {
 			actions.push(this._instantiationService.createInstance(DisconnectConnectionAction, DisconnectConnectionAction.ID, DisconnectConnectionAction.LABEL, context.profile));
 		}
 		actions.push(this._instantiationService.createInstance(EditConnectionAction, EditConnectionAction.ID, EditConnectionAction.LABEL, context.profile));
 		actions.push(this._instantiationService.createInstance(DeleteConnectionAction, DeleteConnectionAction.ID, DeleteConnectionAction.DELETE_CONNECTION_LABEL, context.profile));
 
 		// Contribute refresh action for scriptable objects via contribution
-		if (!this.isScriptableObject(context)) {
+		if (isProfileConnected && !this.isScriptableObject(context)) {
 			actions.push(this._instantiationService.createInstance(RefreshAction, RefreshAction.ID, RefreshAction.LABEL, context.tree, context.profile));
 		}
 		return actions;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #1866

The refresh action doesn't do anything when a connection profile is disconnected and it also doesn't show any indicator that it didn't do anything. By hiding the action we can make it clear that the action only refreshes connected profiles and not disconnected profiles.

Disconnected profiles don't show the refresh context menu action:
![image](https://user-images.githubusercontent.com/87730006/220748899-73999005-1199-4c48-9c4e-1ded7c895d4a.png)

Connected profiles show the refresh context menu action:
![image](https://user-images.githubusercontent.com/87730006/220749125-eeaa9115-9a2c-45b8-a869-7e9c0cee3891.png)
