### PR TITLE
handle table designer errors

### DIFF
--- a/extensions/mssql/src/tableDesigner/tableDesigner.ts
+++ b/extensions/mssql/src/tableDesigner/tableDesigner.ts
@@ -40,6 +40,7 @@ export function registerTableDesignerCommands(appContext: AppContext) {
 				tableIcon: tableIcon
 			}, telemetryInfo);
 		} catch (error) {
+			console.error(error);
 			await vscode.window.showErrorMessage(getErrorMessage(error), { modal: true });
 		}
 	}));
@@ -52,7 +53,7 @@ export function registerTableDesignerCommands(appContext: AppContext) {
 			const schema = context.nodeInfo!.metadata!.schema;
 			const name = context.nodeInfo!.metadata!.name;
 			const connectionString = await azdata.connection.getConnectionString(context.connectionProfile!.id, true);
-			if (!connectionString) {
+			if (connectionString) {
 				throw new Error(FailedToGetConnectionStringError);
 			}
 			const tableIcon = context.nodeInfo!.nodeSubType as azdata.designers.TableIcon;
@@ -71,6 +72,7 @@ export function registerTableDesignerCommands(appContext: AppContext) {
 				tableIcon: tableIcon
 			}, telemetryInfo);
 		} catch (error) {
+			console.error(error);
 			await vscode.window.showErrorMessage(getErrorMessage(error), { modal: true });
 		}
 	}));

--- a/extensions/mssql/src/tableDesigner/tableDesigner.ts
+++ b/extensions/mssql/src/tableDesigner/tableDesigner.ts
@@ -11,53 +11,68 @@ import { generateUuid } from 'vscode-languageclient/lib/utils/uuid';
 import { fillServerInfo } from '../telemetry';
 import * as telemetry from '@microsoft/ads-extension-telemetry';
 import * as nls from 'vscode-nls';
-import { getConfigPreloadDatabaseModel, setConfigPreloadDatabaseModel } from '../utils';
+import { getConfigPreloadDatabaseModel, getErrorMessage, setConfigPreloadDatabaseModel } from '../utils';
 const localize = nls.loadMessageBundle();
 
 const NewTableText = localize('tableDesigner.NewTable', "New Table");
 const DidInformUserKey: string = 'tableDesigner.DidInformUser';
+const FailedToGetConnectionStringError = localize('tableDesigner.FailedToGetConnectionStringError', "Failed to get connection string for the table. Please reconnect to the server and try again.");
 
 export function registerTableDesignerCommands(appContext: AppContext) {
 	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.newTable', async (context: azdata.ObjectExplorerContext) => {
-		void showPreloadDbModelSettingPrompt(appContext);
-		const connectionString = await azdata.connection.getConnectionString(context.connectionProfile!.id, true);
-		const tableIcon = context.nodeInfo!.nodeSubType as azdata.designers.TableIcon;
-		const telemetryInfo = await getTelemetryInfo(context, tableIcon);
-		await azdata.designers.openTableDesigner(sqlProviderName, {
-			title: NewTableText,
-			tooltip: `${context.connectionProfile!.serverName} - ${context.connectionProfile!.databaseName} - ${NewTableText}`,
-			server: context.connectionProfile!.serverName,
-			database: context.connectionProfile!.databaseName,
-			isNewTable: true,
-			id: generateUuid(),
-			connectionString: connectionString,
-			accessToken: context.connectionProfile!.options.azureAccountToken,
-			tableIcon: tableIcon
-		}, telemetryInfo);
+		try {
+			void showPreloadDbModelSettingPrompt(appContext);
+			const connectionString = await azdata.connection.getConnectionString(context.connectionProfile!.id, true);
+			if (!connectionString) {
+				throw new Error(FailedToGetConnectionStringError);
+			}
+			const tableIcon = context.nodeInfo!.nodeSubType as azdata.designers.TableIcon;
+			const telemetryInfo = await getTelemetryInfo(context, tableIcon);
+			await azdata.designers.openTableDesigner(sqlProviderName, {
+				title: NewTableText,
+				tooltip: `${context.connectionProfile!.serverName} - ${context.connectionProfile!.databaseName} - ${NewTableText}`,
+				server: context.connectionProfile!.serverName,
+				database: context.connectionProfile!.databaseName,
+				isNewTable: true,
+				id: generateUuid(),
+				connectionString: connectionString,
+				accessToken: context.connectionProfile!.options.azureAccountToken,
+				tableIcon: tableIcon
+			}, telemetryInfo);
+		} catch (error) {
+			await vscode.window.showErrorMessage(getErrorMessage(error), { modal: true });
+		}
 	}));
 
 	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.designTable', async (context: azdata.ObjectExplorerContext) => {
-		void showPreloadDbModelSettingPrompt(appContext);
-		const server = context.connectionProfile!.serverName;
-		const database = context.connectionProfile!.databaseName;
-		const schema = context.nodeInfo!.metadata!.schema;
-		const name = context.nodeInfo!.metadata!.name;
-		const connectionString = await azdata.connection.getConnectionString(context.connectionProfile!.id, true);
-		const tableIcon = context.nodeInfo!.nodeSubType as azdata.designers.TableIcon;
-		const telemetryInfo = await getTelemetryInfo(context, tableIcon);
-		await azdata.designers.openTableDesigner(sqlProviderName, {
-			title: `${schema}.${name}`,
-			tooltip: `${server} - ${database} - ${schema}.${name}`,
-			server: server,
-			database: database,
-			isNewTable: false,
-			name: name,
-			schema: schema,
-			id: `${sqlProviderName}|${server}|${database}|${schema}|${name}`,
-			connectionString: connectionString,
-			accessToken: context.connectionProfile!.options.azureAccountToken,
-			tableIcon: tableIcon
-		}, telemetryInfo);
+		try {
+			void showPreloadDbModelSettingPrompt(appContext);
+			const server = context.connectionProfile!.serverName;
+			const database = context.connectionProfile!.databaseName;
+			const schema = context.nodeInfo!.metadata!.schema;
+			const name = context.nodeInfo!.metadata!.name;
+			const connectionString = await azdata.connection.getConnectionString(context.connectionProfile!.id, true);
+			if (!connectionString) {
+				throw new Error(FailedToGetConnectionStringError);
+			}
+			const tableIcon = context.nodeInfo!.nodeSubType as azdata.designers.TableIcon;
+			const telemetryInfo = await getTelemetryInfo(context, tableIcon);
+			await azdata.designers.openTableDesigner(sqlProviderName, {
+				title: `${schema}.${name}`,
+				tooltip: `${server} - ${database} - ${schema}.${name}`,
+				server: server,
+				database: database,
+				isNewTable: false,
+				name: name,
+				schema: schema,
+				id: `${sqlProviderName}|${server}|${database}|${schema}|${name}`,
+				connectionString: connectionString,
+				accessToken: context.connectionProfile!.options.azureAccountToken,
+				tableIcon: tableIcon
+			}, telemetryInfo);
+		} catch (error) {
+			await vscode.window.showErrorMessage(getErrorMessage(error), { modal: true });
+		}
 	}));
 }
 


### PR DESCRIPTION
For: https://github.com/microsoft/azuredatastudio/issues/22486

From the logs shared by @cheenamalhotra in the issue above, a nullref exception was thrown when calling the `getConnectionString()` API and later caused an error in table designer.  I've updated STS to also log the callstack so that it is easier for us to find out where the NullRef exception is from.

With this PR I am checking the connection string and fail fast if it is not available and also added error handling so that errors are displayed to the user.

