### PR TITLE
select the row on double click

### DIFF
--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -769,7 +769,8 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	}
 
 	private onTableDoubleClick(event: ITableMouseEvent) {
-		if (event.cell) {
+		// the first column is already handled by rowNumberColumn plugin.
+		if (event.cell && event.cell.cell !== 0) {
 			// upon double clicking, we want to select the entire row so that it is easier to know which
 			// row is selected when the user needs to scroll horizontally.
 			this.table.grid.setSelectedRows([event.cell.row]);

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -549,6 +549,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		this._register(this.dataProvider.onFilterStateChange(() => { this.layout(); }));
 		this._register(this.table.onContextMenu(this.contextMenu, this));
 		this._register(this.table.onClick(this.onTableClick, this));
+		this._register(this.table.onDoubleClick(this.onTableDoubleClick, this));
 		this._register(this.dataProvider.onFilterStateChange(() => {
 			const columns = this.table.columns as FilterableColumn<T>[];
 			this.state.columnFilters = columns.filter((column) => column.filterValues?.length > 0).map(column => {
@@ -764,6 +765,14 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 					await this.editorService.openEditor(input);
 				}
 			}
+		}
+	}
+
+	private onTableDoubleClick(event: ITableMouseEvent) {
+		if (event.cell) {
+			// upon double clicking, we want to select the entire row so that it is easier to know which
+			// row is selected when the user needs to scroll horizontally.
+			this.table.grid.setSelectedRows([event.cell.row]);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #3643

select the entire row when a cell is double clicked so that it is easier to know whichrow is selected when the user needs to scroll horizontally.
![select-row](https://user-images.githubusercontent.com/13777222/227656184-99f453ef-ea22-47ac-beb1-60be98479089.gif)
