### PR TITLE
Move call to STS move api into project.ts

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -665,3 +665,4 @@ export function errorMovingFile(source: string, destination: string, error: stri
 export function moveConfirmationPrompt(source: string, destination: string) { return localize('moveConfirmationPrompt', "Are you sure you want to move {0} to {1}?", source, destination); }
 export const move = localize('Move', "Move");
 export function errorRenamingFile(source: string, destination: string, error: string) { return localize('errorRenamingFile', "Error when renaming file from {0} to {1}. Error: {2}", source, destination, error); }
+export const unhandledMoveNode = localize('unhandledMoveNode', "Unhandled node type for move");

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1884,7 +1884,7 @@ export class ProjectsController {
 
 		if (!moveResult) { // file wasn't moved
 			return;
-		} else if (!moveResult?.success) {// TODO adding telemetry
+		} else if (!moveResult.success) {// TODO adding telemetry
 			void vscode.window.showErrorMessage(constants.errorMovingFile(sourceFileNode.fileSystemUri.fsPath, newPath, utils.getErrorMessage(moveResult.errorMessage)));
 		}
 	}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -2151,14 +2151,14 @@ export class Project implements ISqlProject {
 	 * @param projectFilePath Full file path to .sqlproj
 	 * @param destinationRelativePath path of the destination, relative to .sqlproj
 	 */
-	public async move(node: BaseProjectTreeItem, destinationRelativePath: string): Promise<azdataType.ResultStatus | undefined> {
+	public async move(node: BaseProjectTreeItem, destinationRelativePath: string): Promise<azdataType.ResultStatus> {
 		// trim off the project folder at the beginning of the relative path stored in the tree
 		const projectRelativeUri = vscode.Uri.file(path.basename(this.projectFilePath, constants.sqlprojExtension));
 		const originalRelativePath = utils.trimUri(projectRelativeUri, node.relativeProjectUri);
 		destinationRelativePath = utils.trimUri(projectRelativeUri, vscode.Uri.file(destinationRelativePath));
 
 		if (originalRelativePath === destinationRelativePath) {
-			return;
+			return { success: true, errorMessage: '' };
 		}
 
 		const sqlProjectsService = await utils.getSqlProjectsService();
@@ -2173,6 +2173,9 @@ export class Project implements ISqlProject {
 		}
 		// TODO add support for renaming none scripts after those are added in STS
 		// TODO add support for renaming publish profiles when support is added in DacFx
+		else {
+			result = { success: false, errorMessage: constants.unhandledMoveNode }
+		}
 
 		return result;
 	}


### PR DESCRIPTION
After some more thought, it makes more sense for the calls to STS to update a project to go through project.ts, rather than happening in projectController.ts. This way, all the calls to STS to update a project, like add file, exclude, delete, etc, will go through project.ts.

This also updates `rename()` and `move()` to not swallow errors returned from STS and now shows an error notification if there was an error.