### PR TITLE
Fix path for dacpac reference on windows

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -988,7 +988,7 @@ export class Project implements ISqlProject {
 		}
 
 		const databaseLiteral = settings.databaseVariable ? undefined : settings.databaseName;
-		const result = await this.sqlProjService.addDacpacReference(this.projectFilePath, settings.dacpacFileLocation.fsPath, settings.suppressMissingDependenciesErrors, settings.databaseVariable, settings.serverVariable, databaseLiteral)
+		const result = await this.sqlProjService.addDacpacReference(this.projectFilePath, databaseReferenceEntry.pathForSqlProj(), settings.suppressMissingDependenciesErrors, settings.databaseVariable, settings.serverVariable, databaseLiteral)
 
 		if (!result.success && result.errorMessage) {
 			throw new Error(constants.errorAddingDatabaseReference(settings.dacpacFileLocation.fsPath, result.errorMessage));


### PR DESCRIPTION
I missed this when swapping out the add dacpac reference code in https://github.com/microsoft/azuredatastudio/pull/22116. On Windows, `settings.dacpacFileLocation.fsPath` has a leading backslash that needs to be removed for build to work on Windows, so this replaces that with `pathForSqlProj()` which removes the leading slash
https://github.com/microsoft/azuredatastudio/blob/5b95a47ca6f6baadb49bbd7829c6a3e3d68f57ac/extensions/sql-database-projects/src/models/projectEntry.ts#L69-L72