### PR TITLE
fix exclude for table and externalStreamingJob

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -784,6 +784,8 @@ export class ProjectsController {
 
 			switch (node.type) {
 				case constants.DatabaseProjectItemType.sqlObjectScript:
+				case constants.DatabaseProjectItemType.table:
+				case constants.DatabaseProjectItemType.externalStreamingJob:
 					await project.excludeSqlObjectScript(fileEntry.relativePath);
 					break;
 				case constants.DatabaseProjectItemType.folder:


### PR DESCRIPTION
Fix this error when excluding a table and externalStreamingJob from a sqlproj after #22166. These two have their own DatabaseProjectItemType subtype because they have commands specific to their object types, but they should be handled like the other sqlObjectScripts.
![excludeError](https://user-images.githubusercontent.com/31145923/224787044-dca49138-705a-4d3f-a9c2-ffee59e11184.gif)
