### PR TITLE
Update version of Microsoft.Build.Sql used for building legacy sql projects

### DIFF
--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -15,7 +15,7 @@ import { DBProjectConfigurationKey } from './netcoreTool';
 
 const buildDirectory = 'BuildDirectory';
 const sdkName = 'Microsoft.Build.Sql';
-const microsoftBuildSqlDefaultVersion = '0.1.7-preview';
+const microsoftBuildSqlDefaultVersion = '0.1.9-preview'; // default version of Microsoft.Build.Sql nuget to use for building legacy style projects
 
 const buildFiles: string[] = [
 	'Microsoft.Data.SqlClient.dll',


### PR DESCRIPTION
This updates the default version of Microsoft.Build.Sql to pull the DacFx dlls from for building legacy style sql projects. The default version for creating new SDK-style projects has already been updated in DacFx.
