### PR TITLE
Fix AuthLibrary detection and use MSAL by default

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -48,11 +48,9 @@ import { Iterable } from 'vs/base/common/iterator';
 import { LoadingSpinner } from 'sql/base/browser/ui/loadingSpinner/loadingSpinner';
 import { Tenant, TenantListDelegate, TenantListRenderer } from 'sql/workbench/services/accountManagement/browser/tenantListRenderer';
 import { IAccountManagementService } from 'sql/platform/accounts/common/interfaces';
+import { ADAL_AUTH_LIBRARY, AuthLibrary, getAuthLibrary } from 'sql/workbench/services/accountManagement/utils';
 
 export const VIEWLET_ID = 'workbench.view.accountpanel';
-export type AuthLibrary = 'ADAL' | 'MSAL';
-export const MSAL_AUTH_LIBRARY: AuthLibrary = 'MSAL'; // default
-export const ADAL_AUTH_LIBRARY: AuthLibrary = 'ADAL';
 
 export class AccountPaneContainer extends ViewPaneContainer { }
 
@@ -392,7 +390,7 @@ export class AccountDialog extends Modal {
 		this._splitView!.layout(DOM.getContentHeight(this._container!));
 
 		// Set the initial items of the list
-		const authLibrary: AuthLibrary = this._configurationService.getValue('azure.authenticationLibrary');
+		const authLibrary: AuthLibrary = getAuthLibrary(this._configurationService);
 		let updatedAccounts: azdata.Account[];
 		if (authLibrary) {
 			updatedAccounts = filterAccounts(newProvider.initialAccounts, authLibrary);
@@ -443,7 +441,7 @@ export class AccountDialog extends Modal {
 		if (!providerMapping || !providerMapping.view) {
 			return;
 		}
-		const authLibrary: AuthLibrary = this._configurationService.getValue('azure.authenticationLibrary');
+		const authLibrary: AuthLibrary = getAuthLibrary(this._configurationService);
 		let updatedAccounts: azdata.Account[];
 		if (authLibrary) {
 			updatedAccounts = filterAccounts(args.accountList, authLibrary);

--- a/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
+++ b/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
@@ -33,7 +33,8 @@ const noAccountProvider: azdata.AccountProviderMetadata = {
 const account: azdata.Account = {
 	key: {
 		providerId: hasAccountProvider.id,
-		accountId: 'testAccount1'
+		accountId: 'testAccount1',
+		authLibrary: 'MSAL'
 	},
 	displayInfo: {
 		displayName: 'Test Account 1',
@@ -320,7 +321,12 @@ suite('Account Management Service Tests:', () => {
 		return ams.getAccountsForProvider(hasAccountProvider.id)
 			.then(result => {
 				// Then: I should get back the list of accounts
-				assert.strictEqual(result, accountList);
+				// Since account are filtered by AuthLibrary and list is prepared again, they are not strict equal.
+				// We compare strict equality of actual accounts here.
+				assert.strictEqual(accountList.length, result.length);
+				for (var i = 0; i < accountList.length; i++) {
+					assert.strictEqual(result[i], accountList[i]);
+				}
 			});
 	});
 

--- a/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
+++ b/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
@@ -534,7 +534,8 @@ function getTestState(): AccountManagementState {
 	const testConfigurationService = new TestConfigurationService();
 
 	// Create the account management service
-	let ams = new AccountManagementService(mockInstantiationService.object, new TestStorageService(), undefined!, undefined!, undefined!, testNotificationService, testConfigurationService);
+	let ams = new AccountManagementService(mockInstantiationService.object, new TestStorageService(),
+		undefined, undefined, undefined, testNotificationService, testConfigurationService);
 
 	// Wire up event handlers
 	let evUpdate = new EventVerifierSingle<UpdateAccountListEventParams>();

--- a/src/sql/workbench/services/accountManagement/utils.ts
+++ b/src/sql/workbench/services/accountManagement/utils.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+
+export const AZURE_AUTH_LIBRARY_CONFIG = 'azure.authenticationLibrary';
+
+export type AuthLibrary = 'ADAL' | 'MSAL';
+export const MSAL_AUTH_LIBRARY: AuthLibrary = 'MSAL';
+export const ADAL_AUTH_LIBRARY: AuthLibrary = 'ADAL';
+
+export const DEFAULT_AUTH_LIBRARY: AuthLibrary = MSAL_AUTH_LIBRARY;
+
+export function getAuthLibrary(configurationService: IConfigurationService): AuthLibrary {
+	return configurationService.getValue(AZURE_AUTH_LIBRARY_CONFIG) || DEFAULT_AUTH_LIBRARY;
+}

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -36,10 +36,11 @@ import Severity from 'vs/base/common/severity';
 import { ConnectionStringOptions } from 'sql/platform/capabilities/common/capabilitiesService';
 import { isFalsyOrWhitespace } from 'vs/base/common/strings';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { AuthLibrary, filterAccounts } from 'sql/workbench/services/accountManagement/browser/accountDialog';
+import { filterAccounts } from 'sql/workbench/services/accountManagement/browser/accountDialog';
 import { AuthenticationType, Actions } from 'sql/platform/connection/common/constants';
 import { AdsWidget } from 'sql/base/browser/ui/adsWidget';
 import { createCSSRule } from 'vs/base/browser/dom';
+import { AuthLibrary, getAuthLibrary } from 'sql/workbench/services/accountManagement/utils';
 
 const ConnectionStringText = localize('connectionWidget.connectionString', "Connection string");
 
@@ -112,7 +113,6 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		color: undefined,
 		description: undefined,
 	};
-	private readonly configurationService: IConfigurationService;
 	constructor(options: azdata.ConnectionOption[],
 		callbacks: IConnectionComponentCallbacks,
 		providerName: string,
@@ -122,7 +122,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		@IAccountManagementService private _accountManagementService: IAccountManagementService,
 		@ILogService protected _logService: ILogService,
 		@IErrorMessageService private _errorMessageService: IErrorMessageService,
-		@IConfigurationService configurationService: IConfigurationService
+		@IConfigurationService private _configurationService: IConfigurationService
 	) {
 		super();
 		this._callbacks = callbacks;
@@ -142,7 +142,6 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		}
 		this._providerName = providerName;
 		this._connectionStringOptions = this._connectionManagementService.getProviderProperties(this._providerName).connectionStringOptions;
-		this.configurationService = configurationService;
 	}
 
 	protected getAuthTypeDefault(option: azdata.ConnectionOption, os: OperatingSystem): string {
@@ -689,7 +688,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		let oldSelection = this._azureAccountDropdown.value;
 		const accounts = await this._accountManagementService.getAccounts();
 		const updatedAccounts = accounts.filter(a => a.key.providerId.startsWith('azure'));
-		const authLibrary: AuthLibrary = this.configurationService.getValue('azure.authenticationLibrary');
+		const authLibrary: AuthLibrary = getAuthLibrary(this._configurationService);
 		if (authLibrary) {
 			this._azureAccountList = filterAccounts(updatedAccounts, authLibrary);
 		}


### PR DESCRIPTION
We've been getting issues like below:

"TypeError: Cannot read properties of undefined (reading 'authLibrary')"
Ref: https://github.com/microsoft/azuredatastudio/issues/16655#issuecomment-1422720048

I noticed, we weren't defaulting to MSAL properly in AccountManagementService, this would have caused trouble when migrating accounts from ADAL to MSAL. This PR moves authLibrary to Utils, and ensures MSAL is selected by default.

Should potentially fix https://github.com/microsoft/azuredatastudio/issues/22056, fix https://github.com/microsoft/azuredatastudio/issues/21874, etc.