### PR TITLE
Update sql project file move to use DacFx api

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -664,3 +664,4 @@ export const movingFilesBetweenProjectsNotSupported = localize('movingFilesBetwe
 export function errorMovingFile(source: string, destination: string, error: string) { return localize('errorMovingFile', "Error when moving file from {0} to {1}. Error: {2}", source, destination, error); }
 export function moveConfirmationPrompt(source: string, destination: string) { return localize('moveConfirmationPrompt', "Are you sure you want to move {0} to {1}?", source, destination); }
 export const move = localize('Move', "Move");
+export function errorRenamingFile(source: string, destination: string, error: string) { return localize('errorRenamingFile', "Error when renaming file from {0} to {1}. Error: {2}", source, destination, error); }

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -856,7 +856,12 @@ export class ProjectsController {
 		}
 
 		const newFilePath = path.join(path.dirname(utils.getPlatformSafeFileEntryPath(file?.relativePath!)), `${newFileName}.sql`);
-		await this.move(node, node.projectFileUri.fsPath, newFilePath, node.relativeProjectUri.fsPath);
+
+		try {
+			await this.move(node, node.projectFileUri.fsPath, newFilePath, node.relativeProjectUri.fsPath);
+		} catch (e) {
+			void vscode.window.showErrorMessage(constants.errorRenamingFile(file?.relativePath!, newFilePath, utils.getErrorMessage(e)));
+		}
 
 		this.refreshProjectsTree(context);
 	}

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -14,7 +14,6 @@ import * as vscode from 'vscode';
 import type * as azdataType from 'azdata';
 import * as dataworkspace from 'dataworkspace';
 import type * as mssqlVscode from 'vscode-mssql';
-import * as fse from 'fs-extra';
 
 import { promises as fs } from 'fs';
 import { PublishDatabaseDialog } from '../dialogs/publishDatabaseDialog';
