### PR TITLE
fix undefined error when opening Create Project from Database dialog

### DIFF
--- a/extensions/data-workspace/src/common/pathUtilsHelper.ts
+++ b/extensions/data-workspace/src/common/pathUtilsHelper.ts
@@ -39,7 +39,7 @@ export function isValidFilenameCharacter(c: string): boolean {
 export function sanitizeStringForFilename(s: string): string {
 	// replace invalid characters with an underscore
 	let result = '';
-	for (let i = 0; i < s.length; ++i) {
+	for (let i = 0; i < s?.length; ++i) {
 		result += isValidFilenameCharacter(s[i]) ? s[i] : '_';
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #22479. The first time this function gets called when opening the create project from db dialog, the db dropdown hasn't been populated yet which is why it's passing in undefined.
