### PR TITLE
Update ads-extension-telemetry to 1.4.0

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -107,7 +107,7 @@
     ]
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "@microsoft/ads-service-downloader": "^1.1.0",
     "vscode-nls": "^4.1.2"
   },

--- a/extensions/admin-tool-ext-win/src/main.ts
+++ b/extensions/admin-tool-ext-win/src/main.ts
@@ -52,7 +52,7 @@ function registerCommands(context: vscode.ExtensionContext): void {
  */
 async function handleLaunchSsmsMinPropertiesDialogCommand(connectionContext?: azdata.ObjectExplorerContext): Promise<void> {
 	if (!connectionContext) {
-		TelemetryReporter.sendErrorEvent(TelemetryViews.SsmsMinProperties, 'NoConnectionContext');
+		TelemetryReporter.sendErrorEvent2(TelemetryViews.SsmsMinProperties, 'NoConnectionContext');
 		void vscode.window.showErrorMessage(localize('adminToolExtWin.noConnectionContextForProp', "No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand"));
 		return;
 	}
@@ -64,7 +64,7 @@ async function handleLaunchSsmsMinPropertiesDialogCommand(connectionContext?: az
 	else if (connectionContext.nodeInfo) {
 		nodeType = connectionContext.nodeInfo.nodeType;
 	} else {
-		TelemetryReporter.sendErrorEvent(TelemetryViews.SsmsMinProperties, 'NoOENode');
+		TelemetryReporter.sendErrorEvent2(TelemetryViews.SsmsMinProperties, 'NoOENode');
 		void vscode.window.showErrorMessage(localize('adminToolExtWin.noOENode', "Could not determine Object Explorer node from connectionContext : {0}", JSON.stringify(connectionContext)));
 		return;
 	}
@@ -81,7 +81,7 @@ async function handleLaunchSsmsMinPropertiesDialogCommand(connectionContext?: az
 async function handleLaunchSsmsMinGswDialogCommand(connectionContext?: azdata.ObjectExplorerContext): Promise<void> {
 	const action = 'GenerateScripts';
 	if (!connectionContext) {
-		TelemetryReporter.sendErrorEvent(TelemetryViews.SsmsMinGsw, 'NoConnectionContext');
+		TelemetryReporter.sendErrorEvent2(TelemetryViews.SsmsMinGsw, 'NoConnectionContext');
 		void vscode.window.showErrorMessage(localize('adminToolExtWin.noConnectionContextForGsw', "No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand"));
 		return;
 	}
@@ -98,7 +98,7 @@ async function handleLaunchSsmsMinGswDialogCommand(connectionContext?: azdata.Ob
  */
 async function launchSsmsDialog(action: string, connectionContext: azdata.ObjectExplorerContext): Promise<void> {
 	if (!connectionContext.connectionProfile) {
-		TelemetryReporter.sendErrorEvent(TelemetryViews.SsmsMinDialog, 'NoConnectionProfile');
+		TelemetryReporter.sendErrorEvent2(TelemetryViews.SsmsMinDialog, 'NoConnectionProfile');
 		void vscode.window.showErrorMessage(localize('adminToolExtWin.noConnectionProfile', "No connectionProfile provided from connectionContext : {0}", JSON.stringify(connectionContext)));
 		return;
 	}
@@ -112,7 +112,7 @@ async function launchSsmsDialog(action: string, connectionContext: azdata.Object
 		oeNode = await azdata.objectexplorer.getNode(connectionContext.connectionProfile.id, connectionContext.nodeInfo.nodePath);
 	}
 	else {
-		TelemetryReporter.sendErrorEvent(TelemetryViews.SsmsMinDialog, 'NoOENode');
+		TelemetryReporter.sendErrorEvent2(TelemetryViews.SsmsMinDialog, 'NoOENode');
 		void vscode.window.showErrorMessage(localize('adminToolExtWin.noOENode', "Could not determine Object Explorer node from connectionContext : {0}", JSON.stringify(connectionContext)));
 		return;
 	}
@@ -156,9 +156,10 @@ async function launchSsmsDialog(action: string, connectionContext: azdata.Object
 			runningProcesses.delete(proc.pid);
 			const err = stderr.toString();
 			if ((execException?.code !== 0) || err !== '') {
-				TelemetryReporter.sendErrorEvent(
+				TelemetryReporter.sendErrorEvent2(
 					TelemetryViews.SsmsMinDialog,
 					'LaunchSsmsDialogError',
+					execException,
 					execException ? execException?.code?.toString() : '',
 					getTelemetryErrorType(err));
 			}

--- a/extensions/admin-tool-ext-win/yarn.lock
+++ b/extensions/admin-tool-ext-win/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -213,7 +213,7 @@
     "figures": "^2.0.0",
     "find-remove": "1.2.1",
     "@microsoft/ads-service-downloader": "^1.1.0",
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/azuremonitor/yarn.lock
+++ b/extensions/azuremonitor/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -92,7 +92,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "htmlparser2": "^3.10.1",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -493,7 +493,7 @@ export class DataTierApplicationWizard {
 				.withAdditionalMeasurements(additionalMeasurements)
 				.send();
 		} else {
-			TelemetryReporter.createErrorEvent(TelemetryViews.DataTierApplicationWizard, telemetryAction)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.DataTierApplicationWizard, telemetryAction)
 				.withAdditionalProperties(additionalProps)
 				.withAdditionalMeasurements(additionalMeasurements)
 				.send();

--- a/extensions/dacpac/yarn.lock
+++ b/extensions/dacpac/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -179,7 +179,7 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.7",
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "vscode-nls": "^4.0.0"
   },
   "devDependencies": {

--- a/extensions/data-workspace/src/dialogs/newProjectDialog.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectDialog.ts
@@ -95,7 +95,7 @@ export class NewProjectDialog extends DialogBase {
 		}
 		catch (err) {
 
-			TelemetryReporter.createErrorEvent(TelemetryViews.NewProjectDialog, TelemetryActions.NewProjectDialogCompleted)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.NewProjectDialog, TelemetryActions.NewProjectDialogCompleted, err)
 				.withAdditionalProperties({ projectFileExtension: this.model.projectFileExtension, projectTemplateId: this.model.projectTypeId, error: err?.message ? err.message : err })
 				.send();
 

--- a/extensions/data-workspace/yarn.lock
+++ b/extensions/data-workspace/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/datavirtualization/package.json
+++ b/extensions/datavirtualization/package.json
@@ -105,7 +105,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "@microsoft/ads-service-downloader": "^1.1.0",
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.2",
     "vscode-nls": "^5.2.0"

--- a/extensions/datavirtualization/yarn.lock
+++ b/extensions/datavirtualization/yarn.lock
@@ -206,10 +206,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -80,7 +80,7 @@
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.1",
     "htmlparser2": "^3.10.1",
     "@microsoft/ads-service-downloader": "^1.1.0",
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "vscode-nls": "^4.1.2"
   },
   "devDependencies": {

--- a/extensions/import/yarn.lock
+++ b/extensions/import/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -431,7 +431,7 @@
     "figures": "^2.0.0",
     "find-remove": "1.2.1",
     "@microsoft/ads-service-downloader": "^1.1.0",
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/kusto/yarn.lock
+++ b/extensions/kusto/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1315,7 +1315,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "@microsoft/ads-service-downloader": "^1.1.0",
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.2",
     "find-remove": "1.2.1",

--- a/extensions/mssql/src/objectManagement/commands.ts
+++ b/extensions/mssql/src/objectManagement/commands.ts
@@ -49,7 +49,7 @@ async function handleNewLoginDialogCommand(context: azdata.ObjectExplorerContext
 		await dialog.open();
 	}
 	catch (err) {
-		TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, TelemetryActions.OpenNewObjectDialog).withAdditionalProperties({
+		TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, TelemetryActions.OpenNewObjectDialog, err).withAdditionalProperties({
 			objectType: NodeType.Login
 		}).send();
 		await vscode.window.showErrorMessage(localizedConstants.OpenNewObjectDialogError(localizedConstants.LoginTypeDisplayName, getErrorMessage(err)));

--- a/extensions/mssql/src/objectManagement/commands.ts
+++ b/extensions/mssql/src/objectManagement/commands.ts
@@ -49,7 +49,7 @@ async function handleNewLoginDialogCommand(context: azdata.ObjectExplorerContext
 		await dialog.open();
 	}
 	catch (err) {
-		TelemetryReporter.createErrorEvent(TelemetryViews.ObjectManagement, TelemetryActions.OpenNewObjectDialog).withAdditionalProperties({
+		TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, TelemetryActions.OpenNewObjectDialog).withAdditionalProperties({
 			objectType: NodeType.Login
 		}).send();
 		await vscode.window.showErrorMessage(localizedConstants.OpenNewObjectDialogError(localizedConstants.LoginTypeDisplayName, getErrorMessage(err)));
@@ -63,7 +63,7 @@ async function handleNewUserDialogCommand(context: azdata.ObjectExplorerContext,
 		await dialog.open();
 	}
 	catch (err) {
-		TelemetryReporter.createErrorEvent(TelemetryViews.ObjectManagement, TelemetryActions.OpenNewObjectDialog).withAdditionalProperties({
+		TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, TelemetryActions.OpenNewObjectDialog, err).withAdditionalProperties({
 			objectType: NodeType.User
 		}).send();
 		await vscode.window.showErrorMessage(localizedConstants.OpenNewObjectDialogError(localizedConstants.UserTypeDisplayName, getErrorMessage(err)));
@@ -90,7 +90,7 @@ async function handleObjectPropertiesDialogCommand(context: azdata.ObjectExplore
 		}
 	}
 	catch (err) {
-		TelemetryReporter.createErrorEvent(TelemetryViews.ObjectManagement, TelemetryActions.OpenPropertiesDialog).withAdditionalProperties({
+		TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, TelemetryActions.OpenPropertiesDialog, err).withAdditionalProperties({
 			objectType: context.nodeInfo.nodeType
 		}).send();
 		await vscode.window.showErrorMessage(localizedConstants.OpenObjectPropertiesDialogError(nodeTypeDisplayName, context.nodeInfo.label, getErrorMessage(err)));
@@ -141,7 +141,7 @@ async function handleDeleteObjectCommand(context: azdata.ObjectExplorerContext, 
 			}
 			catch (err) {
 				operation.updateStatus(azdata.TaskStatus.Failed, localizedConstants.DeleteObjectError(nodeTypeDisplayName, context.nodeInfo.label, getErrorMessage(err)));
-				TelemetryReporter.createErrorEvent(TelemetryViews.ObjectManagement, TelemetryActions.DeleteObject).withAdditionalProperties({
+				TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, TelemetryActions.DeleteObject, err).withAdditionalProperties({
 					objectType: context.nodeInfo.nodeType
 				}).send();
 				return;

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -158,7 +158,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 					}
 					catch (err) {
 						operation.updateStatus(azdata.TaskStatus.Failed, getErrorMessage(err));
-						TelemetryReporter.createErrorEvent(TelemetryViews.ObjectManagement, actionName).withAdditionalProperties({
+						TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, actionName, err).withAdditionalProperties({
 							objectType: this.objectType
 						}).send();
 					}
@@ -169,7 +169,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 			this._loadingComponent.loading = false;
 		} catch (err) {
 			const actionName = this.isNewObject ? TelemetryActions.OpenNewObjectDialog : TelemetryActions.OpenPropertiesDialog;
-			TelemetryReporter.createErrorEvent(TelemetryViews.ObjectManagement, actionName).withAdditionalProperties({
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, actionName, err).withAdditionalProperties({
 				objectType: this.objectType
 			}).send();
 			void vscode.window.showErrorMessage(getErrorMessage(err));

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -683,7 +683,7 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^3.2.1",
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "adm-zip": "^0.4.14",
     "error-ex": "^1.3.1",
     "fast-glob": "^3.1.0",

--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -221,10 +221,10 @@
     "@phosphor/disposable" "^1.1.2"
     "@phosphor/signaling" "^1.2.2"
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -208,7 +208,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "vscode-nls": "^4.1.2"
   },
   "devDependencies": {

--- a/extensions/query-history/src/main.ts
+++ b/extensions/query-history/src/main.ts
@@ -29,10 +29,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	// Create the global storage folder now for storing the query history persistance file
 	const storageUri = context.globalStorageUri;
 	try {
+		throw new Error('Test');
 		await fs.mkdir(storageUri.fsPath);
 	} catch (err) {
 		if (err.code !== 'EEXIST') {
-			TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistory, 'CreatingStorageFolder');
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistory, 'CreatingStorageFolder', err);
 			console.error(`Error creating query history global storage folder ${context.globalStorageUri.fsPath}. ${err}`);
 		}
 	}
@@ -114,7 +115,7 @@ async function openQuery(item: QueryHistoryItem): Promise<void> {
 				content: item.queryText
 			}, item.connectionProfile?.providerId);
 	} catch (err) {
-		TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistory, 'OpenQuery');
+		TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistory, 'OpenQuery');
 	}
 
 }
@@ -136,7 +137,7 @@ async function runQuery(item: QueryHistoryItem): Promise<void> {
 		step = 'Run';
 		azdata.queryeditor.runQuery(doc.uri);
 	} catch (err) {
-		TelemetryReporter.createErrorEvent(TelemetryViews.QueryHistory, 'RunQuery')
+		TelemetryReporter.createErrorEvent2(TelemetryViews.QueryHistory, 'RunQuery', err)
 			.withAdditionalProperties({ step })
 			.send();
 	}

--- a/extensions/query-history/src/queryHistoryProvider.ts
+++ b/extensions/query-history/src/queryHistoryProvider.ts
@@ -95,7 +95,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 						// We need to compare URIs, but the event Uri comes in as string so while it should be in the same format as
 						// the textDocument uri.toString() we parse it into a vscode.Uri first to be absolutely sure.
 						if (textEditor?.document.uri.toString() !== vscode.Uri.parse(document.uri).toString()) {
-							TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistoryProvider, 'UriMismatch');
+							TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistoryProvider, 'UriMismatch');
 							// If we couldn't find the document then we can't get the text so just log the error and move on
 							console.error(`Active text editor ${textEditor?.document.uri} does not match URI ${document.uri} for query event`);
 							return;
@@ -128,7 +128,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 			}
 		} catch (err) {
 			console.error(`Error getting persistance storage IV: ${err}`);
-			TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistoryProvider, 'InitializingIV');
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistoryProvider, 'InitializingIV', err);
 			// An IV is required to read/write the encrypted file so if we can't get it then just fail early
 			return;
 		}
@@ -144,7 +144,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 			}
 		} catch (err) {
 			console.error(`Error getting persistance storage key: ${err}`);
-			TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistoryProvider, 'InitializingKey');
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistoryProvider, 'InitializingKey', err);
 			// A key is required to read/write the encrypted file so if we can't get it then just fail early
 			return;
 		}
@@ -166,7 +166,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 					fs.writeFileSync(this._historyStorageFile, encryptedText);
 					writeStorageFileAction.send();
 				} catch (err) {
-					TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistoryProvider, 'WriteStorageFile');
+					TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistoryProvider, 'WriteStorageFile', err);
 					console.error(`Error writing query history to disk: ${err}`);
 				}
 
