### PR TITLE
move publish interfaces out of sqldbproj.d.ts

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -37,7 +37,7 @@ import { DashboardData, PublishData, Status } from '../models/dashboardData/dash
 import { getPublishDatabaseSettings, launchPublishTargetOption } from '../dialogs/publishDatabaseQuickpick';
 import { launchCreateAzureServerQuickPick } from '../dialogs/deployDatabaseQuickpick';
 import { DeployService } from '../models/deploy/deployService';
-import { AddItemOptions, EntryType, GenerateProjectFromOpenApiSpecOptions, IDatabaseReferenceProjectEntry, ISqlProjectPublishSettings, IPublishToDockerSettings, ISqlProject, ItemType, SqlTargetPlatform } from 'sqldbproj';
+import { AddItemOptions, EntryType, GenerateProjectFromOpenApiSpecOptions, IDatabaseReferenceProjectEntry, ISqlProject, ItemType, SqlTargetPlatform } from 'sqldbproj';
 import { AutorestHelper } from '../tools/autorestHelper';
 import { createNewProjectFromDatabaseWithQuickpick } from '../dialogs/createProjectFromDatabaseQuickpick';
 import { addDatabaseReferenceQuickpick } from '../dialogs/addDatabaseReferenceQuickpick';
@@ -48,6 +48,7 @@ import { AzureSqlClient } from '../models/deploy/azureSqlClient';
 import { ConnectionService } from '../models/connections/connectionService';
 import { getPublishToDockerSettings } from '../dialogs/publishToDockerQuickpick';
 import { SqlCmdVariableTreeItem } from '../models/tree/sqlcmdVariableTreeItem';
+import { IPublishToDockerSettings, ISqlProjectPublishSettings } from '../models/deploy/publishSettings';
 
 const maxTableLength = 10;
 

--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseQuickpick.ts
@@ -14,7 +14,7 @@ import { Project } from '../models/project';
 import { getPublishDatabaseSettings } from './publishDatabaseQuickpick';
 import { AzureSqlClient } from '../models/deploy/azureSqlClient';
 import { IAccount } from 'vscode-mssql';
