### PR TITLE
add tooltips to explain migrations list columns

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1124,9 +1124,21 @@ export const SQL_DATABASE = localize('sql.migration.sql.database', "SQL Database
 export const TARGET_AZURE_SQL_INSTANCE_NAME = localize('sql.migration.target.azure.sql.instance.name', "Target name");
 export const TARGET_SERVER_COLUMN = localize('sql.migration.target.azure.sql.instance.server.name', "Target name");
 export const TARGET_DATABASE_COLUMN = localize('sql.migration.target.azure.sql.instance.database.name', "Target database");
-export const MIGRATION_MODE = localize('sql.migration.cutover.type', "Mode");
+export const MIGRATION_MODE = localize('sql.migration.cutover.type', "Migration mode");
 export const START_TIME = localize('sql.migration.start.time', "Start time");
 export const FINISH_TIME = localize('sql.migration.finish.time', "Finish time");
+
+export const SRC_SERVER_TOOL_TIP = localize('sql.migration.src.server.tool.tip', "Name of the source server");
+export const SRC_DATABASE_TOOL_TIP = localize('sql.migration.src.database.tool.tip', "Name of the source database");
+export const STATUS_TOOL_TIP = localize('sql.migration.database.status.tool.tip', "The current status of the migration");
+export const DURATION_TOOL_TIP = localize('sql.migration.database.migration.duration.tool.tip', "The duration of the migration");
+export const AZURE_SQL_TARGET_TOOL_TIP = localize('sql.migration.database.migration.target.type.tool.tip', "The azure resource target type [SQL Managed Instance, SQL Virtual Machine, SQL Database]");
+export const TARGET_SERVER_TOOL_TIP = localize('sql.migration.database.migration.target.instance.server.name.tool.tip', "The target server name");
+export const TARGET_DATABASE_TOOL_TIP = localize('sql.migration.database.migration.target.instance.database.name.tool.tip', "The target database name");
+export const MIGRATION_MODE_TOOL_TIP = localize('sql.migration.database.migration.migration.mode.tool.tip', "In Azure Database Migration Service, you can migrate your databases offline or while they are online. In an offline migration, application downtime starts when the migration starts. To limit downtime to the time it takes you to cut over to the new environment after the migration, use an online migration.");
+export const START_TIME_TOOL_TIP = localize('sql.migration.database.migration.start.time.tool.tip', "The start time for the migration");
+export const FINISH_TIME_TOOL_TIP = localize('sql.migration.database.migration.finish.time.tool.tip', "The fininish time for the migration");
+export const CONTEXT_MENU_TOOL_TIP = localize('sql.migration.database.migration.context.menu.tool.tip', "Click this column to activate the context command menu");
 
 export function STATUS_VALUE(status: string): string {
 	return localize('sql.migration.status.value', "{0}", StatusLookup[status] ?? status);

--- a/extensions/sql-migration/src/dashboard/migrationsListTab.ts
+++ b/extensions/sql-migration/src/dashboard/migrationsListTab.ts
@@ -473,6 +473,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'sourceDatabase',
 						width: 170,
 						type: azdata.ColumnType.hyperlink,
+						toolTip: loc.SRC_DATABASE_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
@@ -481,6 +482,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'sourceServer',
 						width: 170,
 						type: azdata.ColumnType.text,
+						toolTip: loc.SRC_SERVER_TOOL_TIP,
 					},
 					<azdata.HyperlinkColumn>{
 						cssClass: rowCssStyles,
@@ -489,14 +491,16 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'status',
 						width: 160,
 						type: azdata.ColumnType.hyperlink,
+						toolTip: loc.STATUS_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
 						headerCssClass: headerCssStyles,
 						name: loc.MIGRATION_MODE,
 						value: 'mode',
-						width: 55,
+						width: 120,
 						type: azdata.ColumnType.text,
+						toolTip: loc.MIGRATION_MODE_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
@@ -505,6 +509,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'targetType',
 						width: 120,
 						type: azdata.ColumnType.text,
+						toolTip: loc.AZURE_SQL_TARGET_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
@@ -513,6 +518,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'targetDatabase',
 						width: 125,
 						type: azdata.ColumnType.text,
+						toolTip: loc.TARGET_DATABASE_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
@@ -521,6 +527,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'targetServer',
 						width: 125,
 						type: azdata.ColumnType.text,
+						toolTip: loc.TARGET_SERVER_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
@@ -529,6 +536,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'duration',
 						width: 55,
 						type: azdata.ColumnType.text,
+						toolTip: loc.DURATION_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
@@ -537,6 +545,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'startTime',
 						width: 115,
 						type: azdata.ColumnType.text,
+						toolTip: loc.START_TIME_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
@@ -545,6 +554,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'finishTime',
 						width: 115,
 						type: azdata.ColumnType.text,
+						toolTip: loc.FINISH_TIME_TOOL_TIP,
 					},
 					{
 						cssClass: rowCssStyles,
@@ -553,6 +563,7 @@ export class MigrationsListTab extends TabBase<MigrationsListTab> {
 						value: 'contextMenu',
 						width: 25,
 						type: azdata.ColumnType.contextMenu,
+						toolTip: loc.CONTEXT_MENU_TOOL_TIP,
 					}
 				]
 			}).component();


### PR DESCRIPTION
Adding tooltips to the columns in the migrations monitoring list.

![image](https://user-images.githubusercontent.com/61598682/229627222-5931d709-d8c8-40a2-ba07-531aed59dcbd.png)