@@ -191,7 +191,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 		} catch (err) {
 			// Ignore ENOENT errors, those are expected if the storage file doesn't exist (on first run or if results aren't being persisted)
 			if (err.code !== 'ENOENT') {
-				TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistoryProvider, 'ReadStorageFile');
+				TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistoryProvider, 'ReadStorageFile', err);
 				console.error(`Error deserializing stored history items: ${err}`);
 				void vscode.window.showWarningMessage(loc.errorLoading(err));
 				// Rename the file to avoid attempting to load a potentially corrupted or unreadable file every time we start up, we'll make
@@ -200,7 +200,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 					const bakPath = path.join(path.dirname(this._historyStorageFile), `${HISTORY_STORAGE_FILE_NAME}.bak`);
 					await fs.promises.rename(this._historyStorageFile, bakPath);
 				} catch (err) {
-					TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistoryProvider, 'MovingBadStorageFile');
+					TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistoryProvider, 'MovingBadStorageFile', err);
 					console.error(`Error moving corrupted history file: ${err}`);
 				}
 			}
@@ -291,7 +291,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<QueryHistor
 			} catch (err) {
 				// Ignore ENOENT errors, those are expected if the storage file doesn't exist (on first run or if results aren't being persisted)
 				if (err.code !== 'ENOENT') {
-					TelemetryReporter.sendErrorEvent(TelemetryViews.QueryHistoryProvider, 'CleaningUpStorageFile');
+					TelemetryReporter.sendErrorEvent2(TelemetryViews.QueryHistoryProvider, 'CleaningUpStorageFile', err);
 					// Best effort, we don't want other things to fail if we can't delete the file for some reason
 					console.error(`Error cleaning up query history storage: ${this._historyStorageFile}. ${err}`);
 				}

--- a/extensions/query-history/yarn.lock
+++ b/extensions/query-history/yarn.lock
@@ -228,10 +228,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -524,7 +524,7 @@
     ]
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "axios": "^0.27.2",
     "linux-release-info": "^2.0.0",
     "promisify-child-process": "^3.1.1",

