### PR TITLE
Only support 'user with login' in dialog

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/userDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/userDialog.ts
@@ -112,7 +112,9 @@ export class UserDialog extends ObjectManagementDialogBase<ObjectManagement.User
 
 		this.typeDropdown = this.modelView.modelBuilder.dropDown().withProps({
 			ariaLabel: localizedConstants.UserTypeText,
-			values: [localizedConstants.UserWithLoginText, localizedConstants.UserWithWindowsGroupLoginText, localizedConstants.ContainedUserText, localizedConstants.UserWithNoConnectAccess],
+			// only supporting user with login for initial preview
+			//values: [localizedConstants.UserWithLoginText, localizedConstants.UserWithWindowsGroupLoginText, localizedConstants.ContainedUserText, localizedConstants.UserWithNoConnectAccess],
+			values: [localizedConstants.UserWithLoginText],
 			value: getUserTypeDisplayName(this.objectInfo.type),
 			width: DefaultInputWidth,
 			enabled: this.isNewObject


### PR DESCRIPTION
This is part of the changes for https://github.com/microsoft/azuredatastudio/issues/22173.  For March release we will only support User with Login, and add other user types for May.