### PR TITLE
update the display name

### DIFF
--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -195,6 +195,6 @@
 	"title.newDatabaseRole": "New Database Role",
 	"title.newApplicationRole": "New Application Role",
 	"title.newUser": "New User",
-	"title.objectProperties": "Properties",
+	"title.objectProperties": "Properties (Preview)",
 	"title.deleteObject": "Delete"
 }


### PR DESCRIPTION
This PR fixes #22340

![image](https://user-images.githubusercontent.com/13777222/225717674-a89377cd-8093-48f7-954f-9f8f32380a1c.png)


add a preview label for the new ADS properties dialog to differentiate it from the SSMS-Min menu item. when the new feature is ready for GA, I'll update the SSMS-Min extension and remove the menu item contributions for the node types we support natively in ADS.

for the comment about move the new `Properties` menu item to the bottom of the default group, it is not possible due to the way we implemented it in core, `Refresh` will always be the last one in the default group. 


@aasimkhan30 could you please work with the PM to define the menu item order/grouping guideline?