### PR TITLE
Open books in VS Code notebooks if the setting is enabled.

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -19,6 +19,9 @@
       "supported": true
     }
   },
+  "enabledApiProposals": [
+    "notebookEditor"
+  ],
   "contributes": {
     "configuration": {
       "type": "object",

--- a/extensions/notebook/src/typings/refs.d.ts
+++ b/extensions/notebook/src/typings/refs.d.ts
@@ -6,4 +6,5 @@
 /// <reference path='../../../../src/sql/azdata.d.ts'/>
 /// <reference path='../../../../src/sql/azdata.proposed.d.ts'/>
 /// <reference path='../../../../src/vscode-dts/vscode.d.ts'/>
+/// <reference path='../../../../src/vscode-dts/vscode.proposed.notebookEditor.d.ts'/>
 /// <reference types='@types/node'/>


### PR DESCRIPTION
Integrated our Jupyter Books viewlet with the VS Code-style notebooks. I opted to have the extension check the useVSCodeNotebooks flag, rather than changing azdata's showNotebookDocument, to prevent potential side effects for callers that I haven't tested yet.
