### PR TITLE
Remove unused things from ads telemetry service

### DIFF
--- a/src/sql/platform/telemetry/common/adsTelemetryService.ts
+++ b/src/sql/platform/telemetry/common/adsTelemetryService.ts
@@ -6,7 +6,7 @@
 import * as azdata from 'azdata';
 import { IAdsTelemetryService, ITelemetryEvent, ITelemetryEventMeasures, ITelemetryEventProperties } from 'sql/platform/telemetry/common/telemetry';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ITelemetryInfo, ITelemetryService, TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { EventName } from 'sql/platform/telemetry/common/telemetryKeys';
 
 
@@ -87,23 +87,6 @@ export class AdsTelemetryService implements IAdsTelemetryService {
 		@ITelemetryService private telemetryService: ITelemetryService,
 		@ILogService private logService: ILogService
 	) { }
-
-	setEnabled(value: boolean): void {
-		// if (value) {
-		// 	this.telemetryService.telemetryLevel = TelemetryLevel.USAGE;
-		// } else {
-		// 	this.telemetryService.telemetryLevel = TelemetryLevel.NONE;
-		// }
-		throw "Telemetry level is readonly";
-	}
-
-	get isOptedIn(): boolean {
-		return this.telemetryService.telemetryLevel.value !== TelemetryLevel.NONE;
-	}
-
-	getTelemetryInfo(): Promise<ITelemetryInfo> {
-		return this.telemetryService.getTelemetryInfo();
-	}
 
 	/**
 	 * Creates a View event that can be sent later. This is used to log that a particular page or item was seen.
@@ -222,19 +205,6 @@ export class NullAdsTelemetryService implements IAdsTelemetryService {
 
 	_serviceBrand: undefined;
 
-	get isOptedIn(): boolean {
-		return false;
-	}
-
-	setEnabled(value: boolean): void { }
-	getTelemetryInfo(): Promise<ITelemetryInfo> {
-		return Promise.resolve({
-			sessionId: '',
-			machineId: '',
-			firstSessionDate: '',
-			msftInternal: false
-		});
-	}
 	createViewEvent(view: string): ITelemetryEvent { return new NullTelemetryEventImpl(); }
 	sendViewEvent(view: string): void { }
 	createActionEvent(view: string, action: string, target?: string, source?: string, durationInMs?: number): ITelemetryEvent { return new NullTelemetryEventImpl(); }

--- a/src/sql/platform/telemetry/common/telemetry.ts
+++ b/src/sql/platform/telemetry/common/telemetry.ts
@@ -5,7 +5,6 @@
 
 import * as azdata from 'azdata';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { ITelemetryInfo } from 'vs/platform/telemetry/common/telemetry';
 
 export const IAdsTelemetryService = createDecorator<IAdsTelemetryService>('adsTelemetryService');
 
@@ -58,12 +57,6 @@ export interface IAdsTelemetryService {
 
 	// ITelemetryService functions
 	_serviceBrand: undefined;
-
-	setEnabled(value: boolean): void;
-
-	getTelemetryInfo(): Promise<ITelemetryInfo>;
-
-	isOptedIn: boolean;
 
 	// Custom event functions
 	createViewEvent(view: string): ITelemetryEvent;


### PR DESCRIPTION
Left over from previous versions of the telemetry service, don't need with latest changes made from previous VS Code merge. 