### PR TITLE
Port fix for erroring when backup file already exists for sqlproj (#22613)

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -10,6 +10,7 @@ import type * as azdataType from 'azdata';
 import * as vscode from 'vscode';
 import * as mssql from 'mssql';
 
+import { promises as fs } from 'fs';
 import { Uri, window } from 'vscode';
 import { EntryType, IDatabaseReferenceProjectEntry, ISqlProject, ItemType } from 'sqldbproj';
 import { DataSource } from './dataSources/dataSources';
@@ -438,6 +439,18 @@ export class Project implements ISqlProject {
 		}
 
 		TelemetryReporter.sendActionEvent(TelemetryViews.ProjectController, TelemetryActions.updateProjectForRoundtrip);
+
+		// due to bug in DacFx.Projects, if a backup file already exists this will fail
+		// workaround is to rename the existing backup
+
+		if (await utils.exists(this.projectFilePath + '_backup')) {
+			let counter = 2;
+			while (await utils.exists(this.projectFilePath + '_backup' + counter)) {
+				counter++;
+			}
+
+			await fs.rename(this.projectFilePath + '_backup', this.projectFilePath + '_backup' + counter);
+		}
 
 		const result = await this.sqlProjService.updateProjectForCrossPlatform(this.projectFilePath);
 		this.throwIfFailed(result);


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/22573