### PR TITLE
More strict SSL proxy setting fixes

### DIFF
--- a/extensions/azuremonitor/src/azuremonitorServer.ts
+++ b/extensions/azuremonitor/src/azuremonitorServer.ts
@@ -72,7 +72,7 @@ export class AzureMonitorServer {
 		this.config = JSON.parse(rawConfig.toString())!;
 		this.config.installDirectory = path.join(__dirname, this.config.installDirectory);
 		this.config.proxy = vscode.workspace.getConfiguration('http').get<string>('proxy')!;
-		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
+		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL', true);
 
 		const serverdownloader = new ServerProvider(this.config);
 		serverdownloader.eventEmitter.onAny(generateHandleServerProviderEvent());

--- a/extensions/datavirtualization/src/services/serviceClient.ts
+++ b/extensions/datavirtualization/src/services/serviceClient.ts
@@ -30,7 +30,7 @@ export class ServiceClient {
 		const config: IConfig = JSON.parse(rawConfig.toString());
 		config.installDirectory = path.join(context.extensionPath, config.installDirectory);
 		config.proxy = this.apiWrapper.getConfiguration('http').get('proxy');
-		config.strictSSL = this.apiWrapper.getConfiguration('http').get('proxyStrictSSL') || true;
+		config.strictSSL = this.apiWrapper.getConfiguration('http').get('proxyStrictSSL', true);
 
 		const serverdownloader = new ServerProvider(config);
 		serverdownloader.eventEmitter.onAny(this.generateHandleServerProviderEvent());

--- a/extensions/import/src/services/serviceClient.ts
+++ b/extensions/import/src/services/serviceClient.ts
@@ -68,7 +68,7 @@ export class ServiceClient {
 		const config = JSON.parse(rawConfig.toString());
 		config.installDirectory = path.join(context.extensionPath, config.installDirectory);
 		config.proxy = vscode.workspace.getConfiguration('http').get('proxy');
-		config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
+		config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL', true);
 		const serverdownloader = new ServerProvider(config);
 		serverdownloader.eventEmitter.onAny(this.generateHandleServerProviderEvent());
 		return serverdownloader.getOrDownloadServer();

--- a/extensions/kusto/src/kustoServer.ts
+++ b/extensions/kusto/src/kustoServer.ts
@@ -70,7 +70,7 @@ export class KustoServer {
 		this.config = JSON.parse(rawConfig.toString())!;
 		this.config.installDirectory = path.join(__dirname, this.config.installDirectory);
 		this.config.proxy = vscode.workspace.getConfiguration('http').get<string>('proxy')!;
-		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
+		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL', true);
 
 		const serverdownloader = new ServerProvider(this.config);
 		serverdownloader.eventEmitter.onAny(generateHandleServerProviderEvent());

--- a/extensions/sql-migration/src/service/serviceClient.ts
+++ b/extensions/sql-migration/src/service/serviceClient.ts
@@ -81,7 +81,7 @@ export class ServiceClient {
 		const config = JSON.parse(rawConfig.toString());
 		config.installDirectory = path.join(context.extensionPath, config.installDirectory);
 		config.proxy = vscode.workspace.getConfiguration('http').get('proxy');
-		config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
+		config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL', true);
 		const serverdownloader = new ServerProvider(config);
 		serverdownloader.eventEmitter.onAny(this.generateHandleServerProviderEvent());
 		return serverdownloader.getOrDownloadServer();


### PR DESCRIPTION
Realize we had this same logic in a number of other extensions, so fixing this everywhere else...

This will currently always evaluate to true. We should be using the default value parameter of get instead for the fallback value.