### PR TITLE
Add aria label for checkboxes in declarative table

### DIFF
--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -242,6 +242,8 @@ export default class DeclarativeTableComponent extends ContainerBase<any, azdata
 			} else {
 				return localize('blankValue', "blank");
 			}
+		} else if (cellData?.ariaLabel) {
+			return cellData.ariaLabel;
 		}
 
 		return '';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes addresses the accessibility issue https://github.com/microsoft/azuredatastudio/issues/22156 where users using a screenreader wouldn't know what the checkboxes in the table correspond to. 

Before this change, the ariaLabel property for `DeclarativeTableCellValue` was only getting set if the cell type was `string`. This change makes it so that the `ariaLabel` of the cell will get set if the property is set for non-string cells.

checkbox in DeclarativeTable with aria label set (the aria label is the string getting announced before the row number):
![nvdaCheckboxAriaLabel](https://user-images.githubusercontent.com/31145923/226749940-e112c9ae-cbc6-4361-8a23-e1663ab1f010.gif)