-import { ISqlProjectPublishSettings } from 'sqldbproj';
+import { ISqlProjectPublishSettings } from '../models/deploy/publishSettings';
 
 /**
  * Create flow for Deploying a database using only VS Code-native APIs such as QuickPick

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -18,7 +18,7 @@ import { getAgreementDisplayText, getConnectionName, getDockerBaseImages, getPub
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
 import { Deferred } from '../common/promise';
 import { PublishOptionsDialog } from './publishOptionsDialog';
-import { ISqlProjectPublishSettings, IPublishToDockerSettings } from 'sqldbproj';
+import { IPublishToDockerSettings, ISqlProjectPublishSettings } from '../models/deploy/publishSettings';
 
 interface DataSourceDropdownValue extends azdataType.CategoryValue {
 	dataSource: SqlConnectionDataSource;

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -11,8 +11,9 @@ import { promptForPublishProfile } from './publishDatabaseDialog';
 import { getDefaultPublishDeploymentOptions, getVscodeMssqlApi } from '../common/utils';
 import { IConnectionInfo, IFireWallRuleError } from 'vscode-mssql';
 import { getPublishServerName } from './utils';
-import { ISqlProjectPublishSettings, ISqlProject, SqlTargetPlatform } from 'sqldbproj';
+import { ISqlProject, SqlTargetPlatform } from 'sqldbproj';
 import { DBProjectConfigurationKey } from '../tools/netcoreTool';
+import { ISqlProjectPublishSettings } from '../models/deploy/publishSettings';
 
 /**
  * Create flow for Publishing a database using only VS Code-native APIs such as QuickPick

--- a/extensions/sql-database-projects/src/dialogs/publishToDockerQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishToDockerQuickpick.ts
@@ -6,9 +6,10 @@ import * as vscode from 'vscode';
 import * as constants from '../common/constants';
 import * as utils from '../common/utils';
 import * as uiUtils from './utils';
-import { IDockerSettings, IPublishToDockerSettings, ISqlProject } from 'sqldbproj';
+import { ISqlProject } from 'sqldbproj';
 import { getPublishDatabaseSettings } from './publishDatabaseQuickpick';
 import { DockerImageInfo } from '../models/deploy/deployProfile';
+import { IDockerSettings, IPublishToDockerSettings } from '../models/deploy/publishSettings';
 
 /**
  * Gets the settings for publishing a database to docker container using only VS Code-native APIs such as QuickPick

--- a/extensions/sql-database-projects/src/models/deploy/deployProfile.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployProfile.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as azdataType from 'azdata';
-import { ISqlProjectPublishSettings, ISqlConnectionProperties } from 'sqldbproj';
+import { ISqlConnectionProperties } from 'sqldbproj';
 import { IAzureAccountSession } from 'vscode-mssql';
+import { ISqlProjectPublishSettings } from './publishSettings';
 
 export enum AppSettingType {
 	None,

--- a/extensions/sql-database-projects/src/models/deploy/deployService.ts
+++ b/extensions/sql-database-projects/src/models/deploy/deployService.ts
@@ -12,7 +12,8 @@ import * as vscode from 'vscode';
 import { ShellExecutionHelper } from '../../tools/shellExecutionHelper';
 import { AzureSqlClient } from './azureSqlClient';
 import { ConnectionService } from '../connections/connectionService';
-import { DockerImageSpec, IDockerSettings, IPublishToDockerSettings } from 'sqldbproj';
+import { DockerImageSpec } from 'sqldbproj';
+import { IDockerSettings, IPublishToDockerSettings } from './publishSettings';
 
 export class DeployService {
 

--- a/extensions/sql-database-projects/src/models/deploy/publishSettings.ts
+++ b/extensions/sql-database-projects/src/models/deploy/publishSettings.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ISqlConnectionProperties } from 'sqldbproj';
+import { DeploymentOptions as mssqlDeploymentOptions } from 'mssql';
+import { DeploymentOptions as vscodeMssqlDeploymentOptions } from 'vscode-mssql';
+
+export type DeploymentOptions = mssqlDeploymentOptions | vscodeMssqlDeploymentOptions;
+
+/**
+ * Settings to use when publishing a SQL Project
+ */
+export interface ISqlProjectPublishSettings {
+	databaseName: string;
+	serverName: string;
+	connectionUri: string;
+	sqlCmdVariables?: Record<string, string>;
+	deploymentOptions?: DeploymentOptions;
+	profileUsed?: boolean;
+}
+
+/**
+ * Settings for creating the docker container a project is being published to
+ */
+export interface IDockerSettings extends ISqlConnectionProperties {
+	dockerBaseImage: string,
+	dockerBaseImageEula: string,
+}
+
+/**
+ * Settings for publishing a SQL Project to a docker container
+ */
+export interface IPublishToDockerSettings {
+	dockerSettings: IDockerSettings;
+	sqlProjectPublishSettings: ISqlProjectPublishSettings;
+}
+

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -14,7 +14,6 @@ import { SqlDatabaseProjectTreeViewProvider } from '../controllers/databaseProje
 import { ProjectsController } from '../controllers/projectController';
 import { Project } from '../models/project';
 import { BaseProjectTreeItem } from '../models/tree/baseTreeItem';
