### PR TITLE
add vscode mssql handling for getSqlProjectsService()

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -279,6 +279,7 @@ export function getDataWorkspaceExtensionApi(): dataworkspace.IExtension {
 
 export type IDacFxService = mssql.IDacFxService | vscodeMssql.IDacFxService;
 export type ISchemaCompareService = mssql.ISchemaCompareService | vscodeMssql.ISchemaCompareService;
+export type ISqlProjectsService = mssql.ISqlProjectsService | vscodeMssql.ISqlProjectsService;
 
 export async function getDacFxService(): Promise<IDacFxService> {
 	if (getAzdataApi()) {
@@ -302,12 +303,15 @@ export async function getSchemaCompareService(): Promise<ISchemaCompareService> 
 	}
 }
 
-export async function getSqlProjectsService(): Promise<mssql.ISqlProjectsService> {
-	const ext = vscode.extensions.getExtension(mssql.extension.name) as vscode.Extension<mssql.IExtension>;
-	const api = await ext.activate();
-	return api.sqlProjects;
-
-	// TODO: add vscode-mssql support
+export async function getSqlProjectsService(): Promise<ISqlProjectsService> {
+	if (getAzdataApi()) {
+		const ext = vscode.extensions.getExtension(mssql.extension.name) as vscode.Extension<mssql.IExtension>;
+		const api = await ext.activate();
+		return api.sqlProjects;
+	} else {
+		const api = await getVscodeMssqlApi();
+		return api.sqlProjects;
+	}
 }
 
 export async function getVscodeMssqlApi(): Promise<vscodeMssql.IExtension> {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -13,7 +13,7 @@ import * as templates from '../templates/templates';
 import * as vscode from 'vscode';
 import type * as azdataType from 'azdata';
 import * as dataworkspace from 'dataworkspace';
-import type * as mssqlVscode from 'vscode-mssql';
+import * as mssqlVscode from 'vscode-mssql';
 
 import { promises as fs } from 'fs';
 import { PublishDatabaseDialog } from '../dialogs/publishDatabaseDialog';
@@ -183,7 +183,6 @@ export class ProjectsController {
 		}
 
 		const targetPlatform = creationParams.targetPlatform ? constants.targetPlatformToVersion.get(creationParams.targetPlatform)! : constants.defaultDSP;
-		const sdkStyle = creationParams.sdkStyle ? mssql.ProjectType.SdkStyle : mssql.ProjectType.LegacyStyle;
 
 		let newProjFileName = creationParams.newProjName;
 
@@ -198,7 +197,13 @@ export class ProjectsController {
 		}
 
 		const sqlProjectsService = await utils.getSqlProjectsService();
-		await sqlProjectsService.createProject(newProjFilePath, sdkStyle, targetPlatform);
+		if (utils.getAzdataApi()) {
+			const projectStyle = creationParams.sdkStyle ? mssql.ProjectType.SdkStyle : mssql.ProjectType.LegacyStyle;
+			await (sqlProjectsService as mssql.ISqlProjectsService).createProject(newProjFilePath, projectStyle, targetPlatform);
+		} else {
+			const projectStyle = creationParams.sdkStyle ? mssqlVscode.ProjectType.SdkStyle : mssqlVscode.ProjectType.LegacyStyle;
+			await (sqlProjectsService as mssqlVscode.ISqlProjectsService).createProject(newProjFilePath, projectStyle, targetPlatform);
+		}
 
 		await this.addTemplateFiles(newProjFilePath, creationParams.projectTypeId);
 


### PR DESCRIPTION
Adding vscode-mssql handling for getting sql projects service now that it's been added in vscode-mssql
