### PR TITLE
escape the special character

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
+++ b/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
@@ -375,7 +375,8 @@ class DropOverlay extends Themable {
 			// {{SQL CARBON EDIT}}
 			const editor = this.editorService.activeTextEditorControl as ICodeEditor;
 			if (supportsNodeNameDrop(untitledOrFileResources[0].resource.scheme) || untitledOrFileResources[0].resource.scheme === 'Folder') {
-				SnippetController2.get(editor).insert(untitledOrFileResources[0].resource.query);
+				// Snippet support variable and $ is the reserved character, need to escape it so that it will treated as a normal character.
+				SnippetController2.get(editor).insert(untitledOrFileResources[0].resource.query?.replace(/\$/g, '\\$'));
 				editor.focus();
 				return;
 			}


### PR DESCRIPTION
This PR fixes #22057

before:
![escape_before](https://user-images.githubusercontent.com/13777222/222843021-31539464-8cb0-4e07-89b3-bd7573bf3278.gif)


after:
![escape_after](https://user-images.githubusercontent.com/13777222/222843043-413c47a3-e6e7-42a0-a281-7b1867c1ec49.gif)
