### PR TITLE
Switch "Install" to "Download" for downloaded extensions

### DIFF
--- a/src/sql/base/common/locConstants.ts
+++ b/src/sql/base/common/locConstants.ts
@@ -92,4 +92,7 @@ export const outputLineHeightDescription = localize('notebook.outputLineHeight',
 export const outputFontSizeDescription = localize('notebook.outputFontSize', "Font size for the output text for notebook cells. When set to 0 `#editor.fontSize#` is used. (for VS Code Notebooks only)");
 export const outputFontFamilyDescription = localize('notebook.outputFontFamily', "The font family for the output text for notebook cells. When set to empty, the `#editor.fontFamily#` is used. (for VS Code Notebooks only)");
 export const experimentalCustomizationDescription = localize('notebook.editorOptions.experimentalCustomization', 'Settings for code editors used in notebooks. This can be used to customize most editor.* settings. (for VS Code Notebooks only)');
+export const download = localize('azuredatastudio.download', 'Download');
+export const downloadTooltip = localize('azuredatastudio.downloadTooltip', "Download this extension from an external source");
+export const installTooltip = localize('azuredatastudio.installTooltip', "Install this extension");
 //#endregion


### PR DESCRIPTION
This came up from a recent discussion around the gallery and it's been something that's bugged me for a while so just doing it now. Previously we would show the "Install" button for all extensions - even 3rd party ones that open up a download page instead. This PR just changes it to show "Download" instead to make it clearer to users what is going to happen when they click the button. 

![image](https://user-images.githubusercontent.com/28519865/228340042-c23ddd1c-9201-466a-8946-4af06173e7a0.png)

![image](https://user-images.githubusercontent.com/28519865/228340134-4553b587-f8e2-4752-9dde-6ab79faf6efa.png)
