### PR TITLE
Refactoring database references to split literalVariable from databaseName

### DIFF
--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -706,7 +706,7 @@ declare module 'mssql' {
 	}
 
 	interface UserDatabaseReference extends DatabaseReference {
-		databaseVariable: SqlCmdVariable;
+		databaseVariable?: SqlCmdVariable;
 		serverVariable?: SqlCmdVariable;
 	}
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -991,7 +991,7 @@ export class ProjectsController {
 		const databaseReference = context as DatabaseReferenceTreeItem;
 
 		if (databaseReference) {
-			return project.databaseReferences.find(r => r.databaseName === databaseReference.treeItem.label);
+			return project.databaseReferences.find(r => r.referenceName === databaseReference.treeItem.label);
 		}
 
 		return undefined;

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -16,7 +16,7 @@ import { ISystemDatabaseReferenceSettings, IDacpacReferenceSettings, IProjectRef
 import { Deferred } from '../common/promise';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
 import { SystemDatabase } from 'mssql';
-import { DbServerValues, populateResultWithVars } from './utils';
+import { DbServerValues, ensureSetOrDefined, populateResultWithVars } from './utils';
 
 export enum ReferenceType {
 	project,
@@ -172,7 +172,7 @@ export class AddDatabaseReferenceDialog {
 				referenceSettings = projRef;
 			} else { // this.currentReferenceType === ReferenceType.dacpac
 				const dacpacRef: IDacpacReferenceSettings = {
-					databaseName: this.ensureSetOrDefined(this.databaseNameTextbox?.value),
+					databaseName: ensureSetOrDefined(this.databaseNameTextbox?.value),
 					dacpacFileLocation: vscode.Uri.file(<string>this.dacpacTextbox?.value),
 					suppressMissingDependenciesErrors: <boolean>this.suppressMissingDependenciesErrorsCheckbox?.checked
 				};
@@ -181,10 +181,10 @@ export class AddDatabaseReferenceDialog {
 			}
 
 			const dbServerValues: DbServerValues = {
-				dbName: this.ensureSetOrDefined(this.databaseNameTextbox?.value),
-				dbVariable: this.ensureSetOrDefined(utils.removeSqlCmdVariableFormatting(<string>this.databaseVariableTextbox?.value)),
-				serverName: this.ensureSetOrDefined(this.serverNameTextbox?.value),
-				serverVariable: this.ensureSetOrDefined(utils.removeSqlCmdVariableFormatting(<string>this.serverVariableTextbox?.value))
+				dbName: this.databaseNameTextbox?.value,
+				dbVariable: this.databaseVariableTextbox?.value,
+				serverName: this.serverNameTextbox?.value,
+				serverVariable: this.serverVariableTextbox?.value
 			};
 
 			populateResultWithVars(referenceSettings, dbServerValues);
@@ -197,17 +197,6 @@ export class AddDatabaseReferenceDialog {
 		await this.addReference!(this.project, referenceSettings);
 
 		this.dispose();
-	}
-
-	/**
-	 * Returns undefined for settings that are an empty string, meaning they are unset
-	 * @param setting
-	 */
-	private ensureSetOrDefined(setting?: string): string | undefined {
-		if (!setting || setting.trim().length === 0) {
-			return undefined;
-		}
-		return setting;
 	}
 
 	private createRadioButtons(): azdataType.FormComponent {

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceQuickpick.ts
@@ -6,18 +6,14 @@
 import path = require('path');
 import * as vscode from 'vscode';
 import * as constants from '../common/constants';
-import { getSqlProjectsInWorkspace, isValidSqlCmdVariableName, removeSqlCmdVariableFormatting } from '../common/utils';
+import { getSqlProjectsInWorkspace, isValidSqlCmdVariableName } from '../common/utils';
+import { DbServerValues, populateResultWithVars } from './utils';
 import { AddDatabaseReferenceSettings } from '../controllers/projectController';
 import { IDacpacReferenceSettings, IProjectReferenceSettings, ISystemDatabaseReferenceSettings } from '../models/IDatabaseReferenceSettings';
 import { Project } from '../models/project';
 import { getSystemDatabase, getSystemDbOptions, promptDacpacLocation } from './addDatabaseReferenceDialog';
 
-interface DbServerValues {
-	dbName?: string,
-	dbVariable?: string,
-	serverName?: string,
-	serverVariable?: string
-}
+
 
 /**
  * Create flow for adding a database reference using only VS Code-native APIs such as QuickPick
@@ -93,10 +89,8 @@ async function addProjectReference(otherProjectsInWorkspace: vscode.Uri[]): Prom
 		// User cancelled
 		return;
 	}
-	referenceSettings.databaseName = dbServerValues.dbName;
-	referenceSettings.databaseVariable = dbServerValues.dbVariable;
-	referenceSettings.serverName = dbServerValues.serverName;
-	referenceSettings.serverVariable = dbServerValues.serverVariable;
+
+	populateResultWithVars(referenceSettings, dbServerValues);
 
 	// 7. Prompt suppress unresolved ref errors
 	const suppressErrors = await promptSuppressUnresolvedRefErrors();
@@ -124,7 +118,7 @@ async function addSystemDatabaseReference(project: Project): Promise<ISystemData
 	const suppressErrors = await promptSuppressUnresolvedRefErrors();
 
 	return {
-		databaseName: dbName,
+		databaseVariableLiteralValue: dbName,
 		systemDb: getSystemDatabase(selectedSystemDb),
 		suppressMissingDependenciesErrors: suppressErrors
 	};
@@ -181,14 +175,16 @@ async function addDacpacReference(project: Project): Promise<IDacpacReferenceSet
 	// 5. Prompt suppress unresolved ref errors
 	const suppressErrors = await promptSuppressUnresolvedRefErrors();
 
-	return {
-		databaseName: dbServerValues.dbName,
+	// 6. Construct result
+
+	const referenceSettings: IDacpacReferenceSettings = {
 		dacpacFileLocation: dacPacLocation,
-		databaseVariable: removeSqlCmdVariableFormatting(dbServerValues.dbVariable),
-		serverName: dbServerValues.serverName,
-		serverVariable: removeSqlCmdVariableFormatting(dbServerValues.serverVariable),
 		suppressMissingDependenciesErrors: suppressErrors
 	};
+
+	populateResultWithVars(referenceSettings, dbServerValues);
+
+	return referenceSettings;
 }
 
 async function promptLocation(): Promise<string | undefined> {

--- a/extensions/sql-database-projects/src/dialogs/utils.ts
+++ b/extensions/sql-database-projects/src/dialogs/utils.ts
@@ -226,11 +226,22 @@ export interface DbServerValues {
 
 export function populateResultWithVars(referenceSettings: IUserDatabaseReferenceSettings, dbServerValues: DbServerValues) {
 	if (dbServerValues.dbVariable) {
-		referenceSettings.databaseName = dbServerValues.dbName;
-		referenceSettings.databaseVariable = removeSqlCmdVariableFormatting(dbServerValues.dbVariable);
-		referenceSettings.serverName = dbServerValues.serverName;
-		referenceSettings.serverVariable = removeSqlCmdVariableFormatting(dbServerValues.serverVariable);
+		referenceSettings.databaseName = ensureSetOrDefined(dbServerValues.dbName);
+		referenceSettings.databaseVariable = ensureSetOrDefined(removeSqlCmdVariableFormatting(dbServerValues.dbVariable));
+		referenceSettings.serverName = ensureSetOrDefined(dbServerValues.serverName);
+		referenceSettings.serverVariable = ensureSetOrDefined(removeSqlCmdVariableFormatting(dbServerValues.serverVariable));
 	} else {
-		referenceSettings.databaseVariableLiteralValue = dbServerValues.dbName;
+		referenceSettings.databaseVariableLiteralValue = ensureSetOrDefined(dbServerValues.dbName);
 	}
+}
+
+/**
+ * Returns undefined for settings that are an empty string, meaning they are unset
+ * @param setting
+ */
+export function ensureSetOrDefined(setting?: string): string | undefined {
+	if (!setting || setting.trim().length === 0) {
+		return undefined;
+	}
+	return setting;
 }

--- a/extensions/sql-database-projects/src/dialogs/utils.ts
+++ b/extensions/sql-database-projects/src/dialogs/utils.ts
@@ -9,6 +9,8 @@ import * as utils from '../common/utils';
 import * as mssql from 'mssql';
 import { HttpClient } from '../common/httpClient';
 import { AgreementInfo, DockerImageInfo } from '../models/deploy/deployProfile';
+import { IUserDatabaseReferenceSettings } from '../models/IDatabaseReferenceSettings';
+import { removeSqlCmdVariableFormatting } from '../common/utils';
 
 /**
  * Gets connection name from connection object if there is one,
@@ -212,5 +214,23 @@ export function mapExtractTargetEnum(inputTarget: string): mssql.ExtractTarget {
 		}
 	} else {
 		throw new Error(constants.extractTargetRequired);
+	}
+}
+
+export interface DbServerValues {
+	dbName?: string,
+	dbVariable?: string,
+	serverName?: string,
+	serverVariable?: string
+}
+
+export function populateResultWithVars(referenceSettings: IUserDatabaseReferenceSettings, dbServerValues: DbServerValues) {
+	if (dbServerValues.dbVariable) {
+		referenceSettings.databaseName = dbServerValues.dbName;
+		referenceSettings.databaseVariable = removeSqlCmdVariableFormatting(dbServerValues.dbVariable);
+		referenceSettings.serverName = dbServerValues.serverName;
+		referenceSettings.serverVariable = removeSqlCmdVariableFormatting(dbServerValues.serverVariable);
+	} else {
+		referenceSettings.databaseVariableLiteralValue = dbServerValues.dbName;
 	}
 }

--- a/extensions/sql-database-projects/src/models/IDatabaseReferenceSettings.ts
+++ b/extensions/sql-database-projects/src/models/IDatabaseReferenceSettings.ts
@@ -7,7 +7,7 @@ import { SystemDatabase } from 'mssql';
 import { Uri } from 'vscode';
 
 export interface IDatabaseReferenceSettings {
-	databaseName?: string;
+	databaseVariableLiteralValue?: string;
 	suppressMissingDependenciesErrors: boolean;
 }
 
@@ -15,18 +15,19 @@ export interface ISystemDatabaseReferenceSettings extends IDatabaseReferenceSett
 	systemDb: SystemDatabase;
 }
 
-export interface IDacpacReferenceSettings extends IDatabaseReferenceSettings {
-	dacpacFileLocation: Uri;
+export interface IUserDatabaseReferenceSettings extends IDatabaseReferenceSettings {
+	databaseName?: string;
 	databaseVariable?: string;
 	serverName?: string;
 	serverVariable?: string;
 }
 
-export interface IProjectReferenceSettings extends IDatabaseReferenceSettings {
+export interface IDacpacReferenceSettings extends IUserDatabaseReferenceSettings {
+	dacpacFileLocation: Uri;
+}
+
+export interface IProjectReferenceSettings extends IUserDatabaseReferenceSettings {
 	projectRelativePath: Uri | undefined;
 	projectName: string;
 	projectGuid: string;
-	databaseVariable?: string;
-	serverName?: string;
-	serverVariable?: string;
 }

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -360,17 +360,28 @@ export class Project implements ISqlProject {
 		for (const dacpacReference of databaseReferencesResult.dacpacReferences) {
 			this._databaseReferences.push(new DacpacReferenceProjectEntry({
 				dacpacFileLocation: Uri.file(dacpacReference.dacpacPath),
-				databaseName: dacpacReference.dacpacPath,
-				suppressMissingDependenciesErrors: dacpacReference.suppressMissingDependencies
+				suppressMissingDependenciesErrors: dacpacReference.suppressMissingDependencies,
+
+				databaseVariableLiteralValue: dacpacReference.databaseVariableLiteralName,
+				databaseName: dacpacReference.databaseVariable?.varName,
+				databaseVariable: dacpacReference.databaseVariable?.value,
+				serverName: dacpacReference.serverVariable?.varName,
+				serverVariable: dacpacReference.serverVariable?.value
 			}));
 		}
 
 		for (const projectReference of databaseReferencesResult.sqlProjectReferences) {
 			this._databaseReferences.push(new SqlProjectReferenceProjectEntry({
-				projectRelativePath: Uri.file(utils.getPlatformSafeFileEntryPath(projectReference.projectPath)),
 				projectName: path.basename(utils.getPlatformSafeFileEntryPath(projectReference.projectPath), constants.sqlprojExtension),
 				projectGuid: projectReference.projectGuid ?? '',
-				suppressMissingDependenciesErrors: projectReference.suppressMissingDependencies
+				suppressMissingDependenciesErrors: projectReference.suppressMissingDependencies,
+				projectRelativePath: Uri.file(utils.getPlatformSafeFileEntryPath(projectReference.projectPath)),
+
+				databaseVariableLiteralValue: projectReference.databaseVariableLiteralName,
+				databaseName: projectReference.databaseVariable?.varName,
+				databaseVariable: projectReference.databaseVariable?.value,
+				serverName: projectReference.serverVariable?.varName,
+				serverVariable: projectReference.serverVariable?.value
 			}));
 		}
 
@@ -679,12 +690,12 @@ export class Project implements ISqlProject {
 	 */
 	public async addSystemDatabaseReference(settings: ISystemDatabaseReferenceSettings): Promise<void> {
 		// check if reference to this database already exists
-		if (this.databaseReferences.find(r => r.databaseName === settings.databaseName)) {
+		if (this.databaseReferences.find(r => r.referenceName === settings.databaseVariableLiteralValue)) {
 			throw new Error(constants.databaseReferenceAlreadyExists);
 		}
 
 		const systemDb = <unknown>settings.systemDb as SystemDatabase;
-		const result = await this.sqlProjService.addSystemDatabaseReference(this.projectFilePath, systemDb, settings.suppressMissingDependenciesErrors, settings.databaseName);
+		const result = await this.sqlProjService.addSystemDatabaseReference(this.projectFilePath, systemDb, settings.suppressMissingDependenciesErrors, settings.databaseVariableLiteralValue);
 
 		if (!result.success && result.errorMessage) {
 			throw new Error(constants.errorAddingDatabaseReference(utils.systemDatabaseToString(settings.systemDb), result.errorMessage));

--- a/extensions/sql-database-projects/src/models/projectEntry.ts
+++ b/extensions/sql-database-projects/src/models/projectEntry.ts
@@ -44,11 +44,11 @@ export class FileProjectEntry extends ProjectEntry implements IFileProjectEntry 
 }
 
 export class DacpacReferenceProjectEntry extends FileProjectEntry implements IDatabaseReferenceProjectEntry {
-	databaseSqlCmdVariable?: string;
-	databaseName?: string;
+	databaseSqlCmdVariableValue?: string;
+	databaseSqlCmdVariableName?: string;
 	databaseVariableLiteralValue?: string;
-	serverName?: string;
-	serverSqlCmdVariable?: string;
+	serverSqlCmdVariableName?: string;
+	serverSqlCmdVariableValue?: string;
 	suppressMissingDependenciesErrors: boolean;
 
 	constructor(settings: IDacpacReferenceSettings) {
@@ -56,14 +56,14 @@ export class DacpacReferenceProjectEntry extends FileProjectEntry implements IDa
 		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
 
 		if (settings.databaseVariable) { // full SQLCMD variable
-			this.databaseName = settings.databaseName;
-			this.databaseSqlCmdVariable = settings.databaseVariable;
+			this.databaseSqlCmdVariableName = settings.databaseName;
+			this.databaseSqlCmdVariableValue = settings.databaseVariable;
 		} else { // just a literal
 			this.databaseVariableLiteralValue = settings.databaseName;
 		}
 
-		this.serverName = settings.serverName;
-		this.serverSqlCmdVariable = settings.serverVariable;
+		this.serverSqlCmdVariableName = settings.serverName;
+		this.serverSqlCmdVariableValue = settings.serverVariable;
 	}
 
 	/**
@@ -96,10 +96,10 @@ export class SqlProjectReferenceProjectEntry extends FileProjectEntry implements
 	public projectName: string;
 	public projectGuid: string;
 	public databaseVariableLiteralValue?: string;
-	public databaseName?: string;
-	public databaseSqlCmdVariable?: string;
-	public serverName?: string;
-	public serverSqlCmdVariable?: string;
+	public databaseSqlCmdVariableName?: string;
+	public databaseSqlCmdVariableValue?: string;
+	public serverSqlCmdVariableName?: string;
+	public serverSqlCmdVariableValue?: string;
 	public suppressMissingDependenciesErrors: boolean;
 
 	constructor(settings: IProjectReferenceSettings) {
@@ -110,14 +110,14 @@ export class SqlProjectReferenceProjectEntry extends FileProjectEntry implements
 		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
 
 		if (settings.databaseVariable) { // full SQLCMD variable
-			this.databaseName = settings.databaseName;
-			this.databaseSqlCmdVariable = settings.databaseVariable;
+			this.databaseSqlCmdVariableName = settings.databaseName;
+			this.databaseSqlCmdVariableValue = settings.databaseVariable;
 		} else { // just a literal
 			this.databaseVariableLiteralValue = settings.databaseName;
 		}
 
-		this.serverName = settings.serverName;
-		this.serverSqlCmdVariable = settings.serverVariable;
+		this.serverSqlCmdVariableName = settings.serverName;
+		this.serverSqlCmdVariableValue = settings.serverVariable;
 	}
 
 	public get referenceName(): string {

--- a/extensions/sql-database-projects/src/models/projectEntry.ts
+++ b/extensions/sql-database-projects/src/models/projectEntry.ts
@@ -44,25 +44,32 @@ export class FileProjectEntry extends ProjectEntry implements IFileProjectEntry 
 }
 
 export class DacpacReferenceProjectEntry extends FileProjectEntry implements IDatabaseReferenceProjectEntry {
-	databaseVariableLiteralValue?: string;
 	databaseSqlCmdVariable?: string;
+	databaseName?: string;
+	databaseVariableLiteralValue?: string;
 	serverName?: string;
 	serverSqlCmdVariable?: string;
 	suppressMissingDependenciesErrors: boolean;
 
 	constructor(settings: IDacpacReferenceSettings) {
-		super(settings.dacpacFileLocation, '', EntryType.DatabaseReference);
-		this.databaseSqlCmdVariable = settings.databaseVariable;
-		this.databaseVariableLiteralValue = settings.databaseName;
+		super(settings.dacpacFileLocation, /* relativePath doesn't get set for database references */ '', EntryType.DatabaseReference);
+		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
+
+		if (settings.databaseVariable) { // full SQLCMD variable
+			this.databaseName = settings.databaseName;
+			this.databaseSqlCmdVariable = settings.databaseVariable;
+		} else { // just a literal
+			this.databaseVariableLiteralValue = settings.databaseName;
+		}
+
 		this.serverName = settings.serverName;
 		this.serverSqlCmdVariable = settings.serverVariable;
-		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
 	}
 
 	/**
 	 * File name that gets displayed in the project tree
 	 */
-	public get databaseName(): string {
+	public get referenceName(): string {
 		return path.parse(utils.getPlatformSafeFileEntryPath(this.fsUri.fsPath)).name;
 	}
 
@@ -73,39 +80,47 @@ export class DacpacReferenceProjectEntry extends FileProjectEntry implements IDa
 }
 
 export class SystemDatabaseReferenceProjectEntry extends FileProjectEntry implements IDatabaseReferenceProjectEntry {
-	constructor(public databaseName: string, public databaseVariableLiteralValue: string | undefined, public suppressMissingDependenciesErrors: boolean) {
-		super(Uri.file(databaseName), databaseName, EntryType.DatabaseReference);
+	constructor(public referenceName: string, public databaseVariableLiteralValue: string | undefined, public suppressMissingDependenciesErrors: boolean) {
+		super(Uri.file(referenceName), referenceName, EntryType.DatabaseReference);
 	}
 
 	/**
 	 * Returns the name of the system database - this is used for deleting the system database reference
 	 */
 	public override pathForSqlProj(): string {
-		return this.databaseName;
+		return this.referenceName;
 	}
 }
 
 export class SqlProjectReferenceProjectEntry extends FileProjectEntry implements IDatabaseReferenceProjectEntry {
-	projectName: string;
-	projectGuid: string;
-	databaseVariableLiteralValue?: string;
-	databaseSqlCmdVariable?: string;
-	serverName?: string;
-	serverSqlCmdVariable?: string;
-	suppressMissingDependenciesErrors: boolean;
+	public projectName: string;
+	public projectGuid: string;
+	public databaseVariableLiteralValue?: string;
+	public databaseName?: string;
+	public databaseSqlCmdVariable?: string;
+	public serverName?: string;
+	public serverSqlCmdVariable?: string;
+	public suppressMissingDependenciesErrors: boolean;
 
 	constructor(settings: IProjectReferenceSettings) {
-		super(settings.projectRelativePath!, '', EntryType.DatabaseReference);
+		super(settings.projectRelativePath!, /* relativePath doesn't get set for database references */ '', EntryType.DatabaseReference);
+
 		this.projectName = settings.projectName;
 		this.projectGuid = settings.projectGuid;
-		this.databaseSqlCmdVariable = settings.databaseVariable;
-		this.databaseVariableLiteralValue = settings.databaseName;
+		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
+
+		if (settings.databaseVariable) { // full SQLCMD variable
+			this.databaseName = settings.databaseName;
+			this.databaseSqlCmdVariable = settings.databaseVariable;
+		} else { // just a literal
+			this.databaseVariableLiteralValue = settings.databaseName;
+		}
+
 		this.serverName = settings.serverName;
 		this.serverSqlCmdVariable = settings.serverVariable;
-		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
 	}
 
-	public get databaseName(): string {
+	public get referenceName(): string {
 		return this.projectName;
 	}
 

--- a/extensions/sql-database-projects/src/models/projectEntry.ts
+++ b/extensions/sql-database-projects/src/models/projectEntry.ts
@@ -55,12 +55,9 @@ export class DacpacReferenceProjectEntry extends FileProjectEntry implements IDa
 		super(settings.dacpacFileLocation, /* relativePath doesn't get set for database references */ '', EntryType.DatabaseReference);
 		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
 
-		if (settings.databaseVariable) { // full SQLCMD variable
-			this.databaseSqlCmdVariableName = settings.databaseName;
-			this.databaseSqlCmdVariableValue = settings.databaseVariable;
-		} else { // just a literal
-			this.databaseVariableLiteralValue = settings.databaseName;
-		}
+		this.databaseVariableLiteralValue = settings.databaseVariableLiteralValue;
+		this.databaseSqlCmdVariableName = settings.databaseName;
+		this.databaseSqlCmdVariableValue = settings.databaseVariable;
 
 		this.serverSqlCmdVariableName = settings.serverName;
 		this.serverSqlCmdVariableValue = settings.serverVariable;
@@ -109,12 +106,9 @@ export class SqlProjectReferenceProjectEntry extends FileProjectEntry implements
 		this.projectGuid = settings.projectGuid;
 		this.suppressMissingDependenciesErrors = settings.suppressMissingDependenciesErrors;
 
-		if (settings.databaseVariable) { // full SQLCMD variable
-			this.databaseSqlCmdVariableName = settings.databaseName;
-			this.databaseSqlCmdVariableValue = settings.databaseVariable;
-		} else { // just a literal
-			this.databaseVariableLiteralValue = settings.databaseName;
-		}
+		this.databaseVariableLiteralValue = settings.databaseVariableLiteralValue;
+		this.databaseSqlCmdVariableName = settings.databaseName;
+		this.databaseSqlCmdVariableValue = settings.databaseVariable;
 
 		this.serverSqlCmdVariableName = settings.serverName;
 		this.serverSqlCmdVariableValue = settings.serverVariable;

--- a/extensions/sql-database-projects/src/models/tree/databaseReferencesTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/databaseReferencesTreeItem.ts
@@ -58,7 +58,7 @@ export class DatabaseReferencesTreeItem extends BaseProjectTreeItem {
 
 export class DatabaseReferenceTreeItem extends BaseProjectTreeItem {
 	constructor(private reference: IDatabaseReferenceProjectEntry, referencesNodeRelativeProjectUri: vscode.Uri, sqlprojUri: vscode.Uri) {
-		super(vscode.Uri.file(path.join(referencesNodeRelativeProjectUri.fsPath, reference.databaseName)), sqlprojUri);
+		super(vscode.Uri.file(path.join(referencesNodeRelativeProjectUri.fsPath, reference.referenceName)), sqlprojUri);
 		this.entryKey = this.friendlyName;
 	}
 
@@ -72,7 +72,7 @@ export class DatabaseReferenceTreeItem extends BaseProjectTreeItem {
 
 	public get treeItem(): vscode.TreeItem {
 		const refItem = new vscode.TreeItem(this.relativeProjectUri, vscode.TreeItemCollapsibleState.None);
-		refItem.label = this.reference.databaseName;
+		refItem.label = this.reference.referenceName;
 		refItem.contextValue = this.type;
 		refItem.iconPath = IconPathHelper.referenceDatabase;
 

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -281,7 +281,7 @@ declare module 'sqldbproj' {
 	 * Represents a database reference entry in a project file
 	 */
 	export interface IDatabaseReferenceProjectEntry extends IFileProjectEntry {
-		databaseName: string;
+		referenceName: string;
 		databaseVariableLiteralValue?: string;
 		suppressMissingDependenciesErrors: boolean;
 	}

--- a/extensions/sql-database-projects/src/test/baselines/databaseReferencesReadBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/databaseReferencesReadBaseline.xml
@@ -10,7 +10,7 @@
   <Target Name="BeforeBuild">
     <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>
-  <ItemGroup>
+	<ItemGroup>
     <ArtifactReference Condition="'$(NetCoreBuild)' == 'true'" Include="$(SystemDacpacsLocation)\SystemDacpacs\150\msdb.dacpac">
       <SuppressMissingDependenciesErrors>True</SuppressMissingDependenciesErrors>
       <DatabaseVariableLiteralValue>msdbLiteral</DatabaseVariableLiteralValue>
@@ -19,10 +19,14 @@
       <SuppressMissingDependenciesErrors>True</SuppressMissingDependenciesErrors>
       <DatabaseVariableLiteralValue>msdbLiteral</DatabaseVariableLiteralValue>
     </ArtifactReference>
-    <ArtifactReference Include="..\OtherDacpac\ReferencedDacpac.dacpac">
+    <ArtifactReference Include="..\ReferencedDacpac\ReferencedDacpac.dacpac">
       <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
       <DatabaseSqlCmdVariable>dacpacDbVar</DatabaseSqlCmdVariable>
       <ServerSqlCmdVariable>dacpacServerVar</ServerSqlCmdVariable>
+    </ArtifactReference>
+    <ArtifactReference Include="..\OtherDacpac\OtherDacpac.dacpac">
+      <SuppressMissingDependenciesErrors>True</SuppressMissingDependenciesErrors>
+      <DatabaseVariableLiteralValue>OtherDacpacLiteral</DatabaseVariableLiteralValue>
     </ArtifactReference>
   </ItemGroup>
   <ItemGroup>
@@ -44,13 +48,20 @@
     </SqlCmdVariable>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\OtherProject\ReferencedProject.sqlproj">
+    <ProjectReference Include="..\ReferencedProject\ReferencedProject.sqlproj">
       <Name>ReferencedProject</Name>
       <Project>{BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575}</Project>
       <Private>True</Private>
       <SuppressMissingDependenciesErrors>True</SuppressMissingDependenciesErrors>
       <DatabaseSqlCmdVariable>projDbVar</DatabaseSqlCmdVariable>
       <ServerSqlCmdVariable>projServerVar</ServerSqlCmdVariable>
+    </ProjectReference>
+    <ProjectReference Include="..\OtherProject\OtherProject.sqlproj">
+      <Name>OtherProject</Name>
+      <Project>{C0DEBA11-BA5E-5EA7-ACE5-BABB1E70A575}</Project>
+      <Private>True</Private>
+      <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
+      <DatabaseVariableLiteralValue>OtherProjLiteral</DatabaseVariableLiteralValue>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/extensions/sql-database-projects/src/test/baselines/databaseReferencesReadBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/databaseReferencesReadBaseline.xml
@@ -10,7 +10,7 @@
   <Target Name="BeforeBuild">
     <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>
-	<ItemGroup>
+  <ItemGroup>
     <ArtifactReference Condition="'$(NetCoreBuild)' == 'true'" Include="$(SystemDacpacsLocation)\SystemDacpacs\150\msdb.dacpac">
       <SuppressMissingDependenciesErrors>True</SuppressMissingDependenciesErrors>
       <DatabaseVariableLiteralValue>msdbLiteral</DatabaseVariableLiteralValue>

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -561,10 +561,10 @@ describe('Project: database references', function (): void {
 		projFilePath = await testUtils.createTestSqlProjFile(baselines.databaseReferencesReadBaseline);
 		const project = await Project.openProject(projFilePath);
 
-		(project.databaseReferences.length).should.equal(5, 'There should be three database references');
+		(project.databaseReferences.length).should.equal(5, 'There should be five database references');
 
 		await project.deleteDatabaseReference(constants.msdb);
-		(project.databaseReferences.length).should.equal(4, 'There should be three database references after deletion');
+		(project.databaseReferences.length).should.equal(4, 'There should be four database references after deletion');
 
 		let ref = project.databaseReferences.find(r => r.referenceName === constants.msdb);
 		should(ref).equal(undefined, 'msdb reference should be deleted');

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -503,7 +503,7 @@ describe('Project: database references', function (): void {
 		await testUtils.deleteGeneratedTestFolder();
 	});
 
-	it.only('Should read database references correctly', async function (): Promise<void> {
+	it('Should read database references correctly', async function (): Promise<void> {
 		projFilePath = await testUtils.createTestSqlProjFile(baselines.databaseReferencesReadBaseline);
 		const project = await Project.openProject(projFilePath);
 		(project.databaseReferences.length).should.equal(5, 'NUmber of database references');

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -561,10 +561,10 @@ describe('Project: database references', function (): void {
 		projFilePath = await testUtils.createTestSqlProjFile(baselines.databaseReferencesReadBaseline);
 		const project = await Project.openProject(projFilePath);
 
-		(project.databaseReferences.length).should.equal(3, 'There should be three database references');
+		(project.databaseReferences.length).should.equal(5, 'There should be three database references');
 
 		await project.deleteDatabaseReference(constants.msdb);
-		(project.databaseReferences.length).should.equal(2, 'There should be three database references after deletion');
+		(project.databaseReferences.length).should.equal(4, 'There should be three database references after deletion');
 
 		let ref = project.databaseReferences.find(r => r.referenceName === constants.msdb);
 		should(ref).equal(undefined, 'msdb reference should be deleted');

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -521,10 +521,10 @@ describe('Project: database references', function (): void {
 		(projRef!.pathForSqlProj()).should.equal('..\\OtherProject\\ReferencedProject.sqlproj');
 		(projRef!.projectGuid).should.equal('{BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575}');
 		should(projRef!.databaseVariableLiteralValue).equal(undefined, 'databaseVariableLiteralValue for sqlproj');
-		(projRef!.databaseName!).should.equal('projDbVar');
-		(projRef!.databaseSqlCmdVariable!).should.equal('$(SqlCmdVar__1)');
-		(projRef!.serverName!).should.equal('projServerVar');
-		(projRef!.serverSqlCmdVariable!).should.equal('$(SqlCmdVar__2)');
+		(projRef!.databaseSqlCmdVariableName!).should.equal('projDbVar');
+		(projRef!.databaseSqlCmdVariableValue!).should.equal('$(SqlCmdVar__1)');
+		(projRef!.serverSqlCmdVariableName!).should.equal('projServerVar');
+		(projRef!.serverSqlCmdVariableValue!).should.equal('$(SqlCmdVar__2)');
 		(projRef!.suppressMissingDependenciesErrors).should.equal(true, 'suppressMissingDependenciesErrors');
 
 		const dacpacRef: DacpacReferenceProjectEntry | undefined = project.databaseReferences.find(r => r instanceof DacpacReferenceProjectEntry) as DacpacReferenceProjectEntry;
@@ -532,10 +532,10 @@ describe('Project: database references', function (): void {
 		(dacpacRef!.referenceName).should.equal('ReferencedDacpac');
 		(dacpacRef!.pathForSqlProj()).should.equal('..\\OtherDacpac\\ReferencedDacpac.dacpac');
 		should(dacpacRef!.databaseVariableLiteralValue).equal(undefined, 'databaseVariableLiteralValue for dacpac');
-		(dacpacRef!.databaseName!).should.equal('dacpacDbVar');
-		(dacpacRef!.databaseSqlCmdVariable!).should.equal('$(SqlCmdVar__3)');
-		(dacpacRef!.serverName!).should.equal('dacpacServerVar');
-		(dacpacRef!.serverSqlCmdVariable!).should.equal('$(SqlCmdVar__4)');
+		(dacpacRef!.databaseSqlCmdVariableName!).should.equal('dacpacDbVar');
+		(dacpacRef!.databaseSqlCmdVariableValue!).should.equal('$(SqlCmdVar__3)');
+		(dacpacRef!.serverSqlCmdVariableName!).should.equal('dacpacServerVar');
+		(dacpacRef!.serverSqlCmdVariableValue!).should.equal('$(SqlCmdVar__4)');
 		(dacpacRef!.suppressMissingDependenciesErrors).should.equal(false, 'suppressMissingDependenciesErrors');
 	});
 

--- a/extensions/sql-database-projects/src/test/project.test.ts
+++ b/extensions/sql-database-projects/src/test/project.test.ts
@@ -16,7 +16,7 @@ import { exists, convertSlashesForSqlProj, getPlatformSafeFileEntryPath, systemD
 import { Uri, window } from 'vscode';
 import { IDacpacReferenceSettings, IProjectReferenceSettings, ISystemDatabaseReferenceSettings } from '../models/IDatabaseReferenceSettings';
 import { EntryType, ItemType } from 'sqldbproj';
-import { SystemDatabaseReferenceProjectEntry, SqlProjectReferenceProjectEntry } from '../models/projectEntry';
+import { SystemDatabaseReferenceProjectEntry, SqlProjectReferenceProjectEntry, DacpacReferenceProjectEntry } from '../models/projectEntry';
 import { ProjectType, SystemDatabase } from 'mssql';
 
 let projFilePath: string;
@@ -54,7 +54,7 @@ describe('Project: sqlproj content operations', function (): void {
 		// Database references
 		// should only have one database reference even though there are two master.dacpac references (1 for ADS and 1 for SSDT)
 		should(project.databaseReferences.length).equal(1);
-		should(project.databaseReferences[0].databaseName).containEql(constants.master);
+		should(project.databaseReferences[0].referenceName).containEql(constants.master);
 		should(project.databaseReferences[0] instanceof SystemDatabaseReferenceProjectEntry).equal(true);
 
 		// Pre-post deployment scripts
@@ -80,9 +80,9 @@ describe('Project: sqlproj content operations', function (): void {
 		// Database references
 		// should only have two database references even though there are two master.dacpac references (1 for ADS and 1 for SSDT)
 		(project.databaseReferences.length).should.equal(2);
-		(project.databaseReferences[0].databaseName).should.containEql('ReferencedTestProject');
+		(project.databaseReferences[0].referenceName).should.containEql('ReferencedTestProject');
 		(project.databaseReferences[0] instanceof SqlProjectReferenceProjectEntry).should.be.true();
-		(project.databaseReferences[1].databaseName).should.containEql(constants.master);
+		(project.databaseReferences[1].referenceName).should.containEql(constants.master);
 		(project.databaseReferences[1] instanceof SystemDatabaseReferenceProjectEntry).should.be.true();
 	});
 
@@ -292,7 +292,7 @@ describe('Project: sqlproj content operations', function (): void {
 		const project: Project = await Project.openProject(projFilePath);
 
 		(project.sqlProjStyle).should.equal(ProjectType.SdkStyle);
-		(project.outputPath).should.equal('CustomOutputPath\\Dacpacs\\');
+		(project.outputPath).should.equal(path.join(getPlatformSafeFileEntryPath(project.projectFolderPath), getPlatformSafeFileEntryPath('CustomOutputPath\\Dacpacs\\')));
 		(project.configuration).should.equal('Release');
 		(project.getDatabaseSourceValues()).should.deepEqual(['oneSource', 'twoSource', 'redSource', 'blueSource']);
 		(project.getProjectTargetVersion()).should.equal('130');
@@ -504,42 +504,62 @@ describe('Project: database references', function (): void {
 	});
 
 	it('Should read database references correctly', async function (): Promise<void> {
-		const project = await Project.openProject(baselines.databaseReferencesReadBaseline);
+		this.timeout(999_999);
+		projFilePath = await testUtils.createTestSqlProjFile(baselines.databaseReferencesReadBaseline);
+		const project = await Project.openProject(projFilePath);
 		(project.databaseReferences.length).should.equal(3, 'There should be three database references');
 
-		let ref = project.databaseReferences.find(r => r.databaseName === constants.msdb);
-		should(ref).not.equal(undefined, 'msdb reference');
-		(ref!.databaseVariableLiteralValue!).should.equal('msdbLiteral');
-		(ref!.suppressMissingDependenciesErrors).should.equal(true, 'suppressMissingDependenciesErrors');
+		const systemRef: SystemDatabaseReferenceProjectEntry | undefined = project.databaseReferences.find(r => r instanceof SystemDatabaseReferenceProjectEntry) as SystemDatabaseReferenceProjectEntry;
+		should(systemRef).not.equal(undefined, 'msdb reference');
+		(systemRef!.referenceName).should.equal(constants.msdb);
+		(systemRef!.databaseVariableLiteralValue!).should.equal('msdbLiteral');
+		(systemRef!.suppressMissingDependenciesErrors).should.equal(true, 'suppressMissingDependenciesErrors for system db');
 
-		ref = project.databaseReferences.find(r => r.databaseName === '..\\OtherProject\\ReferencedProject.sqlproj')
-		should(ref).not.equal(undefined, 'sqlproj reference');
-		(ref!.suppressMissingDependenciesErrors).should.equal(true, 'suppressMissingDependenciesErrors');
+		const projRef: SqlProjectReferenceProjectEntry | undefined = project.databaseReferences.find(r => r instanceof SqlProjectReferenceProjectEntry) as SqlProjectReferenceProjectEntry;
+		should(projRef).not.equal(undefined, 'sqlproj reference');
+		(projRef!.referenceName).should.equal('ReferencedProject');
+		(projRef!.pathForSqlProj()).should.equal('..\\OtherProject\\ReferencedProject.sqlproj');
+		(projRef!.projectGuid).should.equal('{BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575}');
+		should(projRef!.databaseVariableLiteralValue).equal(undefined, 'databaseVariableLiteralValue for sqlproj');
+		(projRef!.databaseName!).should.equal('projDbVar');
+		(projRef!.databaseSqlCmdVariable!).should.equal('$(SqlCmdVar__1)');
+		(projRef!.serverName!).should.equal('projServerVar');
+		(projRef!.serverSqlCmdVariable!).should.equal('$(SqlCmdVar__2)');
+		(projRef!.suppressMissingDependenciesErrors).should.equal(true, 'suppressMissingDependenciesErrors');
 
-		ref = project.databaseReferences.find(r => r.databaseName === '..\\OtherDacpac\\ReferencedDacpac.sqlproj')
-		should(ref).not.equal(undefined, 'dacpac reference');
-		(ref!.suppressMissingDependenciesErrors).should.equal(false, 'suppressMissingDependenciesErrors');
+		const dacpacRef: DacpacReferenceProjectEntry | undefined = project.databaseReferences.find(r => r instanceof DacpacReferenceProjectEntry) as DacpacReferenceProjectEntry;
+		should(dacpacRef).not.equal(undefined, 'dacpac reference');
+		(dacpacRef!.referenceName).should.equal('ReferencedDacpac');
+		(dacpacRef!.pathForSqlProj()).should.equal('..\\OtherDacpac\\ReferencedDacpac.dacpac');
+		should(dacpacRef!.databaseVariableLiteralValue).equal(undefined, 'databaseVariableLiteralValue for dacpac');
+		(dacpacRef!.databaseName!).should.equal('dacpacDbVar');
+		(dacpacRef!.databaseSqlCmdVariable!).should.equal('$(SqlCmdVar__3)');
+		(dacpacRef!.serverName!).should.equal('dacpacServerVar');
+		(dacpacRef!.serverSqlCmdVariable!).should.equal('$(SqlCmdVar__4)');
+		(dacpacRef!.suppressMissingDependenciesErrors).should.equal(false, 'suppressMissingDependenciesErrors');
 	});
 
 	it('Should delete database references correctly', async function (): Promise<void> {
-		const project = await Project.openProject(baselines.databaseReferencesReadBaseline);
+		projFilePath = await testUtils.createTestSqlProjFile(baselines.databaseReferencesReadBaseline);
+		const project = await Project.openProject(projFilePath);
+
 		(project.databaseReferences.length).should.equal(3, 'There should be three database references');
 
 		await project.deleteDatabaseReference(constants.msdb);
 		(project.databaseReferences.length).should.equal(2, 'There should be three database references after deletion');
 
-		let ref = project.databaseReferences.find(r => r.databaseName === constants.msdb);
+		let ref = project.databaseReferences.find(r => r.referenceName === constants.msdb);
 		should(ref).equal(undefined, 'msdb reference should be deleted');
 	});
 
 	it('Should add system database reference correctly', async function (): Promise<void> {
 		let project = await testUtils.createTestSqlProject();
 
-		const msdbRefSettings: ISystemDatabaseReferenceSettings = { databaseName: 'msdb', systemDb: SystemDatabase.MSDB, suppressMissingDependenciesErrors: true };
+		const msdbRefSettings: ISystemDatabaseReferenceSettings = { databaseVariableLiteralValue: systemDatabaseToString(SystemDatabase.MSDB), systemDb: SystemDatabase.MSDB, suppressMissingDependenciesErrors: true };
 		await project.addSystemDatabaseReference(msdbRefSettings);
 
 		(project.databaseReferences.length).should.equal(1, 'There should be one database reference after adding a reference to msdb');
-		(project.databaseReferences[0].databaseName).should.equal(msdbRefSettings.databaseName, 'databaseName');
+		(project.databaseReferences[0].referenceName).should.equal(msdbRefSettings.databaseVariableLiteralValue, 'databaseName');
 		(project.databaseReferences[0].suppressMissingDependenciesErrors).should.equal(msdbRefSettings.suppressMissingDependenciesErrors, 'suppressMissingDependenciesErrors');
 	});
 
@@ -552,7 +572,7 @@ describe('Project: database references', function (): void {
 		await project.addDatabaseReference({ dacpacFileLocation: Uri.file('test1.dacpac'), suppressMissingDependenciesErrors: true });
 
 		should(project.databaseReferences.length).equal(1, 'There should be a database reference after adding a reference to test1');
-		should(project.databaseReferences[0].databaseName).equal('test1', 'The database reference should be test1');
+		should(project.databaseReferences[0].referenceName).equal('test1', 'The database reference should be test1');
 		should(project.databaseReferences[0].suppressMissingDependenciesErrors).equal(true, 'project.databaseReferences[0].suppressMissingDependenciesErrors should be true');
 	});
 
@@ -569,7 +589,7 @@ describe('Project: database references', function (): void {
 			suppressMissingDependenciesErrors: false
 		});
 		should(project.databaseReferences.length).equal(1, 'There should be a database reference after adding a reference to test2');
-		should(project.databaseReferences[0].databaseName).equal('test2', 'The database reference should be test2');
+		should(project.databaseReferences[0].referenceName).equal('test2', 'The database reference should be test2');
 		should(project.databaseReferences[0].suppressMissingDependenciesErrors).equal(false, 'project.databaseReferences[0].suppressMissingDependenciesErrors should be false');
 	});
 
@@ -588,7 +608,7 @@ describe('Project: database references', function (): void {
 			suppressMissingDependenciesErrors: false
 		});
 		should(project.databaseReferences.length).equal(1, 'There should be a database reference after adding a reference to test3');
-		should(project.databaseReferences[0].databaseName).equal('test3', 'The database reference should be test3');
+		should(project.databaseReferences[0].referenceName).equal('test3', 'The database reference should be test3');
 		should(project.databaseReferences[0].suppressMissingDependenciesErrors).equal(false, 'project.databaseReferences[0].suppressMissingDependenciesErrors should be false');
 	});
 
@@ -607,7 +627,7 @@ describe('Project: database references', function (): void {
 		});
 
 		should(project.databaseReferences.length).equal(1, 'There should be a database reference after adding a reference to project1');
-		should(project.databaseReferences[0].databaseName).equal('project1', 'The database reference should be project1');
+		should(project.databaseReferences[0].referenceName).equal('project1', 'The database reference should be project1');
 		should(project.databaseReferences[0].suppressMissingDependenciesErrors).equal(false, 'project.databaseReferences[0].suppressMissingDependenciesErrors should be false');
 		should(Object.keys(project.sqlCmdVariables).length).equal(0, `There should be no sqlcmd variables added. Actual: ${Object.keys(project.sqlCmdVariables).length}`);
 	});
@@ -629,7 +649,7 @@ describe('Project: database references', function (): void {
 		});
 
 		should(project.databaseReferences.length).equal(1, 'There should be a database reference after adding a reference to project1');
-		should(project.databaseReferences[0].databaseName).equal('project1', 'The database reference should be project1');
+		should(project.databaseReferences[0].referenceName).equal('project1', 'The database reference should be project1');
 		should(project.databaseReferences[0].suppressMissingDependenciesErrors).equal(false, 'project.databaseReferences[0].suppressMissingDependenciesErrors should be false');
 		should(Object.keys(project.sqlCmdVariables).length).equal(1, `There should be one new sqlcmd variable added. Actual: ${Object.keys(project.sqlCmdVariables).length}`);
 	});
@@ -653,7 +673,7 @@ describe('Project: database references', function (): void {
 		});
 
 		should(project.databaseReferences.length).equal(1, 'There should be a database reference after adding a reference to project1');
-		should(project.databaseReferences[0].databaseName).equal('project1', 'The database reference should be project1');
+		should(project.databaseReferences[0].referenceName).equal('project1', 'The database reference should be project1');
 		should(project.databaseReferences[0].suppressMissingDependenciesErrors).equal(false, 'project.databaseReferences[0].suppressMissingDependenciesErrors should be false');
 		should(Object.keys(project.sqlCmdVariables).length).equal(2, `There should be two new sqlcmd variables added. Actual: ${Object.keys(project.sqlCmdVariables).length}`);
 	});
@@ -668,7 +688,7 @@ describe('Project: database references', function (): void {
 		await project.addDatabaseReference(dacpacReference);
 
 		should(project.databaseReferences.length).equal(1, 'There should be one database reference after adding a reference to test.dacpac');
-		should(project.databaseReferences[0].databaseName).equal('test', 'project.databaseReferences[0].databaseName should be test');
+		should(project.databaseReferences[0].referenceName).equal('test', 'project.databaseReferences[0].databaseName should be test');
 
 		// try to add reference to test.dacpac again
 		await testUtils.shouldThrowSpecificError(async () => await project.addDatabaseReference(dacpacReference), constants.databaseReferenceAlreadyExists);
@@ -681,11 +701,11 @@ describe('Project: database references', function (): void {
 
 		should(project.databaseReferences.length).equal(0, 'There should be no database references to start with');
 
-		const systemDbReference: ISystemDatabaseReferenceSettings = { databaseName: systemDatabaseToString(SystemDatabase.Master), systemDb: SystemDatabase.Master, suppressMissingDependenciesErrors: false };
+		const systemDbReference: ISystemDatabaseReferenceSettings = { databaseVariableLiteralValue: systemDatabaseToString(SystemDatabase.Master), systemDb: SystemDatabase.Master, suppressMissingDependenciesErrors: false };
 		await project.addSystemDatabaseReference(systemDbReference);
 		project = await Project.openProject(projFilePath);
 		should(project.databaseReferences.length).equal(1, 'There should be one database reference after adding a reference to master');
-		should(project.databaseReferences[0].databaseName).equal(constants.master, 'project.databaseReferences[0].databaseName should be master');
+		should(project.databaseReferences[0].referenceName).equal(constants.master, 'project.databaseReferences[0].databaseName should be master');
 
 		// try to add reference to master again
 		await testUtils.shouldThrowSpecificError(async () => await project.addSystemDatabaseReference(systemDbReference), constants.databaseReferenceAlreadyExists);
@@ -707,7 +727,7 @@ describe('Project: database references', function (): void {
 		await project.addProjectReference(projectReference);
 
 		should(project.databaseReferences.length).equal(1, 'There should be one database reference after adding a reference to testProject.sqlproj');
-		should(project.databaseReferences[0].databaseName).equal('testProject', 'project.databaseReferences[0].databaseName should be testProject');
+		should(project.databaseReferences[0].referenceName).equal('testProject', 'project.databaseReferences[0].databaseName should be testProject');
 
 		// try to add reference to testProject again
 		await testUtils.shouldThrowSpecificError(async () => await project.addProjectReference(projectReference), constants.databaseReferenceAlreadyExists);
@@ -729,7 +749,7 @@ describe('Project: database references', function (): void {
 		await project.addProjectReference(projectReference);
 
 		should(project.databaseReferences.length).equal(1, 'There should be one database reference after adding a reference to testProject.sqlproj');
-		should(project.databaseReferences[0].databaseName).equal('testProject', 'project.databaseReferences[0].databaseName should be testProject');
+		should(project.databaseReferences[0].referenceName).equal('testProject', 'project.databaseReferences[0].databaseName should be testProject');
 
 		// try to add reference to testProject again with slashes in the other direction
 		projectReference.projectRelativePath = Uri.file('testFolder\\testProject.sqlproj');
@@ -753,7 +773,7 @@ describe('Project: database references', function (): void {
 			suppressMissingDependenciesErrors: false
 		});
 		should(project.databaseReferences.length).equal(1, 'There should be a database reference after adding a reference to test3');
-		should(project.databaseReferences[0].databaseName).equal('test3', 'The database reference should be test3');
+		should(project.databaseReferences[0].referenceName).equal('test3', 'The database reference should be test3');
 		should(Object.keys(project.sqlCmdVariables).length).equal(2, 'There should be 2 sqlcmdvars after adding the dacpac reference');
 
 		// make sure reference to test3.dacpac and SQLCMD variables were added
@@ -778,7 +798,7 @@ describe('Project: database references', function (): void {
 			suppressMissingDependenciesErrors: false
 		});
 		should(project.databaseReferences.length).equal(1, 'There should be a database reference after adding a reference to test3');
-		should(project.databaseReferences[0].databaseName).equal('test3', 'The database reference should be test3');
+		should(project.databaseReferences[0].referenceName).equal('test3', 'The database reference should be test3');
 		should(Object.keys(project.sqlCmdVariables).length).equal(2, 'There should still be 2 sqlcmdvars after adding the dacpac reference again with different sqlcmdvar values');
 
 		projFileText = (await fs.readFile(projFilePath)).toString();

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -728,7 +728,7 @@ describe('ProjectsController', function (): void {
 				{ treeDataProvider: new SqlDatabaseProjectTreeViewProvider(), element: undefined });
 			should(showErrorMessageSpy.notCalled).be.true('showErrorMessage should not have been called');
 			should(project1.databaseReferences.length).equal(1, 'Dacpac reference should have been added');
-			should(project1.databaseReferences[0].databaseName).equal('sameFolderTest');
+			should(project1.databaseReferences[0].referenceName).equal('sameFolderTest');
 			should(project1.databaseReferences[0].pathForSqlProj()).equal('sameFolderTest.dacpac');
 			// make sure reference to sameFolderTest.dacpac was added to project file
 			let projFileText = (await fs.readFile(projFilePath)).toString();
@@ -743,7 +743,7 @@ describe('ProjectsController', function (): void {
 				{ treeDataProvider: new SqlDatabaseProjectTreeViewProvider(), element: undefined });
 			should(showErrorMessageSpy.notCalled).be.true('showErrorMessage should not have been called');
 			should(project1.databaseReferences.length).equal(2, 'Another dacpac reference should have been added');
-			should(project1.databaseReferences[1].databaseName).equal('nestedFolderTest');
+			should(project1.databaseReferences[1].referenceName).equal('nestedFolderTest');
 			should(project1.databaseReferences[1].pathForSqlProj()).equal('refs\\nestedFolderTest.dacpac');
 			// make sure reference to nestedFolderTest.dacpac was added to project file
 			projFileText = (await fs.readFile(projFilePath)).toString();
@@ -758,7 +758,7 @@ describe('ProjectsController', function (): void {
 				{ treeDataProvider: new SqlDatabaseProjectTreeViewProvider(), element: undefined });
 			should(showErrorMessageSpy.notCalled).be.true('showErrorMessage should not have been called');
 			should(project1.databaseReferences.length).equal(3, 'Another dacpac reference should have been added');
-			should(project1.databaseReferences[2].databaseName).equal('outsideFolderTest');
+			should(project1.databaseReferences[2].referenceName).equal('outsideFolderTest');
 			should(project1.databaseReferences[2].pathForSqlProj()).equal('..\\someFolder\\outsideFolderTest.dacpac');
 			// make sure reference to outsideFolderTest.dacpac was added to project file
 			projFileText = (await fs.readFile(projFilePath)).toString();

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -1134,7 +1134,7 @@ declare module 'vscode-mssql' {
 	}
 
 	interface UserDatabaseReference extends DatabaseReference {
-		databaseVariable: SqlCmdVariable;
+		databaseVariable?: SqlCmdVariable;
 		serverVariable?: SqlCmdVariable;
 	}
 


### PR DESCRIPTION
`DatabseNameLiteralValue` and `DatabaseSqlCmdVarName` are two different things, but were being treated as one due to how the SSDT (and therefore ADS) dialogs prompted for them.  I've changed the flow to make the determination whether the user entered a literalValue or variable name as soon as possible, and to keep them separate for the rest of flow.