### PR TITLE
Skip forceRefresh for full (owning) tenant

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -345,13 +345,14 @@ export abstract class AzureAuth implements vscode.Disposable {
 		}
 
 		// construct request
-		// forceRefresh needs to be set true here in order to fetch the correct token, due to this issue
+		// forceRefresh needs to be set true here in order to fetch the correct token for non-full tenants, due to this issue
 		// https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/3687
 		const tokenRequest = {
 			account: account,
 			authority: `${this.loginEndpointUrl}${tenantId}`,
 			scopes: newScope,
-			forceRefresh: true
+			// Force Refresh when tenant is NOT full tenant or organizational id that this account belongs to.
+			forceRefresh: tenantId !== account.tenantId
 		};
 		try {
 			return await this.clientApplication.acquireTokenSilent(tokenRequest);


### PR DESCRIPTION
This PR reduces attempts to force refresh silent auth request when fetching token for account's full tenant (owning tenant), as the issues only apply for non-owning tenants for multi-tenant scenarios.

This should also improve performance when acquiring access tokens silently for full tenant resources.

Helps address #22403 for account org tenants but throttling issue from MSAL.NET is primarily dependent on https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/3687 as MSAL.js doesn't throw throttling error, even though we force refresh on all token requests.