### PR TITLE
add aria-label to announce checkbox status for checkbox column

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -91,8 +91,9 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 	private checkboxSelectionFormatter(row: number, cell: number, value: any, columnDef: Slick.Column<T>, dataContext: T): string {
 		const state = this.getCheckboxPropertyValue(row);
 		const checked = state.checked ? 'checked' : '';
+		const ariaLabelStatus = state.checked ? 'checked' : 'unchecked';
 		const enable = state.enabled ? '' : 'disabled';
-		return `<input type="checkbox" style="pointer-events: none;" tabIndex="-1" ${checked} ${enable}/>`;
+		return `<input type="checkbox" style="pointer-events: none;" tabIndex="-1" aria-label="checkbox ${ariaLabelStatus}" ${checked} ${enable}/>`;
 	}
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses the checkbox status being announced part of https://github.com/microsoft/azuredatastudio/issues/22156 should also address https://github.com/microsoft/azuredatastudio/issues/22187.

The aria-label for the checkbox select column was originally added back in https://github.com/microsoft/azuredatastudio/pull/7008, moved in https://github.com/microsoft/azuredatastudio/pull/13644, then was removed last year in https://github.com/microsoft/azuredatastudio/pull/20514. This PR brings back the aria-label so that "checkbox checked" or "checkbox unchecked" gets announced when the focus is on the checkbox in a table.

before:
![checkboxBefore](https://user-images.githubusercontent.com/31145923/225990157-d62d12e2-cf5b-473a-aa6d-28a2d70c33aa.gif)

after:
![checkboxChecked](https://user-images.githubusercontent.com/31145923/225989772-97d85b36-236e-40f1-a165-f3f0d7c17f17.gif)
