### PR TITLE
[SQL-Migration] Login migrations telemetry

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -494,7 +494,6 @@ export async function collectTargetLogins(
 	const error = new Error(result.errorMessage);
 	logError(TelemetryViews.LoginMigrationWizard, errorMessage, error);
 	throw error;
-
 }
 
 export async function isSourceConnectionSysAdmin(): Promise<boolean> {

--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -9,6 +9,7 @@ import { AzureSqlDatabase, AzureSqlDatabaseServer } from './azure';
 import { generateGuid } from './utils';
 import * as utils from '../api/utils';
 import { TelemetryAction, TelemetryViews, logError } from '../telemetry';
+import * as constants from '../constants/strings';
 
 const query_database_tables_sql = `
 	SELECT
@@ -489,7 +490,11 @@ export async function collectTargetLogins(
 		return results.rows.map(row => getSqlString(row[0])) ?? [];
 	}
 
-	throw new Error(result.errorMessage);
+	const errorMessage = constants.COLLECTING_TARGET_LOGINS_FAILED(result.errorCode ?? 0);
+	const error = new Error(result.errorMessage);
+	logError(TelemetryViews.LoginMigrationWizard, errorMessage, error);
+	throw error;
+
 }
 
 export async function isSourceConnectionSysAdmin(): Promise<boolean> {

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -389,7 +389,9 @@ export const MIGRATE_LOGINS = localize('sql.login.migration.steps.migrate.logins
 export const ESTABLISH_USER_MAPPINGS = localize('sql.login.migration.steps.migrate.logins', "Establish user mappings");
 export const MIGRATE_SERVER_ROLES_AND_SET_PERMISSIONS = localize('sql.login.migration.steps.migrate.logins', "Migrate server roles, set login and server permissions");
 export const LOGIN_MIGRATION_COMPLETED = localize('sql.login.migration.steps.migrate.logins', "Login migration completed");
-
+export function COLLECTING_TARGET_LOGINS_FAILED(errorCode: number): string {
+	return localize('sql.login.migration.collecting.target.logins.failed', "Collecting Target Login Failed with error code {0}", errorCode);
+}
 
 // Azure SQL Target
 export const AZURE_SQL_TARGET_PAGE_TITLE = localize('sql.migration.wizard.target.title', "Azure SQL target");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -390,7 +390,7 @@ export const ESTABLISH_USER_MAPPINGS = localize('sql.login.migration.steps.migra
 export const MIGRATE_SERVER_ROLES_AND_SET_PERMISSIONS = localize('sql.login.migration.steps.migrate.logins', "Migrate server roles, set login and server permissions");
 export const LOGIN_MIGRATION_COMPLETED = localize('sql.login.migration.steps.migrate.logins', "Login migration completed");
 export function COLLECTING_TARGET_LOGINS_FAILED(errorCode: number): string {
-	return localize('sql.login.migration.collecting.target.logins.failed', "Collecting Target Login Failed with error code {0}", errorCode);
+	return localize('sql.login.migration.collecting.target.logins.failed', "Collecting target login failed with error code {0}", errorCode);
 }
 
 // Azure SQL Target

--- a/extensions/sql-migration/src/main.ts
+++ b/extensions/sql-migration/src/main.ts
@@ -12,7 +12,6 @@ import { TelemetryReporter } from './telemetry';
 import { SqlOpsDataClient } from 'dataprotocol-client';
 
 let widget: DashboardWidget;
-let serviceClient: ServiceClient;
 let migrationServiceClient: SqlOpsDataClient | undefined;
 export async function activate(context: vscode.ExtensionContext): Promise<DashboardWidget> {
 	if (!migrationServiceProvider) {
@@ -20,7 +19,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Dashbo
 	}
 	// asynchronously starting the service
 	const outputChannel = vscode.window.createOutputChannel(constants.serviceName);
-	serviceClient = new ServiceClient(outputChannel);
+	let serviceClient = new ServiceClient(outputChannel);
 	migrationServiceClient = await serviceClient.startService(context).catch((e) => {
 		console.error(e);
 		return undefined;

--- a/extensions/sql-migration/src/main.ts
+++ b/extensions/sql-migration/src/main.ts
@@ -12,6 +12,7 @@ import { TelemetryReporter } from './telemetry';
 import { SqlOpsDataClient } from 'dataprotocol-client';
 
 let widget: DashboardWidget;
+let serviceClient: ServiceClient;
 let migrationServiceClient: SqlOpsDataClient | undefined;
 export async function activate(context: vscode.ExtensionContext): Promise<DashboardWidget> {
 	if (!migrationServiceProvider) {
@@ -19,9 +20,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Dashbo
 	}
 	// asynchronously starting the service
 	const outputChannel = vscode.window.createOutputChannel(constants.serviceName);
-	const serviceClient = new ServiceClient(outputChannel);
+	serviceClient = new ServiceClient(outputChannel);
 	migrationServiceClient = await serviceClient.startService(context).catch((e) => {
 		console.error(e);
+		return undefined;
 		return undefined;
 	});
 

--- a/extensions/sql-migration/src/main.ts
+++ b/extensions/sql-migration/src/main.ts
@@ -19,10 +19,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Dashbo
 	}
 	// asynchronously starting the service
 	const outputChannel = vscode.window.createOutputChannel(constants.serviceName);
-	let serviceClient = new ServiceClient(outputChannel);
+	const serviceClient = new ServiceClient(outputChannel);
 	migrationServiceClient = await serviceClient.startService(context).catch((e) => {
 		console.error(e);
-		return undefined;
 		return undefined;
 	});
 

--- a/extensions/sql-migration/src/models/loginMigrationModel.ts
+++ b/extensions/sql-migration/src/models/loginMigrationModel.ts
@@ -65,7 +65,7 @@ export class LoginMigrationModel {
 	public loginMigrationsResult!: contracts.StartLoginMigrationResult;
 	public loginMigrationsError: any;
 	public loginsForMigration!: LoginTableInfo[];
-	public errorCountMap: Map<LoginMigrationStep, any> = new Map<LoginMigrationStep, any>();
+	public errorCountMap: Map<string, any> = new Map<string, any>();
 	public durationPerStep: Map<string, string> = new Map<string, string>();
 	private _currentStepIdx: number = 0;
 	private _logins: Map<string, Login>;
@@ -158,12 +158,12 @@ export class LoginMigrationModel {
 		return loginResults;
 	}
 
-	private setErrorCountMapPerStep(step: LoginMigrationStep, result: mssql.StartLoginMigrationResult) {
+	private setErrorCountMapPerStep(step: LoginMigrationStep, result: contracts.StartLoginMigrationResult) {
 		const errorCount = result.exceptionMap ? Object.keys(result.exceptionMap).length : 0;
 		this.errorCountMap.set(LoginMigrationStep[step], errorCount);
 	}
 
-	private setDurationPerStep(step: LoginMigrationStep, result: mssql.StartLoginMigrationResult) {
+	private setDurationPerStep(step: LoginMigrationStep, result: contracts.StartLoginMigrationResult) {
 		this.durationPerStep.set(LoginMigrationStep[step], result.elapsedTime);
 	}
 

--- a/extensions/sql-migration/src/models/loginMigrationModel.ts
+++ b/extensions/sql-migration/src/models/loginMigrationModel.ts
@@ -66,7 +66,7 @@ export class LoginMigrationModel {
 	public loginMigrationsError: any;
 	public loginsForMigration!: LoginTableInfo[];
 	public errorCountMap: Map<LoginMigrationStep, any> = new Map<LoginMigrationStep, any>();
-	public durationPerStep: Map<LoginMigrationStep, string> = new Map<LoginMigrationStep, string>();
+	public durationPerStep: Map<string, string> = new Map<string, string>();
 	private _currentStepIdx: number = 0;
 	private _logins: Map<string, Login>;
 	private _loginMigrationSteps: LoginMigrationStep[] = [];
@@ -160,11 +160,11 @@ export class LoginMigrationModel {
 
 	private setErrorCountMapPerStep(step: LoginMigrationStep, result: mssql.StartLoginMigrationResult) {
 		const errorCount = result.exceptionMap ? Object.keys(result.exceptionMap).length : 0;
-		this.errorCountMap.set(step, errorCount);
+		this.errorCountMap.set(LoginMigrationStep[step], errorCount);
 	}
 
 	private setDurationPerStep(step: LoginMigrationStep, result: mssql.StartLoginMigrationResult) {
-		this.durationPerStep.set(step, result.elapsedTime);
+		this.durationPerStep.set(LoginMigrationStep[step], result.elapsedTime);
 	}
 
 	private setLoginMigrationSteps(steps: LoginMigrationStep[] = []) {

--- a/extensions/sql-migration/src/models/loginMigrationModel.ts
+++ b/extensions/sql-migration/src/models/loginMigrationModel.ts
@@ -236,8 +236,6 @@ export class LoginMigrationModel {
 				stateMachine._aadDomainName
 			))!;
 
-			console.log("AKMA DEBUG: ", response);
-
 			this.addLoginMigrationResults(LoginMigrationStep.MigrateLogins, response);
 			return true;
 

--- a/extensions/sql-migration/src/models/loginMigrationModel.ts
+++ b/extensions/sql-migration/src/models/loginMigrationModel.ts
@@ -250,6 +250,8 @@ export class LoginMigrationModel {
 				stateMachine._aadDomainName
 			))!;
 
+			console.log("AKMA DEBUG: ", response);
+
 			this.updateLoginMigrationResults(response);
 			this.addLoginMigrationResults(LoginMigrationStep.MigrateLogins, response);
 			return true;

--- a/extensions/sql-migration/src/telemetry.ts
+++ b/extensions/sql-migration/src/telemetry.ts
@@ -38,6 +38,7 @@ export enum TelemetryViews {
 	Utils = 'Utils',
 	LoginMigrationWizardController = 'LoginMigrationWizardController',
 	LoginMigrationWizard = 'LoginMigrationWizard',
+	LoginMigrationStatusWizard = 'LoginMigrationStatusWizard',
 	TdeConfigurationDialog = 'TdeConfigurationDialog',
 }
 
@@ -64,7 +65,8 @@ export enum TelemetryAction {
 	GetInstanceRequirements = 'GetInstanceRequirements',
 	StartDataCollection = 'StartDataCollection',
 	StopDataCollection = 'StopDataCollection',
-	GetDatabasesListFailed = 'GetDatabasesListFailed'
+	GetDatabasesListFailed = 'GetDatabasesListFailed',
+	LoginMigrationCompleted = 'LoginMigrationCompleted'
 }
 
 export enum TelemetryErrorName {

--- a/extensions/sql-migration/src/telemetry.ts
+++ b/extensions/sql-migration/src/telemetry.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import AdsTelemetryReporter, { TelemetryEventMeasures, TelemetryEventProperties } from '@microsoft/ads-extension-telemetry';
+import { MigrationStateModel } from './models/stateMachine';
 const packageJson = require('../package.json');
 let packageInfo = {
 	name: packageJson.name,
@@ -38,7 +39,9 @@ export enum TelemetryViews {
 	Utils = 'Utils',
 	LoginMigrationWizardController = 'LoginMigrationWizardController',
 	LoginMigrationWizard = 'LoginMigrationWizard',
-	LoginMigrationStatusWizard = 'LoginMigrationStatusWizard',
+	LoginMigrationTargetSelectionPage = 'LoginMigrationTargetSelectionPage',
+	LoginMigrationSelectorPage = 'LoginMigrationSelectorPage',
+	LoginMigrationStatusPage = 'LoginMigrationStatusPage',
 	TdeConfigurationDialog = 'TdeConfigurationDialog',
 }
 
@@ -66,6 +69,8 @@ export enum TelemetryAction {
 	StartDataCollection = 'StartDataCollection',
 	StopDataCollection = 'StopDataCollection',
 	GetDatabasesListFailed = 'GetDatabasesListFailed',
+	ConnectToTarget = 'ConnectToTarget',
+	LoginMigrationStarted = 'LoginMigrationStarted',
 	LoginMigrationCompleted = 'LoginMigrationCompleted'
 }
 
@@ -83,4 +88,15 @@ export function sendSqlMigrationActionEvent(telemetryView: TelemetryViews, telem
 		.withAdditionalProperties(additionalProps)
 		.withAdditionalMeasurements(additionalMeasurements)
 		.send();
+}
+
+export function getTelemetryProps(migrationStateModel: MigrationStateModel): TelemetryEventProperties {
+	return {
+		'sessionId': migrationStateModel._sessionId,
+		'subscriptionId': migrationStateModel._targetSubscription?.id,
+		'resourceGroup': migrationStateModel._resourceGroup?.name,
+		'targetType': migrationStateModel._targetType,
+		'tenantId': migrationStateModel._azureAccount?.properties?.tenants[0]?.id,
+		'extensionVersion': migrationStateModel.extensionContext.extension.packageJSON.version,
+	};
 }

--- a/extensions/sql-migration/src/telemetry.ts
+++ b/extensions/sql-migration/src/telemetry.ts
@@ -97,6 +97,5 @@ export function getTelemetryProps(migrationStateModel: MigrationStateModel): Tel
 		'resourceGroup': migrationStateModel._resourceGroup?.name,
 		'targetType': migrationStateModel._targetType,
 		'tenantId': migrationStateModel._azureAccount?.properties?.tenants[0]?.id,
-		'extensionVersion': migrationStateModel.extensionContext.extension.packageJSON.version,
 	};
 }

--- a/extensions/sql-migration/src/telemetry.ts
+++ b/extensions/sql-migration/src/telemetry.ts
@@ -70,8 +70,9 @@ export enum TelemetryAction {
 	StopDataCollection = 'StopDataCollection',
 	GetDatabasesListFailed = 'GetDatabasesListFailed',
 	ConnectToTarget = 'ConnectToTarget',
+	OpenLoginMigrationWizard = 'OpenLoginMigrationWizard',
 	LoginMigrationStarted = 'LoginMigrationStarted',
-	LoginMigrationCompleted = 'LoginMigrationCompleted'
+	LoginMigrationCompleted = 'LoginMigrationCompleted',
 }
 
 export enum TelemetryErrorName {
@@ -98,4 +99,17 @@ export function getTelemetryProps(migrationStateModel: MigrationStateModel): Tel
 		'targetType': migrationStateModel._targetType,
 		'tenantId': migrationStateModel._azureAccount?.properties?.tenants[0]?.id,
 	};
+}
+
+export function sendButtonClickEvent(migrationStateModel: MigrationStateModel, telemetryView: TelemetryViews, buttonPressed: TelemetryAction, pageTitle: string, newPageTitle: string): void {
+	sendSqlMigrationActionEvent(
+		telemetryView,
+		TelemetryAction.PageButtonClick,
+		{
+			...getTelemetryProps(migrationStateModel),
+			'buttonPressed': buttonPressed,
+			'pageTitle': pageTitle,
+			'newPageTitle': newPageTitle
+		},
+		{});
 }

--- a/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
@@ -311,6 +311,7 @@ export class LoginMigrationStatusPage extends MigrationWizardPage {
 				status = LoginMigrationStatusCodes.Succeeded;
 				title = constants.LOGIN_MIGRATION_STATUS_SUCCEEDED;
 				var didLoginFail = Object.keys(stateMachine._loginMigrationModel.loginMigrationsResult.exceptionMap).some(key => key.toLocaleLowerCase() === loginName.toLocaleLowerCase());
+
 				if (didLoginFail) {
 					status = LoginMigrationStatusCodes.Failed;
 					title = constants.LOGIN_MIGRATION_STATUS_FAILED;
@@ -432,7 +433,7 @@ export class LoginMigrationStatusPage extends MigrationWizardPage {
 			{
 				...getTelemetryProps(this.migrationStateModel),
 				'loginsAuthType': this.migrationStateModel._loginMigrationModel.loginsAuthType,
-				'numberLogins': this.migrationStateModel._loginMigrationModel.loginsForMigration.length.toString(),
+				'numberLogins': JSON.stringify(this.migrationStateModel._loginMigrationModel.loginsForMigration.length),
 			},
 			{}
 		);
@@ -445,9 +446,10 @@ export class LoginMigrationStatusPage extends MigrationWizardPage {
 			{
 				...getTelemetryProps(this.migrationStateModel),
 				'loginsAuthType': this.migrationStateModel._loginMigrationModel.loginsAuthType,
-				'numberLoginsFailingPerStep': this.migrationStateModel._loginMigrationModel.errorCountMap.toString(),
-				// each step, will Success : ogin count, Failure and the failure type count. Also duration of the step
-				'hasSystemError': this.migrationStateModel._loginMigrationModel.hasSystemError ? 'true' : 'false',
+				'numberLoginsFailingPerStep': JSON.stringify(this.migrationStateModel._loginMigrationModel.errorCountMap),
+				'durationPerStep': JSON.stringify(this.migrationStateModel._loginMigrationModel.durationPerStep),
+				'hasSystemError': JSON.stringify(this.migrationStateModel._loginMigrationModel.hasSystemError),
+				// AKMA TODO: add error code string count map
 			},
 			{}
 		);

--- a/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
@@ -446,8 +446,8 @@ export class LoginMigrationStatusPage extends MigrationWizardPage {
 			{
 				...getTelemetryProps(this.migrationStateModel),
 				'loginsAuthType': this.migrationStateModel._loginMigrationModel.loginsAuthType,
-				'numberLoginsFailingPerStep': JSON.stringify(this.migrationStateModel._loginMigrationModel.errorCountMap),
-				'durationPerStep': JSON.stringify(this.migrationStateModel._loginMigrationModel.durationPerStep),
+				'numberLoginsFailingPerStep': JSON.stringify(Array.from(this.migrationStateModel._loginMigrationModel.errorCountMap)),
+				'durationPerStep': JSON.stringify(Array.from(this.migrationStateModel._loginMigrationModel.durationPerStep)),
 				'hasSystemError': JSON.stringify(this.migrationStateModel._loginMigrationModel.hasSystemError),
 				// AKMA TODO: add error code string count map
 			},

--- a/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
@@ -433,9 +433,10 @@ export class LoginMigrationStatusPage extends MigrationWizardPage {
 			{
 				...getTelemetryProps(this.migrationStateModel),
 				'loginsAuthType': this.migrationStateModel._loginMigrationModel.loginsAuthType,
-				'numberLogins': JSON.stringify(this.migrationStateModel._loginMigrationModel.loginsForMigration.length),
 			},
-			{}
+			{
+				'numberLogins': this.migrationStateModel._loginMigrationModel.loginsForMigration.length,
+			}
 		);
 	}
 
@@ -447,7 +448,7 @@ export class LoginMigrationStatusPage extends MigrationWizardPage {
 				...getTelemetryProps(this.migrationStateModel),
 				'loginsAuthType': this.migrationStateModel._loginMigrationModel.loginsAuthType,
 				'numberLoginsFailingPerStep': JSON.stringify(Array.from(this.migrationStateModel._loginMigrationModel.errorCountMap)),
-				'durationPerStep': JSON.stringify(Array.from(this.migrationStateModel._loginMigrationModel.durationPerStep)),
+				'durationPerStepTimestamp': JSON.stringify(Array.from(this.migrationStateModel._loginMigrationModel.durationPerStep)),
 				'hasSystemError': JSON.stringify(this.migrationStateModel._loginMigrationModel.hasSystemError),
 				// AKMA TODO: add error code string count map
 			},

--- a/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
@@ -16,6 +16,7 @@ import { azureResource } from 'azurecore';
 import { AzureSqlDatabaseServer, getVMInstanceView, SqlVMServer } from '../api/azure';
 import { collectSourceLogins, collectTargetLogins, getSourceConnectionId, getSourceConnectionProfile, isSourceConnectionSysAdmin, LoginTableInfo } from '../api/sqlUtils';
 import { NetworkInterfaceModel } from '../api/dataModels/azure/networkInterfaceModel';
+import { logError, TelemetryViews } from '../telemetry';
 
 export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 	private _view!: azdata.ModelView;
@@ -631,6 +632,8 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 						await this._showConnectionResults(
 							loginsOnTarget,
 							constants.AZURE_SQL_TARGET_CONNECTION_ERROR_TITLE);
+
+						logError(TelemetryViews.LoginMigrationWizard, 'ConnectingToTargetFailed', error);
 					}
 					finally {
 						connectionButtonLoadingContainer.loading = false;

--- a/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
@@ -645,7 +645,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 							TelemetryAction.ConnectToTarget,
 							{
 								...getTelemetryProps(this.migrationStateModel),
-								'connectionSuccessful': connectionSuccessful ? 'true' : 'false'
+								'connectionSuccessful': JSON.stringify(connectionSuccessful)
 							},
 							{});
 					}

--- a/extensions/sql-migration/src/wizard/wizardController.ts
+++ b/extensions/sql-migration/src/wizard/wizardController.ts
@@ -321,13 +321,13 @@ export class WizardController {
 		return undefined;
 	}
 
-	private async sendPageButtonClickEvent(telemetryVew: TelemetryViews, pageChangeInfo: azdata.window.WizardPageChangeInfo) {
+	private async sendPageButtonClickEvent(telemetryView: TelemetryViews, pageChangeInfo: azdata.window.WizardPageChangeInfo) {
 		const buttonPressed = pageChangeInfo.newPage > pageChangeInfo.lastPage
 			? TelemetryAction.Next
 			: TelemetryAction.Prev;
 		const pageTitle = this._wizardObject.pages[pageChangeInfo.lastPage]?.title;
 		sendSqlMigrationActionEvent(
-			telemetryVew,
+			telemetryView,
 			TelemetryAction.PageButtonClick,
 			{
 				...getTelemetryProps(this._model),

--- a/extensions/sql-migration/src/wizard/wizardController.ts
+++ b/extensions/sql-migration/src/wizard/wizardController.ts
@@ -16,7 +16,7 @@ import { SummaryPage } from './summaryPage';
 import { LoginMigrationStatusPage } from './loginMigrationStatusPage';
 import { DatabaseSelectorPage } from './databaseSelectorPage';
 import { LoginSelectorPage } from './loginSelectorPage';
-import { sendSqlMigrationActionEvent, TelemetryAction, TelemetryViews, logError, getTelemetryProps } from '../telemetry';
+import { sendSqlMigrationActionEvent, sendButtonClickEvent, TelemetryAction, TelemetryViews, logError, getTelemetryProps } from '../telemetry';
 import * as styles from '../constants/styles';
 import { MigrationLocalStorage, MigrationServiceContext } from '../models/migrationLocalStorage';
 import { azureResource } from 'azurecore';
@@ -216,6 +216,10 @@ export class WizardController {
 		wizardSetupPromises.push(...pages.map(p => p.registerWizardContent()));
 		wizardSetupPromises.push(this._wizardObject.open());
 
+		// Emit telemetry for starting login migration wizard
+		const firstPageTitle = this._wizardObject.pages.length > 0 ? this._wizardObject.pages[0].title : "";
+		sendButtonClickEvent(this._model, TelemetryViews.LoginMigrationWizard, TelemetryAction.OpenLoginMigrationWizard, "", firstPageTitle);
+
 		this._model.extensionContext.subscriptions.push(
 			this._wizardObject.onPageChanged(
 				async (pageChangeInfo: azdata.window.WizardPageChangeInfo) => {
@@ -326,15 +330,8 @@ export class WizardController {
 			? TelemetryAction.Next
 			: TelemetryAction.Prev;
 		const pageTitle = this._wizardObject.pages[pageChangeInfo.lastPage]?.title;
-		sendSqlMigrationActionEvent(
-			telemetryView,
-			TelemetryAction.PageButtonClick,
-			{
-				...getTelemetryProps(this._model),
-				'buttonPressed': buttonPressed,
-				'pageTitle': pageTitle
-			},
-			{});
+		const newPageTitle = this._wizardObject.pages[pageChangeInfo.newPage]?.title;
+		sendButtonClickEvent(this._model, telemetryView, buttonPressed, pageTitle, newPageTitle);
 	}
 
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR enhances telemetry for login migrations (and  in the following ways:

- Add details for starting migration (number of logins migrating, type of logins)
- Log Migration result (number of errors per step, duration of each step, type of logins, if system error occurred)
- Add sql-migration extension to our telemetry
- Adds details when trying to connect to target
- Tracks clicking "done" from the wizard
-  Fixes bucketizing for navigating telemetry in the login migration wizard 

Sample usage of kusto query for new telemetry:
RawEventsADS
| where EventName contains 'sql-migration'
| extend view = tostring(Properties['view'])
| extend action = tostring(Properties['action'])
| extend buttonPressed = tostring(Properties['buttonpressed'])
| extend pageTitle = tostring(Properties['pagetitle'])
| extend adsVersion = tostring(Properties['common.adsversion'])
| extend targetType = tostring(Properties['targettype'])
| extend tenantId = tostring(Properties['tenantid'])
| extend subscriptionId = tostring(Properties['subscriptionid'])
| where view contains "login"
//| where adsVersion contains "1.42.0-insider"
| where ClientTimestamp >= ago(18h)
| project EventName, ClientTimestamp, SessionId, view, pageTitle, action, buttonPressed, targetType
    , tenantId, subscriptionId
    , adsVersion, OSVersion, Properties

 