### PR TITLE
Make screenreader announce task status

### DIFF
--- a/src/sql/workbench/contrib/tasks/browser/tasksRenderer.ts
+++ b/src/sql/workbench/contrib/tasks/browser/tasksRenderer.ts
@@ -103,6 +103,7 @@ export class TaskHistoryRenderer implements IRenderer {
 			// Determine the task title and set hover text equal to that
 			templateData.label.textContent = element.taskName + ' ' + taskStatus;
 			templateData.label.title = templateData.label.textContent;
+			templateData.label.setAttribute('role', 'alert');
 
 			let description: string | undefined;
 			// Determine the target name and set hover text equal to that


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses https://github.com/microsoft/azuredatastudio/issues/22158. This makes it so that the label of tasks gets announced when it first show ups and changes. I initially tried setting `aria-live="polite"` and `assertive`, but it was only announcing when the label changed to "task succeeded" and not the initial "task in progress"  message. Setting role to alert announces both.
![announceTaskProgress](https://user-images.githubusercontent.com/31145923/227384667-43805a82-7930-4e2d-8b19-6b8129604b6b.gif)

