### PR TITLE
fix add database reference dialog test

### DIFF
--- a/extensions/sql-database-projects/src/test/dialogs/addDatabaseReferenceDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/addDatabaseReferenceDialog.test.ts
@@ -66,7 +66,7 @@ describe('Add Database Reference Dialog', () => {
 		should(dialog.dialog.okButton.enabled).equal(false, 'Ok button should be disabled after clearing the database name textbox');
 
 		// fill in db name and ok button should be enabled
-		dialog.databaseNameTextbox!.value = 'master';
+		dialog.databaseNameTextbox!.value = 'Master';
 		dialog.tryEnableAddReferenceButton();
 		should(dialog.dialog.okButton.enabled).equal(true, 'Ok button should be enabled after the database name textbox is filled');
 
@@ -102,7 +102,7 @@ describe('Add Database Reference Dialog', () => {
 		// change reference type back to system db
 		dialog.systemDbRadioButtonClick();
 		should(dialog.locationDropdown?.value).equal(constants.differentDbSameServer);
-		should(dialog.databaseNameTextbox?.value).equal('master', `Database name textbox should be set to master. Actual:${dialog.databaseNameTextbox?.value}`);
+		should(dialog.databaseNameTextbox?.value).equal('Master', `Database name textbox should be set to Master. Actual:${dialog.databaseNameTextbox?.value}`);
 		should(dialog.dialog.okButton.enabled).equal(true, 'Ok button should be enabled because database name is filled');
 	});
 


### PR DESCRIPTION
This test started failing after Master was switched to be uppercase in https://github.com/microsoft/azuredatastudio/pull/22215 to match how DacFx.Projects is storing it.