### PR TITLE
Adding null checks and fixing values in slickgrid checkbox column plugin 

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -219,12 +219,16 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		const propertyValue = dataItem[this._options.title];
 		let checkboxEnabled: boolean = true;
 		let checkboxChecked: boolean = false;
+
 		if (typeof propertyValue === 'boolean') {
 			checkboxEnabled = true;
 			checkboxChecked = propertyValue;
 		} else if (propertyValue !== undefined) {
 			checkboxEnabled = propertyValue.enabled === undefined ? true : propertyValue.enabled;
 			checkboxChecked = propertyValue.checked === undefined ? false : propertyValue.checked;
+		} else if (propertyValue === undefined) { // If the value is undefined the checkbox will be enabled and unchecked
+			checkboxEnabled = true;
+			checkboxChecked = false;
 		}
 
 		return {

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -60,7 +60,7 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 	private _handler = new Slick.EventHandler();
 	private _options: ICheckboxSelectColumnOptions;
 	public index: number;
-	private _headerCheckbox: HTMLInputElement;
+	private _headerCheckbox: HTMLInputElement | undefined;
 	private _onChange = new Emitter<ICheckboxCellActionEventArgs>();
 	private _onCheckAllChange = new Emitter<ICheckAllActionEventArgs>();
 	public readonly onChange: vsEvent<ICheckboxCellActionEventArgs> = this._onChange.event;
@@ -193,7 +193,9 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 				break;
 			}
 		}
-		this._headerCheckbox.checked = checked;
+		if (this._headerCheckbox) {
+			this._headerCheckbox.checked = checked;
+		}
 	}
 
 	public destroy(): void {
@@ -234,7 +236,8 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 	private setCheckboxPropertyValue(row: number, value: boolean): void {
 		const dataItem = this._grid?.getDataItem(row);
 		const propertyValue = dataItem[this._options.title];
-		if (typeof propertyValue === 'boolean') {
+		// If property value is undefined we treat the cell value as a boolean
+		if (propertyValue === undefined || typeof propertyValue === 'boolean') {
 			(<any>dataItem)[this._options.title] = value;
 		} else {
 			(<any>dataItem)[this._options.title] = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #21887 
When the cell values are undefined, I am falling back to simple Boolean values for the cell. There was also a null check that I added for header checkboxes 


![azuredatastudio_cvPqIWHXoL](https://user-images.githubusercontent.com/6816294/221718924-734c7dfc-95ab-4491-bf5c-0fb3fc1d2508.gif)
