### PR TITLE
add sql project commands to data workspace activation events

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -15,7 +15,9 @@
   "activationEvents": [
     "onView:dataworkspace.views.main",
     "onCommand:projects.openExisting",
-    "onCommand:projects.new"
+    "onCommand:projects.new",
+    "onCommand:sqlDatabaseProjects.createProjectFromDatabase",
+    "onCommand:sqlDatabaseProjects.updateProjectFromDatabase"
   ],
   "main": "./out/main",
   "repository": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/22194. The data workspace extension used to have a `*` activation event that was removed in https://github.com/microsoft/azuredatastudio/pull/22005. The sql projects extension was also updated in that PR, but since we aren't releasing sql projects this release, the data workspace extension wasn't getting activated when the sql projects was getting activated from these commands. 

As a temporary fix before the next sql projects extension is released, this adds these commands as activation events for data workspace.