### PR TITLE
change publish options to use declarative table

### DIFF
--- a/extensions/sql-database-projects/src/models/options/deployOptionsModel.ts
+++ b/extensions/sql-database-projects/src/models/options/deployOptionsModel.ts
@@ -39,10 +39,20 @@ export class DeployOptionsModel {
 		let data: any[][] = [];
 		Object.entries(this.deploymentOptions.booleanOptionsDictionary).forEach(option => {
 			// option[1] holds checkedbox value and displayName
-			data.push([option[1].value, option[1].displayName]);
+			data.push([
+				{
+					value: option[1].value,
+					style: cssStyles.optionsTableRowCheckbox,
+					ariaLabel: option[1].displayName
+				},
+				{
+					value: option[1].displayName,
+					style: cssStyles.optionsTableRowLabel,
+				}
+			]);
 		});
 
-		return data.sort((a, b) => a[1].localeCompare(b[1]));
+		return data.sort((a, b) => a[1].value.localeCompare(b[1].value));
 	}
 
 	/*


### PR DESCRIPTION
Similar to the change made in https://github.com/microsoft/azuredatastudio/pull/22390 for the exclude object types table, this updates the other tab, publish options, to use `DeclarativeTableComponent` instead of `TableComponent` to avoid the accessibility issues of wrong row numbers being announced.

before:
<img width="504" alt="Screen Shot 2023-03-21 at 4 41 04 PM" src="https://user-images.githubusercontent.com/31145923/226766326-b2883499-02ac-4635-9bf7-1e90758eddf3.png">

after:
<img width="511" alt="Screen Shot 2023-03-21 at 4 40 27 PM" src="https://user-images.githubusercontent.com/31145923/226766317-3747689e-089f-4c39-a759-f935007ad127.png">

gif that shows the option description at the bottom still gets updated when the selected row changes and that the reset button still works:
![publishOptionsDeclarativeTable](https://user-images.githubusercontent.com/31145923/226765308-1b6feafb-a300-425b-b368-6a0d2fc02fd4.gif)
