### PR TITLE
Fixing new connections not expanding in object explorer.

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -276,22 +276,6 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			}
 
 		} else {
-
-			// Check if the new profile is already part of the tree
-			let isProfileAlreadyPartOfTree = false;
-			const groupStack = [<ConnectionProfileGroup>(this._tree.getInput())];
-			while (groupStack.length > 0 && !isProfileAlreadyPartOfTree) {
-				const group = groupStack.pop();
-				if (group) {
-					group.connections.forEach(connection => {
-						if (connection.id === newProfile.id) {
-							isProfileAlreadyPartOfTree = true;
-						}
-					});
-					group.children.forEach(child => groupStack.push(child));
-				}
-			}
-
 			if (newProfile) {
 				const groups = this._connectionManagementService.getConnectionGroups();
 				const profile = ConnectionUtils.findProfileInGroup(newProfile, groups);
@@ -309,14 +293,8 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			}
 			await this.refreshTree();
 			if (newProfile && !newProfileIsSelected) {
-				await this._tree!.reveal(newProfile);
-				// If profile was already part of the tree then we don't want to select it again as it will create a new object explorer session for it. Instead we just want to focus it.
-				if (isProfileAlreadyPartOfTree) {
-					this._tree.setFocus(newProfile);
-				} else {
-					await this._tree.select(newProfile);
-					await this._tree.expand(newProfile);
-				}
+				await this._tree.reveal(newProfile);
+				this._tree.select(newProfile);
 			}
 		}
 

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -294,7 +294,8 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			await this.refreshTree();
 			if (newProfile && !newProfileIsSelected) {
 				await this._tree.reveal(newProfile);
-				this._tree.select(newProfile);
+				await this._tree.select(newProfile);
+				await this._tree.expand(newProfile);
 			}
 		}
 

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -294,7 +294,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			await this.refreshTree();
 			if (newProfile && !newProfileIsSelected) {
 				await this._tree!.reveal(newProfile);
-				this._tree.setFocus(newProfile);
+				await this._tree.select(newProfile);
 			}
 		}
 

