### PR TITLE
fix console error when trying to drag a sql project node

### DIFF
--- a/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
+++ b/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
@@ -115,7 +115,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 	}
 
 	handleDrag(treeItems: readonly WorkspaceTreeItem[], dataTransfer: vscode.DataTransfer): void | Thenable<void> {
-		// don't do anything if trying to drag the project node since it is'nt supported and there's an error when trying to
+		// don't do anything if trying to drag the project node since it isn't supported and there's an error when trying to
 		// convert the project node to JSON https://github.com/microsoft/azuredatastudio/issues/22529
 		const relativePath = treeItems[0].element?.relativeProjectUri?.fsPath.substring(1); // remove leading slash
 		const projBaseName = path.basename(treeItems[0].element.projectFileUri.fsPath, path.extname(treeItems[0].element.projectFileUri.fsPath));

--- a/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
+++ b/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
@@ -115,6 +115,14 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 	}
 
 	handleDrag(treeItems: readonly WorkspaceTreeItem[], dataTransfer: vscode.DataTransfer): void | Thenable<void> {
+		// don't do anything if trying to drag the project node since it is'nt supported and there's an error when trying to
+		// convert the project node to JSON https://github.com/microsoft/azuredatastudio/issues/22529
+		const relativePath = treeItems[0].element?.relativeProjectUri?.fsPath.substring(1); // remove leading slash
+		const projBaseName = path.basename(treeItems[0].element.projectFileUri.fsPath, path.extname(treeItems[0].element.projectFileUri.fsPath));
+		if (relativePath === projBaseName) {
+			return;
+		}
+
 		dataTransfer.set('application/vnd.code.tree.WorkspaceTreeDataProvider', new vscode.DataTransferItem(treeItems.map(t => t.element)));
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #22529. Drag and dropping a project node isn't supported, so this avoids the error by not even trying to convert the project node to JSON if the node is a project node.
