### PR TITLE
add aria labels to a couple radio groups in sql database projects

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -416,7 +416,7 @@ export class PublishDatabaseDialog {
 		const radioButtonContainer = view.modelBuilder.flexContainer()
 			.withLayout({ flexFlow: 'column' })
 			.withItems([this.existingServerRadioButton, this.dockerServerRadioButton])
-			.withProps({ ariaRole: 'radiogroup' })
+			.withProps({ ariaRole: 'radiogroup', ariaLabel: constants.publishTo })
 			.component();
 
 		let flexRadioButtonsModel: azdataType.FlexContainer = view.modelBuilder.flexContainer()

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -492,7 +492,7 @@ export class UpdateProjectFromDatabaseDialog {
 		let radioButtons = view.modelBuilder.flexContainer()
 			.withLayout({ flexFlow: 'column' })
 			.withItems([this.compareActionRadioButton, this.updateActionRadioButton])
-			.withProps({ ariaRole: 'radiogroup' })
+			.withProps({ ariaRole: 'radiogroup', ariaLabel: constants.actionLabel })
 			.component();
 
 		const actionLabel = view.modelBuilder.text().withProps({


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses https://github.com/microsoft/azuredatastudio/issues/22098 and https://github.com/microsoft/azuredatastudio/issues/22133. Adding an aria label to the container of the radio group in a couple of the sql database projects dialogs.
![radioGroupAriaLabel](https://user-images.githubusercontent.com/31145923/227607344-84ba249d-cd54-4c27-93f9-09430fea9d5f.gif)

