### PR TITLE
Fix for Edit Data grid newline on multiline strings

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -209,9 +209,12 @@ export class EditDataGridPanel extends GridParentComponent {
 				returnVal = '\'NULL\'';
 			}
 			else if (Services.DBCellValue.isDBCellValue(value)) {
+				// If a cell is not edited and retrieved direct from the SQL server, it would be in the form of a DBCellValue.
+				// We use the DBCellValue's displayValue as the text value.
 				returnVal = this.replaceLinebreaks(value.displayValue);
 			}
 			else if (typeof value === 'string') {
+				// Once a cell has been edited, the cell value will no longer be a DBCellValue until refresh.
 				returnVal = this.replaceLinebreaks(value);
 			}
 			return returnVal;
@@ -1138,9 +1141,13 @@ export class EditDataGridPanel extends GridParentComponent {
 		let itemToEdit = event.item[event.cell];
 
 		if (Services.DBCellValue.isDBCellValue(itemToEdit)) {
+			// If a cell is not edited and retrieved direct from the SQL server, it would be in the form of a DBCellValue.
+			// We use it's displayValue to check if the cell contains unicode NULL and linebreaks.
 			result = !this.hasNullAndLinebreak(itemToEdit.displayValue)
 		}
 		else if (typeof itemToEdit === 'string' || (itemToEdit && itemToEdit.text)) {
+			// Once a cell has been edited, the cell value will no longer be a DBCellValue until refresh.
+			// In this case, just check directly if it's a string or if it's an item with .text, use the text.
 			if (itemToEdit.text) {
 				result = !this.hasNullAndLinebreak(itemToEdit.text);
 			} else {
@@ -1192,11 +1199,15 @@ export class EditDataGridPanel extends GridParentComponent {
 			valueToDisplay = '\'NULL\'';
 		}
 		else if (Services.DBCellValue.isDBCellValue(value)) {
+			// If a cell is not edited and retrieved direct from the SQL server, it would be in the form of a DBCellValue.
+			// We use it's displayValue and remove newlines for display purposes only.
 			valueToDisplay = (value.displayValue + '');
 			valueToDisplay = valueToDisplay.replace(/(\r\n|\n|\r)/g, '\u0000');
 			valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
 		}
 		else if (typeof value === 'string' || (value && value.text)) {
+			// Once a cell has been edited, the cell value will no longer be a DBCellValue until refresh.
+			// In this case, use directly if it's a string or if it's an item with .text, use the text.
 			if (value.text) {
 				valueToDisplay = value.text;
 			} else {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -1135,7 +1135,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		this.logService.debug('onBeforeEditCell called with grid: ' + event.grid + ' row: ' + event.row
 			+ ' cell: ' + event.cell + ' item: ' + event.item + ' column: ' + event.column);
 
-		let itemToEdit = event.item[event.cell].displayValue;
+		let itemToEdit = event.item[event.cell];
 
 		if (Services.DBCellValue.isDBCellValue(itemToEdit)) {
 			result = !this.hasNullAndLinebreak(itemToEdit.displayValue)
@@ -1156,8 +1156,11 @@ export class EditDataGridPanel extends GridParentComponent {
 	}
 
 	private hasNullAndLinebreak(inputString: string): boolean {
-		let linebreakMatch = inputString.match(/(\r\n|\n|\r)/g);
-		return linebreakMatch?.length > 0 && inputString.indexOf('\u0000') !== -1;
+		if (inputString) {
+			let linebreakMatch = inputString.match(/(\r\n|\n|\r)/);
+			return linebreakMatch?.length > 0 && inputString.indexOf('\u0000') !== -1;
+		}
+		return false;
 	}
 
 	handleInitializeTable(): void {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -1136,11 +1136,6 @@ export class EditDataGridPanel extends GridParentComponent {
 		});
 	}
 
-	private static hasForbiddenNewlineCharacter(inputString: string): boolean {
-		// allow-any-unicode-next-line
-		return (inputString.indexOf('\u0000') !== -1 || inputString.indexOf('↵') !== -1 || inputString.indexOf('⏎') !== -1);
-	}
-
 	onBeforeEditCell(event: Slick.OnBeforeEditCellEventArgs<any>): boolean {
 		let result = true;
 		this.logService.debug('onBeforeEditCell called with grid: ' + event.grid + ' row: ' + event.row
@@ -1148,7 +1143,8 @@ export class EditDataGridPanel extends GridParentComponent {
 
 		let itemToEdit = event.item[event.cell].displayValue;
 
-		if (Services.DBCellValue.isDBCellValue(itemToEdit) && EditDataGridPanel.hasForbiddenNewlineCharacter(itemToEdit.displayValue)) {
+		// allow-any-unicode-next-line
+		if (Services.DBCellValue.isDBCellValue(itemToEdit) && (itemToEdit.displayValue.indexOf('\u0000') !== -1 || itemToEdit.displayValue.indexOf('↵') !== -1 || itemToEdit.displayValue.indexOf('⏎') !== -1)) {
 			result = false;
 			this.notificationService.warn(cellWithInvalidCharMessage);
 		}

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -1137,13 +1137,27 @@ export class EditDataGridPanel extends GridParentComponent {
 
 		let itemToEdit = event.item[event.cell].displayValue;
 
-		// allow-any-unicode-next-line
-		if (Services.DBCellValue.isDBCellValue(itemToEdit) && itemToEdit.displayValue.indexOf('\u0000') !== -1) {
-			result = false;
+		if (Services.DBCellValue.isDBCellValue(itemToEdit)) {
+			result = !this.hasNullAndLinebreak(itemToEdit.displayValue)
+		}
+		else if (typeof itemToEdit === 'string' || (itemToEdit && itemToEdit.text)) {
+			if (itemToEdit.text) {
+				result = !this.hasNullAndLinebreak(itemToEdit.text);
+			} else {
+				result = !this.hasNullAndLinebreak(itemToEdit.text);
+			}
+		}
+
+		if (!result) {
 			this.notificationService.warn(cellWithNullCharMessage);
 		}
 
 		return result;
+	}
+
+	private hasNullAndLinebreak(inputString: string): boolean {
+		let linebreakMatch = inputString.match(/(\r\n|\n|\r)/g);
+		return linebreakMatch?.length > 0 && inputString.indexOf('\u0000') !== -1;
 	}
 
 	handleInitializeTable(): void {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -476,7 +476,8 @@ export class EditDataGridPanel extends GridParentComponent {
 		if (newlineMatches && newlineMatches.length > 0) {
 			this.newlinePattern = newlineMatches[0];
 		}
-		return inputStr.replace(/(\r\n|\n|\r)/g, '\u0000');
+		// allow-any-unicode-next-line
+		return inputStr.replace(/(\r\n|\n|\r)/g, '↵');
 	}
 
 	/**
@@ -643,7 +644,8 @@ export class EditDataGridPanel extends GridParentComponent {
 					? self.rowIdMappings[self.currentCell.row]
 					: self.currentCell.row;
 
-				return self.dataService.updateCell(sessionRowId, self.currentCell.column - 1, this.newlinePattern ? self.currentEditCellValue.replace('\u0000', this.newlinePattern) : self.currentEditCellValue);
+				// allow-any-unicode-next-line
+				return self.dataService.updateCell(sessionRowId, self.currentCell.column - 1, this.newlinePattern ? self.currentEditCellValue.replace('↵', this.newlinePattern) : self.currentEditCellValue);
 			}).then(
 				result => {
 					// last entered input is no longer needed as we have entered a valid input to commit.

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -1144,7 +1144,7 @@ export class EditDataGridPanel extends GridParentComponent {
 			if (itemToEdit.text) {
 				result = !this.hasNullAndLinebreak(itemToEdit.text);
 			} else {
-				result = !this.hasNullAndLinebreak(itemToEdit.text);
+				result = !this.hasNullAndLinebreak(itemToEdit);
 			}
 		}
 

--- a/src/sql/workbench/contrib/editData/browser/media/editData.css
+++ b/src/sql/workbench/contrib/editData/browser/media/editData.css
@@ -97,6 +97,11 @@
 	font-style: italic
 }
 
+.editDataGrid .slick-cell .grid-cell-value-container.contains-null-char-cell {
+	background-color: var(--color-cell-invalid-cell, rgb(215, 230, 16));
+	color: black
+}
+
 .editDataGrid .slick-cell .grid-cell-value-container.loading-cell {
 	font-style: italic
 }

--- a/src/sql/workbench/contrib/editData/browser/media/editData.css
+++ b/src/sql/workbench/contrib/editData/browser/media/editData.css
@@ -97,11 +97,6 @@
 	font-style: italic
 }
 
-.editDataGrid .slick-cell .grid-cell-value-container.contains-null-char-cell {
-	background-color: var(--color-cell-invalid-cell, rgb(215, 230, 16));
-	color: black
-}
-
 .editDataGrid .slick-cell .grid-cell-value-container.loading-cell {
 	font-style: italic
 }


### PR DESCRIPTION
PR adds proper regex for replacing null characters after an edit.

It adds a check to see if the unicode null character exists in a pre-edit string or not. If it does, you will not be able to edit it and the cell's text will be highlighted in yellow along with an warning explaining why you cannot edit the cell if it is selected, either automatically upon launch if it's the first cell or when a user tries to click it. (although I am not able to test this scenario in SSMS as I found it was not possible to add it via SSMS to a SQL server) 

Also removes row number in loadItem as it's not being used at all and does not exist on Slickgrid.

Initial screen with comparison to SSMS:
![EditDataScreenshotDefault](https://user-images.githubusercontent.com/18018452/224107042-e01312c0-581a-4dcb-a402-7ded4c9328cf.png)

Screen while editing multiline cell:
![EditDataScreenshotEdit](https://user-images.githubusercontent.com/18018452/224107103-29b6f52e-cc1b-4e71-818d-0c6ad0645f1f.png)

Screen after editing multiline cell:
![EditDataScreenshotPostEdit](https://user-images.githubusercontent.com/18018452/224107162-cb900f14-e91c-4fcc-9633-c3eb7a28895d.png)

Hypothetical (test scenario without checks) screen of a cell containing the unicode null character (message has been changed slightly to say it contains the unicode null character and that it is not supported for editing):
![Invalid Cell Click Mockup](https://user-images.githubusercontent.com/18018452/224107434-9e2a36e8-e92c-44e2-b33f-3dfb875ffd88.png)


This PR fixes #22170
