### PR TITLE
Bump sql-migration version in insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.0",
-							"lastUpdated": "02/13/2023",
+							"version": "1.4.2",
+							"lastUpdated": "03/01/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR updates the Insiders extension gallery to the latest release candidate version of the SQL Migration extension. Some of the key changes are:

- [SQL migration extension - fix target selection bug ](https://github.com/microsoft/azuredatastudio/pull/21977)
- [Adding aria role to hyperlink cell in slickgrid](https://github.com/microsoft/azuredatastudio/pull/21998)
- [[SQL Migration] Allow folders inside blob containers](https://github.com/microsoft/azuredatastudio/pull/21952)
- [Update login migration infobox for public preview](https://github.com/microsoft/azuredatastudio/pull/22074)
- [[SQL-Migration] Login migrations telemetry](https://github.com/microsoft/azuredatastudio/pull/22038)
- [Improve error handling for ValidateIR](https://github.com/microsoft/azuredatastudio/pull/22091)
- [Add assessment support for SQL Server 2022](https://github.com/microsoft/azuredatastudio/pull/22110)

Link to Azure Data Studio - Extensions pipeline run containing vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=192348&view=results