### PR TITLE
Update ads-extension-telemetry to 3.0.1

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -107,7 +107,7 @@
     ]
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
     "vscode-nls": "^4.1.2"
   },

--- a/extensions/admin-tool-ext-win/yarn.lock
+++ b/extensions/admin-tool-ext-win/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -213,7 +213,7 @@
     "figures": "^2.0.0",
     "find-remove": "1.2.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/azuremonitor/yarn.lock
+++ b/extensions/azuremonitor/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -92,7 +92,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "htmlparser2": "^3.10.1",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/dacpac/yarn.lock
+++ b/extensions/dacpac/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -179,7 +179,7 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.7",
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "vscode-nls": "^4.0.0"
   },
   "devDependencies": {

--- a/extensions/data-workspace/yarn.lock
+++ b/extensions/data-workspace/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/datavirtualization/package.json
+++ b/extensions/datavirtualization/package.json
@@ -105,7 +105,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.2",
     "vscode-nls": "^5.2.0"

--- a/extensions/datavirtualization/yarn.lock
+++ b/extensions/datavirtualization/yarn.lock
@@ -206,10 +206,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -80,7 +80,7 @@
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.1",
     "htmlparser2": "^3.10.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "vscode-nls": "^4.1.2"
   },
   "devDependencies": {

--- a/extensions/import/yarn.lock
+++ b/extensions/import/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -431,7 +431,7 @@
     "figures": "^2.0.0",
     "find-remove": "1.2.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/kusto/yarn.lock
+++ b/extensions/kusto/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1449,7 +1449,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.2",
     "find-remove": "1.2.1",

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -683,7 +683,7 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^3.2.1",
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "adm-zip": "^0.4.14",
     "error-ex": "^1.3.1",
     "fast-glob": "^3.1.0",

--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -221,10 +221,10 @@
     "@phosphor/disposable" "^1.1.2"
     "@phosphor/signaling" "^1.2.2"
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -208,7 +208,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "vscode-nls": "^4.1.2"
   },
   "devDependencies": {

--- a/extensions/query-history/yarn.lock
+++ b/extensions/query-history/yarn.lock
@@ -228,10 +228,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -524,7 +524,7 @@
     ]
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "axios": "^0.27.2",
     "linux-release-info": "^2.0.0",
     "promisify-child-process": "^3.1.1",

--- a/extensions/resource-deployment/yarn.lock
+++ b/extensions/resource-deployment/yarn.lock
@@ -189,10 +189,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -111,7 +111,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "vscode-nls": "^4.0.0"
   },
   "devDependencies": {

--- a/extensions/schema-compare/yarn.lock
+++ b/extensions/schema-compare/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/sql-assessment/package.json
+++ b/extensions/sql-assessment/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "vscode-nls": "^4.1.2",
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "vscode-languageclient": "^5.3.0-next.1"
   },
   "__metadata": {

--- a/extensions/sql-assessment/yarn.lock
+++ b/extensions/sql-assessment/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -63,7 +63,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@microsoft/vscode-azext-utils": "^0.1.1",
     "fast-glob": "^3.2.7",
     "promisify-child-process": "^3.1.1",

--- a/extensions/sql-bindings/yarn.lock
+++ b/extensions/sql-bindings/yarn.lock
@@ -222,10 +222,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -508,7 +508,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@xmldom/xmldom": "0.8.4",
     "axios": "^0.27.2",
     "extract-zip": "^2.0.1",

--- a/extensions/sql-database-projects/yarn.lock
+++ b/extensions/sql-database-projects/yarn.lock
@@ -222,10 +222,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -164,7 +164,7 @@
   "dependencies": {
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
-    "@microsoft/ads-extension-telemetry": "^3.0.0",
+    "@microsoft/ads-extension-telemetry": "^3.0.1",
     "uuid": "^8.3.2",
     "vscode-nls": "^4.1.2"
   },

--- a/extensions/sql-migration/yarn.lock
+++ b/extensions/sql-migration/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@microsoft/ads-extension-telemetry@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.0.tgz#ca67d4b0adae3adb318b33f3312501b483a8df03"
-  integrity sha512-kDoGORLozfuspTeY2Zlrj2MKTCVWghs0pBxXBTSWYD0Sbre/+DHSPvKegCFWWgqep5xaxsyiHaGCXzRzZUb46Q==
+"@microsoft/ads-extension-telemetry@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-3.0.1.tgz#82d4288f8ad96920512ab4edf87d009412e683bb"
+  integrity sha512-OsHLKvz4DEZg9THkI+Jk4aINgYv4X3qgbqnVAqY8f9zsWTiR+o4vt/F5w0w3kwpbU3ppRHa03yFTBEjYyGSg1g==
   dependencies:
     "@vscode/extension-telemetry" "0.6.1"
 


### PR DESCRIPTION
Fix to exclude error message in error event stack traces when include error message isn't explicitly set to true. 