### PR TITLE
Remove Preview tag from Sql database projects extension

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3481,7 +3481,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": ""
 				},
 				{
 					"extensionId": "71",


### PR DESCRIPTION
This PR removes the "Preview" tag from Sql Database projects extension, since it is GAing with this release.