--- a/extensions/resource-deployment/yarn.lock
+++ b/extensions/resource-deployment/yarn.lock
@@ -189,10 +189,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -111,7 +111,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "vscode-nls": "^4.0.0"
   },
   "devDependencies": {

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -382,7 +382,7 @@ export class SchemaCompareMainWindow {
 			this.comparisonResult = await service.schemaCompare(this.operationId, this.sourceEndpointInfo, this.targetEndpointInfo, azdata.TaskExecutionMode.execute, this.deploymentOptions);
 
 			if (!this.comparisonResult || !this.comparisonResult.success) {
-				TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonFailed', undefined, getTelemetryErrorType(this.comparisonResult?.errorMessage))
+				TelemetryReporter.createErrorEvent2(TelemetryViews.SchemaCompareMainWindow, 'SchemaComparisonFailed', undefined, undefined, getTelemetryErrorType(this.comparisonResult?.errorMessage))
 					.withAdditionalProperties({
 						operationId: this.comparisonResult.operationId
 					}).send();
@@ -783,7 +783,7 @@ export class SchemaCompareMainWindow {
 			const result = await service.schemaCompareCancel(this.operationId);
 
 			if (!result || !result.success) {
-				TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareCancelFailed', undefined, getTelemetryErrorType(result.errorMessage))
+				TelemetryReporter.createErrorEvent2(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareCancelFailed', undefined, undefined, getTelemetryErrorType(result.errorMessage))
 					.withAdditionalProperties({
 						'operationId': this.operationId
 					}).send();
@@ -820,7 +820,7 @@ export class SchemaCompareMainWindow {
 		const service = await this.getService();
 		const result = await service.schemaCompareGenerateScript(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.script);
 		if (!result || !result.success) {
-			TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareGenerateScriptFailed', undefined, getTelemetryErrorType(result.errorMessage))
+			TelemetryReporter.createErrorEvent2(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareGenerateScriptFailed', undefined, undefined, getTelemetryErrorType(result.errorMessage))
 				.withAdditionalProperties({
 					'operationId': this.comparisonResult.operationId
 				}).send();
@@ -900,7 +900,7 @@ export class SchemaCompareMainWindow {
 				}
 
 				if (!result || !result.success || result.errorMessage) {
-					TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareApplyFailed', undefined, getTelemetryErrorType(result?.errorMessage))
+					TelemetryReporter.createErrorEvent2(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareApplyFailed', undefined, undefined, getTelemetryErrorType(result?.errorMessage))
 						.withAdditionalProperties({
 							'operationId': this.comparisonResult.operationId,
 							'targetType': getSchemaCompareEndpointString(this.targetEndpointInfo.endpointType)
@@ -1107,7 +1107,7 @@ export class SchemaCompareMainWindow {
 		let startTime = Date.now();
 		const result = await service.schemaCompareOpenScmp(fileUri.fsPath);
 		if (!result || !result.success) {
-			TelemetryReporter.sendErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareOpenScmpFailed', undefined, getTelemetryErrorType(result.errorMessage));
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareOpenScmpFailed', undefined, undefined, getTelemetryErrorType(result.errorMessage));
 			vscode.window.showErrorMessage(loc.openScmpErrorMessage(result.errorMessage));
 			return;
 		}
@@ -1210,7 +1210,7 @@ export class SchemaCompareMainWindow {
 		const service = await this.getService();
 		const result = await service.schemaCompareSaveScmp(this.sourceEndpointInfo, this.targetEndpointInfo, azdata.TaskExecutionMode.execute, this.deploymentOptions, filePath.fsPath, sourceExcludes, targetExcludes);
 		if (!result || !result.success) {
-			TelemetryReporter.createErrorEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareSaveScmpFailed', undefined, getTelemetryErrorType(result.errorMessage))
+			TelemetryReporter.createErrorEvent2(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareSaveScmpFailed', undefined, undefined, getTelemetryErrorType(result.errorMessage))
 				.withAdditionalProperties({
 					operationId: this.comparisonResult.operationId
 				}).send();

--- a/extensions/schema-compare/yarn.lock
+++ b/extensions/schema-compare/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/sql-assessment/package.json
+++ b/extensions/sql-assessment/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "vscode-nls": "^4.1.2",
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "vscode-languageclient": "^5.3.0-next.1"
   },
   "__metadata": {

--- a/extensions/sql-assessment/yarn.lock
+++ b/extensions/sql-assessment/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -63,7 +63,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "@microsoft/vscode-azext-utils": "^0.1.1",
     "fast-glob": "^3.2.7",
     "promisify-child-process": "^3.1.1",

--- a/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-bindings/src/dialogs/addSqlBindingQuickpick.ts
@@ -110,7 +110,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined):
 
 			if (!result.success) {
 				void vscode.window.showErrorMessage(result.errorMessage);
-				TelemetryReporter.createErrorEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding)
+				TelemetryReporter.createErrorEvent2(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding, undefined)
 					.withAdditionalProperties(propertyBag).send();
 				return;
 			}
@@ -126,7 +126,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined):
 				.withAdditionalProperties(propertyBag).send();
 		} catch (e) {
 			void vscode.window.showErrorMessage(utils.getErrorMessage(e));
-			TelemetryReporter.createErrorEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding, undefined, utils.getErrorType(e))
+			TelemetryReporter.createErrorEvent2(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.finishAddSqlBinding, e, undefined, utils.getErrorType(e))
 				.withAdditionalProperties(propertyBag).send();
 			return;
 		}
@@ -135,7 +135,7 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined):
 		exitReason = 'error';
 		void vscode.window.showErrorMessage(utils.getErrorMessage(e));
 
-		TelemetryReporter.createErrorEvent(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.exitSqlBindingsQuickpick, undefined, utils.getErrorType(e))
+		TelemetryReporter.createErrorEvent2(TelemetryViews.SqlBindingsQuickPick, TelemetryActions.exitSqlBindingsQuickpick, e, undefined, utils.getErrorType(e))
 			.withAdditionalProperties(propertyBag).send();
 	} finally {
 		propertyBag.quickPickStep = quickPickStep;

--- a/extensions/sql-bindings/src/services/azureFunctionsService.ts
+++ b/extensions/sql-bindings/src/services/azureFunctionsService.ts
@@ -34,7 +34,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 			exitReason = ExitReason.error;
 			propertyBag.exitReason = exitReason;
 			telemetryStep = CreateAzureFunctionStep.noAzureFunctionsExtension;
-			TelemetryReporter.createErrorEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, telemetryStep)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.CreateAzureFunctionWithSqlBinding, telemetryStep)
 				.withAdditionalProperties(propertyBag).send();
 			return;
 		}
@@ -275,7 +275,7 @@ export async function createAzureFunction(node?: ITreeNodeInfo): Promise<void> {
 		// an error occurred during createFunction
 		exitReason = ExitReason.error;
 		void vscode.window.showErrorMessage(constants.errorNewAzureFunction(error));
-		TelemetryReporter.createErrorEvent(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick, undefined, errorType)
+		TelemetryReporter.createErrorEvent2(TelemetryViews.CreateAzureFunctionWithSqlBinding, TelemetryActions.exitCreateAzureFunctionQuickpick, error, undefined, errorType)
 			.withAdditionalProperties(propertyBag).send();
 		return;
 	} finally {

--- a/extensions/sql-bindings/yarn.lock
+++ b/extensions/sql-bindings/yarn.lock
@@ -222,10 +222,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -508,7 +508,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "@xmldom/xmldom": "0.8.4",
     "axios": "^0.27.2",
     "extract-zip": "^2.0.1",

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -298,7 +298,7 @@ export class ProjectsController {
 			this.buildInfo[currentBuildIndex].status = Status.failed;
 			this.buildInfo[currentBuildIndex].timeToCompleteAction = utils.timeConversion(timeToFailureBuild);
 
-			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, TelemetryActions.build)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.build, err)
 				.withAdditionalMeasurements({ duration: timeToFailureBuild })
 				.withAdditionalProperties({ databaseSource: utils.getWellKnownDatabaseSources(project.getDatabaseSourceValues()).join(';') })
 				.send();
@@ -347,7 +347,7 @@ export class ProjectsController {
 			}
 		} catch (error) {
 			void utils.showErrorMessageWithOutputChannel(constants.publishToNewAzureServerFailed, error, this._outputChannel);
-			TelemetryReporter.sendErrorEvent(TelemetryViews.ProjectController, TelemetryActions.publishToNewAzureServer);
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.publishToNewAzureServer, error);
 		}
 	}
 
@@ -385,7 +385,7 @@ export class ProjectsController {
 			}
 		} catch (error) {
 			void utils.showErrorMessageWithOutputChannel(constants.publishToContainerFailed, error, this._outputChannel);
-			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, TelemetryActions.publishToContainer)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.publishToContainer, error)
 				.withAdditionalProperties({ dockerBaseImage: dockerImageNameForTelemetry })
 				.send();
 		}
@@ -486,7 +486,7 @@ export class ProjectsController {
 		telemetryProps.databaseSource = utils.getWellKnownDatabaseSources(project.getDatabaseSourceValues()).join(';');
 
 		if (!dacpacPath) {
-			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, TelemetryActions.publishProject)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.publishProject)
 				.withAdditionalProperties(telemetryProps)
 				.withAdditionalMeasurements(telemetryMeasures)
 				.send();
@@ -539,7 +539,7 @@ export class ProjectsController {
 			telemetryProps.actionDuration = timeToFailurePublish.toString();
 			telemetryProps.totalDuration = (actionEndTime - buildStartTime).toString();
 
-			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, TelemetryActions.publishProject)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.publishProject, err)
 				.withAdditionalProperties(telemetryProps)
 				.send();
 
@@ -603,7 +603,7 @@ export class ProjectsController {
 				props.errorMessage = message;
 			}
 
-			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, TelemetryActions.projectSchemaCompareCommandInvoked)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.projectSchemaCompareCommandInvoked, err)
 				.withAdditionalProperties(props)
 				.send();
 
