### PR TITLE
Update migration service to 4.5.0.28 and dotnet version to 7.0

### DIFF
--- a/extensions/sql-migration/config.json
+++ b/extensions/sql-migration/config.json
@@ -1,12 +1,12 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.migration-{#fileName#}",
 	"useDefaultLinuxRuntime": true,
-	"version": "4.5.0.12",
+	"version": "4.5.0.28",
 	"downloadFileNames": {
-		"Windows_86": "win-x86-net6.0.zip",
-		"Windows_64": "win-x64-net6.0.zip",
-		"OSX": "osx-x64-net6.0.tar.gz",
-		"Linux": "rhel-x64-net6.0.tar.gz"
+		"Windows_86": "win-x86-net7.0.zip",
+		"Windows_64": "win-x64-net7.0.zip",
+		"OSX": "osx-x64-net7.0.tar.gz",
+		"Linux": "rhel-x64-net7.0.tar.gz"
 	},
 	"installDirectory": "./migrationService/{#platform#}/{#version#}",
 	"executableFiles": ["MicrosoftSqlToolsMigration", "MicrosoftSqlToolsMigration.exe"],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the JSON-RPC Migration service to the latest version. Critically, it also changes the dotnet version to 7.0. The STS dotnet version was recently changed, which changed the names of the release packages and broke our existing links. 