### PR TITLE
Clean up buildConnectionInfo

### DIFF
--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -312,7 +312,7 @@ export interface IConnectionManagementService {
 	/**
 	 * Serialize connection string with optional provider
 	 */
-	buildConnectionInfo(connectionString: string, provider?: string): Thenable<azdata.ConnectionInfo>;
+	buildConnectionInfo(connectionString: string, provider?: string): Promise<azdata.ConnectionInfo>;
 
 	providerRegistered(providerId: string): boolean;
 	/**

--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -310,9 +310,9 @@ export interface IConnectionManagementService {
 	getConnectionString(connectionId: string, includePassword: boolean): Thenable<string>;
 
 	/**
-	 * Serialize connection string with optional provider
+	 * Deserialize connection string using the specified provider
 	 */
-	buildConnectionInfo(connectionString: string, provider?: string): Promise<azdata.ConnectionInfo>;
+	buildConnectionInfo(connectionString: string, provider: string): Promise<azdata.ConnectionInfo>;
 
 	providerRegistered(providerId: string): boolean;
 	/**

--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -286,7 +286,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 		return undefined!;
 	}
 
-	buildConnectionInfo(connectionString: string, provider?: string): Thenable<azdata.ConnectionInfo> {
+	buildConnectionInfo(connectionString: string, provider?: string): Promise<azdata.ConnectionInfo> {
 		return undefined!;
 	}
 

--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -286,7 +286,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 		return undefined!;
 	}
 
-	buildConnectionInfo(connectionString: string, provider?: string): Promise<azdata.ConnectionInfo> {
+	buildConnectionInfo(connectionString: string, provider: string): Promise<azdata.ConnectionInfo> {
 		return undefined!;
 	}
 

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1674,9 +1674,6 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		});
 	}
 
-	/**
-	 * Serialize connection with options provider
-	 */
 	public async buildConnectionInfo(connectionString: string, providerId: string): Promise<azdata.ConnectionInfo> {
 		const connectionProviderInfo = this._providers.get(providerId);
 		if (!connectionProviderInfo) {

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1676,16 +1676,14 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 	/**
 	 * Serialize connection with options provider
-	 * TODO this could be a map reduce operation
 	 */
-	public buildConnectionInfo(connectionString: string, provider: string): Thenable<azdata.ConnectionInfo> {
-		let connectionProvider = this._providers.get(provider);
-		if (connectionProvider) {
-			return connectionProvider.onReady.then(e => {
-				return e.buildConnectionInfo(connectionString);
-			});
+	public async buildConnectionInfo(connectionString: string, providerId: string): Promise<azdata.ConnectionInfo> {
+		const connectionProviderInfo = this._providers.get(providerId);
+		if (!connectionProviderInfo) {
+			throw new Error(nls.localize('connection.unknownProvider', "Unknown provider '{0}'", providerId));
 		}
-		return Promise.resolve(undefined);
+		const provider = await connectionProviderInfo.onReady;
+		return provider.buildConnectionInfo(connectionString)
 	}
 
 	public getProviderProperties(providerName: string): ConnectionProviderProperties {

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -938,6 +938,11 @@ suite('SQL ConnectionManagementService tests', () => {
 		assert.strictEqual(result.options, options);
 	});
 
+	test('buildConnectionInfo with unknown provider should throw', async () => {
+		let testConnectionString = 'test_connection_string';
+		await assert.rejects(() => connectionManagementService.buildConnectionInfo(testConnectionString, 'INVALID'));
+	});
+
 	test('removeConnectionProfileCredentials should return connection profile without password', () => {
 		let profile = Object.assign({}, connectionProfile);
 		connectionStore.setup(x => x.getProfileWithoutPassword(TypeMoq.It.isAny())).returns(() => {


### PR DESCRIPTION
Doing some quick cleanup I noticed while looking at this for https://github.com/microsoft/azuredatastudio/pull/22341

1. Since undefined has never been a part of the typings having it throw if it can't find the provider instead - especially now that we're displaying the error to the user
2. Converting to async for better readability (and Thenable->Promise since there's no need to use Thenable here)
3. Making provider required - maybe that was optional at some point in the past but it's definitely required now