-import { getPublishToDockerSettings } from '../dialogs/publishToDockerQuickpick';
 import { getDockerImageSpec } from '../models/deploy/deployService';
 
 export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvider, sqldbproj.IExtension {
@@ -227,10 +226,6 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 
 	public generateProjectFromOpenApiSpec(options?: sqldbproj.GenerateProjectFromOpenApiSpecOptions): Promise<sqldbproj.ISqlProject | undefined> {
 		return this.projectController.generateProjectFromOpenApiSpec(options);
-	}
-
-	public getPublishToDockerSettings(project: sqldbproj.ISqlProject): Promise<sqldbproj.IPublishToDockerSettings | undefined> {
-		return getPublishToDockerSettings(project);
 	}
 
 	public getDockerImageSpec(projectName: string, baseImage: string, imageUniqueId?: string): sqldbproj.DockerImageSpec {

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -5,8 +5,6 @@
 
 declare module 'sqldbproj' {
 	import * as vscode from 'vscode';
-	import { DeploymentOptions as mssqlDeploymentOptions } from 'mssql';
-	import { DeploymentOptions as vscodeMssqlDeploymentOptions } from 'vscode-mssql';
 
 	export const enum extension {
 		name = 'Microsoft.sql-database-projects',
@@ -65,12 +63,6 @@ declare module 'sqldbproj' {
 		 * @param options The additional options to use
 		 */
 		addItemPrompt(project: ISqlProject, relativeFilePath: string, options?: AddItemOptions): Promise<void>;
-
-		/**
-		 * Gathers information required for publishing a project to a docker container, prompting the user as necessary
-		 * @param project The Project being published
-		 */
-		getPublishToDockerSettings(project: ISqlProject): Promise<IPublishToDockerSettings | undefined>;
 
 		/**
 		 * Gets the information required to start a docker container for publishing to
@@ -325,36 +317,6 @@ declare module 'sqldbproj' {
 		dbName: string,
 		profileName?: string,
 		connectionRetryTimeout?: number
-	}
-
-	/**
-	 * Settings for creating the docker container a project is being published to
-	 */
-	export interface IDockerSettings extends ISqlConnectionProperties {
-		dockerBaseImage: string,
-		dockerBaseImageEula: string,
-	}
-
-	/**
-	 * Settings for publishing a SQL Project to a docker container
-	 */
-	export interface IPublishToDockerSettings {
-		dockerSettings: IDockerSettings;
-		sqlProjectPublishSettings: ISqlProjectPublishSettings;
-	}
-
-	export type DeploymentOptions = mssqlDeploymentOptions | vscodeMssqlDeploymentOptions;
-
-	/**
-	 * Settings to use when publishing a SQL Project
-	 */
-	export interface ISqlProjectPublishSettings {
-		databaseName: string;
-		serverName: string;
-		connectionUri: string;
-		sqlCmdVariables?: Record<string, string>;
-		deploymentOptions?: DeploymentOptions;
-		profileUsed?: boolean;
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
+++ b/extensions/sql-database-projects/src/test/deploy/deployService.test.ts
@@ -18,7 +18,7 @@ import { ShellExecutionHelper } from '../../tools/shellExecutionHelper';
 import * as TypeMoq from 'typemoq';
 import { AzureSqlClient } from '../../models/deploy/azureSqlClient';
 import { ConnectionService } from '../../models/connections/connectionService';
-import { IPublishToDockerSettings } from 'sqldbproj';
+import { IPublishToDockerSettings } from '../../models/deploy/publishSettings';
 
 export interface TestContext {
 	outputChannel: vscode.OutputChannel;

--- a/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
@@ -16,7 +16,7 @@ import { Project } from '../../models/project';
 import { ProjectsController } from '../../controllers/projectController';
 import { emptySqlDatabaseProjectTypeId } from '../../common/constants';
 import { createContext, mockDacFxOptionsResult, TestContext } from '../testContext';
-import { ISqlProjectPublishSettings, IPublishToDockerSettings } from 'sqldbproj';
+import { IPublishToDockerSettings, ISqlProjectPublishSettings } from '../../models/deploy/publishSettings';
 
 let testContext: TestContext;
 describe('Publish Database Dialog', () => {


### PR DESCRIPTION
Moving these publish interfaces out of sqldbproj.d.ts to remove the need for the imports from `mssql` and `vscode-mssql`, which were causing some difficulties for extensions consuming sqldbproj.d.ts. These publish interfaces were moved into sqldbproj.d.ts last year for another project, but they are no longer being used and don't need to be exposed outside of the extension anymore.
