### PR TITLE
Fix incorrect default for proxy setting when downloading STS

### DIFF
--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -96,7 +96,7 @@ export class SqlToolsServer {
 		this.config = JSON.parse(rawConfig.toString());
 		this.config.installDirectory = path.join(configDir, this.config.installDirectory);
 		this.config.proxy = vscode.workspace.getConfiguration('http').get('proxy');
-		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
+		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL', true);
 		return getOrDownloadServer(this.config, handleServerProviderEvent);
 	}
 


### PR DESCRIPTION
Fixing up the strict null stuff and noticed this was being done incorrectly - it will always evaluate to true. We should be using the default value parameter of `get` instead. 