### PR TITLE
Add fix to enter press on last row of Edit Data.

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -1214,7 +1214,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		let valueToDisplay = '';
 		let cellClasses = 'grid-cell-value-container';
 		/* tslint:disable:no-null-keyword */
-		let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull) || value === 'NULL';
+		let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && (value.isNull || value.displayValue.length === 0)) || value === 'NULL';
 		let isStringNull = (Services.DBCellValue.isDBCellValue(value) && !value.isNull && value.displayValue === 'NULL');
 		if (valueMissing) {
 			valueToDisplay = 'NULL';


### PR DESCRIPTION
Since SlickGrid cannot move to the non existent new row when enter is pressed and therefore cannot trigger the cell submission process, this code will manually call the cell submission process if we press enter on the null row, then move to the newly created row below if successful. Invalid edits have been tested to work. Additionally, empty cells with a blank display value that aren't null are now properly treated as empty null cells (previously they weren't, causing blank spaces to appear after a new row has been added)

Valid edit and refresh afterwards:
![ValidEditWithEnterPress](https://user-images.githubusercontent.com/18018452/225748660-b108a5ed-3590-4b08-8287-6b98af195c85.gif)

Invalid edit and correct one afterwards:
![InvalidEditWithEnterPress](https://user-images.githubusercontent.com/18018452/225749242-94ae0555-8ff0-4071-8730-73193d4bfa6b.gif)

Fixes #19126

