### PR TITLE
Bring back arc/azcli test files

### DIFF
--- a/extensions/arc/src/test/mocks/fakeControllerModel.ts
+++ b/extensions/arc/src/test/mocks/fakeControllerModel.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// import { ControllerInfo } from 'arc';
+// import { v4 as uuid } from 'uuid';
+// import { ControllerModel } from '../../models/controllerModel';
+// import { AzureArcTreeDataProvider } from '../../ui/tree/azureArcTreeDataProvider';
+
+// export class FakeControllerModel extends ControllerModel {
+
+// 	constructor(treeDataProvider?: AzureArcTreeDataProvider, info?: Partial<ControllerInfo>) {
+// 		const _info: ControllerInfo = Object.assign({ id: uuid(), endpoint: '', kubeConfigFilePath: '', kubeClusterContext: '', name: '', namespace: '', username: '', rememberPassword: false, resources: [], resourceGroup: '', connectionMode: '', location: '', customLocation: '' }, info);
+// 		super(treeDataProvider!, _info);
+// 	}
+
+// }

--- a/extensions/azcli/src/test/testUtils.ts
+++ b/extensions/azcli/src/test/testUtils.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Asserts that the specified promise was rejected. This is similar to should(..).be.rejected but
+ * allows specifying a message in the thrown Error to add more information to the failure.
+ * @param promise The promise to verify was rejected
+ * @param message The message to include in the error if the promise isn't rejected
+ */
+// export async function assertRejected(promise: Promise<any>, message: string): Promise<void> {
+// 	try {
+// 		await promise;
+// 	} catch {
+// 		return;
+// 	}
+// 	throw new Error(message);
+// }
+


### PR DESCRIPTION
Bringing them back but commenting them out in case we decide to re-enable the arc/azcli tests in the future. 