### PR TITLE
hide exclude folder from context menu until it's supported

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -419,7 +419,7 @@
         },
         {
           "command": "sqlDatabaseProjects.exclude",
-          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/",
+          "when": "view == dataworkspace.views.main && viewItem =~ /^databaseProject.itemType.file/",
           "group": "9_dbProjectsLast@1"
         },
         {


### PR DESCRIPTION
After the swap to use the DacFx.Projects library, excluding folders is not yet supported. Rather than show an error when a user tries to exclude a folder, it's better to hide it from the folder context menu until it is supported.

before:
![image](https://user-images.githubusercontent.com/31145923/227652367-d63ce199-ff19-4a34-9b1a-a3c74d288df4.png)

after:
![image](https://user-images.githubusercontent.com/31145923/227652256-e9915af1-d7a1-4c53-afdb-b37cae67f243.png)

