### PR TITLE
Handle out of sync extension activations for encryption keys updated event

### DIFF
--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -81,6 +81,13 @@ export class AzureAccountProviderService implements vscode.Disposable {
 		return this._onEncryptionKeysUpdated;
 	}
 
+	public async getEncryptionKeys(): Promise<CacheEncryptionKeys | undefined> {
+		if (!this._cachePluginProvider) {
+			await this.onDidChangeConfiguration();
+		}
+		return this._cachePluginProvider?.getCacheEncryptionKeys();
+	}
+
 	public dispose() {
 		while (this._disposables.length) {
 			const item = this._disposables.pop();

--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -81,11 +81,11 @@ export class AzureAccountProviderService implements vscode.Disposable {
 		return this._onEncryptionKeysUpdated;
 	}
 
-	public async getEncryptionKeys(): Promise<CacheEncryptionKeys | undefined> {
+	public async getEncryptionKeys(): Promise<CacheEncryptionKeys> {
 		if (!this._cachePluginProvider) {
 			await this.onDidChangeConfiguration();
 		}
-		return this._cachePluginProvider?.getCacheEncryptionKeys();
+		return this._cachePluginProvider!.getCacheEncryptionKeys();
 	}
 
 	public dispose() {

--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -174,6 +174,10 @@ export class AzureAccountProviderService implements vscode.Disposable {
 
 			// MSAL Cache Plugin
 			this._cachePluginProvider = new MsalCachePluginProvider(tokenCacheKeyMsal, this._userStoragePath, this._credentialProvider, this._onEncryptionKeysUpdated);
+			if (this._authLibrary === Constants.AuthLibrary.MSAL) {
+				// Initialize cache provider and encryption keys
+				await this._cachePluginProvider.init();
+			}
 
 			const msalConfiguration: Configuration = {
 				auth: {

--- a/extensions/azurecore/src/account-provider/utils/fileEncryptionHelper.ts
+++ b/extensions/azurecore/src/account-provider/utils/fileEncryptionHelper.ts
@@ -53,10 +53,18 @@ export class FileEncryptionHelper {
 
 		// Emit event with cache encryption keys to send notification to provider services.
 		if (this._authLibrary === AuthLibrary.MSAL && this._onEncryptionKeysUpdated) {
-			this._onEncryptionKeysUpdated.fire({
-				iv: this._ivBuffer.toString(this._bufferEncoding),
-				key: this._keyBuffer.toString(this._bufferEncoding)
-			});
+			this._onEncryptionKeysUpdated.fire(this.getEncryptionKeys());
+			Logger.verbose('FileEncryptionHelper: Fired encryption keys updated event.');
+		}
+	}
+
+	/**
+	 * Provides encryption keys in use for instant access.
+	 */
+	public getEncryptionKeys(): CacheEncryptionKeys {
+		return {
+			iv: this._ivBuffer!.toString(this._bufferEncoding),
+			key: this._keyBuffer!.toString(this._bufferEncoding)
 		}
 	}
 

--- a/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
+++ b/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
@@ -33,6 +33,10 @@ export class MsalCachePluginProvider {
 		return this._msalFilePath + '.lockfile';
 	}
 
+	public getCacheEncryptionKeys(): CacheEncryptionKeys {
+		return this._fileEncryptionHelper.getEncryptionKeys();
+	}
+
 	public getCachePlugin(): ICachePlugin {
 		const lockFilePath = this.getLockfilePath();
 		const beforeCacheAccess = async (cacheContext: TokenCacheContext): Promise<void> => {

--- a/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
+++ b/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
@@ -33,6 +33,10 @@ export class MsalCachePluginProvider {
 		return this._msalFilePath + '.lockfile';
 	}
 
+	public async init(): Promise<void> {
+		await this._fileEncryptionHelper.init();
+	}
+
 	public getCacheEncryptionKeys(): CacheEncryptionKeys {
 		return this._fileEncryptionHelper.getEncryptionKeys();
 	}

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -322,7 +322,7 @@ declare module 'azurecore' {
 		 */
 		onEncryptionKeysUpdated: vscode.Event<CacheEncryptionKeys>;
 		/**
-		 * Fetches MSAL cache encryption keys currently in use, for instant access.
+		 * Fetches MSAL cache encryption keys currently in use.
 		 */
 		getEncryptionKeys(): Promise<CacheEncryptionKeys | undefined>;
 	}

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -324,7 +324,7 @@ declare module 'azurecore' {
 		/**
 		 * Fetches MSAL cache encryption keys currently in use.
 		 */
-		getEncryptionKeys(): Promise<CacheEncryptionKeys | undefined>;
+		getEncryptionKeys(): Promise<CacheEncryptionKeys>;
 	}
 
 	export type GetSubscriptionsResult = { subscriptions: azureResource.AzureResourceSubscription[], errors: Error[] };

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -321,6 +321,10 @@ declare module 'azurecore' {
 		 * by connection providers to read/write to the same access token cache for stable connectivity.
 		 */
 		onEncryptionKeysUpdated: vscode.Event<CacheEncryptionKeys>;
+		/**
+		 * Fetches MSAL cache encryption keys currently in use, for instant access.
+		 */
+		getEncryptionKeys(): Promise<CacheEncryptionKeys | undefined>;
 	}
 
 	export type GetSubscriptionsResult = { subscriptions: azureResource.AzureResourceSubscription[], errors: Error[] };

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -242,11 +242,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 			return azureResourceUtils.runResourceQuery(account, subscriptions, ignoreErrors, query);
 		},
 		onEncryptionKeysUpdated: eventEmitter!.event,
-		async getEncryptionKeys(): Promise<azurecore.CacheEncryptionKeys | undefined> {
+		async getEncryptionKeys(): Promise<azurecore.CacheEncryptionKeys> {
 			if (!providerService) {
 				throw new Error("Failed to initialize Azure account provider.");
 			}
-			return await providerService?.getEncryptionKeys();
+			return await providerService!.getEncryptionKeys();
 		}
 	};
 }

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -241,7 +241,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 			query: string): Promise<azurecore.ResourceQueryResult<T>> {
 			return azureResourceUtils.runResourceQuery(account, subscriptions, ignoreErrors, query);
 		},
-		onEncryptionKeysUpdated: eventEmitter!.event
+		onEncryptionKeysUpdated: eventEmitter!.event,
+		async getEncryptionKeys(): Promise<azurecore.CacheEncryptionKeys | undefined> {
+			return await providerService?.getEncryptionKeys();
+		}
 	};
 }
 

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -243,6 +243,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 		},
 		onEncryptionKeysUpdated: eventEmitter!.event,
 		async getEncryptionKeys(): Promise<azurecore.CacheEncryptionKeys | undefined> {
+			if (!providerService) {
+				throw new Error("Failed to initialize Azure account provider.");
+			}
 			return await providerService?.getEncryptionKeys();
 		}
 	};

--- a/extensions/machine-learning/src/test/stubs.ts
+++ b/extensions/machine-learning/src/test/stubs.ts
@@ -62,5 +62,7 @@ export class AzurecoreApiStub implements azurecore.IExtension {
 		throw new Error('Method not implemented.');
 	}
 	onEncryptionKeysUpdated: any
-
+	getEncryptionKeys(): Promise<azurecore.CacheEncryptionKeys> {
+		throw new Error('Method not implemented.');
+	}
 }


### PR DESCRIPTION
Noticed an issue with firing of event from SqlToolsServer - in case where azurecore cache gets activated first, event if fired only once. And if event listener is not registered, we end up losing emitted event.

Since we absolutely need to read encryption keys to work, I'm introducing a direct access API to be able to read Encryption keys right after STS activation and send notification to backend service. Not considering emitting event multiple times to avoid unnecessary events being fired that would impact performance.