### PR TITLE
Fixing URI openings for execution plans 

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanContribution.ts
@@ -13,7 +13,7 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWo
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IExecutionPlanService } from 'sql/workbench/services/executionPlan/common/interfaces';
-import { ExecutionPlanInput } from 'sql/workbench/contrib/executionPlan/common/executionPlanInput';
+import { ExecutionPlanInput } from 'sql/workbench/contrib/executionPlan/browser/executionPlanInput';
 import { ExecutionPlanEditor } from 'sql/workbench/contrib/executionPlan/browser/executionPlanEditor';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ExecutionPlanComparisonEditor } from 'sql/workbench/contrib/executionPlan/browser/executionPlanComparisonEditor';
@@ -88,7 +88,7 @@ export class ExecutionPlanEditorOverrideContribution extends Disposable implemen
 }
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
-	.registerWorkbenchContribution(ExecutionPlanEditorOverrideContribution, LifecyclePhase.Restored);
+	.registerWorkbenchContribution(ExecutionPlanEditorOverrideContribution, LifecyclePhase.Starting);
 
 const comparisonExecutionPlanEditor = EditorPaneDescriptor.create(
 	ExecutionPlanComparisonEditor,

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanEditor.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanEditor.ts
@@ -9,7 +9,7 @@ import { IEditorOpenContext } from 'vs/workbench/common/editor';
 import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
-import { ExecutionPlanInput } from 'sql/workbench/contrib/executionPlan/common/executionPlanInput';
+import { ExecutionPlanInput } from 'sql/workbench/contrib/executionPlan/browser/executionPlanInput';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';

--- a/src/sql/workbench/contrib/executionPlan/browser/executionPlanInput.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/executionPlanInput.ts
@@ -11,6 +11,7 @@ import { EditorModel } from 'vs/workbench/common/editor/editorModel';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import * as azdata from 'azdata';
+import { ExecutionPlanEditor } from 'sql/workbench/contrib/executionPlan/browser/executionPlanEditor';
 
 export class ExecutionPlanInput extends EditorInput {
 
@@ -60,6 +61,10 @@ export class ExecutionPlanInput extends EditorInput {
 		}
 
 		return path.basename(this._uri.fsPath);
+	}
+
+	public override get editorId(): string {
+		return ExecutionPlanEditor.ID;
 	}
 
 	public async content(): Promise<string> {

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -51,7 +51,7 @@ import { HybridDataProvider } from 'sql/base/browser/ui/table/hybridDataProvider
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { alert, status } from 'vs/base/browser/ui/aria/aria';
 import { IExecutionPlanService } from 'sql/workbench/services/executionPlan/common/interfaces';
-import { ExecutionPlanInput } from 'sql/workbench/contrib/executionPlan/common/executionPlanInput';
+import { ExecutionPlanInput } from 'sql/workbench/contrib/executionPlan/browser/executionPlanInput';
 import { CopyAction } from 'vs/editor/contrib/clipboard/browser/clipboard';
 import { formatDocumentWithSelectedProvider, FormattingMode } from 'vs/editor/contrib/format/browser/format';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -33,21 +33,23 @@ export class ExecutionPlanService implements IExecutionPlanService {
 	 * @param providerId Optional provider id to wait for.
 	 */
 	private async ensureCapabilitiesRegistered(providerId?: string): Promise<void> {
-		let providers: string[] = [];
+		let providers: string[] = Object.keys(this._capabilitiesService.providers);
+
+		// If the provider is already registered, return.
+		if (providerId && providers?.includes(providerId) || (!providerId && providers?.length > 0)) {
+			return;
+		}
+
+
 		// Wait until the capabilities service has registered some providers.
 		await new Promise<void>(resolve => {
 			let retryCount = 0;
 			const intervalId = setInterval(() => {
 				while (retryCount < 5) {
 					providers = Object.keys(this._capabilitiesService.providers);
-					if (providers) {
-						if (providerId && providers[providerId]) {
-							clearInterval(intervalId);
-							resolve();
-						} else if (providers) {
-							clearInterval(intervalId);
-							resolve();
-						}
+					if (providerId && providers?.includes(providerId) || (!providerId && providers?.length > 0)) {
+						clearInterval(intervalId);
+						resolve();
 					}
 					retryCount++;
 				}

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -29,22 +29,22 @@ export class ExecutionPlanService implements IExecutionPlanService {
 
 	/**
 	 * This ensures that the capabilities service has registered the providers to handle execution plan requests for the given file format.
-	 * @param fileFormat Execution plan file format
+	 * @param fileExtension Execution plan file format
 	 */
-	public async ensureFileFormatHandlerRegistered(fileFormat: string): Promise<void> {
+	public async ensureFileExtensionHandlerRegistered(fileExtension: string) {
 		for (let provider in this._capabilitiesService.providers) {
-			if (this._capabilitiesService.providers[provider].connection.supportedExecutionPlanFileExtensions?.includes(fileFormat)) {
+			if (this._capabilitiesService.providers[provider].connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
 				return;
 			}
 		}
 		await new Promise<void>(resolve => {
 			this._capabilitiesService.onCapabilitiesRegistered(e => {
-				if (e.features.connection.supportedExecutionPlanFileExtensions.includes(fileFormat)) {
+				if (e.features.connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
 					resolve();
 				}
 			});
 			setTimeout(() => {
-				throw new Error(localize('executionPlanService.ensureFileFormatHandlerRegistered', "Execution plan provider which supports file format '{0}' was not registered after 30 seconds.", fileFormat));
+				throw new Error(localize('executionPlanService.ensureFileExtensionHandlerRegistered', "Execution plan provider which supports file format '{0}' was not registered after 30 seconds.", fileExtension));
 			}, 30000);
 		});
 	}
@@ -62,7 +62,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 					}
 				});
 				setTimeout(() => {
-					throw new Error(localize('executionPlanService.ensureCapabilitiesRegistered', "Provider with id {0} is not registered.", providerId));
+					throw new Error(localize('executionPlanService.ensureCapabilitiesRegistered', "Provider with id {0} was not registered after 30 seconds.", providerId));
 				}, 30000);
 			});
 		}
@@ -104,16 +104,16 @@ export class ExecutionPlanService implements IExecutionPlanService {
 
 	/**
 	 * Runs the actions using the provider that supports the fileFormat provided.
-	 * @param fileFormat fileformat of the underlying execution plan file. It is used to get the provider that support it.
+	 * @param fileExtension file extension of the underlying execution plan file. It is used to get the provider that support it.
 	 * @param action executionPlanService action to be performed.
 	 */
-	private async _runAction<T>(fileFormat: string, action: (handler: azdata.executionPlan.ExecutionPlanProvider) => Thenable<T>): Promise<T> {
-		await this.ensureFileFormatHandlerRegistered(fileFormat);
+	private async _runAction<T>(fileExtension: string, action: (handler: azdata.executionPlan.ExecutionPlanProvider) => Thenable<T>): Promise<T> {
+		await this.ensureFileExtensionHandlerRegistered(fileExtension);
 		let providers = Object.keys(this._capabilitiesService.providers);
 		let epProviders: string[] = [];
 		for (let i = 0; i < providers.length; i++) {
 			const providerCapabilities = this._capabilitiesService.getCapabilities(providers[i]);
-			if (providerCapabilities.connection.supportedExecutionPlanFileExtensions?.includes(fileFormat)) {
+			if (providerCapabilities.connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
 				epProviders.push(providers[i]);
 			}
 		}

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -40,7 +40,6 @@ export class ExecutionPlanService implements IExecutionPlanService {
 			return;
 		}
 
-
 		// Wait until the capabilities service has registered some providers.
 		await new Promise<void>(resolve => {
 			let retryCount = 0;

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -70,12 +70,6 @@ export class ExecutionPlanService implements IExecutionPlanService {
 
 	private async getExecutionPlanProvider(providerId: string): Promise<azdata.executionPlan.ExecutionPlanProvider> {
 		await this.ensureCapabilitiesRegistered(providerId);
-		const provider = this._capabilitiesService.providers[providerId];
-		// Return undefined if the provider is not registered or it is not a execution plan provider.
-		if (!provider || !provider.connection?.isExecutionPlanProvider) {
-			return undefined;
-		}
-
 		let handler = this._providers[providerId];
 		if (handler) {
 			return handler;

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -53,8 +53,13 @@ export class ExecutionPlanService implements IExecutionPlanService {
 					}
 					retryCount++;
 				}
+
 				clearInterval(intervalId);
-				resolve();
+				if (providerId) {
+					throw new Error(localize('providerNotRegisteredError', "Provider {0} is not found to handle execution plans", providerId));
+				} else {
+					throw new Error(localize('providerNotRegisteredError', "No providers are found to handle execution plans"));
+				}
 			}, 1000);
 		});
 	}

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -33,8 +33,8 @@ export class ExecutionPlanService implements IExecutionPlanService {
 	 * @param fileExtension Execution plan file format
 	 */
 	public async ensureFileExtensionHandlerRegistered(fileExtension: string): Promise<void> {
-		for (let provider in Object.keys(this._capabilitiesService.providers)) {
-			if (this._capabilitiesService.providers[provider].connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
+		for (let providerId in Object.keys(this._capabilitiesService.providers)) {
+			if (this._capabilitiesService.providers[providerId].connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
 				// We already have a provider registered that can handle this file extension so we're done
 				return;
 			}
@@ -44,14 +44,15 @@ export class ExecutionPlanService implements IExecutionPlanService {
 		await new Promise<void>((resolve, reject) => {
 			listener = this._capabilitiesService.onCapabilitiesRegistered(e => {
 				if (e.features.connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
+					listener.dispose();
 					resolve();
 				}
 			});
 			setTimeout(() => {
+				listener.dispose();
 				reject(new Error(localize('executionPlanService.ensureFileExtensionHandlerRegistered', "Execution plan provider which supports file format '{0}' was not registered after 30 seconds.", fileExtension)));
 			}, 30000);
 		});
-		listener.dispose();
 	}
 
 	/**
@@ -64,15 +65,16 @@ export class ExecutionPlanService implements IExecutionPlanService {
 			await new Promise<void>((resolve, reject) => {
 				listener = this._capabilitiesService.onCapabilitiesRegistered(e => {
 					if (e.id === providerId) {
+						listener.dispose();
 						resolve();
 					}
 				});
 				setTimeout(() => {
+					listener.dispose();
 					reject(new Error(localize('executionPlanService.ensureCapabilitiesRegistered', "Provider with id {0} was not registered after 30 seconds.", providerId)));
 				}, 30000);
 			});
 		}
-		listener.dispose();
 	}
 
 	private async getExecutionPlanProvider(providerId: string): Promise<azdata.executionPlan.ExecutionPlanProvider> {

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -37,16 +37,16 @@ export class ExecutionPlanService implements IExecutionPlanService {
 				return;
 			}
 		}
-		await new Promise<void>(resolve => {
+		await (new Promise<void>((resolve, reject) => {
 			this._capabilitiesService.onCapabilitiesRegistered(e => {
 				if (e.features.connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
 					resolve();
 				}
 			});
 			setTimeout(() => {
-				throw new Error(localize('executionPlanService.ensureFileExtensionHandlerRegistered', "Execution plan provider which supports file format '{0}' was not registered after 30 seconds.", fileExtension));
+				reject(new Error(localize('executionPlanService.ensureFileExtensionHandlerRegistered', "Execution plan provider which supports file format '{0}' was not registered after 30 seconds.", fileExtension)));
 			}, 30000);
-		});
+		}).catch(e => { throw e; }));
 	}
 
 	/**
@@ -55,16 +55,16 @@ export class ExecutionPlanService implements IExecutionPlanService {
 	private async ensureCapabilitiesRegistered(providerId: string): Promise<void> {
 		// Wait until the provider with the given id is registered.
 		if (!this._capabilitiesService.providers[providerId]) {
-			await new Promise<void>(resolve => {
+			await (new Promise<void>((resolve, reject) => {
 				this._capabilitiesService.onCapabilitiesRegistered(e => {
 					if (e.id === providerId) {
 						resolve();
 					}
 				});
 				setTimeout(() => {
-					throw new Error(localize('executionPlanService.ensureCapabilitiesRegistered', "Provider with id {0} was not registered after 30 seconds.", providerId));
+					reject(new Error(localize('executionPlanService.ensureCapabilitiesRegistered', "Provider with id {0} was not registered after 30 seconds.", providerId)));
 				}, 30000);
-			});
+			}).catch(e => { throw e; }));
 		}
 	}
 

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -38,7 +38,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 				return;
 			}
 		}
-		await (new Promise<void>((resolve, reject) => {
+		await new Promise<void>((resolve, reject) => {
 			this._capabilitiesService.onCapabilitiesRegistered(e => {
 				if (e.features.connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
 					resolve();
@@ -47,7 +47,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 			setTimeout(() => {
 				reject(new Error(localize('executionPlanService.ensureFileExtensionHandlerRegistered', "Execution plan provider which supports file format '{0}' was not registered after 30 seconds.", fileExtension)));
 			}, 30000);
-		}).catch(e => { throw e; }));
+		});
 	}
 
 	/**
@@ -56,7 +56,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 	private async ensureCapabilitiesRegistered(providerId: string): Promise<void> {
 		// Wait until the provider with the given id is registered.
 		if (!this._capabilitiesService.providers[providerId]) {
-			await (new Promise<void>((resolve, reject) => {
+			await new Promise<void>((resolve, reject) => {
 				this._capabilitiesService.onCapabilitiesRegistered(e => {
 					if (e.id === providerId) {
 						resolve();
@@ -65,7 +65,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 				setTimeout(() => {
 					reject(new Error(localize('executionPlanService.ensureCapabilitiesRegistered', "Provider with id {0} was not registered after 30 seconds.", providerId)));
 				}, 30000);
-			}).catch(e => { throw e; }));
+			});
 		}
 	}
 

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -31,7 +31,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 	 * This ensures that the capabilities service has registered the providers to handle execution plan requests for the given file format.
 	 * @param fileExtension Execution plan file format
 	 */
-	public async ensureFileExtensionHandlerRegistered(fileExtension: string) {
+	public async ensureFileExtensionHandlerRegistered(fileExtension: string): Promise<void> {
 		for (let provider in Object.keys(this._capabilitiesService.providers)) {
 			if (this._capabilitiesService.providers[provider].connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
 				// We already have a provider registered that can handle this file extension so we're done

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -34,6 +34,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 	public async ensureFileExtensionHandlerRegistered(fileExtension: string) {
 		for (let provider in Object.keys(this._capabilitiesService.providers)) {
 			if (this._capabilitiesService.providers[provider].connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
+				// We already have a provider registered that can handle this file extension so we're done
 				return;
 			}
 		}

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -44,7 +44,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 				}
 			});
 			setTimeout(() => {
-				throw new Error(localize('executionPlanService.ensureFileFormatHandlerRegistered', "Execution plan provider which supports file format {0} is not registered.", fileFormat));
+				throw new Error(localize('executionPlanService.ensureFileFormatHandlerRegistered', "Execution plan provider which supports file format '{0}' was not registered after 30 seconds.", fileFormat));
 			}, 30000);
 		});
 	}

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -29,7 +29,6 @@ export class ExecutionPlanService implements IExecutionPlanService {
 
 	/**
 	 * This ensures that the capabilities service has registered the providers to handle execution plan requests.
-	 * @param providerId Optional provider id to wait for.
 	 */
 	private async ensureCapabilitiesRegistered(): Promise<void> {
 

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -31,7 +31,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 	 * This ensures that the capabilities service has registered the providers to handle execution plan requests for the given file format.
 	 * @param fileFormat Execution plan file format
 	 */
-	public async ensureFileFormatHandlerRegistered(fileFormat: string) {
+	public async ensureFileFormatHandlerRegistered(fileFormat: string): Promise<void> {
 		for (let provider in this._capabilitiesService.providers) {
 			if (this._capabilitiesService.providers[provider].connection.supportedExecutionPlanFileExtensions?.includes(fileFormat)) {
 				return;

--- a/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
+++ b/src/sql/workbench/services/executionPlan/common/executionPlanService.ts
@@ -32,7 +32,7 @@ export class ExecutionPlanService implements IExecutionPlanService {
 	 * @param fileExtension Execution plan file format
 	 */
 	public async ensureFileExtensionHandlerRegistered(fileExtension: string) {
-		for (let provider in this._capabilitiesService.providers) {
+		for (let provider in Object.keys(this._capabilitiesService.providers)) {
 			if (this._capabilitiesService.providers[provider].connection.supportedExecutionPlanFileExtensions?.includes(fileExtension)) {
 				return;
 			}


### PR DESCRIPTION
This PR fixes #20902 

This PR registers execution plan editor early in the workbench lifecycle. That will  make it available for the URI based file to use when ADS starts. 