### PR TITLE
switch exclude object types table to use declarative table component

### DIFF
--- a/extensions/sql-database-projects/src/common/uiConstants.ts
+++ b/extensions/sql-database-projects/src/common/uiConstants.ts
@@ -11,6 +11,10 @@ export namespace cssStyles {
 	export const fontWeightBold = { 'font-weight': 'bold' };
 	export const titleFontSize = 13;
 
+	export const optionsTableHeader = { 'display': 'none', 'border': 'none !important' };
+	export const optionsTableRowLabel = { ...text, 'border-left': 'none', 'border-right': 'none', 'border-top': 'none', 'border-bottom': 'none' }
+	export const optionsTableRowCheckbox = { 'border-left': 'none', 'border-right': 'none', 'border-top': 'none', 'border-bottom': 'none' }
+
 	export const publishDialogLabelWidth = '205px';
 	export const publishDialogTextboxWidth = '190px';
 	export const publishDialogDropdownWidth = '192px';

--- a/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishOptionsDialog.ts
@@ -11,6 +11,7 @@ import type * as azdataType from 'azdata';
 import { PublishDatabaseDialog } from './publishDatabaseDialog';
 import { DeployOptionsModel } from '../models/options/deployOptionsModel';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
+import { cssStyles } from '../common/uiConstants';
 
 export class PublishOptionsDialog {
 
@@ -25,7 +26,7 @@ export class PublishOptionsDialog {
 	private optionsChanged: boolean = false;
 	private isResetOptionsClicked: boolean = false;
 	private excludeObjectTypesOptionsTab: azdataType.window.DialogTab | undefined;
-	private excludeObjectTypesOptionsTable: azdataType.TableComponent | undefined;
+	private excludeObjectTypesOptionsTable: azdataType.DeclarativeTableComponent | undefined;
 	private excludeObjectTypesOptionsFlexBuilder: azdataType.FlexContainer | undefined;
 
 	constructor(defaultOptions: mssql.DeploymentOptions, private publish: PublishDatabaseDialog) {
@@ -135,21 +136,39 @@ export class PublishOptionsDialog {
 
 	private initializeExcludeObjectTypesOptionsDialogTab(): void {
 		this.excludeObjectTypesOptionsTab?.registerContent(async view => {
-			this.excludeObjectTypesOptionsTable = view.modelBuilder.table().component();
+			this.excludeObjectTypesOptionsTable = view.modelBuilder.declarativeTable().withProps({
+				width: '480px',
+				columns: [
+					{
+						valueType: utils.getAzdataApi()!.DeclarativeDataType.boolean,
+						width: '10%',
+						isReadOnly: false,
+						displayName: '',
+						headerCssStyles: cssStyles.optionsTableHeader,
+					},
+					{
+						valueType: utils.getAzdataApi()!.DeclarativeDataType.string,
+						width: '90%',
+						displayName: '',
+						isReadOnly: true,
+						headerCssStyles: cssStyles.optionsTableHeader,
+					}
+				],
+			}).component();
 			await this.updateExcludeObjectsTable();
 
 			// Update exclude type options value on checkbox onchange
-			this.disposableListeners.push(this.excludeObjectTypesOptionsTable!.onCellAction!((rowState) => {
-				const checkboxState = <azdataType.ICheckboxCellActionEventArgs>rowState;
-				if (checkboxState && checkboxState.row !== undefined) {
-					// data[row][1] contains the exclude type option display name
-					const displayName = this.excludeObjectTypesOptionsTable?.data[checkboxState.row][1];
-					this.optionsModel.setExcludeObjectTypesOptionValue(displayName, checkboxState.checked);
-					this.optionsChanged = true;
-					// customButton[0] is the reset button, enabling it when option checkbox is changed
-					this.dialog.customButtons[0].enabled = true;
-				}
-			}));
+			this.excludeObjectTypesOptionsTable.onDataChanged(() => {
+				this.excludeObjectTypesOptionsTable!.dataValues?.forEach((row) => {
+					const displayName = <string>row[1].value;
+					const checkboxValue = <boolean>row[0].value;
+					this.optionsModel.setExcludeObjectTypesOptionValue(displayName, checkboxValue);
+				});
+				this.optionsChanged = true;
+
+				// customButton[0] is the reset button, enabling it when option checkbox is changed
+				this.dialog.customButtons[0].enabled = true;
+			});
 
 			this.excludeObjectTypesOptionsFlexBuilder = view.modelBuilder.flexContainer()
 				.withLayout({
@@ -194,25 +213,9 @@ export class PublishOptionsDialog {
 	*/
 	private async updateExcludeObjectsTable(): Promise<void> {
 		const data = this.optionsModel.getExcludeObjectTypesOptionsData();
+		await this.excludeObjectTypesOptionsTable?.setDataValues(data);
+
 		await this.excludeObjectTypesOptionsTable?.updateProperties({
-			data: data,
-			columns: [
-				<azdataType.CheckboxColumn>
-				{
-					value: constants.OptionInclude,
-					type: utils.getAzdataApi()!.ColumnType.checkBox,
-					action: utils.getAzdataApi()!.ActionOnCellCheckboxCheck.customAction,
-					headerCssClass: 'display-none',
-					cssClass: 'no-borders align-with-header',
-					width: 50
-				},
-				{
-					value: constants.OptionName,
-					headerCssClass: 'display-none',
-					cssClass: 'no-borders align-with-header',
-					width: 50
-				}
-			],
 			ariaRowCount: data.length
 		});
 	}

--- a/extensions/sql-database-projects/src/models/options/deployOptionsModel.ts
+++ b/extensions/sql-database-projects/src/models/options/deployOptionsModel.ts
@@ -6,6 +6,7 @@
 import * as mssql from 'mssql';
 import * as vscode from 'vscode';
 import * as constants from '../../common/constants';
+import { cssStyles } from '../../common/uiConstants';
 
 export class DeployOptionsModel {
 	// key is the option display name and values are checkboxValue and optionName
@@ -93,10 +94,19 @@ export class DeployOptionsModel {
 		let data: any[][] = [];
 		Object.entries(this.deploymentOptions.objectTypesDictionary).forEach(option => {
 			// option[1] is the display name and option[0] is the optionName
-			data.push([this.getExcludeObjectTypeOptionCheckStatus(option[0]), option[1]]);
+			data.push([
+				{
+					value: this.getExcludeObjectTypeOptionCheckStatus(option[0]),
+					style: cssStyles.optionsTableRowCheckbox,
+					ariaLabel: option[1]
+				},
+				{
+					value: option[1],
+					style: cssStyles.optionsTableRowLabel
+				}]);
 		});
 
-		return data.sort((a, b) => a[1].localeCompare(b[1]));
+		return data.sort((a, b) => a[1].value.localeCompare(b[1].value));
 	}
 
 	/*


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses some of the accessibility issues with the row counts and checkbox status not getting announced. These issues seemed related to the use of slickgrid in the `TableComponent` for virtual scrolling. Since this table always has around 70 rows, it doesn't need that functionality and switching to the `DeclarativeTableComponent`

 - Rows with the checkbox checked getting skipped https://github.com/microsoft/azuredatastudio/issues/22189
 - checkbox state not getting announced https://github.com/microsoft/azuredatastudio/issues/22187
 - wrong row number being announced https://github.com/microsoft/azuredatastudio/issues/22162

before:
<img width="496" alt="Screen Shot 2023-03-21 at 11 31 45 AM" src="https://user-images.githubusercontent.com/31145923/226707563-87552af2-5687-4f9b-98df-e0fc0d242be9.png">


after:

<img width="548" alt="Screen Shot 2023-03-21 at 11 31 07 AM" src="https://user-images.githubusercontent.com/31145923/226707532-212bae0d-eb0f-4389-8d63-84eb46371960.png">

mac - Voiceover:
![objectTpesDeclarativeTable](https://user-images.githubusercontent.com/31145923/226703617-1b8f2e5d-d3be-4cda-8395-5bc96eb536b8.gif)

windows - NVDA:
![windowsExcludeOptions](https://user-images.githubusercontent.com/31145923/226707836-083d52dc-7a10-4069-b7fd-ec392b98ffc3.gif)

