### PR TITLE
update dacpac extension in RC gallery

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1230,14 +1230,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.12.0",
-							"lastUpdated": "1/20/2023",
+							"version": "1.13.0",
+							"lastUpdated": "3/6/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.12.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.13.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Updating the dacpac extension to 1.13.0 in RC to the same version that was released in insiders in https://github.com/microsoft/azuredatastudio/pull/21946
