### PR TITLE
Add warning message when pii logging enabled

### DIFF
--- a/extensions/azurecore/src/constants.ts
+++ b/extensions/azurecore/src/constants.ts
@@ -41,6 +41,8 @@ export const NoSystemKeyChainSection = 'noSystemKeychain';
 
 export const oldMsalCacheFileName = 'azureTokenCacheMsal-azure_publicCloud';
 
+export const piiLogging = 'piiLogging';
+
 /** MSAL Account version */
 export const AccountVersion = '2.0';
 

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -97,6 +97,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 	const authLibrary: string = vscode.workspace.getConfiguration(Constants.AzureSection).get(Constants.AuthenticationLibrarySection)
 		?? Constants.DefaultAuthLibrary;
 
+	const piiLogging = vscode.workspace.getConfiguration(Constants.AzureSection).get(Constants.piiLogging, false)
+	if (piiLogging) {
+		const disable = await vscode.window.showWarningMessage(loc.piiWarning, loc.disable, loc.dismiss);
+		if (disable) {
+			await vscode.workspace.getConfiguration(Constants.AzureSection).update(Constants.piiLogging, false, vscode.ConfigurationTarget.Global);
+		}
+	}
 	updatePiiLoggingLevel();
 
 	let eventEmitter: vscode.EventEmitter<azurecore.CacheEncryptionKeys>;

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -99,10 +99,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 
 	const piiLogging = vscode.workspace.getConfiguration(Constants.AzureSection).get(Constants.piiLogging, false)
 	if (piiLogging) {
-		const disable = await vscode.window.showWarningMessage(loc.piiWarning, loc.disable, loc.dismiss);
-		if (disable) {
-			await vscode.workspace.getConfiguration(Constants.AzureSection).update(Constants.piiLogging, false, vscode.ConfigurationTarget.Global);
-		}
+		void vscode.window.showWarningMessage(loc.piiWarning, loc.disable, loc.dismiss).then(async (value) => {
+			if (value === loc.disable) {
+				await vscode.workspace.getConfiguration(Constants.AzureSection).update(Constants.piiLogging, false, vscode.ConfigurationTarget.Global);
+			}
+		});
+
 	}
 	updatePiiLoggingLevel();
 

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -66,7 +66,10 @@ export const typeIcon = localize('azurecore.typeIcon', "Type Icon");
 export const reloadPrompt = localize('azurecore.reloadPrompt', "Authentication Library has changed, please reload Azure Data Studio.");
 export const reloadChoice = localize('azurecore.reloadChoice', "Reload Azure Data Studio");
 
-export const deprecatedOption = localize('azurecore.deprecated', "Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL instead.")
+export const deprecatedOption = localize('azurecore.deprecated', "Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL instead.");
+export const piiWarning = localize('azurecore.piiLogging.warning', "Warning: PII Logging is enabled. Enabling this option allows personally idetifiable information to be logged and should only be used for debugging purposes.");
+export const disable = localize('azurecore.disable', 'Disable');
+export const dismiss = localize('azurecore.dismiss', 'Dismiss');
 
 // Azure Resource Types
 export const sqlServer = localize('azurecore.sqlServer', "SQL server");

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -67,7 +67,7 @@ export const reloadPrompt = localize('azurecore.reloadPrompt', "Authentication L
 export const reloadChoice = localize('azurecore.reloadChoice', "Reload Azure Data Studio");
 
 export const deprecatedOption = localize('azurecore.deprecated', "Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL instead.");
-export const piiWarning = localize('azurecore.piiLogging.warning', "Warning: PII Logging is enabled. Enabling this option allows personally identifiable information to be logged and should only be used for debugging purposes.");
+export const piiWarning = localize('azurecore.piiLogging.warning', "Warning: Azure PII Logging is enabled. Enabling this option allows personally identifiable information to be logged and should only be used for debugging purposes.");
 export const disable = localize('azurecore.disable', 'Disable');
 export const dismiss = localize('azurecore.dismiss', 'Dismiss');
 

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -67,7 +67,7 @@ export const reloadPrompt = localize('azurecore.reloadPrompt', "Authentication L
 export const reloadChoice = localize('azurecore.reloadChoice', "Reload Azure Data Studio");
 
 export const deprecatedOption = localize('azurecore.deprecated', "Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL instead.");
-export const piiWarning = localize('azurecore.piiLogging.warning', "Warning: PII Logging is enabled. Enabling this option allows personally idetifiable information to be logged and should only be used for debugging purposes.");
+export const piiWarning = localize('azurecore.piiLogging.warning', "Warning: PII Logging is enabled. Enabling this option allows personally identifiable information to be logged and should only be used for debugging purposes.");
 export const disable = localize('azurecore.disable', 'Disable');
 export const dismiss = localize('azurecore.dismiss', 'Dismiss');
 


### PR DESCRIPTION
Add a warning message upon startup of the AzureCore extension if pii logging enabled:
![Screenshot 2023-03-29 at 4 10 20 PM](https://user-images.githubusercontent.com/18150417/228688112-784b279c-22f3-4baf-8e2a-354c2df48327.png)

This PR fixes #22389

