### PR TITLE
Show message indicating that ADAL is being deprecated

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -127,7 +127,7 @@
               "Azure Active Directory Authentication Library",
               "Microsoft Authentication Library"
             ],
-            "deprecationMessage": "Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL instead."
+            "deprecationMessage": "Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL (default option) instead."
           }
         }
       }

--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -126,7 +126,8 @@
             "enumDescriptions": [
               "Azure Active Directory Authentication Library",
               "Microsoft Authentication Library"
-            ]
+            ],
+            "deprecationMessage": "Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL instead."
           }
         }
       }

--- a/extensions/azurecore/src/constants.ts
+++ b/extensions/azurecore/src/constants.ts
@@ -68,7 +68,7 @@ export const AzureTokenFolderName = 'Azure Accounts';
 
 export const MSALCacheName = 'accessTokenCache';
 
-export const DefaultAuthLibrary = 'ADAL';
+export const DefaultAuthLibrary = 'MSAL';
 
 export enum BuiltInCommands {
 	SetContext = 'setContext'

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -305,6 +305,9 @@ async function onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): Pro
 		updatePiiLoggingLevel();
 	}
 	if (e.affectsConfiguration('azure.authenticationLibrary')) {
+		if (vscode.workspace.getConfiguration(Constants.AzureSection).get('authenticationLibrary') === 'ADAL') {
+			await displayDeprecated();
+		}
 		await displayReloadAds();
 	}
 }
@@ -328,3 +331,6 @@ async function displayReloadAds(): Promise<boolean> {
 
 }
 
+async function displayDeprecated(): Promise<void> {
+	await vscode.window.showInformationMessage(loc.deprecatedOption);
+}

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -306,7 +306,7 @@ async function onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): Pro
 	}
 	if (e.affectsConfiguration('azure.authenticationLibrary')) {
 		if (vscode.workspace.getConfiguration(Constants.AzureSection).get('authenticationLibrary') === 'ADAL') {
-			await displayDeprecated();
+			void vscode.window.showInformationMessage(loc.deprecatedOption);
 		}
 		await displayReloadAds();
 	}
@@ -329,8 +329,4 @@ async function displayReloadAds(): Promise<boolean> {
 		return false;
 	}
 
-}
-
-async function displayDeprecated(): Promise<void> {
-	await vscode.window.showInformationMessage(loc.deprecatedOption);
 }

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -66,6 +66,8 @@ export const typeIcon = localize('azurecore.typeIcon', "Type Icon");
 export const reloadPrompt = localize('azurecore.reloadPrompt', "Authentication Library has changed, please reload Azure Data Studio.");
 export const reloadChoice = localize('azurecore.reloadChoice', "Reload Azure Data Studio");
 
+export const deprecatedOption = localize('azurecore.deprecated', "Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL instead.")
+
 // Azure Resource Types
 export const sqlServer = localize('azurecore.sqlServer', "SQL server");
 export const sqlDatabase = localize('azurecore.sqlDatabase', "SQL database");


### PR DESCRIPTION
This will display a message to the user upon selection of the ADAL Auth Library indicating that ADAL is being deprecated:

![Screenshot 2023-03-23 at 3 34 47 PM](https://user-images.githubusercontent.com/18150417/227379665-b5aa735c-8efd-4459-a972-3ec2e5d85bb0.png)

Also I found one more location where MSAL was not set as default Auth Library, but this is only used as a fallback if the authentication library setting could not be fetched.