### PR TITLE
turn on noUnusedParameters in Schema Compare

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -736,7 +736,7 @@ export class SchemaCompareMainWindow {
 			title: loc.compare
 		}).component();
 
-		this.compareButton.onDidClick(async () => {
+		this.compareButton.onDidClick(async (_click) => {
 			await this.startCompare();
 		});
 	}
@@ -751,7 +751,7 @@ export class SchemaCompareMainWindow {
 			title: loc.stop
 		}).component();
 
-		this.cancelCompareButton.onDidClick(async () => {
+		this.cancelCompareButton.onDidClick(async (_click) => {
 			await this.cancelCompare();
 		});
 	}
@@ -806,7 +806,7 @@ export class SchemaCompareMainWindow {
 			},
 		}).component();
 
-		this.generateScriptButton.onDidClick(async () => {
+		this.generateScriptButton.onDidClick(async (_click) => {
 			await this.generateScript();
 		});
 	}
@@ -843,7 +843,7 @@ export class SchemaCompareMainWindow {
 			title: loc.options
 		}).component();
 
-		this.optionsButton.onDidClick(async () => {
+		this.optionsButton.onDidClick(async (_click) => {
 			TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareOptionsOpened');
 			// create fresh every time
 			this.schemaCompareOptionDialog = new SchemaCompareOptionsDialog(this.deploymentOptions, this);
@@ -861,7 +861,7 @@ export class SchemaCompareMainWindow {
 			},
 		}).component();
 
-		this.applyButton.onDidClick(async () => {
+		this.applyButton.onDidClick(async (_click) => {
 			await this.publishChanges();
 		});
 	}
@@ -998,7 +998,7 @@ export class SchemaCompareMainWindow {
 			title: loc.switchDirectionDescription
 		}).component();
 
-		this.switchButton.onDidClick(async () => {
+		this.switchButton.onDidClick(async (_click) => {
 			TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareSwitch');
 			// switch source and target
 			[this.sourceEndpointInfo, this.targetEndpointInfo] = [this.targetEndpointInfo, this.sourceEndpointInfo];
@@ -1032,7 +1032,7 @@ export class SchemaCompareMainWindow {
 			secondary: true
 		}).component();
 
-		this.selectSourceButton.onDidClick(async () => {
+		this.selectSourceButton.onDidClick(async (_click) => {
 			TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareSelectSource');
 			this.schemaCompareDialog = new SchemaCompareDialog(this, undefined, this.extensionContext);
 			this.promise = this.schemaCompareDialog.openDialog();
@@ -1046,7 +1046,7 @@ export class SchemaCompareMainWindow {
 			secondary: true
 		}).component();
 
-		this.selectTargetButton.onDidClick(async () => {
+		this.selectTargetButton.onDidClick(async (_click) => {
 			TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareSelectTarget');
 			this.schemaCompareDialog = new SchemaCompareDialog(this, undefined, this.extensionContext);
 			this.promise = await this.schemaCompareDialog.openDialog();
@@ -1064,7 +1064,7 @@ export class SchemaCompareMainWindow {
 			title: loc.openScmpDescription
 		}).component();
 
-		this.openScmpButton.onDidClick(async () => {
+		this.openScmpButton.onDidClick(async (_click) => {
 			await this.openScmp();
 		});
 	}
@@ -1180,7 +1180,7 @@ export class SchemaCompareMainWindow {
 			enabled: false
 		}).component();
 
-		this.saveScmpButton.onDidClick(async () => {
+		this.saveScmpButton.onDidClick(async (_click) => {
 			await this.saveScmp();
 		});
 	}

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -736,7 +736,7 @@ export class SchemaCompareMainWindow {
 			title: loc.compare
 		}).component();
 
-		this.compareButton.onDidClick(async (click) => {
+		this.compareButton.onDidClick(async () => {
 			await this.startCompare();
 		});
 	}
@@ -751,7 +751,7 @@ export class SchemaCompareMainWindow {
 			title: loc.stop
 		}).component();
 
-		this.cancelCompareButton.onDidClick(async (click) => {
+		this.cancelCompareButton.onDidClick(async () => {
 			await this.cancelCompare();
 		});
 	}
@@ -806,7 +806,7 @@ export class SchemaCompareMainWindow {
 			},
 		}).component();
 
-		this.generateScriptButton.onDidClick(async (click) => {
+		this.generateScriptButton.onDidClick(async () => {
 			await this.generateScript();
 		});
 	}
@@ -843,7 +843,7 @@ export class SchemaCompareMainWindow {
 			title: loc.options
 		}).component();
 
-		this.optionsButton.onDidClick(async (click) => {
+		this.optionsButton.onDidClick(async () => {
 			TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareOptionsOpened');
 			// create fresh every time
 			this.schemaCompareOptionDialog = new SchemaCompareOptionsDialog(this.deploymentOptions, this);
@@ -861,7 +861,7 @@ export class SchemaCompareMainWindow {
 			},
 		}).component();
 
-		this.applyButton.onDidClick(async (click) => {
+		this.applyButton.onDidClick(async () => {
 			await this.publishChanges();
 		});
 	}
@@ -998,7 +998,7 @@ export class SchemaCompareMainWindow {
 			title: loc.switchDirectionDescription
 		}).component();
 
-		this.switchButton.onDidClick(async (click) => {
+		this.switchButton.onDidClick(async () => {
 			TelemetryReporter.sendActionEvent(TelemetryViews.SchemaCompareMainWindow, 'SchemaCompareSwitch');
 			// switch source and target
 			[this.sourceEndpointInfo, this.targetEndpointInfo] = [this.targetEndpointInfo, this.sourceEndpointInfo];
@@ -1064,7 +1064,7 @@ export class SchemaCompareMainWindow {
 			title: loc.openScmpDescription
 		}).component();
 
-		this.openScmpButton.onDidClick(async (click) => {
+		this.openScmpButton.onDidClick(async () => {
 			await this.openScmp();
 		});
 	}
@@ -1180,7 +1180,7 @@ export class SchemaCompareMainWindow {
 			enabled: false
 		}).component();
 
-		this.saveScmpButton.onDidClick(async (click) => {
+		this.saveScmpButton.onDidClick(async () => {
 			await this.saveScmp();
 		});
 	}

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -363,7 +363,7 @@ describe('SchemaCompareMainWindow.results @DacFx@', function (): void {
 	function createServiceMock() {
 		let sc = new SchemaCompareTestService(testStateScmp.SUCCESS_NOT_EQUAL);
 		let service = TypeMoq.Mock.ofInstance(new SchemaCompareTestService());
-		service.setup(x => x.schemaCompareGetDefaultOptions()).returns(x => sc.schemaCompareGetDefaultOptions());
+		service.setup(x => x.schemaCompareGetDefaultOptions()).returns(() => sc.schemaCompareGetDefaultOptions());
 		service.setup(x => x.schemaCompare(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => sc.schemaCompare('', undefined, undefined, undefined, undefined));
 		return service;
 	}

--- a/extensions/schema-compare/src/test/testContext.ts
+++ b/extensions/schema-compare/src/test/testContext.ts
@@ -295,7 +295,7 @@ export function createViewContext(): ViewTestContext {
 		columns: [] as string[],
 		onRowSelected: onClick.event,
 		onCellAction: onClick.event,
-		appendData: (_: any[][]) => undefined
+		appendData: (_data: any[][]) => undefined
 	});
 	let tableBuilder: azdata.ComponentBuilder<azdata.TableComponent, azdata.TableComponentProperties> = {
 		component: () => table(),

--- a/extensions/schema-compare/src/test/testContext.ts
+++ b/extensions/schema-compare/src/test/testContext.ts
@@ -295,7 +295,7 @@ export function createViewContext(): ViewTestContext {
 		columns: [] as string[],
 		onRowSelected: onClick.event,
 		onCellAction: onClick.event,
-		appendData: (data: any[][]) => undefined
+		appendData: (_: any[][]) => undefined
 	});
 	let tableBuilder: azdata.ComponentBuilder<azdata.TableComponent, azdata.TableComponentProperties> = {
 		component: () => table(),

--- a/extensions/schema-compare/src/test/testSchemaCompareService.ts
+++ b/extensions/schema-compare/src/test/testSchemaCompareService.ts
@@ -20,11 +20,11 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		}
 	}
 
-	schemaComparePublishDatabaseChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+	schemaComparePublishDatabaseChanges(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaComparePublishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: mssql.ExtractTarget, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
+	schemaComparePublishProjectChanges(_: string, __: string, ___: mssql.ExtractTarget, ____: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
 		throw new Error('Method not implemented.');
 	}
 
@@ -38,19 +38,19 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		return Promise.resolve(result);
 	}
 
-	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludeExcludeResult> {
+	schemaCompareIncludeExcludeNode(_: string, __: mssql.DiffEntry, ___: boolean, ____: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludeExcludeResult> {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaCompareOpenScmp(filePath: string): Thenable<mssql.SchemaCompareOpenScmpResult> {
+	schemaCompareOpenScmp(_: string): Thenable<mssql.SchemaCompareOpenScmpResult> {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaCompareSaveScmp(sourceEndpointInfo: mssql.SchemaCompareEndpointInfo, targetEndpointInfo: mssql.SchemaCompareEndpointInfo, taskExecutionMode: azdata.TaskExecutionMode, deploymentOptions: mssql.DeploymentOptions, scmpFilePath: string, excludedSourceObjects: mssql.SchemaCompareObjectId[], excludedTargetObjects: mssql.SchemaCompareObjectId[]): Thenable<azdata.ResultStatus> {
+	schemaCompareSaveScmp(_: mssql.SchemaCompareEndpointInfo, __: mssql.SchemaCompareEndpointInfo, ____: azdata.TaskExecutionMode, _____: mssql.DeploymentOptions, ______: string, _______: mssql.SchemaCompareObjectId[], ________: mssql.SchemaCompareObjectId[]): Thenable<azdata.ResultStatus> {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaCompare(operationId: string, sourceEndpointInfo: mssql.SchemaCompareEndpointInfo, targetEndpointInfo: mssql.SchemaCompareEndpointInfo, taskExecutionMode: azdata.TaskExecutionMode, deploymentOptions: mssql.DeploymentOptions): Thenable<mssql.SchemaCompareResult> {
+	schemaCompare(_: string, __: mssql.SchemaCompareEndpointInfo, ___: mssql.SchemaCompareEndpointInfo, ____: azdata.TaskExecutionMode, _____: mssql.DeploymentOptions): Thenable<mssql.SchemaCompareResult> {
 		let result: mssql.SchemaCompareResult;
 		if (this.testState === testStateScmp.FAILURE) {
 			result = {
@@ -105,7 +105,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		return Promise.resolve(result);
 	}
 
-	schemaCompareGenerateScript(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+	schemaCompareGenerateScript(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
 		let result: azdata.ResultStatus;
 		if (this.testState === testStateScmp.FAILURE) {
 			result = {
@@ -123,7 +123,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		return Promise.resolve(result);
 	}
 
-	schemaCompareCancel(operationId: string): Thenable<azdata.ResultStatus> {
+	schemaCompareCancel(_: string): Thenable<azdata.ResultStatus> {
 		let result: azdata.ResultStatus;
 		if (this.testState === testStateScmp.FAILURE) {
 			result = {
@@ -144,7 +144,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 	handle?: number;
 	readonly providerId: string = 'MSSQL';
 
-	registerOnUpdated(handler: () => any): void {
+	registerOnUpdated(_: () => any): void {
 	}
 }
 

--- a/extensions/schema-compare/src/test/testSchemaCompareService.ts
+++ b/extensions/schema-compare/src/test/testSchemaCompareService.ts
@@ -20,11 +20,11 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		}
 	}
 
-	schemaComparePublishDatabaseChanges(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+	schemaComparePublishDatabaseChanges(_operationId: string, _targetServerName: string, _targetDatabaseName: string, _taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaComparePublishProjectChanges(_: string, __: string, ___: mssql.ExtractTarget, ____: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
+	schemaComparePublishProjectChanges(_operationId: string, _targetProjectPath: string, _targetFolderStructure: mssql.ExtractTarget, _taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaComparePublishProjectResult> {
 		throw new Error('Method not implemented.');
 	}
 
@@ -38,19 +38,19 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		return Promise.resolve(result);
 	}
 
-	schemaCompareIncludeExcludeNode(_: string, __: mssql.DiffEntry, ___: boolean, ____: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludeExcludeResult> {
+	schemaCompareIncludeExcludeNode(_operationId: string, _diffEntry: mssql.DiffEntry, _IncludeRequest: boolean, _taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludeExcludeResult> {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaCompareOpenScmp(_: string): Thenable<mssql.SchemaCompareOpenScmpResult> {
+	schemaCompareOpenScmp(_filePath: string): Thenable<mssql.SchemaCompareOpenScmpResult> {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaCompareSaveScmp(_: mssql.SchemaCompareEndpointInfo, __: mssql.SchemaCompareEndpointInfo, ____: azdata.TaskExecutionMode, _____: mssql.DeploymentOptions, ______: string, _______: mssql.SchemaCompareObjectId[], ________: mssql.SchemaCompareObjectId[]): Thenable<azdata.ResultStatus> {
+	schemaCompareSaveScmp(_sourceEndpointInfo: mssql.SchemaCompareEndpointInfo, _targetEndpointInfo: mssql.SchemaCompareEndpointInfo, _taskExecutionMode: azdata.TaskExecutionMode, _deploymentOptions: mssql.DeploymentOptions, _scmpFilePath: string, _excludedSourceObjects: mssql.SchemaCompareObjectId[], _excludedTargetObjects: mssql.SchemaCompareObjectId[]): Thenable<azdata.ResultStatus> {
 		throw new Error('Method not implemented.');
 	}
 
-	schemaCompare(_: string, __: mssql.SchemaCompareEndpointInfo, ___: mssql.SchemaCompareEndpointInfo, ____: azdata.TaskExecutionMode, _____: mssql.DeploymentOptions): Thenable<mssql.SchemaCompareResult> {
+	schemaCompare(_operationId: string, _sourceEndpointInfo: mssql.SchemaCompareEndpointInfo, _targetEndpointInfo: mssql.SchemaCompareEndpointInfo, _taskExecutionMode: azdata.TaskExecutionMode, _deploymentOptions: mssql.DeploymentOptions): Thenable<mssql.SchemaCompareResult> {
 		let result: mssql.SchemaCompareResult;
 		if (this.testState === testStateScmp.FAILURE) {
 			result = {
@@ -105,7 +105,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		return Promise.resolve(result);
 	}
 
-	schemaCompareGenerateScript(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+	schemaCompareGenerateScript(_operationId: string, _targetServerName: string, _targetDatabaseName: string, _taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
 		let result: azdata.ResultStatus;
 		if (this.testState === testStateScmp.FAILURE) {
 			result = {
@@ -123,7 +123,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		return Promise.resolve(result);
 	}
 
-	schemaCompareCancel(_: string): Thenable<azdata.ResultStatus> {
+	schemaCompareCancel(_operationId: string): Thenable<azdata.ResultStatus> {
 		let result: azdata.ResultStatus;
 		if (this.testState === testStateScmp.FAILURE) {
 			result = {
@@ -144,7 +144,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 	handle?: number;
 	readonly providerId: string = 'MSSQL';
 
-	registerOnUpdated(_: () => any): void {
+	registerOnUpdated(_handler: () => any): void {
 	}
 }
 

--- a/extensions/schema-compare/tsconfig.json
+++ b/extensions/schema-compare/tsconfig.json
@@ -14,7 +14,6 @@
 		"declaration": false,
 		"strict": false,
 		"noImplicitAny": false,
-		"noUnusedParameters": false,
 		"noImplicitReturns": false,
 		"noUnusedLocals": false,
 		"strictNullChecks": false


### PR DESCRIPTION
I felt like doing some code cleanup, so this turns on the `noUnusedParameters` check in the schema compare extension. Most of the errors were from test functions having unused parameters, and the rest were click handlers that weren't actually using the click parameter being passed in.
