### PR TITLE
Bump STS version

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.6.0.22",
+	"version": "4.6.0.23",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
This PR fixes #22549 with STS update: https://github.com/microsoft/sqltoolsservice/compare/4.6.0.22...4.6.0.23

![image](https://user-images.githubusercontent.com/13396919/229191883-e7139204-efb7-4f90-bdec-a41fe6a4c1f8.png)

