### PR TITLE
Improve missing placeholder warning message

### DIFF
--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -167,7 +167,7 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		for (let i: number = 0; i < links.length; i++) {
 			const placeholderIndex = text.indexOf(`{${i}}`);
 			if (placeholderIndex < 0) {
-				this.logService.warn(`Could not find placeholder text {${i}} in text '${this.value}'. Link: ${links[i]}`);
+				this.logService.warn(`Could not find placeholder text {${i}} in text '${this.value}'. Link: ${JSON.stringify(links[i])}`);
 				// Just continue on so we at least show the rest of the text if just one was missed or something
 				continue;
 			}

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -167,7 +167,7 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		for (let i: number = 0; i < links.length; i++) {
 			const placeholderIndex = text.indexOf(`{${i}}`);
 			if (placeholderIndex < 0) {
-				this.logService.warn(`Could not find placeholder text {${i}} in text ${this.value}`);
+				this.logService.warn(`Could not find placeholder text {${i}} in text '${this.value}'. Link: ${links[i]}`);
 				// Just continue on so we at least show the rest of the text if just one was missed or something
 				continue;
 			}

--- a/src/sql/workbench/browser/ui/infoBox/infoBox.ts
+++ b/src/sql/workbench/browser/ui/infoBox/infoBox.ts
@@ -141,7 +141,7 @@ export class InfoBox extends Disposable implements IThemable {
 		for (let i = 0; i < this._links.length; i++) {
 			const placeholderIndex = text.indexOf(`{${i}}`);
 			if (placeholderIndex < 0) {
-				this._logService.warn(`Could not find placeholder text {${i}} in text ${text}`);
+				this._logService.warn(`Could not find placeholder text {${i}} in text '${text}'. Link: ${JSON.stringify(this._links[i])}`);
 				// Just continue on so we at least show the rest of the text if just one was missed or something
 				continue;
 			}


### PR DESCRIPTION
If the component doesn't have any text it can be hard to figure out where it came from, providing the link as well can help track it down.

Previously: 

` WARN Could not find placeholder text {0} in text `

Now:
`WARN Could not find placeholder text {0} in text ''. Link: {"text":"Known issues, limitations, and troubleshooting","url":"https://aka.ms/dms-migrations-troubleshooting"}`