### PR TITLE
fix action bar size

### DIFF
--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -66,7 +66,7 @@ const NO_ACTIONBAR_ADDITIONAL_PADDING = 75;
 const ACTIONBAR_WIDTH = 36;
 
 // minimum height needed to show the full actionbar
-const ACTIONBAR_HEIGHT = 120;
+const ACTIONBAR_HEIGHT = 140;
 
 // this handles min size if rows is greater than the min grid visible rows
 const MIN_GRID_HEIGHT = (MIN_GRID_HEIGHT_ROWS * ROW_HEIGHT) + HEADER_HEIGHT + ESTIMATED_SCROLL_BAR_HEIGHT;


### PR DESCRIPTION
This PR fixes #22252

Recently a new export to markdown action was added, but the min-height is not adjusted.

![image](https://user-images.githubusercontent.com/13777222/224439188-cc5168ce-16bc-4663-86cc-83581b7e13ca.png)
