### PR TITLE
Hookup sqlcmdvar delete

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -809,7 +809,9 @@ export class ProjectsController {
 				success = true;
 			}
 		} else if (node instanceof SqlCmdVariableTreeItem) {
-			// TODO: handle deleting sqlcmd var from project after swap
+			const sqlProjectsService = await utils.getSqlProjectsService();
+			const result = await sqlProjectsService.deleteSqlCmdVariable(project.projectFilePath, node.friendlyName);
+			success = result.success;
 		} else if (node instanceof FileNode || FolderNode) {
 			const fileEntry = this.getFileProjectEntry(project, node);
 
@@ -924,6 +926,8 @@ export class ProjectsController {
 
 		// TODO: update after swap
 		await project.addSqlCmdVariable(variableName, defaultValue);
+		// const sqlProjectsService = await utils.getSqlProjectsService();
+		// sqlProjectsService.addSqlCmdVariable(project.projectFilePath, variableName, defaultValue);
 
 		this.refreshProjectsTree(context);
 	}

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -926,8 +926,6 @@ export class ProjectsController {
 
 		// TODO: update after swap
 		await project.addSqlCmdVariable(variableName, defaultValue);
-		// const sqlProjectsService = await utils.getSqlProjectsService();
-		// sqlProjectsService.addSqlCmdVariable(project.projectFilePath, variableName, defaultValue);
 
 		this.refreshProjectsTree(context);
 	}

--- a/extensions/sql-database-projects/src/models/tree/sqlcmdVariableTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/sqlcmdVariableTreeItem.ts
@@ -58,7 +58,7 @@ export class SqlCmdVariablesTreeItem extends BaseProjectTreeItem {
  * Represents a SQLCMD variable in a .sqlproj
  */
 export class SqlCmdVariableTreeItem extends BaseProjectTreeItem {
-	constructor(private sqlcmdVar: string, sqlprojUri: vscode.Uri, sqlCmdNodeRelativeProjectUri: vscode.Uri) {
+	constructor(private sqlcmdVar: string, sqlCmdNodeRelativeProjectUri: vscode.Uri, sqlprojUri: vscode.Uri,) {
 		super(vscode.Uri.file(path.join(sqlCmdNodeRelativeProjectUri.fsPath, sqlcmdVar)), sqlprojUri);
 	}
 

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -9,7 +9,7 @@ import * as sqldbproj from 'sqldbproj';
 import * as vscode from 'vscode';
 import * as constants from '../common/constants';
 import { IconPathHelper } from '../common/iconHelper';
-import { getDataWorkspaceExtensionApi } from '../common/utils';
+import { getDataWorkspaceExtensionApi, getSqlProjectsService } from '../common/utils';
 import { SqlDatabaseProjectTreeViewProvider } from '../controllers/databaseProjectTreeViewProvider';
 import { ProjectsController } from '../controllers/projectController';
 import { Project } from '../models/project';
@@ -41,6 +41,11 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	public async getProjectTreeDataProvider(projectFilePath: vscode.Uri): Promise<vscode.TreeDataProvider<BaseProjectTreeItem>> {
 		const provider = new SqlDatabaseProjectTreeViewProvider();
 		const project = await Project.openProject(projectFilePath.fsPath);
+
+		// open project in STS
+		const sqlProjectsService = await getSqlProjectsService();
+		await sqlProjectsService.openProject(projectFilePath.fsPath);
+
 		provider.load([project]);
 		return provider;
 	}


### PR DESCRIPTION
This hooks up the sqlcmd variable delete to the STS project apis. It also adds opening projects in STS when the projectProvider loads projects to display them in the projects view