### PR TITLE
change system dbs back to lowercase in sql projects

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -21,8 +21,8 @@ export const openApiSpecFileExtensions = ['yaml', 'yml', 'json'];
 
 //#region Placeholder values
 export const schemaCompareExtensionId = 'microsoft.schema-compare';
-export const master = 'Master';
-export const msdb = 'MSDB';
+export const master = 'master';
+export const msdb = 'msdb';
 export const MicrosoftDatatoolsSchemaSqlSql = 'Microsoft.Data.Tools.Schema.Sql.Sql';
 export const databaseSchemaProvider = 'DatabaseSchemaProvider';
 export const sqlProjectSdk = 'Microsoft.Build.Sql';


### PR DESCRIPTION
I had changed these last week in https://github.com/microsoft/azuredatastudio/pull/22215 because DacFx was expecting the uppercase values, but after discussion, changing them back to lowercase since that's the more common way to see them cased. A separate change will be made in DacFx to handle the different casing.

lowercase system db names back in the UI:
![image](https://user-images.githubusercontent.com/31145923/225769954-bcd571a0-018c-4b9d-a995-27440807e975.png)
