### PR TITLE
Adding null checks to let users delete server groups on fresh ADS install

### DIFF
--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -269,18 +269,25 @@ export class ConnectionConfig {
 		subgroups.push(group);
 		// Get all connections in the settings
 		let profiles = this.configurationService.inspect<IConnectionProfileStore[]>(CONNECTIONS_CONFIG_KEY).userValue;
-		// Remove the profiles from the connections
-		profiles = profiles!.filter(value => {
-			let providerConnectionProfile = ConnectionProfile.createFromStoredProfile(value, this._capabilitiesService);
-			return !connections.some((val) => val.getOptionsKey() === providerConnectionProfile.getOptionsKey());
-		});
+
+		if (profiles) {
+			// Remove the profiles from the connections
+			profiles = profiles!.filter(value => {
+				let providerConnectionProfile = ConnectionProfile.createFromStoredProfile(value, this._capabilitiesService);
+				return !connections.some((val) => val.getOptionsKey() === providerConnectionProfile.getOptionsKey());
+			});
+		}
 
 		// Get all groups in the settings
 		let groups = this.configurationService.inspect<IConnectionProfileGroup[]>(GROUPS_CONFIG_KEY).userValue;
-		// Remove subgroups in the settings
-		groups = groups!.filter((grp) => {
-			return !subgroups.some((item) => item.id === grp.id);
-		});
+
+		if (groups) {
+			// Remove subgroups in the settings
+			groups = groups!.filter((grp) => {
+				return !subgroups.some((item) => item.id === grp.id);
+			});
+		}
+
 		return Promise.all([
 			this.configurationService.updateValue(CONNECTIONS_CONFIG_KEY, profiles, ConfigurationTarget.USER),
 			this.configurationService.updateValue(GROUPS_CONFIG_KEY, groups, ConfigurationTarget.USER)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Just adding null checks fixes this issue. On a new ADS installs the profiles are undefined and filter function returns a runtime exceptions causing the group to not get deleted. 
This PR fixes #21831 
