### PR TITLE
Bump tools service to 4.6.0.14

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.6.0.13",
+	"version": "4.6.0.14",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/1609827/226667303-21609253-c71b-4cad-977a-0987e5726be0.png">

the commit titled "bump tools service" should really be "bump DacFx.Packages"; my bad.