### PR TITLE
Add kusto endpoints for non-public clouds

### DIFF
--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -155,7 +155,7 @@ const usGovAzureSettings: ProviderSettings = {
 			},
 			azureKustoResource: {
 				id: SettingIds.kusto,
-				endpoint: 'https://sqlazureusg.kusto.usgovcloudapi.net',
+				endpoint: 'https://kusto.kusto.usgovcloudapi.net',
 				azureResourceId: AzureResource.AzureKusto,
 			},
 			powerBiResource: {
@@ -224,7 +224,7 @@ const chinaAzureSettings: ProviderSettings = {
 			},
 			azureKustoResource: {
 				id: SettingIds.kusto,
-				endpoint: 'https://sqlazurechi2.chinanorth2.kusto.chinacloudapi.cn',
+				endpoint: 'https://kusto.kusto.chinacloudapi.cn',
 				azureResourceId: AzureResource.AzureKusto,
 			},
 			powerBiResource: {

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -153,6 +153,11 @@ const usGovAzureSettings: ProviderSettings = {
 				endpointSuffix: '.core.usgovcloudapi.net/',
 				azureResourceId: AzureResource.AzureStorage
 			},
+			azureKustoResource: {
+				id: SettingIds.kusto,
+				endpoint: 'https://sqlazureusg.kusto.usgovcloudapi.net',
+				azureResourceId: AzureResource.AzureKusto,
+			},
 			powerBiResource: {
 				id: SettingIds.powerbi,
 				endpoint: 'https://analysis.windows.net/powerbi/api/',
@@ -216,6 +221,11 @@ const chinaAzureSettings: ProviderSettings = {
 				endpoint: '',
 				endpointSuffix: '.core.chinacloudapi.cn',
 				azureResourceId: AzureResource.AzureStorage
+			},
+			azureKustoResource: {
+				id: SettingIds.kusto,
+				endpoint: 'https://sqlazurechi2.chinanorth2.kusto.chinacloudapi.cn',
+				azureResourceId: AzureResource.AzureKusto,
 			},
 			powerBiResource: {
 				id: SettingIds.powerbi,


### PR DESCRIPTION
This PR adds Kusto endpoints for non-public clouds.

Fixes the first part of #22437