### PR TITLE
Notify STS when encryption keys are updated in azurecore

### DIFF
--- a/extensions/azurecore/src/account-provider/utils/fileEncryptionHelper.ts
+++ b/extensions/azurecore/src/account-provider/utils/fileEncryptionHelper.ts
@@ -9,12 +9,14 @@ import * as vscode from 'vscode';
 import { AuthLibrary } from '../../constants';
 import * as LocalizedConstants from '../../localizedConstants';
 import { Logger } from '../../utils/Logger';
+import { CacheEncryptionKeys } from 'azurecore';
 
 export class FileEncryptionHelper {
 	constructor(
 		private readonly _authLibrary: AuthLibrary,
 		private readonly _credentialService: azdata.CredentialProvider,
-		protected readonly _fileName: string
+		protected readonly _fileName: string,
+		private readonly _onEncryptionKeysUpdated?: vscode.EventEmitter<CacheEncryptionKeys>
 	) {
 		this._algorithm = this._authLibrary === AuthLibrary.MSAL ? 'aes-256-cbc' : 'aes-256-gcm';
 		this._bufferEncoding = this._authLibrary === AuthLibrary.MSAL ? 'utf16le' : 'hex';
@@ -47,6 +49,14 @@ export class FileEncryptionHelper {
 		} else {
 			this._ivBuffer = Buffer.from(iv, this._bufferEncoding);
 			this._keyBuffer = Buffer.from(key, this._bufferEncoding);
+		}
+
+		// Emit event with cache encryption keys to send notification to provider services.
+		if (this._authLibrary === AuthLibrary.MSAL && this._onEncryptionKeysUpdated) {
+			this._onEncryptionKeysUpdated.fire({
+				iv: this._ivBuffer.toString(this._bufferEncoding),
+				key: this._keyBuffer.toString(this._bufferEncoding)
+			});
 		}
 	}
 

--- a/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
+++ b/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
@@ -9,18 +9,21 @@ import { promises as fsPromises } from 'fs';
 import * as lockFile from 'lockfile';
 import * as path from 'path';
 import * as azdata from 'azdata';
+import * as vscode from 'vscode';
 import { AccountsClearTokenCacheCommand, AuthLibrary } from '../../constants';
 import { Logger } from '../../utils/Logger';
 import { FileEncryptionHelper } from './fileEncryptionHelper';
+import { CacheEncryptionKeys } from 'azurecore';
 
 export class MsalCachePluginProvider {
 	constructor(
 		private readonly _serviceName: string,
 		private readonly _msalFilePath: string,
-		private readonly _credentialService: azdata.CredentialProvider
+		private readonly _credentialService: azdata.CredentialProvider,
+		private readonly _onEncryptionKeysUpdated: vscode.EventEmitter<CacheEncryptionKeys>
 	) {
 		this._msalFilePath = path.join(this._msalFilePath, this._serviceName);
-		this._fileEncryptionHelper = new FileEncryptionHelper(AuthLibrary.MSAL, this._credentialService, this._serviceName);
+		this._fileEncryptionHelper = new FileEncryptionHelper(AuthLibrary.MSAL, this._credentialService, this._serviceName, this._onEncryptionKeysUpdated);
 	}
 
 	private _lockTaken: boolean = false;

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -316,10 +316,11 @@ declare module 'azurecore' {
 		provideResources(): azureResource.IAzureResourceProvider[];
 		runGraphQuery<T extends azureResource.AzureGraphResource>(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors: boolean, query: string): Promise<ResourceQueryResult<T>>;
 		/**
-		 * Event emitted when encryption keys are updated in credential store.
-		 * Returns encryption keys for connection providers use.
+		 * Event emitted when MSAL cache encryption keys are updated in credential store.
+		 * Returns encryption keys used for encryption/decryption of MSAL cache that can be used
+		 * by connection providers to read/write to the same access token cache for stable connectivity.
 		 */
-		getOnEncryptionKeysUpdated: vscode.Event<CacheEncryptionKeys>;
+		onEncryptionKeysUpdated: vscode.Event<CacheEncryptionKeys>;
 	}
 
 	export type GetSubscriptionsResult = { subscriptions: azureResource.AzureResourceSubscription[], errors: Error[] };

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -317,7 +317,7 @@ declare module 'azurecore' {
 		runGraphQuery<T extends azureResource.AzureGraphResource>(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors: boolean, query: string): Promise<ResourceQueryResult<T>>;
 		/**
 		 * Event emitted when encryption keys are updated in credential store.
-		 * Returns Credential Ids for connection providers use.
+		 * Returns encryption keys for connection providers use.
 		 */
 		getOnEncryptionKeysUpdated: vscode.Event<CacheEncryptionKeys>;
 	}

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -5,7 +5,7 @@
 
 declare module 'azurecore' {
 	import * as azdata from 'azdata';
-	import { TreeDataProvider } from 'vscode';
+	import * as vscode from 'vscode';
 	import { BlobItem } from '@azure/storage-blob';
 
 	/**
@@ -314,8 +314,12 @@ declare module 'azurecore' {
 		getRegionDisplayName(region?: string): string;
 		getProviderMetadataForAccount(account: AzureAccount): AzureAccountProviderMetadata;
 		provideResources(): azureResource.IAzureResourceProvider[];
-
 		runGraphQuery<T extends azureResource.AzureGraphResource>(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors: boolean, query: string): Promise<ResourceQueryResult<T>>;
+		/**
+		 * Event emitted when encryption keys are updated in credential store.
+		 * Returns Credential Ids for connection providers use.
+		 */
+		getOnEncryptionKeysUpdated: vscode.Event<CacheEncryptionKeys>;
 	}
 
 	export type GetSubscriptionsResult = { subscriptions: azureResource.AzureResourceSubscription[], errors: Error[] };
@@ -333,6 +337,7 @@ declare module 'azurecore' {
 	export type AzureRestResponse = { response: any, errors: Error[] };
 	export type GetBlobsResult = { blobs: azureResource.Blob[], errors: Error[] };
 	export type GetStorageAccountAccessKeyResult = { keyName1: string, keyName2: string, errors: Error[] };
+	export type CacheEncryptionKeys = { key: string; iv: string; }
 
 	export namespace azureResource {
 

--- a/extensions/machine-learning/src/test/stubs.ts
+++ b/extensions/machine-learning/src/test/stubs.ts
@@ -61,5 +61,6 @@ export class AzurecoreApiStub implements azurecore.IExtension {
 	provideResources(): azurecore.azureResource.IAzureResourceProvider[] {
 		throw new Error('Method not implemented.');
 	}
+	getOnEncryptionKeysUpdated: any
 
 }

--- a/extensions/machine-learning/src/test/stubs.ts
+++ b/extensions/machine-learning/src/test/stubs.ts
@@ -61,6 +61,6 @@ export class AzurecoreApiStub implements azurecore.IExtension {
 	provideResources(): azurecore.azureResource.IAzureResourceProvider[] {
 		throw new Error('Method not implemented.');
 	}
-	getOnEncryptionKeysUpdated: any
+	onEncryptionKeysUpdated: any
 
 }

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1615,3 +1615,25 @@ export namespace RenameObjectRequest {
 }
 
 // ------------------------------- < Object Management > ------------------------------------
+
+// ------------------------------- < Encryption IV/KEY updation Event > ------------------------------------
+/**
+ * Parameters for the MSAL cache encryption key notification
+ */
+export class DidChangeEncryptionIVKeyParams {
+	/**
+	 * Buffer encoded IV string for MSAL cache encryption
+	 */
+	public iv: string;
+	/**
+	 * Buffer encoded Key string for MSAL cache encryption
+	 */
+	public key: string;
+}
+
+/**
+ * Notification sent when the encryption keys are changed.
+ */
+export namespace EncryptionKeysChangedNotification {
+	export const type = new NotificationType<DidChangeEncryptionIVKeyParams, void>('connection/encryptionKeysChanged');
+}

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -100,7 +100,7 @@ export class SqlToolsServer {
 	 */
 	private async handleEncryptionKeyEventNotification(client: SqlOpsDataClient) {
 		if (getAzureAuthenticationLibraryConfig() === 'MSAL' && getEnableSqlAuthenticationProviderConfig()) {
-			let onDidEncryptionKeysChanged = (await this.getAzureCoreAPI()).getOnEncryptionKeysUpdated;
+			let onDidEncryptionKeysChanged = (await this.getAzureCoreAPI()).onEncryptionKeysUpdated;
 			// Register event listener from Azure Core extension
 			onDidEncryptionKeysChanged((keys: azurecore.CacheEncryptionKeys) => {
 				// Send client notification for updated encryption keys
@@ -116,7 +116,7 @@ export class SqlToolsServer {
 	private async getAzureCoreAPI(): Promise<azurecore.IExtension> {
 		const api = (await vscode.extensions.getExtension(azurecore.extension.name)?.activate()) as azurecore.IExtension;
 		if (!api) {
-			throw new Error('azure core API undefined for mssql extension');
+			throw new Error('Azure core extension could not be activated.');
 		}
 		return api;
 	}

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -9,6 +9,7 @@ import * as Constants from './constants';
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as path from 'path';
+import * as azurecore from 'azurecore';
 import { getAzureAuthenticationLibraryConfig, getCommonLaunchArgsAndCleanupOldLogFiles, getConfigTracingLevel, getEnableSqlAuthenticationProviderConfig, getOrDownloadServer, getParallelMessageProcessingConfig, TracingLevel } from './utils';
 import { TelemetryReporter, LanguageClientErrorHandler } from './telemetry';
 import { SqlOpsDataClient, ClientOptions } from 'dataprotocol-client';
@@ -19,7 +20,7 @@ import { SchemaCompareService } from './schemaCompare/schemaCompareService';
 import { AppContext } from './appContext';
 import { DacFxService } from './dacfx/dacFxService';
 import { CmsService } from './cms/cmsService';
-import { CompletionExtensionParams, CompletionExtLoadRequest } from './contracts';
+import { CompletionExtensionParams, CompletionExtLoadRequest, DidChangeEncryptionIVKeyParams, EncryptionKeysChangedNotification } from './contracts';
 import { promises as fs } from 'fs';
 import * as nls from 'vscode-nls';
 import { LanguageExtensionService } from './languageExtension/languageExtensionService';
@@ -82,12 +83,42 @@ export class SqlToolsServer {
 			statusView.text = localize('startingServiceStatusMsg', "Starting {0}", Constants.serviceName);
 			this.client.start();
 			await Promise.all([this.activateFeatures(context), clientReadyPromise]);
+			await this.handleEncryptionKeyEventNotification(this.client);
 			return this.client;
 		} catch (e) {
 			TelemetryReporter.sendTelemetryEvent('ServiceInitializingFailed');
 			void vscode.window.showErrorMessage(localize('failedToStartServiceErrorMsg', "Failed to start {0}", Constants.serviceName));
 			throw e;
 		}
+	}
+
+	/**
+	 * This is a hop notification handler to send Encryption Key and Iv information from Azure Core extension to backend
+	 * SqlToolsService. This notification is needed for Azure authentication flows to be able to read/write into
+	 * shared MSAL cache.
+	 * @param client SqlOpsDataClient instance
+	 */
+	private async handleEncryptionKeyEventNotification(client: SqlOpsDataClient) {
+		if (getAzureAuthenticationLibraryConfig() === 'MSAL' && getEnableSqlAuthenticationProviderConfig()) {
+			let onDidEncryptionKeysChanged = (await this.getAzureCoreAPI()).getOnEncryptionKeysUpdated;
+			// Register event listener from Azure Core extension
+			onDidEncryptionKeysChanged((keys: azurecore.CacheEncryptionKeys) => {
+				// Send client notification for updated encryption keys
+				client.sendNotification(EncryptionKeysChangedNotification.type,
+					<DidChangeEncryptionIVKeyParams>{
+						key: keys.key,
+						iv: keys.iv
+					});
+			});
+		}
+	}
+
+	private async getAzureCoreAPI(): Promise<azurecore.IExtension> {
+		const api = (await vscode.extensions.getExtension(azurecore.extension.name)?.activate()) as azurecore.IExtension;
+		if (!api) {
+			throw new Error('azure core API undefined for mssql extension');
+		}
+		return api;
 	}
 
 	private async download(context: AppContext): Promise<string> {


### PR DESCRIPTION
Sends notification to backend SqlToolsService to update encryption keys in a cross-platform compatible way.. 
Addresses https://github.com/microsoft/azuredatastudio/issues/22364 paired with https://github.com/microsoft/sqltoolsservice/pull/1955