### PR TITLE
add reload project

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -142,11 +142,21 @@ export class Project implements ISqlProject {
 
 	/**
 	 * Open and load a .sqlproj file
+	 * @param projectFilePath
+	 * @param promptIfNeedsUpdating whether or not to prompt the user if the project needs to be updated
+	 * @param reload whether to reload the project from the project file
+	 * @returns
 	 */
-	public static async openProject(projectFilePath: string, promptIfNeedsUpdating: boolean = false): Promise<Project> {
+	public static async openProject(projectFilePath: string, promptIfNeedsUpdating: boolean = false, reload: boolean = false): Promise<Project> {
 		const proj = new Project(projectFilePath);
 
 		proj.sqlProjService = await utils.getSqlProjectsService();
+
+		if (reload) {
+			// close the project in STS so that it will reload the project from the .sqlproj, rather than using the cached Project in STS
+			await proj.sqlProjService.closeProject(projectFilePath);
+		}
+
 		await proj.readProjFile();
 
 		if (!proj.isCrossPlatformCompatible && promptIfNeedsUpdating) {

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -40,7 +40,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 */
 	public async getProjectTreeDataProvider(projectFilePath: vscode.Uri): Promise<vscode.TreeDataProvider<BaseProjectTreeItem>> {
 		const provider = new SqlDatabaseProjectTreeViewProvider();
-		const project = await Project.openProject(projectFilePath.fsPath, true);
+		const project = await Project.openProject(projectFilePath.fsPath, true, true);
 
 		// open project in STS
 		const sqlProjectsService = await getSqlProjectsService();
@@ -112,7 +112,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 * Opens and loads a .sqlproj file
 	 */
 	public openProject(projectFilePath: string): Promise<sqldbproj.ISqlProject> {
-		return Project.openProject(projectFilePath, true);
+		return Project.openProject(projectFilePath, true, true);
 	}
 
 	public addItemPrompt(project: sqldbproj.ISqlProject, relativeFilePath: string, options?: sqldbproj.AddItemOptions): Promise<void> {


### PR DESCRIPTION
Add reload project parameter to `openProject()` so that the refresh tree button actually works and reloads the project if the project was updated outside of the sql projects extension
