### PR TITLE
Adding Schema migration in Sql Migration extension

### DIFF
--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -243,6 +243,24 @@ export function getTargetConnectionProfile(
 	};
 }
 
+export async function getSqlDbConnectionString(serverName: string,
+	tenantId: string,
+	databaseName: string,
+	userName: string,
+	password: string): Promise<string> {
+	const connectionProfile = await getSqlDbConnectionProfile(serverName,
+		tenantId,
+		databaseName,
+		userName,
+		password);
+	const result = await azdata.connection.connect(connectionProfile, false, false);
+	if (result.connected && result.connectionId) {
+		return azdata.connection.getConnectionString(result.connectionId, true);
+	}
+
+	return '';
+}
+
 export async function getSourceConnectionString(): Promise<string> {
 	return await azdata.connection.getConnectionString((await getSourceConnectionProfile()).connectionId, true);
 }

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -586,6 +586,7 @@ export const DATABASE_TABLE_REFRESH_LABEL = localize('sql.migration.database.tab
 export const DATABASE_TABLE_SOURCE_DATABASE_COLUMN_LABEL = localize('sql.migration.database.table.source.column.label', "Source database");
 export const DATABASE_TABLE_TARGET_DATABASE_COLUMN_LABEL = localize('sql.migration.database.table.target.column.label', "Target database");
 export const DATABASE_TABLE_SELECTED_TABLES_COLUMN_LABEL = localize('sql.migration.database.table.tables.column.label', "Select tables");
+export const DATABASE_TABLE_MIGRATE_SCHEMA_COLUMN_LABEL = localize('sql.migration.database.table.tables.column.label', "Migrate Schema");
 export const DATABASE_TABLE_CONNECTION_ERROR = localize('sql.migration.database.connection.error', "An error occurred while connecting to target migration database.");
 export function DATABASE_TABLE_CONNECTION_ERROR_MESSAGE(message: string): string {
 	return localize('sql.migration.database.connection.error.message', "Connection error:{0} {1}", EOL, message);
@@ -664,6 +665,7 @@ export function SELECT_DATABASE_TABLES_TITLE(targetDatabaseName: string): string
 	return localize('sql.migration.table.select.label', "Select tables for {0}", targetDatabaseName);
 }
 export const TABLE_SELECTION_EDIT = localize('sql.migration.table.selection.edit', "Edit");
+export const MIGRATE_SCHEMA_BUTTON = localize('sql.migration.table.selection.edit', "Migrate");
 
 export function TABLE_SELECTION_COUNT(selectedCount: number, rowCount: number): string {
 	return localize('sql.migration.table.selection.count', "{0} of {1}", selectedCount, rowCount);

--- a/extensions/sql-migration/src/models/sqlSchemaMigrationModel.ts
+++ b/extensions/sql-migration/src/models/sqlSchemaMigrationModel.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getSourceConnectionString, getSqlDbConnectionString } from '../api/sqlUtils';
+import { MigrationStateModel } from './stateMachine';
+
+export enum SchemaMigrationState {
+	NotStarted = 'NotStarted',
+	InProgress = 'InProgress',
+	Succeeded = 'Succeeded',
+	Failed = 'Failed',
+}
+
+export enum SchemaMigrationDbState {
+	InProgress = 'InProgress',
+	Succeeded = 'Succeeded',
+	Failed = 'Failed',
+}
+
+export interface SchemaMigrationResult {
+	perDbResult: SchemaMigrationPerDbResult[];
+	state: SchemaMigrationState;
+}
+
+export interface SchemaMigrationPerDbResult {
+	sourceDbName: string;
+	targetDbName: string;
+	status: SchemaMigrationDbState;
+}
+
+export class SqlSchemaMigrationModel {
+	public schemaMigrationResult: SchemaMigrationResult;
+
+	constructor() {
+		this.schemaMigrationResult = {
+			perDbResult: [],
+			state: SchemaMigrationState.NotStarted
+		}
+	}
+
+	public async MigrateSchema(sourceDatabaseName: string, stateMachine: MigrationStateModel,
+		reportSchemaMigrationComplete: (sourceDbName: string, succeeded: boolean) => Promise<void>): Promise<SchemaMigrationResult> {
+		const sourceConnectionString = await getSourceConnectionString();
+		const targetDbName = stateMachine._sourceTargetMapping.get(sourceDatabaseName)?.databaseName ?? ""
+		const targetConnectionString = await getSqlDbConnectionString(
+			stateMachine.targetServerName,
+			stateMachine._azureTenant.id,
+			targetDbName,
+			stateMachine._targetUserName,
+			stateMachine._targetPassword)
+
+		// Start async schema migration call
+		const result = await stateMachine.migrationService.migrateSqlSchema(
+			sourceConnectionString,
+			targetConnectionString,
+			reportSchemaMigrationComplete
+		);
+
+		this.schemaMigrationResult.perDbResult.push
+		{
+			result?.sourceDbName;
+			result?.targetDbname;
+			result?.succeeded;
+		}
+
+		return this.schemaMigrationResult;
+	}
+}
+

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -19,6 +19,8 @@ import { excludeDatabases, getEncryptConnectionValue, getSourceConnectionId, get
 import { LoginMigrationModel } from './loginMigrationModel';
 import { TdeMigrationDbResult, TdeMigrationModel } from './tdeModels';
 import { NetworkInterfaceModel } from '../api/dataModels/azure/networkInterfaceModel';
+import { SqlSchemaMigrationModel } from './sqlSchemaMigrationModel';
+
 const localize = nls.loadMessageBundle();
 
 export enum ValidateIrState {
@@ -274,6 +276,8 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 	public serverName!: string;
 
 	public tdeMigrationConfig: TdeMigrationModel = new TdeMigrationModel();
+
+	public sqlSchemaMigrationModel: SqlSchemaMigrationModel = new SqlSchemaMigrationModel();
 
 	private _stateChangeEventEmitter = new vscode.EventEmitter<StateChangeEvent>();
 	private _currentState: State;

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -1338,14 +1338,17 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			case MigrationTargetType.SQLMI:
 				const sqlMi = this._targetServerInstance as SqlManagedInstance;
 				this._targetServerName = sqlMi.properties.fullyQualifiedDomainName;
+				break;
 			case MigrationTargetType.SQLDB:
 				const sqlDb = this._targetServerInstance as AzureSqlDatabaseServer;
 				this._targetServerName = sqlDb.properties.fullyQualifiedDomainName;
+				break;
 			case MigrationTargetType.SQLVM:
 				// For sqlvm, we need to use ip address from the network interface to connect to the server
 				const sqlVm = this._targetServerInstance as SqlVMServer;
 				const networkInterfaces = Array.from(sqlVm.networkInterfaces.values());
 				this._targetServerName = NetworkInterfaceModel.getIpAddress(networkInterfaces);
+				break;
 		}
 	}
 

--- a/extensions/sql-migration/src/service/contracts.ts
+++ b/extensions/sql-migration/src/service/contracts.ts
@@ -503,8 +503,10 @@ export interface ISqlMigrationService {
 		reportUpdate: (dbName: string, succeeded: boolean, message: string) => void): Promise<TdeMigrationResult | undefined>;
 	migrateSqlSchema(
 		sourceConnectionString: string,
+		sourceDatabaseName: string,
 		targetConnectionString: string,
-		reportSchemaMigrationComplete: (sourceDbName: string, succeeded: boolean) => void): Promise<SchemaMigrationResult | undefined>;
+		TargetDatabaseName: string,
+		reportSchemaMigrationComplete: (sourceDbName: string, status: string) => void): Promise<void>;
 }
 
 export interface TdeMigrationRequest {
@@ -554,18 +556,21 @@ export interface TdeMigrateProgressParams {
 }
 
 export interface SchemaMigrationParams {
-	sourceSqlConnectionString: string;
-	targetSqlConnectionString: string;
+	sourceConnectionString: string;
+	sourceDatabaseName: string;
+	targetConnectionString: string;
+	targetDatabaseName: string;
 }
 
 export interface SchemaMigrationResult {
-	sourceDbName: string;
-	targetDbname: string;
-	succeeded: boolean;
+	sourceDatabaseName: string;
+	targetDatabasename: string;
+	status: string;
+	errorMessage: string;
 }
 
 export namespace SchemaMigrationRequest {
-	export const type = new RequestType<SchemaMigrationParams, SchemaMigrationResult, void, void>('migration/schemamigration');
+	export const type = new RequestType<SchemaMigrationParams, boolean, void, void>('migration/schemamigration');
 }
 
 export namespace SchemaMigrationCompleteEvent {

--- a/extensions/sql-migration/src/service/contracts.ts
+++ b/extensions/sql-migration/src/service/contracts.ts
@@ -501,6 +501,10 @@ export interface ISqlMigrationService {
 		networkSharePath: string,
 		accessToken: string,
 		reportUpdate: (dbName: string, succeeded: boolean, message: string) => void): Promise<TdeMigrationResult | undefined>;
+	migrateSqlSchema(
+		sourceConnectionString: string,
+		targetConnectionString: string,
+		reportSchemaMigrationComplete: (sourceDbName: string, succeeded: boolean) => void): Promise<SchemaMigrationResult | undefined>;
 }
 
 export interface TdeMigrationRequest {
@@ -547,4 +551,23 @@ export interface TdeMigrateProgressParams {
 	name: string;
 	success: boolean;
 	message: string;
+}
+
+export interface SchemaMigrationParams {
+	sourceSqlConnectionString: string;
+	targetSqlConnectionString: string;
+}
+
+export interface SchemaMigrationResult {
+	sourceDbName: string;
+	targetDbname: string;
+	succeeded: boolean;
+}
+
+export namespace SchemaMigrationRequest {
+	export const type = new RequestType<SchemaMigrationParams, SchemaMigrationResult, void, void>('migration/schemamigration');
+}
+
+export namespace SchemaMigrationCompleteEvent {
+	export const type = new NotificationType<SchemaMigrationResult, void>('migration/schemamigrationcomplete');
 }


### PR DESCRIPTION
This PR adds schema migration to the sql migration extension in the database backup page. 
There is a a hyperlink button for each source-target database mapping setup for migration. Pressing this button sends an async call to the schema migration nuget. This is setup to be responsive to multiple schema migration calls in quick succession with no ui blocking. The extension is updated based on a callback function that is called when the migrationservice backend sends the corresponding schemamigrationcomplete event back.
Schema migrations can be started as long as it's in failed/notstarted state. Not started maps to showing the 'Migrate' button. Allowing for another migration when in failed state allows for retrying.

Currently there is no display for errors. TODO work is to show where the schema migration nuget is locally logging the progress.

There's an additional bugfix in this PR related to custom getter for targetServerName in statemachine.ts. The previous iteration used a switch statement without breaks. Because of this if you entered the statement from one of the first two cases it would run code for the next two. This was causing migrate button to onyl work on the second press because it needed to set targetServerName to skip the switch statement. Fix is adding breaks.
![image](https://user-images.githubusercontent.com/108432101/227044223-ef067ab8-35db-4ddc-b02f-8e27ba6ecda5.png)
![image](https://user-images.githubusercontent.com/108432101/227044351-3f023519-9596-4812-8c0a-69e48091876d.png)
![image](https://user-images.githubusercontent.com/108432101/227044575-79291c98-3cc2-456a-9232-4a550034ba48.png)