--- a/src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution.ts
+++ b/src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution.ts
@@ -50,6 +50,12 @@ const serverTreeConfig: IConfigurationNode = {
 			'type': 'boolean',
 			'default': false,
 			'description': localize('serverTree.useAsyncServerTree', "(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.")
+		},
+		'serverTree.nodeExpansionTimeout': {
+			'type': 'number',
+			'default': '45',
+			'description': localize('serverTree.nodeExpansionTimeout', "The timeout in seconds for expanding a node in the Servers view"),
+			'minimum': 1
 		}
 	}
 };

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
@@ -122,17 +122,17 @@ suite('ServerTreeView onAddConnectionProfile handler tests', () => {
 
 
 
-	test('onAddConnectionProfile handler focuses the new profile when no profile is already selected', async () => {
+	test('onAddConnectionProfile handler selects the new profile when no profile is already selected', async () => {
 		let newProfile = <IConnectionProfile>{
 			id: 'test_connection'
 		};
 		await runAddConnectionProfileHandler(undefined, newProfile);
 		mockRefreshTreeMethod.verify(x => x(), TypeMoq.Times.once());
 		mockTree.verify(x => x.clearSelection(), TypeMoq.Times.never());
-		mockTree.verify(x => x.setFocus(TypeMoq.It.is(profile => profile === newProfile)), TypeMoq.Times.once());
+		mockTree.verify(x => x.select(TypeMoq.It.is(profile => profile === newProfile)), TypeMoq.Times.once());
 	});
 
-	test('onAddConnectionProfile handler focuses the new profile when a different profile is already selected', async () => {
+	test('onAddConnectionProfile handler selects the new profile when a different profile is already selected', async () => {
 		let oldProfile = <IConnectionProfile>{
 			id: 'old_connection'
 		};
@@ -142,7 +142,7 @@ suite('ServerTreeView onAddConnectionProfile handler tests', () => {
 		await runAddConnectionProfileHandler(oldProfile, newProfile);
 		mockRefreshTreeMethod.verify(x => x(), TypeMoq.Times.once());
 		mockTree.verify(x => x.clearSelection(), TypeMoq.Times.once());
-		mockTree.verify(x => x.setFocus(TypeMoq.It.is(profile => profile === newProfile)), TypeMoq.Times.once());
+		mockTree.verify(x => x.select(TypeMoq.It.is(profile => profile === newProfile)), TypeMoq.Times.once());
 	});
 
 	test('onAddConnectionProfile handler does not clear the selection when the new profile is already selected', async () => {

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -498,6 +498,9 @@ export class ObjectExplorerService implements IObjectExplorerService {
 										sessionId: session.sessionId
 									};
 									resultMap.set(provider.providerId, emptyResult);
+									if (resultMap.size === allProviders.length) {
+										resolveExpansion();
+									}
 								}
 							}, error => {
 								reject(error);

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -425,7 +425,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 						}
 						this.logService.trace(`${session.sessionId}: got providers for node expansion: ${allProviders.map(p => p.providerId).join(', ')}`);
 
-						const resolveExpansionResult = () => {
+						const resolveExpansion = () => {
 							resolve(self.mergeResults(allProviders, resultMap, node.nodePath));
 							// Have to delete it after get all responses otherwise couldn't find session for not the first response
 							clearTimeout(timeout);
@@ -440,7 +440,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 							resultMap.set(e.providerId, e);
 							// When get all responses from all providers, merge results
 							if (resultMap.size === allProviders.length) {
-								resolveExpansionResult();
+								resolveExpansion();
 							}
 						});
 
@@ -455,7 +455,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 								this.logService.warn(`${session.sessionId}: Node expansion timed out for node ${node.nodePath} for providers ${missingProviders.map(p => p.providerId).join(', ')}`);
 								this._notificationService.error(nls.localize('nodeExpansionTimeout', "Node expansion timed out for node {0} for providers {1}", node.nodePath, missingProviders.map(p => p.providerId).join(', ')));
 							}
-							resolveExpansionResult();
+							resolveExpansion();
 						}, expansionTimeout * 1000);
 
 						self._sessions[session.sessionId!].nodes[node.nodePath].expandEmitter.event((expandResult: NodeExpandInfoWithProviderId) => {
@@ -481,7 +481,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 							// When get all responses from all providers, merge results
 							if (resultMap.size === allProviders.length) {
-								resolveExpansionResult();
+								resolveExpansion();
 							}
 						});
 						if (newRequest) {

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -22,7 +22,6 @@ import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { ServerTreeActionProvider } from 'sql/workbench/services/objectExplorer/browser/serverTreeActionProvider';
 import { ITree } from 'sql/base/parts/tree/browser/tree';
 import { AsyncServerTree, ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
-import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ObjectExplorerRequestStatus } from 'sql/workbench/services/objectExplorer/browser/treeSelectionHandler';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
@@ -444,7 +443,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 								resultMap.set(expandResult.providerId, expandResult);
 								// If we got an error result back then send error our error event
 								// We only do this for the MSSQL provider
-								if (expandResult.errorMessage && expandResult.providerId === mssqlProviderName) {
+								if (expandResult.errorMessage) {
 									const errorType = expandResult.errorMessage.indexOf('Object Explorer task didn\'t complete') !== -1 ? 'Timeout' : 'Other';
 									// For folders send the actual name of the folder (since the nodeTypeId isn't useful in this case and the names are controlled by us)
 									const nodeType = node.nodeTypeId === NodeType.Folder ? node.label : node.nodeTypeId;

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -429,6 +429,17 @@ export class ObjectExplorerService implements IObjectExplorerService {
 						// Incase node status not found.
 						this._onNodeExpandedError.event(e => {
 							resultMap.set(e.providerId, e);
+							// When get all responses from all providers, merge results
+							if (resultMap.size === allProviders.length) {
+								resolve(self.mergeResults(allProviders, resultMap, node.nodePath));
+								clearTimeout(timeout);
+
+								// Have to delete it after get all responses otherwise couldn't find session for not the first response
+								if (newRequest) {
+									delete self._sessions[session.sessionId!].nodes[node.nodePath];
+									this.logService.trace(`Deleted node ${node.nodePath} from session ${session.sessionId}`);
+								}
+							}
 						});
 
 						const expansionTimeout = this._configurationService.getValue<number>('serverTree.nodeExpansionTimeout');

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -436,10 +436,13 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 					// Incase node status not found.
 					this._onNodeExpandedError.event(e => {
-						resultMap.set(e.providerId, e);
-						// When get all responses from all providers, merge results
-						if (resultMap.size === allProviders.length) {
-							resolveExpansion();
+						//Ignore errors from other sessions and nodepaths.
+						if (e.sessionId === session.sessionId && e.nodePath === node.nodePath) {
+							resultMap.set(e.providerId, e);
+							// When get all responses from all providers, merge results
+							if (resultMap.size === allProviders.length) {
+								resolveExpansion();
+							}
 						}
 					});
 

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -427,6 +427,10 @@ export class ObjectExplorerService implements IObjectExplorerService {
 							 * it's not going to respond and resolve the promise with the results we have so far
 							 */
 							if (resultMap.size === allProviders.length || retryCount === expansionTimeout) {
+								if (resultMap.size !== allProviders.length) {
+									const missingProviders = allProviders.filter(p => !resultMap.has(p.providerId));
+									this.logService.warn(`${session.sessionId}: Node expansion timed out for node ${node.nodePath} for providers ${missingProviders.map(p => p.providerId).join(', ')}`);
+								}
 								resolve(self.mergeResults(allProviders, resultMap, node.nodePath));
 								if (newRequest) {
 									delete self._sessions[session.sessionId!].nodes[node.nodePath];

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -439,7 +439,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 						resultMap.set(e.providerId, e);
 						// When get all responses from all providers, merge results
 						if (resultMap.size === allProviders.length) {
-							//resolveExpansion();
+							resolveExpansion();
 						}
 					});
 
@@ -479,7 +479,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 						// When get all responses from all providers, merge results
 						if (resultMap.size === allProviders.length) {
-							//resolveExpansion();
+							resolveExpansion();
 						}
 					});
 					if (newRequest) {

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -418,8 +418,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 							nodeProviders = nodeProviders.sort((a, b) => a.group!.toLowerCase().localeCompare(b.group!.toLowerCase()));
 							allProviders.push(...nodeProviders);
 						}
-
-
+						this.logService.trace(`${session.sessionId}: got providers for node expansion: ${allProviders.map(p => p.providerId).join(', ')}`);
 
 						let retryCount = 0;
 						const expansionTimeout = this._configurationService.getValue<number>('serverTree.nodeExpansionTimeout');
@@ -441,6 +440,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 						self._sessions[session.sessionId!].nodes[node.nodePath].expandEmitter.event((expandResult: NodeExpandInfoWithProviderId) => {
 							if (expandResult && expandResult.providerId) {
+								this.logService.trace(`${session.sessionId}: Received expand result for node ${node.nodePath} from provider ${expandResult.providerId}`);
 								resultMap.set(expandResult.providerId, expandResult);
 								// If we got an error result back then send error our error event
 								// We only do this for the MSSQL provider

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -22,6 +22,7 @@ import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { ServerTreeActionProvider } from 'sql/workbench/services/objectExplorer/browser/serverTreeActionProvider';
 import { ITree } from 'sql/base/parts/tree/browser/tree';
 import { AsyncServerTree, ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ObjectExplorerRequestStatus } from 'sql/workbench/services/objectExplorer/browser/treeSelectionHandler';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -455,7 +456,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 								if (expandResult.errorMessage) {
 									const errorType = expandResult.errorMessage.indexOf('Object Explorer task didn\'t complete') !== -1 ? 'Timeout' : 'Other';
 									// For folders send the actual name of the folder (since the nodeTypeId isn't useful in this case and the names are controlled by us)
-									const nodeType = node.nodeTypeId === NodeType.Folder ? node.label : node.nodeTypeId;
+									const nodeType = expandResult.providerId === mssqlProviderName && node.nodeTypeId === NodeType.Folder ? node.label : node.nodeTypeId;
 									this._telemetryService.createErrorEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.TelemetryError.ObjectExplorerExpandError, undefined, errorType)
 										.withAdditionalProperties({
 											nodeType,

--- a/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
@@ -124,7 +124,7 @@ export class TreeSelectionHandler {
 			let connectionProfile: ConnectionProfile | undefined = undefined;
 			let options: IConnectionCompletionOptions = {
 				params: undefined,
-				saveTheConnection: false, // don't save the connection as the tree loads the connections from the saved connections
+				saveTheConnection: true,
 				showConnectionDialogOnError: true,
 				showFirewallRuleOnError: true,
 				showDashboard: isDoubleClick // only show the dashboard if the action is double click

--- a/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
@@ -124,7 +124,7 @@ export class TreeSelectionHandler {
 			let connectionProfile: ConnectionProfile | undefined = undefined;
 			let options: IConnectionCompletionOptions = {
 				params: undefined,
-				saveTheConnection: true,
+				saveTheConnection: false, // don't save the connection as the tree loads the connections from the saved connections
 				showConnectionDialogOnError: true,
 				showFirewallRuleOnError: true,
 				showDashboard: isDoubleClick // only show the dashboard if the action is double click

--- a/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
@@ -20,10 +20,12 @@ import { TestConnectionManagementService } from 'sql/platform/connection/test/co
 import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
 import { NullAdsTelemetryService } from 'sql/platform/telemetry/common/adsTelemetryService';
 import { ConnectionOptionSpecialType, ServiceOptionType } from 'sql/platform/connection/common/interfaces';
+import { TestConfigurationService } from 'sql/platform/connection/test/common/testConfigurationService';
 
 suite('SQL Object Explorer Service tests', () => {
 	let sqlOEProvider: TypeMoq.Mock<TestObjectExplorerProvider>;
 	let connectionManagementService: TypeMoq.Mock<TestConnectionManagementService>;
+	let configurationService: TypeMoq.Mock<TestConfigurationService>;
 	let connection: ConnectionProfile;
 	let connectionToFail: ConnectionProfile;
 	let conProfGroup: ConnectionProfileGroup;
@@ -267,10 +269,13 @@ suite('SQL Object Explorer Service tests', () => {
 			resolve(connection);
 		}));
 
+		configurationService = TypeMoq.Mock.ofType(TestConfigurationService, TypeMoq.MockBehavior.Strict);
+		configurationService.setup(x => x.getValue('serverTree.nodeExpansionTimeout')).returns(() => 45);
+
 		connectionManagementService.setup(x => x.getCapabilities(mssqlProviderName)).returns(() => undefined);
 
 		const logService = new NullLogService();
-		objectExplorerService = new ObjectExplorerService(connectionManagementService.object, new NullAdsTelemetryService(), capabilitiesService, logService);
+		objectExplorerService = new ObjectExplorerService(connectionManagementService.object, new NullAdsTelemetryService(), capabilitiesService, logService, configurationService.object);
 		objectExplorerService.registerProvider(mssqlProviderName, sqlOEProvider.object);
 		sqlOEProvider.setup(x => x.createNewSession(TypeMoq.It.is<azdata.ConnectionInfo>(x => x.options['serverName'] === connection.serverName))).returns(() => new Promise<any>((resolve) => {
 			resolve(response);

--- a/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
@@ -21,10 +21,12 @@ import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/t
 import { NullAdsTelemetryService } from 'sql/platform/telemetry/common/adsTelemetryService';
 import { ConnectionOptionSpecialType, ServiceOptionType } from 'sql/platform/connection/common/interfaces';
 import { TestConfigurationService } from 'sql/platform/connection/test/common/testConfigurationService';
+import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 
 suite('SQL Object Explorer Service tests', () => {
 	let sqlOEProvider: TypeMoq.Mock<TestObjectExplorerProvider>;
 	let connectionManagementService: TypeMoq.Mock<TestConnectionManagementService>;
+	let notificationService: TypeMoq.Mock<TestNotificationService>;
 	let configurationService: TypeMoq.Mock<TestConfigurationService>;
 	let connection: ConnectionProfile;
 	let connectionToFail: ConnectionProfile;
@@ -274,8 +276,18 @@ suite('SQL Object Explorer Service tests', () => {
 
 		connectionManagementService.setup(x => x.getCapabilities(mssqlProviderName)).returns(() => undefined);
 
+		notificationService = TypeMoq.Mock.ofType(TestNotificationService, TypeMoq.MockBehavior.Strict);
+		notificationService.setup(x => x.error(TypeMoq.It.isAny())).returns(() => undefined);
+
 		const logService = new NullLogService();
-		objectExplorerService = new ObjectExplorerService(connectionManagementService.object, new NullAdsTelemetryService(), capabilitiesService, logService, configurationService.object);
+		objectExplorerService = new ObjectExplorerService(
+			connectionManagementService.object,
+			new NullAdsTelemetryService(),
+			capabilitiesService,
+			logService,
+			configurationService.object,
+			notificationService.object);
+
 		objectExplorerService.registerProvider(mssqlProviderName, sqlOEProvider.object);
 		sqlOEProvider.setup(x => x.createNewSession(TypeMoq.It.is<azdata.ConnectionInfo>(x => x.options['serverName'] === connection.serverName))).returns(() => new Promise<any>((resolve) => {
 			resolve(response);


### PR DESCRIPTION
This PR addresses issue #22303.

The "expandOrRefreshNode" function in Object Explorer can sometimes get stuck in an infinite wait state when node providers fail to return nodes, preventing the main promise of the method from resolving. To address this, I've implemented a new method that checks if the required results are available within 45 seconds. If not, the promise is forcibly resolved.

Additionally, I've added a new check to ensure that no duplicate sessions are created for connections in the OE tree. If a node is already part of the tree, it is just focused rather than selected again (which can create a new session) and fetch nodes. 

![image](https://user-images.githubusercontent.com/6816294/224617475-624a7271-7c9a-40c1-ac91-6d39c1da6c6b.png)

Node timeouts
https://user-images.githubusercontent.com/6816294/224863028-ff74bba6-5cac-4b43-9f82-a968771a02c2.mp4

