### PR TITLE
dispose view after the operation is done

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/loginDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/loginDialog.ts
@@ -84,7 +84,7 @@ export class LoginDialog extends ObjectManagementDialogBase<ObjectManagement.Log
 		}
 	}
 
-	protected async onDispose(): Promise<void> {
+	protected async disposeView(): Promise<void> {
 		await this.objectManagementService.disposeLoginView(this.contextId);
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -60,7 +60,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 		const dialogTitle = isNewObject ? NewObjectDialogTitle(objectTypeDisplayName) : ObjectPropertiesDialogTitle(objectTypeDisplayName, objectName);
 		this.dialogObject = azdata.window.createModelViewDialog(dialogTitle, getDialogName(objectType, isNewObject), dialogWidth);
 		this.dialogObject.okButton.label = OkText;
-		this.disposables.push(this.dialogObject.onClosed(async () => { await this.dispose(); }));
+		this.disposables.push(this.dialogObject.onClosed(async (reason: azdata.window.CloseReason) => { await this.dispose(reason); }));
 		this._helpButton = azdata.window.createButton(HelpText, 'left');
 		this.disposables.push(this._helpButton.onClick(async () => {
 			await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(docUrl));
@@ -81,8 +81,13 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 	protected abstract initializeData(): Promise<ViewInfoType>;
 	protected abstract initializeUI(): Promise<void>;
 	protected abstract onComplete(): Promise<void>;
-	protected abstract onDispose(): Promise<void>;
+	protected async onDispose(): Promise<void> { }
 	protected abstract validateInput(): Promise<string[]>;
+
+	/**
+	 * Dispose the information related to this view in the backend service.
+	 */
+	protected abstract disposeView(): Promise<void>;
 
 	protected onObjectValueChange(): void {
 		this.dialogObject.okButton.enabled = JSON.stringify(this.objectInfo) !== JSON.stringify(this._originalObjectInfo);
@@ -165,6 +170,8 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 						TelemetryReporter.createErrorEvent2(TelemetryViews.ObjectManagement, actionName, err).withAdditionalProperties({
 							objectType: this.objectType
 						}).send();
+					} finally {
+						await this.disposeView();
 					}
 				}
 			});
@@ -180,9 +187,12 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 		}
 	}
 
-	private async dispose(): Promise<void> {
+	private async dispose(reason: azdata.window.CloseReason): Promise<void> {
 		await this.onDispose();
 		this.disposables.forEach(disposable => disposable.dispose());
+		if (reason !== 'ok') {
+			await this.disposeView();
+		}
 	}
 
 	protected async runValidation(showErrorMessage: boolean = true): Promise<boolean> {

--- a/extensions/mssql/src/objectManagement/ui/userDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/userDialog.ts
@@ -69,7 +69,7 @@ export class UserDialog extends ObjectManagementDialogBase<ObjectManagement.User
 		}
 	}
 
-	protected async onDispose(): Promise<void> {
+	protected async disposeView(): Promise<void> {
 		await this.objectManagementService.disposeUserView(this.contextId);
 	}
 


### PR DESCRIPTION
when the dialog is canceled (by pressing escape key or clicking the cancel button), the disposeView request should be send immediately, but when OK button is clicked, the disposeView request should be send after the operation is complete.