### PR TITLE
add ariaLive to publish options description

### DIFF
--- a/extensions/datavirtualization/src/test/stubs.ts
+++ b/extensions/datavirtualization/src/test/stubs.ts
@@ -248,7 +248,7 @@ export class MockInputBoxComponent extends MockUIComponent implements azdata.Inp
 	onEnterKeyPressed: vscode.Event<string>;
 	value?: string;
 	ariaLabel?: string;
-	ariaLive?: string;
+	ariaLive?: azdata.AriaLiveValue;
 	placeHolder?: string;
 	inputType?: azdata.InputBoxInputType;
 	required?: boolean;

--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -538,7 +538,7 @@
     "@types/semver": "^7.3.1",
     "@types/sinon": "^9.0.8",
     "@types/yamljs": "0.2.30",
-    "@microsoft/azdata-test": "^3.0.1",
+    "@microsoft/azdata-test": "^3.0.2",
     "mocha": "^7.1.1",
     "should": "^13.2.3",
     "sinon": "^9.2.0",

--- a/extensions/resource-deployment/yarn.lock
+++ b/extensions/resource-deployment/yarn.lock
@@ -196,10 +196,10 @@
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 
-"@microsoft/azdata-test@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/azdata-test/-/azdata-test-3.0.1.tgz#a8b89a12de42f277d33aae71c277d0c8efcfbee0"
-  integrity sha512-Zrctm/zKufwIRF9jfw8TOBzr5woLdKXAGNTlbAQl0IGLzVoIGULj9Gqdc1Ikhrov3rM0NkbAF/PY6j6BHiW8Tw==
+"@microsoft/azdata-test@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/azdata-test/-/azdata-test-3.0.2.tgz#71cfbbc2ee9c1805311f3a5828b50679a5e6d73c"
+  integrity sha512-NMoSKp/Zgs+1ZIe07w+FeKhqMaxgViLGmLTQHPfYN7RRTFErJBd8JgskxYoLZbgcctfVsV+Yw+zQEn1+g2mPKg==
   dependencies:
     http-proxy-agent "^5.0.0"
     https-proxy-agent "^5.0.0"

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -104,8 +104,10 @@ export class PublishOptionsDialog {
 				const row = this.optionsTable?.selectedRows![0];
 				// data[row][1] contains the option display name
 				const displayName = this.optionsTable?.data[row!][1];
+				const description = this.optionsModel.getOptionDescription(displayName);
 				await this.descriptionText?.updateProperties({
-					value: this.optionsModel.getOptionDescription(displayName)
+					value: description,
+					ariaLive: description
 				});
 			}));
 

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -104,10 +104,9 @@ export class PublishOptionsDialog {
 				const row = this.optionsTable?.selectedRows![0];
 				// data[row][1] contains the option display name
 				const displayName = this.optionsTable?.data[row!][1];
-				const description = this.optionsModel.getOptionDescription(displayName);
 				await this.descriptionText?.updateProperties({
-					value: description,
-					ariaLive: description
+					value: this.optionsModel.getOptionDescription(displayName),
+					ariaLive: 'polite'
 				});
 			}));
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3574,7 +3574,7 @@ declare module 'azdata' {
 
 	export interface InputBoxProperties extends ComponentProperties {
 		value?: string | undefined;
-		ariaLive?: string | undefined;
+		ariaLive?: AriaLiveValue | undefined;
 		placeHolder?: string | undefined;
 		inputType?: InputBoxInputType | undefined;
 		required?: boolean | undefined;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1807,6 +1807,9 @@ declare module 'azdata' {
 		ariaLive?: AriaLiveValue
 	}
 
+	/**
+	 * Supported values for aria-live accessibility attribute
+	 */
 	export type AriaLiveValue = 'polite' | 'assertive' | 'off';
 
 	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ContainerProperties> extends ComponentBuilder<TComponent, TPropertyBag> {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1802,7 +1802,7 @@ declare module 'azdata' {
 
 	export interface TextComponentProperties {
 		/**
-		 * Corresponds to the aria-live accessibility attribute for this component. The accepted values are polite, assertive, and off
+		 * Corresponds to the aria-live accessibility attribute for this component.
 		 */
 		ariaLive?: 'polite' | 'assertive' | 'off';
 	}
@@ -1817,7 +1817,7 @@ declare module 'azdata' {
 
 	export interface ContainerProperties extends ComponentProperties {
 		/**
-		 * Corresponds to the aria-live accessibility attribute for this component. The accepted values are polite, assertive, and off
+		 * Corresponds to the aria-live accessibility attribute for this component.
 		 */
 		ariaLive?: 'polite' | 'assertive' | 'off';
 	}

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1802,7 +1802,7 @@ declare module 'azdata' {
 
 	export interface TextComponentProperties {
 		/**
-		 * Corresponds to the aria-live accessibility attribute for this component
+		 * Corresponds to the aria-live accessibility attribute for this component. The accepted values are polite, assertive, and off
 		 */
 		ariaLive?: string;
 	}
@@ -1817,7 +1817,7 @@ declare module 'azdata' {
 
 	export interface ContainerProperties extends ComponentProperties {
 		/**
-		 * Corresponds to the aria-live accessibility attribute for this component
+		 * Corresponds to the aria-live accessibility attribute for this component. The accepted values are polite, assertive, and off
 		 */
 		ariaLive?: string;
 	}

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1802,10 +1802,12 @@ declare module 'azdata' {
 
 	export interface TextComponentProperties {
 		/**
-		 * Corresponds to the aria-live accessibility attribute for this component.
+		 * Corresponds to the aria-live accessibility attribute for this component
 		 */
-		ariaLive?: 'polite' | 'assertive' | 'off';
+		ariaLive?: AriaLiveValue
 	}
+
+	export type AriaLiveValue = 'polite' | 'assertive' | 'off';
 
 	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ContainerProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
 		/**
@@ -1817,9 +1819,9 @@ declare module 'azdata' {
 
 	export interface ContainerProperties extends ComponentProperties {
 		/**
-		 * Corresponds to the aria-live accessibility attribute for this component.
+		 * Corresponds to the aria-live accessibility attribute for this component
 		 */
-		ariaLive?: 'polite' | 'assertive' | 'off';
+		ariaLive?: AriaLiveValue
 	}
 	export namespace queryeditor {
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1804,7 +1804,7 @@ declare module 'azdata' {
 		/**
 		 * Corresponds to the aria-live accessibility attribute for this component. The accepted values are polite, assertive, and off
 		 */
-		ariaLive?: string;
+		ariaLive?: 'polite' | 'assertive' | 'off';
 	}
 
 	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ContainerProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
@@ -1819,7 +1819,7 @@ declare module 'azdata' {
 		/**
 		 * Corresponds to the aria-live accessibility attribute for this component. The accepted values are polite, assertive, and off
 		 */
-		ariaLive?: string;
+		ariaLive?: 'polite' | 'assertive' | 'off';
 	}
 	export namespace queryeditor {
 

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1004,10 +1004,10 @@ class InputBoxWrapper extends ComponentWrapper implements azdata.InputBoxCompone
 		this.setProperty('value', v);
 	}
 
-	public get ariaLive(): string {
+	public get ariaLive(): azdata.AriaLiveValue {
 		return this.properties['ariaLive'];
 	}
-	public set ariaLive(v: string) {
+	public set ariaLive(v: azdata.AriaLiveValue) {
 		this.setProperty('ariaLive', v);
 	}
 
@@ -1392,11 +1392,11 @@ class TextComponentWrapper extends ComponentWrapper implements azdata.TextCompon
 		this.setProperty('textType', type);
 	}
 
-	public get ariaLive(): string | undefined {
+	public get ariaLive(): azdata.AriaLiveValue | undefined {
 		return this.properties['ariaLive'];
 	}
 
-	public set ariaLive(ariaLive: string | undefined) {
+	public set ariaLive(ariaLive: azdata.AriaLiveValue | undefined) {
 		this.setProperty('ariaLive', ariaLive);
 	}
 }

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1004,10 +1004,10 @@ class InputBoxWrapper extends ComponentWrapper implements azdata.InputBoxCompone
 		this.setProperty('value', v);
 	}
 
-	public get ariaLive(): azdata.AriaLiveValue {
+	public get ariaLive(): azdata.AriaLiveValue | undefined {
 		return this.properties['ariaLive'];
 	}
-	public set ariaLive(v: azdata.AriaLiveValue) {
+	public set ariaLive(v: azdata.AriaLiveValue | undefined) {
 		this.setProperty('ariaLive', v);
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #22165. This adds ariaLive to the option descriptions so that they get announced by the screenreader when the option description changes.
![optionsDescription3](https://user-images.githubusercontent.com/31145923/225709867-a8302e55-61a5-4a42-94e0-6ae86b6ceae0.gif)
