### PR TITLE
add tooltip to icon buttons in sql projects extension

### DIFF
--- a/extensions/data-workspace/src/dialogs/newProjectDialog.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectDialog.ts
@@ -215,6 +215,7 @@ export class NewProjectDialog extends DialogBase {
 
 		const browseFolderButton = view.modelBuilder.button().withProps({
 			ariaLabel: constants.BrowseButtonText,
+			title: constants.BrowseButtonText,
 			iconPath: IconPathHelper.folder,
 			height: '16px',
 			width: '18px'

--- a/extensions/data-workspace/src/dialogs/openExistingDialog.ts
+++ b/extensions/data-workspace/src/dialogs/openExistingDialog.ts
@@ -163,6 +163,7 @@ export class OpenExistingDialog extends DialogBase {
 
 		const localClonePathBrowseFolderButton = view.modelBuilder.button().withProps({
 			ariaLabel: constants.BrowseButtonText,
+			title: constants.BrowseButtonText,
 			iconPath: IconPathHelper.folder,
 			width: '18px',
 			height: '16px',
@@ -203,6 +204,7 @@ export class OpenExistingDialog extends DialogBase {
 
 		const localProjectBrowseFolderButton = view.modelBuilder.button().withProps({
 			ariaLabel: constants.BrowseButtonText,
+			title: constants.BrowseButtonText,
 			iconPath: IconPathHelper.folder,
 			width: '18px',
 			height: '16px'

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -239,6 +239,7 @@ export class CreateProjectFromDatabaseDialog {
 	private createSelectConnectionButton(view: azdataType.ModelView): azdataType.Component {
 		this.selectConnectionButton = view.modelBuilder.button().withProps({
 			ariaLabel: constants.selectConnection,
+			title: constants.selectConnection,
 			iconPath: IconPathHelper.selectConnection,
 			height: '16px',
 			width: '16px'
@@ -354,6 +355,7 @@ export class CreateProjectFromDatabaseDialog {
 	private createBrowseFolderButton(view: azdataType.ModelView): azdataType.ButtonComponent {
 		const browseFolderButton = view.modelBuilder.button().withProps({
 			ariaLabel: constants.browseButtonText,
+			title: constants.browseButtonText,
 			iconPath: IconPathHelper.folder_blue,
 			height: '18px',
 			width: '18px'

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -807,6 +807,7 @@ export class PublishDatabaseDialog {
 	private createSelectConnectionButton(view: azdataType.ModelView): azdataType.Component {
 		this.selectConnectionButton = view.modelBuilder.button().withProps({
 			ariaLabel: constants.selectConnection,
+			title: constants.selectConnection,
 			iconPath: IconPathHelper.selectConnection,
 			height: '16px',
 			width: '16px'
@@ -849,6 +850,7 @@ export class PublishDatabaseDialog {
 	private createLoadProfileButton(view: azdataType.ModelView): azdataType.ButtonComponent {
 		let loadProfileButton: azdataType.ButtonComponent = view.modelBuilder.button().withProps({
 			ariaLabel: constants.loadProfilePlaceholderText,
+			title: constants.loadProfilePlaceholderText,
 			iconPath: IconPathHelper.folder_blue,
 			height: '18px',
 			width: '18px'

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -352,6 +352,7 @@ export class UpdateProjectFromDatabaseDialog {
 	private createConnectionButton(view: azdata.ModelView) {
 		this.connectionButton = view.modelBuilder.button().withProps({
 			ariaLabel: constants.selectConnection,
+			title: constants.selectConnection,
 			iconPath: IconPathHelper.selectConnection,
 			height: '20px',
 			width: '20px'
@@ -412,6 +413,7 @@ export class UpdateProjectFromDatabaseDialog {
 	private createBrowseFileButton(view: azdata.ModelView): azdata.ButtonComponent {
 		const browseFolderButton = view.modelBuilder.button().withProps({
 			ariaLabel: constants.browseButtonText,
+			title: constants.browseButtonText,
 			iconPath: IconPathHelper.folder_blue,
 			height: '18px',
 			width: '18px'
@@ -492,7 +494,7 @@ export class UpdateProjectFromDatabaseDialog {
 		let radioButtons = view.modelBuilder.flexContainer()
 			.withLayout({ flexFlow: 'column' })
 			.withItems([this.compareActionRadioButton, this.updateActionRadioButton])
-			.withProps({ ariaRole: 'radiogroup' })
+			.withProps({ ariaRole: 'radiogroup', ariaLabel: constants.actionLabel })
 			.component();
 
 		const actionLabel = view.modelBuilder.text().withProps({


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses https://github.com/microsoft/azuredatastudio/issues/22219 and https://github.com/microsoft/azuredatastudio/issues/22161 by adding a tooltip to the icon buttons in the sql database projects extension.
![hoverText](https://user-images.githubusercontent.com/31145923/227644953-86cb4a50-4d9c-4cc2-977b-a9ef17b74968.gif)
