### PR TITLE
Change project build failure notification to be modal

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -312,7 +312,7 @@ export class ProjectsController {
 				// DotNetErrors already get shown by the netCoreTool so just show this one in the console
 				console.error(message);
 			} else {
-				void vscode.window.showErrorMessage(constants.projBuildFailed(message));
+				void vscode.window.showErrorMessage(constants.projBuildFailed(message), { modal: true });
 			}
 			return '';
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses https://github.com/microsoft/azuredatastudio/issues/22163. This changes the build error notification to be modal so that users using a screen reader will not miss it.
![buildErrorModal](https://user-images.githubusercontent.com/31145923/223881819-7d344c08-cf9b-411e-9120-5c24a4f6b3cc.gif)
