### PR TITLE
Show error if trying to create or open project when no project extension is installed

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -23,6 +23,7 @@ export const gitCloneError = localize('gitCloneError', "Error during git clone. 
 export const openedProjectsUndefinedAfterRefresh = localize('openedProjectsUndefinedAfterRefresh', "List of opened projects should not be undefined after refresh from disk.");
 export const dragAndDropNotSupported = localize('dragAndDropNotSupported', "This project type does not support drag and drop.");
 export const onlyMovingOneFileIsSupported = localize('onlyMovingOneFileIsSupported', "Only moving one file at a time is supported.");
+export const noProjectProvidingExtensionsInstalled = localize('noProjectProvidingExtensionsInstalled', "No database project extensions are installed. Please install a database project extension to use this feature.");
 
 // UI
 export const OkButtonText = localize('dataworkspace.ok', "OK");

--- a/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
+++ b/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
@@ -9,6 +9,7 @@ import { WorkspaceService } from '../services/workspaceService';
 import { defaultProjectSaveLocation } from './projectLocationHelper';
 import { openSpecificProjectNewProjectDialog } from '../dialogs/newProjectDialog';
 import { isValidBasename, isValidBasenameErrorMessage, isValidFilenameCharacter, sanitizeStringForFilename } from './pathUtilsHelper';
+import { noProjectProvidingExtensionsInstalled } from './constants';
 
 export class DataWorkspaceExtension implements IExtension {
 	constructor(private workspaceService: WorkspaceService) {
@@ -39,6 +40,10 @@ export class DataWorkspaceExtension implements IExtension {
 	}
 
 	openSpecificProjectNewProjectDialog(projectType: IProjectType): Promise<vscode.Uri | undefined> {
+		if (!this.workspaceService.isProjectProviderAvailable) {
+			void vscode.window.showErrorMessage(noProjectProvidingExtensionsInstalled);
+		}
+
 		return openSpecificProjectNewProjectDialog(projectType, this.workspaceService);
 	}
 

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -100,7 +100,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	Logger.log(`Registering commands took ${new Date().getTime() - registerCommandStartTime}ms`);
 
 	context.subscriptions.push(vscode.extensions.onDidChange(() => {
-		workspaceService.checkIfProjectProviderAvailable();
+		workspaceService.updateIfProjectProviderAvailable();
 	}));
 
 	const iconPathHelperTime = new Date().getTime();

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -16,6 +16,7 @@ import { getAzdataApi } from './common/utils';
 import { createNewProjectWithQuickpick } from './dialogs/newProjectQuickpick';
 import Logger from './common/logger';
 import { TelemetryReporter } from './common/telemetry';
+import { noProjectProvidingExtensionsInstalled } from './common/constants';
 
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
 	const startTime = new Date().getTime();
@@ -46,6 +47,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		// Make sure all project providing extensions are activated to be sure the project templates show up
 		await workspaceService.ensureProviderExtensionLoaded(undefined, true);
 
+		if (!workspaceService.isProjectProviderAvailable) {
+			void vscode.window.showErrorMessage(noProjectProvidingExtensionsInstalled);
+			return;
+		}
+
 		if (azdataApi) {
 			const dialog = new NewProjectDialog(workspaceService);
 			await dialog.open();
@@ -57,6 +63,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	context.subscriptions.push(vscode.commands.registerCommand('projects.openExisting', async () => {
 		// Make sure all project providing extensions are activated so that all supported project types show up in the file filter
 		await workspaceService.ensureProviderExtensionLoaded(undefined, true);
+
+		if (!workspaceService.isProjectProviderAvailable) {
+			void vscode.window.showErrorMessage(noProjectProvidingExtensionsInstalled);
+			return;
+		}
 
 		if (azdataApi) {
 			const dialog = new OpenExistingDialog(workspaceService);

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -99,6 +99,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	}));
 	Logger.log(`Registering commands took ${new Date().getTime() - registerCommandStartTime}ms`);
 
+	context.subscriptions.push(vscode.extensions.onDidChange(() => {
+		workspaceService.checkIfProjectProviderAvailable();
+	}));
+
 	const iconPathHelperTime = new Date().getTime();
 	IconPathHelper.setExtensionContext(context);
 	Logger.log(`IconPathHelper took ${new Date().getTime() - iconPathHelperTime}ms`);

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -41,7 +41,7 @@ export class WorkspaceService implements IWorkspaceService {
 		Logger.log(`Checking ${vscode.extensions.all.length} extensions to see if there is a project provider is available`);
 		const startTime = new Date().getTime();
 
-		this._isProjectProviderAvailable = vscode.extensions.all.find(e => e.packageJSON.contributes?.projects?.length > 0) !== undefined;
+		this._isProjectProviderAvailable = vscode.extensions.all.some(e => e.packageJSON.contributes?.projects?.length > 0);
 		Logger.log(`isProjectProviderAvailable is ${this._isProjectProviderAvailable}. Total time = ${new Date().getTime() - startTime}ms`);
 	}
 

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -29,7 +29,7 @@ export class WorkspaceService implements IWorkspaceService {
 
 	constructor() {
 		Logger.log(`Calling getProjectsInWorkspace() from WorkspaceService constructor`);
-		this.checkIfProjectProviderAvailable();
+		this.updateIfProjectProviderAvailable();
 		this.getProjectsInWorkspace(undefined, true).catch(err => Logger.error(`Error initializing projects in workspace ${err}`));
 	}
 
@@ -37,19 +37,12 @@ export class WorkspaceService implements IWorkspaceService {
 		return this._isProjectProviderAvailable;
 	}
 
-	public checkIfProjectProviderAvailable(): void {
+	public updateIfProjectProviderAvailable(): void {
 		Logger.log(`Checking ${vscode.extensions.all.length} extensions to see if there is a project provider is available`);
 		const startTime = new Date().getTime();
-		for (const extension of vscode.extensions.all) {
-			const projectTypes = extension.packageJSON.contributes && extension.packageJSON.contributes.projects as string[];
-			if (projectTypes && projectTypes.length > 0) {
-				Logger.log(`Project provider found. Total time = ${new Date().getTime() - startTime}ms`);
-				this._isProjectProviderAvailable = true;
-			}
-		}
 
-		Logger.log(`No project providers found. Total time = ${new Date().getTime() - startTime}ms`);
-		this._isProjectProviderAvailable = false;
+		this._isProjectProviderAvailable = vscode.extensions.all.find(e => e.packageJSON.contributes?.projects?.length > 0) !== undefined;
+		Logger.log(`isProjectProviderAvailable is ${this._isProjectProviderAvailable}. Total time = ${new Date().getTime() - startTime}ms`);
 	}
 
 	/**

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -25,25 +25,31 @@ export class WorkspaceService implements IWorkspaceService {
 
 	private openedProjects: vscode.Uri[] | undefined = undefined;
 	private excludedProjects: string[] | undefined;
+	private _isProjectProviderAvailable: boolean = false;
 
 	constructor() {
 		Logger.log(`Calling getProjectsInWorkspace() from WorkspaceService constructor`);
+		this.checkIfProjectProviderAvailable();
 		this.getProjectsInWorkspace(undefined, true).catch(err => Logger.error(`Error initializing projects in workspace ${err}`));
 	}
 
 	get isProjectProviderAvailable(): boolean {
+		return this._isProjectProviderAvailable;
+	}
+
+	public checkIfProjectProviderAvailable(): void {
 		Logger.log(`Checking ${vscode.extensions.all.length} extensions to see if there is a project provider is available`);
 		const startTime = new Date().getTime();
 		for (const extension of vscode.extensions.all) {
 			const projectTypes = extension.packageJSON.contributes && extension.packageJSON.contributes.projects as string[];
 			if (projectTypes && projectTypes.length > 0) {
 				Logger.log(`Project provider found. Total time = ${new Date().getTime() - startTime}ms`);
-				return true;
+				this._isProjectProviderAvailable = true;
 			}
 		}
 
 		Logger.log(`No project providers found. Total time = ${new Date().getTime() - startTime}ms`);
-		return false;
+		this._isProjectProviderAvailable = false;
 	}
 
 	/**

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -31,6 +31,21 @@ export class WorkspaceService implements IWorkspaceService {
 		this.getProjectsInWorkspace(undefined, true).catch(err => Logger.error(`Error initializing projects in workspace ${err}`));
 	}
 
+	get isProjectProviderAvailable(): boolean {
+		Logger.log(`Checking ${vscode.extensions.all.length} extensions to see if there is a project provider is available`);
+		const startTime = new Date().getTime();
+		for (const extension of vscode.extensions.all) {
+			const projectTypes = extension.packageJSON.contributes && extension.packageJSON.contributes.projects as string[];
+			if (projectTypes && projectTypes.length > 0) {
+				Logger.log(`Project provider found. Total time = ${new Date().getTime() - startTime}ms`);
+				return true;
+			}
+		}
+
+		Logger.log(`No project providers found. Total time = ${new Date().getTime() - startTime}ms`);
+		return false;
+	}
+
 	/**
 	 * Verify that a workspace is open or that if one isn't and we're running in ADS, it's ok to create a workspace and restart ADS
 	 */


### PR DESCRIPTION
Now that the projects view is always visible in ADS after https://github.com/microsoft/azuredatastudio/pull/22005, this adds showing an error if a user tries to open or create a project without an extension that contributes a database project type installed.
![dataworkspaceError](https://user-images.githubusercontent.com/31145923/221063284-600d29c7-8e35-47a2-8384-3e69af28ea1d.gif)
