### PR TITLE
fix object management dialog's validation issue

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -204,7 +204,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 				level: azdata.window.MessageLevel.Error
 			};
 		} else {
-			this.dialogObject.message = { text: '' };
+			this.dialogObject.message = undefined;
 		}
 		return errors.length === 0;
 	}

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -198,7 +198,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 
 	protected async runValidation(showErrorMessage: boolean = true): Promise<boolean> {
 		const errors = await this.validateInput();
-		if (errors.length > 0 && (this.dialogObject.message || showErrorMessage)) {
+		if (errors.length > 0 && (this.dialogObject.message?.text || showErrorMessage)) {
 			this.dialogObject.message = {
 				text: errors.join(EOL),
 				level: azdata.window.MessageLevel.Error

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4985,7 +4985,7 @@ declare module 'azdata' {
 			 * Set the informational message shown in the dialog. Hidden when the message is
 			 * undefined or the text is empty or undefined. The default level is error.
 			 */
-			message: DialogMessage;
+			message?: DialogMessage;
 
 			/**
 			 * Set the dialog name when opening


### PR DESCRIPTION
This PR fixes #22447

In this PR https://github.com/microsoft/azuredatastudio/pull/22430, I changed the way we reset the message from `undefined` to `{text: ''}` but didn't update the place we check for message existence, as a result, the validation message is showing even on initial load.

Fix:
1. Mark the `message` property as optional 
2. Check for `message` as well as the `message.text` property when determining the message existence.