@@ -728,7 +728,7 @@ export class ProjectsController {
 		} catch (err) {
 			void vscode.window.showErrorMessage(utils.getErrorMessage(err));
 
-			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectTree, TelemetryActions.addItemFromTree)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectTree, TelemetryActions.addItemFromTree, err)
 				.withAdditionalProperties(telemetryProps)
 				.withAdditionalMeasurements(telemetryMeasurements)
 				.send();
@@ -756,7 +756,7 @@ export class ProjectsController {
 			this.refreshProjectsTree(treeNode);
 		} catch (err) {
 			void vscode.window.showErrorMessage(utils.getErrorMessage(err));
-			TelemetryReporter.sendErrorEvent(TelemetryViews.ProjectTree, TelemetryActions.addExistingItem);
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.ProjectTree, TelemetryActions.addExistingItem, err);
 		}
 	}
 
@@ -770,7 +770,7 @@ export class ProjectsController {
 			TelemetryReporter.sendActionEvent(TelemetryViews.ProjectTree, TelemetryActions.excludeFromProject);
 			await project.exclude(fileEntry);
 		} else {
-			TelemetryReporter.sendErrorEvent(TelemetryViews.ProjectTree, TelemetryActions.excludeFromProject);
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.ProjectTree, TelemetryActions.excludeFromProject);
 			void vscode.window.showErrorMessage(constants.unableToPerformAction(constants.excludeAction, node.relativeProjectUri.path));
 		}
 
