### PR TITLE
Preserve name and group when using Connection String

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -1216,13 +1216,13 @@ export class ConnectionWidget extends lifecycle.Disposable {
 				model.azureAccount = this.authToken;
 				model.savePassword = this._rememberPasswordCheckBox.checked;
 				model.databaseName = this.databaseName;
+				if (this._customOptionWidgets) {
+					this._customOptionWidgets.forEach((widget, i) => {
+						model.options[this._customOptions[i].name] = widget.value;
+					});
+				}
 			}
 			model.connectionName = this.connectionName;
-			if (this._customOptionWidgets) {
-				this._customOptionWidgets.forEach((widget, i) => {
-					model.options[this._customOptions[i].name] = widget.value;
-				});
-			}
 			if (this._serverGroupSelectBox) {
 				if (this._serverGroupSelectBox.value === this.DefaultServerGroup.name) {
 					model.groupFullName = '';

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -1205,7 +1205,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 				} catch (err) {
 					this._logService.error(`${this._providerName} Failed to parse the connection string : ${err}`)
 					this._errorMessageService.showDialog(Severity.Error, localize('connectionWidget.Error', "Error"),
-						localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string. {0}", utils.getErrorMessage(err)));
+						localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string. {0}", utils.getErrorMessage(err)), err.stack);
 					return false;
 				}
 			} else {

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -20,6 +20,7 @@ import { IAccountManagementService } from 'sql/platform/accounts/common/interfac
 
 import * as azdata from 'azdata';
 
+import * as utils from 'vs/base/common/errors';
 import * as lifecycle from 'vs/base/common/lifecycle';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { localize } from 'vs/nls';
@@ -1197,17 +1198,14 @@ export class ConnectionWidget extends lifecycle.Disposable {
 				try {
 					const connInfo = await this._connectionManagementService.buildConnectionInfo(this.connectionString, this._providerName);
 					if (!connInfo) {
-						this._logService.error(`${this._providerName}.buildConnectionInfo returned an undefined value.`)
-						this._errorMessageService.showDialog(Severity.Error, localize('connectionWidget.Error', "Error"), localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string."),);
-						return false;
+						throw Error(localize('connectionWidget.ConnectionStringUndefined', 'No connection info returned.'));
 					}
 					model.options = connInfo.options;
 					model.savePassword = true;
 				} catch (err) {
-					this._logService.error(`Failed to parse the connection string : ${err}`)
+					this._logService.error(`${this._providerName} Failed to parse the connection string : ${err}`)
 					this._errorMessageService.showDialog(Severity.Error, localize('connectionWidget.Error', "Error"),
-						localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string."),
-						String(err));
+						localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string. {0}", utils.getErrorMessage(err)));
 					return false;
 				}
 			} else {

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -1194,12 +1194,17 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		let validInputs = this.validateInputs();
 		if (validInputs) {
 			if (this.useConnectionString) {
-				const connInfo = await this._connectionManagementService.buildConnectionInfo(this.connectionString, this._providerName);
-				if (connInfo) {
+				try {
+					const connInfo = await this._connectionManagementService.buildConnectionInfo(this.connectionString, this._providerName);
+					if (!connInfo) {
+						throw Error(this._providerName + ".buildConnectionInfo had an undefined result.");
+					}
 					model.options = connInfo.options;
 					model.savePassword = true;
-				} else {
-					this._errorMessageService.showDialog(Severity.Error, localize('connectionWidget.Error', "Error"), localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string."));
+				} catch (err) {
+					this._errorMessageService.showDialog(Severity.Error, localize('connectionWidget.Error', "Error"),
+						localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string."),
+						String(err));
 					return false;
 				}
 			} else {

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -1209,26 +1209,26 @@ export class ConnectionWidget extends lifecycle.Disposable {
 				model.authenticationType = this.authenticationType;
 				model.azureAccount = this.authToken;
 				model.savePassword = this._rememberPasswordCheckBox.checked;
-				model.connectionName = this.connectionName;
 				model.databaseName = this.databaseName;
-				if (this._customOptionWidgets) {
-					this._customOptionWidgets.forEach((widget, i) => {
-						model.options[this._customOptions[i].name] = widget.value;
-					});
-				}
-				if (this._serverGroupSelectBox) {
-					if (this._serverGroupSelectBox.value === this.DefaultServerGroup.name) {
-						model.groupFullName = '';
-						model.saveProfile = true;
-						model.groupId = this.findGroupId(model.groupFullName);
-					} else if (this._serverGroupSelectBox.value === this.NoneServerGroup.name) {
-						model.groupFullName = '';
-						model.saveProfile = false;
-					} else if (this._serverGroupSelectBox.value !== this._addNewServerGroup.name) {
-						model.groupFullName = this._serverGroupSelectBox.value;
-						model.saveProfile = true;
-						model.groupId = this.findGroupId(model.groupFullName);
-					}
+			}
+			model.connectionName = this.connectionName;
+			if (this._customOptionWidgets) {
+				this._customOptionWidgets.forEach((widget, i) => {
+					model.options[this._customOptions[i].name] = widget.value;
+				});
+			}
+			if (this._serverGroupSelectBox) {
+				if (this._serverGroupSelectBox.value === this.DefaultServerGroup.name) {
+					model.groupFullName = '';
+					model.saveProfile = true;
+					model.groupId = this.findGroupId(model.groupFullName);
+				} else if (this._serverGroupSelectBox.value === this.NoneServerGroup.name) {
+					model.groupFullName = '';
+					model.saveProfile = false;
+				} else if (this._serverGroupSelectBox.value !== this._addNewServerGroup.name) {
+					model.groupFullName = this._serverGroupSelectBox.value;
+					model.saveProfile = true;
+					model.groupId = this.findGroupId(model.groupFullName);
 				}
 			}
 		}

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -1197,11 +1197,14 @@ export class ConnectionWidget extends lifecycle.Disposable {
 				try {
 					const connInfo = await this._connectionManagementService.buildConnectionInfo(this.connectionString, this._providerName);
 					if (!connInfo) {
-						throw Error(this._providerName + ".buildConnectionInfo had an undefined result.");
+						this._logService.error(`${this._providerName}.buildConnectionInfo returned an undefined value.`)
+						this._errorMessageService.showDialog(Severity.Error, localize('connectionWidget.Error', "Error"), localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string."),);
+						return false;
 					}
 					model.options = connInfo.options;
 					model.savePassword = true;
 				} catch (err) {
+					this._logService.error(`Failed to parse the connection string : ${err}`)
 					this._errorMessageService.showDialog(Severity.Error, localize('connectionWidget.Error', "Error"),
 						localize('connectionWidget.ConnectionStringError', "Failed to parse the connection string."),
 						String(err));


### PR DESCRIPTION
Optional name and grouping should not be ignored
when creating a new connection using a connection string.

<img width="498" alt="grafik" src="https://user-images.githubusercontent.com/951587/226760951-c132971a-02d8-4704-95dc-aef9bbe0e33b.png">

<img width="240" alt="grafik" src="https://user-images.githubusercontent.com/951587/226761169-fee924ea-a959-4538-9b4b-1221ca548913.png">


This PR fixes https://github.com/Azure/azure-cosmosdb-ads-extension/issues/46

Also improves error handling if the extension failed to parse the connection string:

<img width="643" alt="grafik" src="https://user-images.githubusercontent.com/951587/226760611-d3e0debb-92bc-4a75-968f-07f853455b63.png">
<img width="642" alt="grafik" src="https://user-images.githubusercontent.com/951587/226760672-9cea80e9-0920-4cd5-b084-20969fae1293.png">

"Copy details" will copy the error message and the stacktrace to the clipboard.