### PR TITLE
Cleaning update children logic in async server tree

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTree.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTree.ts
@@ -125,9 +125,9 @@ export class AsyncServerTree extends WorkbenchAsyncDataTree<ConnectionProfileGro
 	}
 
 	public override async updateChildren(element?: ServerTreeElement, recursive?: boolean, rerender?: boolean, options?: IAsyncDataTreeUpdateChildrenOptions<ServerTreeElement>): Promise<void> {
-		const viewState = this.getExpandedState(element);
+		const expandedChildren = this.getExpandedState(element);
 		await super.updateChildren(element, recursive, rerender, options);
-		await this.expandElements(viewState);
+		await this.expandElements(expandedChildren);
 	}
 
 	public async expandElements(elements: ServerTreeElement[]): Promise<void> {

--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTree.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTree.ts
@@ -125,18 +125,9 @@ export class AsyncServerTree extends WorkbenchAsyncDataTree<ConnectionProfileGro
 	}
 
 	public override async updateChildren(element?: ServerTreeElement, recursive?: boolean, rerender?: boolean, options?: IAsyncDataTreeUpdateChildrenOptions<ServerTreeElement>): Promise<void> {
-		const viewState = this.getViewState();
-		const expandedElementIds = viewState?.expanded;
+		const viewState = this.getExpandedState(element);
 		await super.updateChildren(element, recursive, rerender, options);
-		if (expandedElementIds) {
-			for (let i = 0; i <= expandedElementIds.length; i++) {
-				const id = expandedElementIds[i];
-				const node = this.getDataNodeById(id);
-				if (node) {
-					await this.expand(node.element);
-				}
-			}
-		}
+		await this.expandElements(viewState);
 	}
 
 	public async expandElements(elements: ServerTreeElement[]): Promise<void> {


### PR DESCRIPTION
Cleaning up restoring expanded state for update children by using existing methods defined for this use case. 
