### PR TITLE
update parse query action

### DIFF
--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -143,3 +143,15 @@
 	width: 100%;
 	margin-left: 0;
 }
+
+.carbon-taskbar .monaco-action-bar .action-item .codicon.action-label[class*='codicon-'] {
+	font-size: 11px;
+	padding-left: 0px;
+	font-family: inherit;
+}
+
+.carbon-taskbar .monaco-action-bar .action-item .codicon.action-label[class*='codicon-']:before {
+	font-size: 16px;
+	font-family: 'codicon';
+	padding-right: 2px;
+}

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -34,7 +34,7 @@ import { FileQueryEditorInput } from 'sql/workbench/contrib/query/browser/fileQu
 import { FileQueryEditorSerializer, QueryEditorLanguageAssociation, UntitledQueryEditorSerializer } from 'sql/workbench/contrib/query/browser/queryEditorFactory';
 import { UntitledQueryEditorInput } from 'sql/base/query/browser/untitledQueryEditorInput';
 import { ILanguageAssociationRegistry, Extensions as LanguageAssociationExtensions } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
-import { NewQueryTask, OE_NEW_QUERY_ACTION_ID, DE_NEW_QUERY_COMMAND_ID, CATEGORIES, ParseQueryCommandId } from 'sql/workbench/contrib/query/browser/queryActions';
+import { NewQueryTask, OE_NEW_QUERY_ACTION_ID, DE_NEW_QUERY_COMMAND_ID, CATEGORIES, ParseSyntaxCommandId } from 'sql/workbench/contrib/query/browser/queryActions';
 import { TreeNodeContextKey } from 'sql/workbench/services/objectExplorer/common/treeNodeContextKey';
 import { MssqlNodeContext } from 'sql/workbench/services/objectExplorer/browser/mssqlNodeContext';
 import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
