### PR TITLE
Fixing connection without saved password not connecting in Async Server Tree

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -472,6 +472,8 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				await this._connectionManagementService.deleteConnection(profile);
 			}
 			const connectionProfile = this.getConnectionInTreeInput(profile.id);
+
+			// For the connection profile, we need to clear the password from the last session if the user doesn't want to save it
 			if (!connectionProfile.savePassword) {
 				connectionProfile.password = '';
 			}

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -472,6 +472,9 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				await this._connectionManagementService.deleteConnection(profile);
 			}
 			const connectionProfile = this.getConnectionInTreeInput(profile.id);
+			if (!connectionProfile.savePassword) {
+				connectionProfile.password = '';
+			}
 			// Delete the node from the tree
 			await this._objectExplorerService.deleteObjectExplorerNode(connectionProfile);
 			// Collapse the node

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -270,6 +270,9 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			showFirewallRuleOnError: true
 		};
 
+		if (params && options.params === undefined) {
+			options.params = params;
+		}
 		try {
 			const connectionResult = await this._connectionManagementService.connectAndSaveProfile(connection, uri, options, params && params.input);
 			this._connecting = false;

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -416,7 +416,9 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				connectionType: this._connectionStatusManager.isEditorTypeUri(owner.uri) ? ConnectionType.editor : ConnectionType.default,
 				input: owner,
 				runQueryOnCompletion: RunQueryOnConnectionMode.none,
-				showDashboard: options.showDashboard
+				showDashboard: options.showDashboard,
+				isEditConnection: true,
+				oldProfileId: connection.id
 			};
 			return this.showConnectionDialog(params, options, connection, connectionResult).then(() => {
 				return connectionResult;

--- a/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
@@ -305,8 +305,8 @@ export class TreeUpdateUtils {
 
 					// If the node update takes too long, reject the promise
 					const nodeUpdateTimeout = () => {
-						reject(new Error(nls.localize('objectExplorerTimeout', "Object Explorer expansion timed out for '{0}'", connection.databaseName)));
 						cleanup();
+						reject(new Error(nls.localize('objectExplorerTimeout', "Object Explorer expansion timed out for '{0}'", connection.databaseName)));
 					}
 					const nodeUpdateTimer = setTimeout(nodeUpdateTimeout, expansionTimeoutValueSec * 1000);
 


### PR DESCRIPTION

1. Bug 1: fixing connections with forgot password not connecting.

Previously, we encountered a bug when attempting to connect a profile that didn't have a saved password. Our usual workflow involved opening a connection dialog and prompting users to enter their password before connecting to the server. In such cases, the 'onConnectionProfileConnected' event was triggered. However, this created an issue since the connection returned from the connection dialog was completely new, and we couldn't locate it in the tree.

This PR modifies the connection management service. Instead of triggering the 'onConnectionProfileConnected' event, the service now triggers an 'onConnectionProfileEdited' event. This event includes the profile ID of the old connection in the tree and the new connection from the connection dialog. The 'onConnectionProfileEdited' handler is then able to locate the old connection in the tree and replace it with the new connection from the dialog.

This should not interfere with the old tree as the old tree is not using 'onConnectionProfileConnected' and 'onConnectionProfileEdited' events. 

2. Bug 2:
When disconnecting connections where the 'save password' option is set to false, we now remove the saved password from the connection.