@@ -1864,10 +1863,10 @@ export class ProjectsController {
 		let folderPath;
 		// target is the root of project, which is the .sqlproj
 		if (target.element.projectFileUri.fsPath === target.element.fileSystemUri.fsPath) {
-			folderPath = path.dirname(target.element.projectFileUri.fsPath!);
+			folderPath = path.basename(path.dirname(target.element.projectFileUri.fsPath!));
 		} else {
 			// target is another file or folder
-			folderPath = target.element.fileSystemUri.fsPath.endsWith(constants.sqlFileExtension) ? path.dirname(target.element.fileSystemUri.fsPath) : target.element.fileSystemUri.fsPath;
+			folderPath = target.element.relativeProjectUri.fsPath.endsWith(constants.sqlFileExtension) ? path.dirname(target.element.relativeProjectUri.fsPath) : target.element.relativeProjectUri.fsPath;
 		}
 
 		const newPath = path.join(folderPath!, sourceFileNode.friendlyName);
@@ -1884,15 +1883,41 @@ export class ProjectsController {
 
 		// Move the file
 		try {
-			const project = await Project.openProject(projectUri.fsPath);
-
-			// TODO: swap out with DacFx projects apis - currently moving pre/post deploy scripts don't work, but they should work after the swap
-			await fse.move(sourceFileNode.fileSystemUri.fsPath, newPath!);
-			await project.exclude(project.files.find(f => f.fsUri.fsPath === sourceFileNode.fileSystemUri.fsPath)!);
-			await project.addExistingItem(newPath!);
+			await this.move(sourceFileNode, projectUri.fsPath, newPath, sourceFileNode.relativeProjectUri.fsPath);
 		} catch (e) {
 			void vscode.window.showErrorMessage(constants.errorMovingFile(sourceFileNode.fileSystemUri.fsPath, newPath, utils.getErrorMessage(e)));
 		}
+	}
+
+	/**
+	 * Moves a file to a different location
+	 * @param node Node being moved
+	 * @param projectFilePath Full file path to .sqlproj
+	 * @param destinationRelativePath path of the destination, relative to .sqlproj
+	 * @param originalRelativePath path of the original location, relative to .sqlproj
+	 */
+	private async move(node: FileNode, projectFilePath: string, destinationRelativePath: string, originalRelativePath: string): Promise<void> {
+		if (originalRelativePath === destinationRelativePath) {
+			return;
+		}
+
+		// trim off the project folder at the beginning of the relative path stored in the tree
+		const projectRelativeUri = vscode.Uri.file(path.basename(projectFilePath, constants.sqlprojExtension));
+		originalRelativePath = utils.trimUri(projectRelativeUri, vscode.Uri.file(originalRelativePath));
+		destinationRelativePath = utils.trimUri(projectRelativeUri, vscode.Uri.file(destinationRelativePath));
+
+		const sqlProjectsService = await utils.getSqlProjectsService();
+
+		if (node instanceof SqlObjectFileNode) {
+			const result = await sqlProjectsService.moveSqlObjectScript(projectFilePath, destinationRelativePath, originalRelativePath)
+			console.error(JSON.stringify(result));
+		} else if (node instanceof PreDeployNode) {
+			await sqlProjectsService.movePreDeploymentScript(projectFilePath, destinationRelativePath, originalRelativePath)
+		} else if (node instanceof PostDeployNode) {
+			await sqlProjectsService.movePostDeploymentScript(projectFilePath, destinationRelativePath, originalRelativePath)
+		}
+		// TODO add support for renaming none scripts after those are added in STS
+		// TODO add support for renaming publish profiles when support is added in DacFx
 	}
 }
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1904,8 +1904,7 @@ export class ProjectsController {
 		const sqlProjectsService = await utils.getSqlProjectsService();
 
 		if (node instanceof SqlObjectFileNode) {
-			const result = await sqlProjectsService.moveSqlObjectScript(projectFilePath, destinationRelativePath, originalRelativePath)
-			console.error(JSON.stringify(result));
+			await sqlProjectsService.moveSqlObjectScript(projectFilePath, destinationRelativePath, originalRelativePath)
 		} else if (node instanceof PreDeployNode) {
 			await sqlProjectsService.movePreDeploymentScript(projectFilePath, destinationRelativePath, originalRelativePath)
 		} else if (node instanceof PostDeployNode) {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -856,17 +856,7 @@ export class ProjectsController {
 		}
 
 		const newFilePath = path.join(path.dirname(utils.getPlatformSafeFileEntryPath(file?.relativePath!)), `${newFileName}.sql`);
-		const sqlProjectsService = await utils.getSqlProjectsService();
-
-		if (node instanceof SqlObjectFileNode) {
-			await sqlProjectsService.moveSqlObjectScript(project.projectFilePath, newFilePath, file!.relativePath)
-		} else if (node instanceof PreDeployNode) {
-			await sqlProjectsService.movePreDeploymentScript(project.projectFilePath, newFilePath, file!.relativePath)
-		} else if (node instanceof PostDeployNode) {
-			await sqlProjectsService.movePostDeploymentScript(project.projectFilePath, newFilePath, file!.relativePath)
-		}
-		// TODO add support for renaming none scripts after those are added in STS
-		// TODO add support for renaming publish profiles when support is added in DacFx
+		await this.move(node, node.projectFileUri.fsPath, newFilePath, node.relativeProjectUri.fsPath);
 
 		this.refreshProjectsTree(context);
 	}
@@ -1896,7 +1886,7 @@ export class ProjectsController {
 	 * @param destinationRelativePath path of the destination, relative to .sqlproj
 	 * @param originalRelativePath path of the original location, relative to .sqlproj
 	 */
-	private async move(node: FileNode, projectFilePath: string, destinationRelativePath: string, originalRelativePath: string): Promise<void> {
+	private async move(node: BaseProjectTreeItem, projectFilePath: string, destinationRelativePath: string, originalRelativePath: string): Promise<void> {
 		if (originalRelativePath === destinationRelativePath) {
 			return;
 		}

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -858,7 +858,7 @@ export class ProjectsController {
 		const newFilePath = path.join(path.dirname(utils.getPlatformSafeFileEntryPath(file?.relativePath!)), `${newFileName}.sql`);
 
 		try {
-			await this.move(node, node.projectFileUri.fsPath, newFilePath, node.relativeProjectUri.fsPath);
+			await this.move(node, node.projectFileUri.fsPath, newFilePath);
 		} catch (e) {
 			void vscode.window.showErrorMessage(constants.errorRenamingFile(file?.relativePath!, newFilePath, utils.getErrorMessage(e)));
 		}
@@ -1878,7 +1878,7 @@ export class ProjectsController {
 
 		// Move the file
 		try {
-			await this.move(sourceFileNode, projectUri.fsPath, newPath, sourceFileNode.relativeProjectUri.fsPath);
+			await this.move(sourceFileNode, projectUri.fsPath, newPath);
 		} catch (e) {
 			void vscode.window.showErrorMessage(constants.errorMovingFile(sourceFileNode.fileSystemUri.fsPath, newPath, utils.getErrorMessage(e)));
 		}
@@ -1889,17 +1889,16 @@ export class ProjectsController {
 	 * @param node Node being moved
 	 * @param projectFilePath Full file path to .sqlproj
 	 * @param destinationRelativePath path of the destination, relative to .sqlproj
-	 * @param originalRelativePath path of the original location, relative to .sqlproj
 	 */
-	private async move(node: BaseProjectTreeItem, projectFilePath: string, destinationRelativePath: string, originalRelativePath: string): Promise<void> {
+	private async move(node: BaseProjectTreeItem, projectFilePath: string, destinationRelativePath: string): Promise<void> {
+		// trim off the project folder at the beginning of the relative path stored in the tree
+		const projectRelativeUri = vscode.Uri.file(path.basename(projectFilePath, constants.sqlprojExtension));
+		const originalRelativePath = utils.trimUri(projectRelativeUri, node.relativeProjectUri);
+		destinationRelativePath = utils.trimUri(projectRelativeUri, vscode.Uri.file(destinationRelativePath));
+
 		if (originalRelativePath === destinationRelativePath) {
 			return;
 		}
-
-		// trim off the project folder at the beginning of the relative path stored in the tree
-		const projectRelativeUri = vscode.Uri.file(path.basename(projectFilePath, constants.sqlprojExtension));
-		originalRelativePath = utils.trimUri(projectRelativeUri, vscode.Uri.file(originalRelativePath));
-		destinationRelativePath = utils.trimUri(projectRelativeUri, vscode.Uri.file(destinationRelativePath));
 
 		const sqlProjectsService = await utils.getSqlProjectsService();
 


### PR DESCRIPTION
This switches `moveFile()` used for drag and drop to use the DacFx api exposed in STS to move the file on disk and in the .sqlproj. Also moves the move part to a helper function so both rename and moveFile can call it.
