### PR TITLE
remove non-exist commands from commandPalette menu contribution point

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -464,23 +464,11 @@
           "when": "false"
         },
         {
-          "command": "mssql.newServerRole",
-          "when": "false"
-        },
-        {
           "command": "mssql.newLogin",
           "when": "false"
         },
         {
-          "command": "mssql.newDatabaseRole",
-          "when": "false"
-        },
-        {
           "command": "mssql.newUser",
-          "when": "false"
-        },
-        {
-          "command": "mssql.newApplicationRole",
           "when": "false"
         },
         {


### PR DESCRIPTION
https://github.com/microsoft/azuredatastudio/issues/22207

these commands were added and then removed due to schedule change, but I missed removing them from the commandPalette.