### PR TITLE
Add New Notebook task to server and database dashboards.

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { NewNotebookTask } from 'sql/workbench/contrib/notebook/browser/notebookActions';
+import { NewQueryTask } from 'sql/workbench/contrib/query/browser/queryActions';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 import { generateDashboardWidgetSchema, generateDashboardTabSchema } from './dashboardPageContribution';
@@ -96,7 +98,8 @@ export const databaseDashboardSettingSchema: IJSONSchema = {
 			},
 			widget: {
 				'tasks-widget': [
-					'newQuery',
+					NewQueryTask.ID,
+					NewNotebookTask.ID,
 					{ name: 'backup', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11 || connectionProvider == \'PGSQL\'' },
 					{ name: 'restore', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11 || connectionProvider == \'PGSQL\'' }
 				]

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { generateDashboardTabSchema, generateDashboardWidgetSchema } from 'sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution';
+import { NewNotebookTask } from 'sql/workbench/contrib/notebook/browser/notebookActions';
+import { NewQueryTask } from 'sql/workbench/contrib/query/browser/queryActions';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 
@@ -78,7 +80,8 @@ const defaultVal = [
 		name: 'Tasks',
 		widget: {
 			'tasks-widget': [
-				'newQuery',
+				NewQueryTask.ID,
+				NewNotebookTask.ID,
 				{ name: 'restore', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11 || connectionProvider == \'PGSQL\'' }]
 		},
 		gridItemConfig: {

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -17,7 +17,7 @@ import { IWorkbenchActionRegistry, Extensions as WorkbenchActionsExtensions } fr
 import { SyncActionDescriptor, registerAction2, MenuRegistry, MenuId, Action2 } from 'vs/platform/actions/common/actions';
 
 import { NotebookEditor } from 'sql/workbench/contrib/notebook/browser/notebookEditor';
-import { NewNotebookAction } from 'sql/workbench/contrib/notebook/browser/notebookActions';
+import { NewNotebookAction, NewNotebookTask } from 'sql/workbench/contrib/notebook/browser/notebookActions';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { IConfigurationRegistry, Extensions as ConfigExtensions, ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
 import { GridOutputComponent } from 'sql/workbench/contrib/notebook/browser/outputs/gridOutput.component';
@@ -101,8 +101,10 @@ actionRegistry.registerWorkbenchAction(
 	NewNotebookAction.LABEL
 );
 
-const DE_NEW_NOTEBOOK_COMMAND_ID = 'dataExplorer.newNotebook';
 // New Notebook
+new NewNotebookTask().registerTask();
+
+const DE_NEW_NOTEBOOK_COMMAND_ID = 'dataExplorer.newNotebook';
 CommandsRegistry.registerCommand({
 	id: DE_NEW_NOTEBOOK_COMMAND_ID,
 	handler: async (accessor, args: TreeViewItemHandleArg) => {
@@ -134,7 +136,6 @@ CommandsRegistry.registerCommand({
 	}
 });
 
-// New Notebook
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: '0_query',
 	order: 3,

--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -225,12 +225,16 @@
 }
 
 .monaco-workbench .notebook-action.new-notebook,
-.monaco-workbench.hc-light .notebook-action.new-notebook {
+.monaco-workbench.hc-light .notebook-action.new-notebook,
+.monaco-workbench .codicon.new-notebook,
+.monaco-workbench.hc-light .codicon.new-notebook {
 	background: url("./media/light/new_notebook.svg") center center no-repeat;
 }
 
 .monaco-workbench.vs-dark .notebook-action.new-notebook,
-.monaco-workbench.hc-black .notebook-action.new-notebook {
+.monaco-workbench.hc-black .notebook-action.new-notebook,
+.monaco-workbench.vs-dark .codicon.new-notebook,
+.monaco-workbench.hc-black .codicon.new-notebook {
 	background: url("./media/dark/new_notebook_inverse.svg") center center
 		no-repeat;
 }

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as azdata from 'azdata';
+import type * as azdata from 'azdata';
 import * as path from 'vs/base/common/path';
 
 import { Action, IAction, Separator } from 'vs/base/common/actions';
@@ -30,7 +30,7 @@ import { CellContext } from 'sql/workbench/contrib/notebook/browser/cellViews/co
 import { URI } from 'vs/base/common/uri';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IActionProvider } from 'vs/base/browser/ui/dropdown/dropdown';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
@@ -39,6 +39,8 @@ import { INotebookViews } from 'sql/workbench/services/notebook/browser/notebook
 import { Schemas } from 'vs/base/common/network';
 import { CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES, CONFIG_WORKBENCH_USEVSCODENOTEBOOKS } from 'sql/workbench/common/constants';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { Task } from 'sql/workbench/services/tasks/browser/tasksRegistry';
+import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 
 const msgLoading = localize('loading', "Loading kernels...");
 export const msgChanging = localize('changing', "Changing kernel...");
@@ -835,6 +837,49 @@ export class AttachToDropdown extends SelectBox {
 	}
 }
 
+async function openNewNotebook(
+	telemetryService: IAdsTelemetryService,
+	notebookService: INotebookService,
+	configurationService: IConfigurationService,
+	commandService: ICommandService,
+	profile?: azdata.IConnectionProfile
+): Promise<void> {
+	telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.NewNotebookFromConnections)
+		.withConnectionInfo(profile)
+		.send();
+
+	const usePreviewFeatures = configurationService.getValue(CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES);
+	const useVSCodeNotebooks = configurationService.getValue(CONFIG_WORKBENCH_USEVSCODENOTEBOOKS);
+	if (usePreviewFeatures && useVSCodeNotebooks) {
+		await commandService.executeCommand('ipynb.newUntitledIpynb');
+	} else {
+		await notebookService.openNotebook(URI.from({ scheme: 'untitled' }), { connectionProfile: profile });
+	}
+}
+
+export class NewNotebookTask extends Task {
+	public static ID = 'newNotebook';
+	public static LABEL = localize('newNotebookTask.newNotebook', "New Notebook");
+	public static ICON = 'new-notebook';
+
+	constructor() {
+		super({
+			id: NewNotebookTask.ID,
+			title: NewNotebookTask.LABEL,
+			iconPath: undefined,
+			iconClass: NewNotebookTask.ICON
+		});
+	}
+
+	public runTask(accessor: ServicesAccessor, profile: IConnectionProfile): Promise<void> {
+		const telemetryService = accessor.get(IAdsTelemetryService);
+		const notebookService = accessor.get(INotebookService);
+		const configurationService = accessor.get(IConfigurationService);
+		const commandService = accessor.get(ICommandService);
+		return openNewNotebook(telemetryService, notebookService, configurationService, commandService, profile);
+	}
+}
+
 export class NewNotebookAction extends Action {
 
 	public static readonly ID = 'notebook.command.new';
@@ -854,24 +899,15 @@ export class NewNotebookAction extends Action {
 	}
 
 	override async run(context?: azdata.ObjectExplorerContext): Promise<void> {
-		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.NewNotebookFromConnections)
-			.withConnectionInfo(context?.connectionProfile)
-			.send();
-
-		const usePreviewFeatures = this._configurationService.getValue(CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES);
-		const useVSCodeNotebooks = this._configurationService.getValue(CONFIG_WORKBENCH_USEVSCODENOTEBOOKS);
-		if (usePreviewFeatures && useVSCodeNotebooks) {
-			await this._commandService.executeCommand('ipynb.newUntitledIpynb');
-		} else {
-			let connProfile: azdata.IConnectionProfile;
-			if (context && context.nodeInfo) {
-				let node = await this.objectExplorerService.getTreeNode(context.connectionProfile.id, context.nodeInfo.nodePath);
-				connProfile = TreeUpdateUtils.getConnectionProfile(node).toIConnectionProfile();
-			} else if (context && context.connectionProfile) {
-				connProfile = context.connectionProfile;
-			}
-			await this._notebookService.openNotebook(URI.from({ scheme: 'untitled' }), { connectionProfile: connProfile });
+		let connProfile: azdata.IConnectionProfile;
+		if (context && context.nodeInfo) {
+			let node = await this.objectExplorerService.getTreeNode(context.connectionProfile.id, context.nodeInfo.nodePath);
+			connProfile = TreeUpdateUtils.getConnectionProfile(node).toIConnectionProfile();
+		} else if (context && context.connectionProfile) {
+			connProfile = context.connectionProfile;
 		}
+
+		await openNewNotebook(this._telemetryService, this._notebookService, this._configurationService, this._commandService, connProfile);
 	}
 }
 


### PR DESCRIPTION
The New Notebook dashboard button got removed in the big BDC cleanup. We were using an mssqlCluster new notebook command before. This change adds a new internal task for opening a new notebook from the dashboard.

This PR fixes #22514 
