### PR TITLE
pass SystemDacpacsLocation when building legacy style sql projects

### DIFF
--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -139,7 +139,7 @@ export class BuildHelper {
 		if (sqlProjStyle === ProjectType.SdkStyle) {
 			return ` build ${projectPath} /p:NetCoreBuild=true /p:SystemDacpacsLocation=${buildDirPath}`;
 		} else {
-			return ` build ${projectPath} /p:NetCoreBuild=true /p:NETCoreTargetsPath=${buildDirPath}`;
+			return ` build ${projectPath} /p:NetCoreBuild=true /p:NETCoreTargetsPath=${buildDirPath} /p:SystemDacpacsLocation=${buildDirPath}`;
 		}
 	}
 }


### PR DESCRIPTION
The old project XML logic in ADS used to add system db references for legacy projects with the variable  `$(NETCoreTargetsPath)`, so the path would look like` $(NETCoreTargetsPath)\SystemDacpacs\160\master.dacpac`. The new projects library adds system db references for both legacy and SDK-style projects with the variable `$(SystemDacpacsLocation)`, so now this variable also needs to get passed in when building legacy projects.
