### PR TITLE
Send parallel message processing argument to Migration Service in STS

### DIFF
--- a/extensions/sql-migration/src/service/serviceClient.ts
+++ b/extensions/sql-migration/src/service/serviceClient.ts
@@ -108,6 +108,7 @@ export class ServiceClient {
 		launchArgs.push('--log-file', path.join(context.logUri.fsPath));
 		launchArgs.push('--tracing-level', this.getConfigTracingLevel());
 		launchArgs.push('--autoflush-log');
+		launchArgs.push('--parallel-message-processing');
 		return { command: executablePath, args: launchArgs, transport: TransportKind.stdio };
 	}
 


### PR DESCRIPTION
Send parallel message processing argument to Migration Service in STS. STS can already support this argument but does not honor it being set yet. Separate changes in STS to follow to support setting parallelMessage processing on the MessageDispatcher used by MigrationService when this flag is set.

Tested with STS changes locally by sending multiple requests to STS concurrently.  Picutred below is both notification events being handled and running concurrently.

STS changes: https://github.com/microsoft/sqltoolsservice/pull/1968

![image](https://user-images.githubusercontent.com/108432101/227620821-21b99b32-9b42-4ab1-98a9-bf3f798df1a1.png)
