### PR TITLE
Disable the vscode SQL notebook controller since it breaks query editor.

### DIFF
--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -115,7 +115,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	registerTableDesignerCommands(appContext);
 	registerObjectManagementCommands(appContext);
 
-	// context.subscriptions.push(new SqlNotebookController()); Temporarily isabled due to breaking query editor
+	// context.subscriptions.push(new SqlNotebookController()); Temporarily disabled due to breaking query editor
 
 	context.subscriptions.push(TelemetryReporter);
 

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -22,7 +22,7 @@ import { IconPathHelper } from './iconHelper';
 import * as nls from 'vscode-nls';
 import { INotebookConvertService } from './notebookConvert/notebookConvertService';
 import { registerTableDesignerCommands } from './tableDesigner/tableDesigner';
-import { SqlNotebookController } from './sqlNotebook/sqlNotebookController';
+// import { SqlNotebookController } from './sqlNotebook/sqlNotebookController';
 import { registerObjectManagementCommands } from './objectManagement/commands';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from './telemetry';
 
@@ -115,7 +115,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	registerTableDesignerCommands(appContext);
 	registerObjectManagementCommands(appContext);
 
-	context.subscriptions.push(new SqlNotebookController());
+	// context.subscriptions.push(new SqlNotebookController()); Temporarily isabled due to breaking query editor
 
 	context.subscriptions.push(TelemetryReporter);
 


### PR DESCRIPTION
Fixes #22044

When I added a listener for query completion in the SQL kernel, it broke the rest of the editors listening on the MSSQL provider. Disabling this controller for now.