@@ -827,7 +827,7 @@ export class ProjectsController {
 
 			this.refreshProjectsTree(context);
 		} else {
-			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectTree, TelemetryActions.deleteObjectFromProject)
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectTree, TelemetryActions.deleteObjectFromProject)
 				.withAdditionalProperties({ objectType: node.constructor.name })
 				.send();
 
@@ -1394,7 +1394,7 @@ export class ProjectsController {
 			return project;
 		} catch (err) {
 			void vscode.window.showErrorMessage(constants.generatingProjectFailed(utils.getErrorMessage(err)));
-			TelemetryReporter.sendErrorEvent(TelemetryViews.ProjectController, TelemetryActions.generateProjectFromOpenApiSpec);
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.generateProjectFromOpenApiSpec, err);
 			this._outputChannel.show();
 			return;
 		}
@@ -1580,7 +1580,7 @@ export class ProjectsController {
 			await workspaceApi.addProjectsToWorkspace([vscode.Uri.file(newProjFilePath)]);
 		} catch (err) {
 			void vscode.window.showErrorMessage(utils.getErrorMessage(err));
-			TelemetryReporter.sendErrorEvent(TelemetryViews.ProjectController, TelemetryActions.createProjectFromDatabase);
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.createProjectFromDatabase, err);
 		}
 	}
 
