### PR TITLE
Fix datavirtualization wizard opening to wrong database

### DIFF
--- a/extensions/datavirtualization/package.json
+++ b/extensions/datavirtualization/package.json
@@ -2,7 +2,7 @@
   "name": "datavirtualization",
   "displayName": "%title.datavirtualization%",
   "description": "%config.extensionDescription%",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "publisher": "Microsoft",
   "icon": "resources/extension.png",
   "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",

--- a/extensions/datavirtualization/src/wizards/wizardCommands.ts
+++ b/extensions/datavirtualization/src/wizards/wizardCommands.ts
@@ -98,5 +98,6 @@ export class OpenMssqlHdfsTableFromFileWizardCommand extends Command {
 function convertIConnectionProfile(profile: azdata.IConnectionProfile): azdata.connection.ConnectionProfile {
 	const connection = azdata.connection.ConnectionProfile.createFrom(profile.options);
 	connection.providerId = profile.providerName;
+	connection.databaseName = profile.databaseName;
 	return connection;
 }


### PR DESCRIPTION
azdata.connection.ConnectionProfile.createFrom isn't getting the updated database correctly - there's a couple issues.

1. The options property bag has `database` - not `databaseName`
2. The value of `database` seems to be the original value of the connection itself, not the one of the current context (i.e. I have a connection to master, but then right click on a database and it ends up with `options.database` being `master` and `databaseName` being the database I clicked)

For a quick fix I'm just directly copying over the databaseName value, although following up with 2 to see what's going on there is something we should do at some point. 

(also did a bit of cleanup of some unused stuff I noticed while fixing this)