@@ -199,7 +199,7 @@ actionRegistry.registerWorkbenchAction(
 actionRegistry.registerWorkbenchAction(
 	SyncActionDescriptor.create(
 		ParseSyntaxAction,
-		ParseQueryCommandId,
+		ParseSyntaxCommandId,
 		ParseSyntaxAction.LABEL,
 		{ primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyP }
 	),

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -34,7 +34,7 @@ import { FileQueryEditorInput } from 'sql/workbench/contrib/query/browser/fileQu
 import { FileQueryEditorSerializer, QueryEditorLanguageAssociation, UntitledQueryEditorSerializer } from 'sql/workbench/contrib/query/browser/queryEditorFactory';
 import { UntitledQueryEditorInput } from 'sql/base/query/browser/untitledQueryEditorInput';
 import { ILanguageAssociationRegistry, Extensions as LanguageAssociationExtensions } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
-import { NewQueryTask, OE_NEW_QUERY_ACTION_ID, DE_NEW_QUERY_COMMAND_ID, CATEGORIES } from 'sql/workbench/contrib/query/browser/queryActions';
+import { NewQueryTask, OE_NEW_QUERY_ACTION_ID, DE_NEW_QUERY_COMMAND_ID, CATEGORIES, ParseQueryCommandId } from 'sql/workbench/contrib/query/browser/queryActions';
 import { TreeNodeContextKey } from 'sql/workbench/services/objectExplorer/common/treeNodeContextKey';
 import { MssqlNodeContext } from 'sql/workbench/services/objectExplorer/browser/mssqlNodeContext';
 import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
@@ -199,8 +199,9 @@ actionRegistry.registerWorkbenchAction(
 actionRegistry.registerWorkbenchAction(
 	SyncActionDescriptor.create(
 		ParseSyntaxAction,
-		ParseSyntaxAction.ID,
-		ParseSyntaxAction.LABEL
+		ParseQueryCommandId,
+		ParseSyntaxAction.LABEL,
+		{ primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyP }
 	),
 	ParseSyntaxAction.LABEL
 );

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -918,9 +918,7 @@ export class ExportAsNotebookAction extends QueryTaskbarAction {
 		@ICommandService private _commandService: ICommandService
 	) {
 		super(connectionManagementService, editor, ExportAsNotebookAction.ID, ExportAsNotebookAction.IconClass);
-
-		this.label = nls.localize('queryEditor.exportSqlAsNotebookLabel', "Export");
-		this.tooltip = nls.localize('queryEditor.exportSqlAsNotebook', "Export as Notebook");
+		this.label = nls.localize('queryEditor.exportSqlAsNotebook', "Export as Notebook");
 	}
 
 	public override async run(): Promise<void> {

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -48,6 +48,7 @@ import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { gen3Version, sqlDataWarehouse } from 'sql/platform/connection/common/constants';
 import { Dropdown } from 'sql/base/browser/ui/editableDropdown/browser/dropdown';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import { Codicon } from 'vs/base/common/codicons';
 
 /**
  * Action class that query-based Actions will extend. This base class automatically handles activating and
@@ -916,9 +917,10 @@ export class ExportAsNotebookAction extends QueryTaskbarAction {
 		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
 		@ICommandService private _commandService: ICommandService
 	) {
-		super(connectionManagementService, editor, ConnectDatabaseAction.ID, ExportAsNotebookAction.IconClass);
+		super(connectionManagementService, editor, ExportAsNotebookAction.ID, ExportAsNotebookAction.IconClass);
 
-		this.label = nls.localize('queryEditor.exportSqlAsNotebook', "Export as Notebook");
+		this.label = nls.localize('queryEditor.exportSqlAsNotebookLabel', "Export");
+		this.tooltip = nls.localize('queryEditor.exportSqlAsNotebook', "Export as Notebook");
 	}
 
 	public override async run(): Promise<void> {
@@ -929,3 +931,15 @@ export class ExportAsNotebookAction extends QueryTaskbarAction {
 export const CATEGORIES = {
 	ExecutionPlan: { value: nls.localize('ExecutionPlan', 'Execution Plan'), original: 'Execution Plan' }
 };
+
+export const ParseQueryCommandId = 'parseQueryAction';
+
+export class ParseQueryTaskbarAction extends Action {
+	constructor(@ICommandService private _commandService: ICommandService) {
+		super(ParseQueryCommandId, nls.localize('queryEditor.parse', "Parse"), Codicon.check.classNames);
+	}
+
+	public override async run(): Promise<void> {
+		this._commandService.executeCommand(ParseQueryCommandId);
+	}
+}

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -930,14 +930,16 @@ export const CATEGORIES = {
 	ExecutionPlan: { value: nls.localize('ExecutionPlan', 'Execution Plan'), original: 'Execution Plan' }
 };
 
-export const ParseQueryCommandId = 'parseQueryAction';
-
-export class ParseQueryTaskbarAction extends Action {
+// A wrapper for the ParseSyntaxAction.
+// We are not able to reference the ParseSyntaxAction directly in QueryEditor.ts because there is a circular dependency issue.
+// The command id is also defined here to avoid duplication.
+export const ParseSyntaxCommandId = 'parseQueryAction';
+export class ParseSyntaxTaskbarAction extends Action {
 	constructor(@ICommandService private _commandService: ICommandService) {
-		super(ParseQueryCommandId, nls.localize('queryEditor.parse', "Parse"), Codicon.check.classNames);
+		super(ParseSyntaxCommandId, nls.localize('queryEditor.parse', "Parse"), Codicon.check.classNames);
 	}
 
 	public override async run(): Promise<void> {
-		this._commandService.executeCommand(ParseQueryCommandId);
+		this._commandService.executeCommand(ParseSyntaxCommandId);
 	}
 }

--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -100,7 +100,7 @@ export class QueryEditor extends EditorPane {
 	private _toggleSqlcmdMode: actions.ToggleSqlCmdModeAction;
 	private _toggleActualExecutionPlanMode: actions.ToggleActualExecutionPlanModeAction;
 	private _exportAsNotebookAction: actions.ExportAsNotebookAction;
-	private _parseQueryAction: actions.ParseQueryTaskbarAction;
+	private _parseQueryAction: actions.ParseSyntaxTaskbarAction;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -212,7 +212,7 @@ export class QueryEditor extends EditorPane {
 		this._toggleSqlcmdMode = this.instantiationService.createInstance(actions.ToggleSqlCmdModeAction, this, false);
 		this._toggleActualExecutionPlanMode = this.instantiationService.createInstance(actions.ToggleActualExecutionPlanModeAction, this, false);
 		this._exportAsNotebookAction = this.instantiationService.createInstance(actions.ExportAsNotebookAction, this);
-		this._parseQueryAction = this.instantiationService.createInstance(actions.ParseQueryTaskbarAction);
+		this._parseQueryAction = this.instantiationService.createInstance(actions.ParseSyntaxTaskbarAction);
 		this.setTaskbarContent();
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES)) {

--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -100,6 +100,7 @@ export class QueryEditor extends EditorPane {
 	private _toggleSqlcmdMode: actions.ToggleSqlCmdModeAction;
 	private _toggleActualExecutionPlanMode: actions.ToggleActualExecutionPlanModeAction;
 	private _exportAsNotebookAction: actions.ExportAsNotebookAction;
+	private _parseQueryAction: actions.ParseQueryTaskbarAction;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -211,6 +212,7 @@ export class QueryEditor extends EditorPane {
 		this._toggleSqlcmdMode = this.instantiationService.createInstance(actions.ToggleSqlCmdModeAction, this, false);
 		this._toggleActualExecutionPlanMode = this.instantiationService.createInstance(actions.ToggleActualExecutionPlanModeAction, this, false);
 		this._exportAsNotebookAction = this.instantiationService.createInstance(actions.ExportAsNotebookAction, this);
+		this._parseQueryAction = this.instantiationService.createInstance(actions.ParseQueryTaskbarAction);
 		this.setTaskbarContent();
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES)) {
@@ -269,6 +271,8 @@ export class QueryEditor extends EditorPane {
 				this.removeResultsEditor();
 			}
 		}
+
+		this._parseQueryAction.enabled = this.input.state.connected && !this.input.state.executing;
 	}
 
 	/**
@@ -332,6 +336,7 @@ export class QueryEditor extends EditorPane {
 				{ element: Taskbar.createTaskbarSeparator() },
 				{ action: this._estimatedQueryPlanAction },
 				{ action: this._toggleActualExecutionPlanMode },
+				{ action: this._parseQueryAction }
 			);
 			if (previewFeaturesEnabled) {
 				content.push(


### PR DESCRIPTION
This PR fixes: #22295
1. Add proper CSS styles to taskbar so that it can handle codicon. 
2. Update the strings used by parse query action.
3. Add `Parse` to query editor toolbar for MSSQL.
4. Add keybindings for Parse Query action.

![image](https://user-images.githubusercontent.com/13777222/229240475-fe1b79c0-d5e1-42d1-882a-c03a58eb989e.png)
