### PR TITLE
hide extensions with 'hidden' flag

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -727,6 +727,12 @@ abstract class AbstractExtensionGalleryService implements IExtensionGalleryServi
 		let query = new Query()
 			.withPage(1, pageSize);
 
+		// {{SQL CARBON EDIT}} exclude extensions matching excludeFlags options
+		if (options.excludeFlags) {
+			query = query.withFilter(FilterType.ExcludeWithFlags, options.excludeFlags);
+		}
+		// {{SQL CARBON EDIT}}} - END
+
 		if (text) {
 			// Use category filter instead of "category:themes"
 			text = text.replace(/\bcategory:("([^"]*)"|([^"]\S*))(\s+|\b|$)/g, (_, quotedCategory, category) => {


### PR DESCRIPTION
This PR fixes #22469
bring back a SQL CARBON edit that was removed in https://github.com/microsoft/azuredatastudio/pull/20883/files#diff-603115949ed162957f481f65cc3266ebf96b817933aa46cf23c25be3592d1e5cL667.