### PR TITLE
Remove hasEditor from ICellEditorProvider

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -147,10 +147,6 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		return this._editor;
 	}
 
-	public override hasEditor(): boolean {
-		return true;
-	}
-
 	public cellGuid(): string {
 		return this.cellModel.cellGuid;
 	}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/interfaces.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/interfaces.ts
@@ -38,10 +38,6 @@ export abstract class CellView extends AngularDisposable implements OnDestroy, I
 		return undefined;
 	}
 
-	public hasEditor(): boolean {
-		return false;
-	}
-
 	public abstract cellGuid(): string;
 
 	public deltaDecorations(newDecorationsRange: NotebookRange | NotebookRange[], oldDecorationsRange: NotebookRange | NotebookRange[]): void {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -375,10 +375,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 		if (!this._cellEditor?.getEditor()?.getControl()) {
 			this._cellEditor = this._notebookEditor?.cellEditors?.find(e => e.cellGuid() === this.cellModel?.cellGuid);
 		}
-		if (this._cellEditor?.hasEditor) {
-			return this._cellEditor.getEditor()?.getControl();
-		}
-		return undefined;
+		return this._cellEditor.getEditor()?.getControl();
 	}
 
 	public async getFileContentBase64(fileUri: URI): Promise<string> {

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -719,9 +719,6 @@ export class NotebookEditorStub implements INotebookEditor {
 
 export class CellEditorProviderStub implements ICellEditorProvider {
 	isCellOutput = false;
-	hasEditor(): boolean {
-		throw new Error('Method not implemented.');
-	}
 	cellGuid(): string {
 		throw new Error('Method not implemented.');
 	}

--- a/src/sql/workbench/services/notebook/browser/notebookService.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookService.ts
@@ -194,10 +194,9 @@ export interface INotebookSection {
 }
 
 export interface ICellEditorProvider {
-	hasEditor(): boolean;
 	isCellOutput: boolean;
 	cellGuid(): string;
-	getEditor(): BaseTextEditor<ICodeEditorViewState>;
+	getEditor(): BaseTextEditor<ICodeEditorViewState> | undefined;
 	deltaDecorations(newDecorationsRange: NotebookRange | NotebookRange[], oldDecorationsRange: NotebookRange | NotebookRange[]): void;
 }
 


### PR DESCRIPTION
This started off with me noticing in markdownToolbar.component.ts that we weren't calling the hasEditor function itself - only checking that the function existed. But then looking at it I don't even see why this needs to exist - the same logic can be done by calling getEditor and checking if it's undefined or not. So just removing it to keep things simpler. 