@@ -1691,7 +1691,7 @@ export class ProjectsController {
 				.send();
 		} catch (err) {
 			void vscode.window.showErrorMessage(utils.getErrorMessage(err));
-			TelemetryReporter.sendErrorEvent(TelemetryViews.ProjectController, TelemetryActions.updateProjectFromDatabase);
+			TelemetryReporter.sendErrorEvent2(TelemetryViews.ProjectController, TelemetryActions.updateProjectFromDatabase, err);
 		}
 	}
 
@@ -1747,7 +1747,7 @@ export class ProjectsController {
 		);
 
 		if (!comparisonResult || !comparisonResult.success) {
-			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, 'SchemaComparisonFailed')
+			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectController, 'SchemaComparisonFailed')
 				.withAdditionalProperties({
 					operationId: comparisonResult.operationId
 				}).send();

--- a/extensions/sql-database-projects/yarn.lock
+++ b/extensions/sql-database-projects/yarn.lock
@@ -222,10 +222,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -155,7 +155,7 @@
   "dependencies": {
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.1",
     "@microsoft/ads-service-downloader": "^1.1.0",
-    "@microsoft/ads-extension-telemetry": "^1.3.4",
+    "@microsoft/ads-extension-telemetry": "^1.4.0",
     "uuid": "^8.3.2",
     "vscode-nls": "^4.1.2"
   },

