### PR TITLE
support default action for OE node

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -493,7 +493,8 @@
         {
           "command": "mssql.designTable",
           "when": "connectionProvider == MSSQL && nodeType == Table && nodeSubType != LedgerDropped",
-          "group": "0_query@3"
+          "group": "0_query@3",
+          "isDefault": true
         },
         {
           "command": "mssql.newTable",
@@ -513,7 +514,8 @@
         {
           "command": "mssql.objectProperties",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User)$/ && config.workbench.enablePreviewFeatures",
-          "group": "0_query@1"
+          "group": "0_query@1",
+          "isDefault": true
         },
         {
           "command": "mssql.deleteObject",

--- a/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
@@ -11,9 +11,10 @@ import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/br
 // import { IProgressRunner, IProgressService } from 'vs/platform/progress/common/progress';
 import { TreeNode } from 'sql/workbench/services/objectExplorer/common/treeNode';
 import { TreeUpdateUtils } from 'sql/workbench/services/objectExplorer/browser/treeUpdateUtils';
-import { AsyncServerTree } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
+import { AsyncServerTree, ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { onUnexpectedError } from 'vs/base/common/errors';
+import { ConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
 
 export interface ObjectExplorerRequestStatus {
 	inProgress: boolean;
@@ -54,14 +55,14 @@ export class TreeSelectionHandler {
 	/**
 	 * Handle selection of tree element
 	 */
-	public onTreeSelect(event: any, tree: AsyncServerTree | ITree, connectionManagementService: IConnectionManagementService, objectExplorerService: IObjectExplorerService, capabilitiesService: ICapabilitiesService, connectionCompleteCallback: () => void) {
+	public onTreeSelect(event: any, tree: AsyncServerTree | ITree, connectionManagementService: IConnectionManagementService, objectExplorerService: IObjectExplorerService, capabilitiesService: ICapabilitiesService, connectionCompleteCallback: () => void, doubleClickHandler: (node: ServerTreeElement) => void) {
 		let sendSelectionEvent = ((event: any, selection: any, isDoubleClick: boolean, userInteraction: boolean, requestStatus: ObjectExplorerRequestStatus | undefined = undefined) => {
 			// userInteraction: defensive - don't touch this something else is handling it.
 			if (userInteraction === true && this._lastClicked && this._lastClicked[0] === selection[0]) {
 				this._lastClicked = undefined;
 			}
 			if (!TreeUpdateUtils.isInDragAndDrop) {
-				this.handleTreeItemSelected(connectionManagementService, objectExplorerService, capabilitiesService, isDoubleClick, this.isKeyboardEvent(event), selection, tree, connectionCompleteCallback, requestStatus);
+				this.handleTreeItemSelected(connectionManagementService, objectExplorerService, capabilitiesService, isDoubleClick, this.isKeyboardEvent(event), selection, tree, connectionCompleteCallback, requestStatus, doubleClickHandler);
 			}
 		});
 
@@ -110,63 +111,65 @@ export class TreeSelectionHandler {
 	 * @param tree
 	 * @param connectionCompleteCallback A function that gets called after a connection is established due to the selection, if needed
 	 * @param requestStatus Used to identify if a new session should be created or not to avoid creating back to back sessions
+	 * @param doubleClickHandler
 	 */
-	private handleTreeItemSelected(connectionManagementService: IConnectionManagementService, objectExplorerService: IObjectExplorerService, capabilitiesService: ICapabilitiesService, isDoubleClick: boolean, isKeyboard: boolean, selection: any[], tree: AsyncServerTree | ITree, connectionCompleteCallback: () => void, requestStatus: ObjectExplorerRequestStatus | undefined): void {
+	private async handleTreeItemSelected(connectionManagementService: IConnectionManagementService,
+		objectExplorerService: IObjectExplorerService,
+		capabilitiesService: ICapabilitiesService,
+		isDoubleClick: boolean,
+		isKeyboard: boolean,
+		selection: any[],
+		tree: AsyncServerTree | ITree,
+		connectionCompleteCallback: () => void,
+		requestStatus: ObjectExplorerRequestStatus | undefined,
+		doubleClickHandler: (node: ServerTreeElement) => void): Promise<void> {
+		if (!selection || selection.length === 0) {
+			return;
+		}
+		const selectedNode = selection[0];
+		if (selectedNode instanceof ConnectionProfile && !capabilitiesService.getCapabilities(selectedNode.providerName)) {
+			connectionManagementService.handleUnsupportedProvider(selectedNode.providerName).catch(onUnexpectedError);
+			return;
+		}
+
 		if (tree instanceof AsyncServerTree) {
-			if (selection && selection.length > 0 && (selection[0] instanceof ConnectionProfile)) {
-				if (!capabilitiesService.getCapabilities(selection[0].providerName)) {
-					connectionManagementService.handleUnsupportedProvider(selection[0].providerName).catch(onUnexpectedError);
-					return;
-				}
+			if (selectedNode instanceof ConnectionProfile) {
 				this.onTreeActionStateChange(true);
 			}
 		} else {
-			let connectionProfile: ConnectionProfile | undefined = undefined;
-			let options: IConnectionCompletionOptions = {
-				params: undefined,
-				saveTheConnection: true,
-				showConnectionDialogOnError: true,
-				showFirewallRuleOnError: true,
-				showDashboard: isDoubleClick // only show the dashboard if the action is double click
-			};
-			if (selection && selection.length > 0 && (selection[0] instanceof ConnectionProfile)) {
-				connectionProfile = <ConnectionProfile>selection[0];
-				if (!capabilitiesService.getCapabilities(connectionProfile.providerName)) {
-					connectionManagementService.handleUnsupportedProvider(connectionProfile.providerName).catch(onUnexpectedError);
-					return;
-				}
-
-				if (connectionProfile) {
+			if (selectedNode instanceof TreeNode || selectedNode instanceof ConnectionProfile || selectedNode instanceof ConnectionProfileGroup) {
+				if (isDoubleClick) {
+					doubleClickHandler(selectedNode);
+				} else if (selectedNode instanceof ConnectionProfile) {
+					let options: IConnectionCompletionOptions = {
+						params: undefined,
+						saveTheConnection: true,
+						showConnectionDialogOnError: true,
+						showFirewallRuleOnError: true,
+						showDashboard: false
+					};
 					this.onTreeActionStateChange(true);
 
-					TreeUpdateUtils.connectAndCreateOeSession(connectionProfile, options, connectionManagementService, objectExplorerService, tree, requestStatus).then(sessionCreated => {
+					try {
+						const sessionCreated = await TreeUpdateUtils.connectAndCreateOeSession(selectedNode, options, connectionManagementService, objectExplorerService, tree, requestStatus);
 						// Clears request status object that was created when the first timeout callback is executed.
 						if (this._requestStatus) {
 							this._requestStatus = undefined;
 						}
-
 						if (!sessionCreated) {
 							this.onTreeActionStateChange(false);
 						}
 						if (connectionCompleteCallback) {
 							connectionCompleteCallback();
 						}
-					}, error => {
+					} catch (error) {
 						this.onTreeActionStateChange(false);
-					});
-				}
-			} else if (isDoubleClick && selection && selection.length > 0 && (selection[0] instanceof TreeNode)) {
-				let treeNode = selection[0];
-				if (TreeUpdateUtils.isAvailableDatabaseNode(treeNode)) {
-					connectionProfile = TreeUpdateUtils.getConnectionProfile(treeNode);
-					if (connectionProfile) {
-						connectionManagementService.showDashboard(connectionProfile);
 					}
 				}
 			}
 
 			if (isKeyboard) {
-				tree.toggleExpansion(selection[0]);
+				tree.toggleExpansion(selectedNode);
 			}
 		}
 	}

--- a/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
@@ -62,7 +62,7 @@ export class TreeSelectionHandler {
 				this._lastClicked = undefined;
 			}
 			if (!TreeUpdateUtils.isInDragAndDrop) {
-				this.handleTreeItemSelected(connectionManagementService, objectExplorerService, capabilitiesService, isDoubleClick, this.isKeyboardEvent(event), selection, tree, connectionCompleteCallback, requestStatus, doubleClickHandler);
+				this.handleTreeItemSelected(connectionManagementService, objectExplorerService, capabilitiesService, isDoubleClick, this.isKeyboardEvent(event), selection, tree, connectionCompleteCallback, requestStatus, doubleClickHandler).catch(onUnexpectedError);
 			}
 		});
 

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -23,6 +23,7 @@ export interface IMenuItem {
 	when?: ContextKeyExpression;
 	group?: 'navigation' | string;
 	order?: number;
+	isDefault?: boolean; // {{SQL CARBON EDIT}} - Used by object explorer, indicating whether this is the action to be executed when a node is double clicked.
 }
 
 export interface ISubmenuItem {
@@ -365,6 +366,8 @@ export class MenuItemAction implements IAction {
 	private readonly _options: IMenuActionOptions | undefined;
 
 	readonly id: string;
+
+	isDefault: boolean = false; // {{SQL CARBON EDIT}}} - Add isDefault property to MenuItemAction.
 
 	// {{SQL CARBON EDIT}} -- remove readonly since notebook component sets these
 	label: string;

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -154,6 +154,11 @@ class Menu implements IMenu {
 						? new MenuItemAction(item.command, item.alt, options, this._contextKeyService, this._commandService)
 						: new SubmenuItemAction(item, this._menuService, this._contextKeyService, options);
 
+					// {{SQL CARBON EDIT}} - Set isDefault property
+					if (isIMenuItem(item)) {
+						(<MenuItemAction>action).isDefault = item.isDefault;
+					}
+					// {{SQL CARBON EDIT}} - End
 					activeActions.push(action);
 				}
 			}

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -313,6 +313,7 @@ namespace schema {
 		alt?: string;
 		when?: string;
 		group?: string;
+		isDefault?: boolean; // {{SQL CARBON EDIT}} - Used by object explorer, indicating whether this is the action to be executed when a node is double clicked.
 	}
 
 	export interface IUserFriendlySubmenuItem {
@@ -824,6 +825,8 @@ menusExtensionPoint.setHandler(extensions => {
 					}
 
 					item = { command, alt, group: undefined, order: undefined, when: undefined };
+
+					(<IMenuItem>item).isDefault = menuItem.isDefault; // {{SQL CARBON EDIT}}} Set isDefault property.
 				} else {
 					if (menu.supportsSubmenus === false) {
 						collector.error(localize('unsupported.submenureference', "Menu item references a submenu for a menu which doesn't have submenu support."));


### PR DESCRIPTION
This PR fixes #950
This PR fixes #16377
This PR fixes #22427

There are 3 ways we can implement this feature:
1. in the node information, include a command property and use it as the default command.
2. create another menu similar to the current object explorer item context menu contribution point.
3. add a `isDefault` property to the existing menu contribution (the implementation in this PR)

the downside of the first 2 implementations is that the logic of when the menu item is available needs to be duplicated either in backend service (approach 1)or the package.json (approach2).  the third approach is chosen because of minimum change required from extension side.

![double-click](https://user-images.githubusercontent.com/13777222/227652730-f436b3bd-90d3-4d17-b591-a7af51446f15.gif)

when there are multiple default actions, an error will be logged for us to troubleshoot.
![image](https://user-images.githubusercontent.com/13777222/227652795-c0e8eecf-880c-48b2-9320-e6ff75285f09.png)

I have covered both the tree view and async server tree. 