--- a/extensions/sql-migration/yarn.lock
+++ b/extensions/sql-migration/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-extension-telemetry@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.4.tgz#25d34cff39171a79663816faa6ba889e07dfb5ab"
-  integrity sha512-XTkMUA4BsTVNETjrKE4M3xaXlmk7m93Xy/eQHxHhzf8POjtPTvlw+8i96W8lTiRPnN81yAVE7YOB3GExsur6RA==
+"@microsoft/ads-extension-telemetry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.4.0.tgz#73b156f399c810b58949e83021da9071335a29a0"
+  integrity sha512-uiPD12Jeu3/CGPCQctyZKE+2FLwn+/iXLoLn80EoJ0MTnonHo1AREvbtR1y6JpOjh8hJXBdh6LjCxs15giIESg==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 
@@ -22,16 +22,6 @@
     tar "^6.1.11"
     tmp "^0.0.33"
     yauzl "^2.10.0"
-
-"@tootallnate/once@2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
-  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
-
-"@tootallnate/once@2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
-  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -223,49 +213,10 @@ vscode-languageserver-types@3.14.0:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
   integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
 
-vscode-jsonrpc@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
-  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
-
-vscode-languageclient@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz#7cfc83a294c409f58cfa2b910a8cfeaad0397193"
-  integrity sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==
-  dependencies:
-    semver "^5.5.0"
-    vscode-languageserver-protocol "3.14.1"
-
-vscode-languageserver-protocol@3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
-  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
-  dependencies:
-    vscode-jsonrpc "^4.0.0"
-    vscode-languageserver-types "3.14.0"
-
-vscode-languageserver-types@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
-  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
-
 vscode-nls@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-4.1.2.tgz#ca8bf8bb82a0987b32801f9fddfdd2fb9fd3c167"
   integrity sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
-yauzl@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This brings in an enhancement I made based on some recent discussions with the privacy folks that means we can collect error information since the telemetry package strips out user paths automatically. Pass in an Error object to get/sendErrorEvent2 and will add the message and stack from that. 