### PR TITLE
Fix some no unsafe assignment errors in azurecore

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuthError.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuthError.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export class AzureAuthError extends Error {
-	constructor(localizedMessage: string, public readonly originalMessage: string, private readonly originalException: any) {
+	constructor(localizedMessage: string, public readonly originalMessage: string, private readonly originalException: unknown) {
 		super(localizedMessage);
 	}
 

--- a/extensions/azurecore/src/account-provider/utils/fileDatabase.ts
+++ b/extensions/azurecore/src/account-provider/utils/fileDatabase.ts
@@ -15,8 +15,9 @@ export class AlreadyInitializedError extends Error {
 
 }
 
+type DbMap = { [key: string]: string };
 export class FileDatabase {
-	private db: { [key: string]: string } = {};
+	private db: DbMap = {};
 	private isDirty = false;
 	private isSaving = false;
 	private isInitialized = false;
@@ -106,7 +107,7 @@ export class FileDatabase {
 		}
 
 		try {
-			this.db = JSON.parse(fileContents);
+			this.db = JSON.parse(fileContents) as DbMap;
 		} catch (ex) {
 			Logger.error(`Error occurred when reading file database contents as JSON, ADAL cache will be reset: ${ex}`);
 			await this.createFile();

--- a/extensions/azurecore/src/azureDataGridProvider.ts
+++ b/extensions/azurecore/src/azureDataGridProvider.ts
@@ -7,7 +7,7 @@ import * as azdata from 'azdata';
 import { AppContext } from './appContext';
 import { AzureResourceServiceNames } from './azureResource/constants';
 import { IAzureResourceSubscriptionService } from './azureResource/interfaces';
-import { azureResource } from 'azurecore';
+import { AzureAccountProperties, azureResource } from 'azurecore';
 import * as azureResourceUtils from './azureResource/utils';
 import * as constants from './constants';
 import * as loc from './localizedConstants';
@@ -56,7 +56,7 @@ export class AzureDataGridProvider implements azdata.DataGridProvider {
 									type: item.type,
 									typeDisplayName: utils.getResourceTypeDisplayName(item.type),
 									iconPath: utils.getResourceTypeIcon(this._appContext, item.type),
-									portalEndpoint: account.properties.providerSettings.settings.portalEndpoint
+									portalEndpoint: (account.properties as AzureAccountProperties).providerSettings.settings.portalEndpoint
 								};
 							});
 						items.push(...newItems);

--- a/extensions/azurecore/src/azureResource/providers/cosmosdb/mongo/cosmosDbMongoTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/cosmosdb/mongo/cosmosDbMongoTreeDataProvider.ts
@@ -11,7 +11,7 @@ import { AzureResourceItemType } from '../../../constants';
 import { generateGuid } from '../../../utils';
 import { IAzureResourceService } from '../../../interfaces';
 import { ResourceTreeDataProviderBase } from '../../resourceTreeDataProviderBase';
-import { azureResource } from 'azurecore';
+import { AzureAccountProperties, azureResource } from 'azurecore';
 import * as azdata from 'azdata';
 
 export class CosmosDbMongoTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
@@ -52,7 +52,7 @@ export class CosmosDbMongoTreeDataProvider extends ResourceTreeDataProviderBase<
 				azureAccount: account.key.accountId,
 				azureTenantId: databaseServer.tenant,
 				azureResourceId: databaseServer.id,
-				azurePortalEndpoint: account.properties.providerSettings.settings.portalEndpoint
+				azurePortalEndpoint: (account.properties as AzureAccountProperties).providerSettings.settings.portalEndpoint
 			},
 			childProvider: CosmosDbMongoTreeDataProvider.COSMOSDG_MONGO_PROVIDER_ID,
 			type: azdata.ExtensionNodeType.Server

--- a/extensions/azurecore/src/azureResource/providers/mysqlFlexibleServer/mysqlFlexibleServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/mysqlFlexibleServer/mysqlFlexibleServerTreeDataProvider.ts
@@ -11,7 +11,7 @@ import { AzureResourceItemType } from '../../constants';
 import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
-import { azureResource } from 'azurecore';
+import { AzureAccountProperties, azureResource } from 'azurecore';
 import { Account, ExtensionNodeType, TreeItem, connection } from 'azdata';
 
 export class MysqlFlexibleServerTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
@@ -54,7 +54,7 @@ export class MysqlFlexibleServerTreeDataProvider extends ResourceTreeDataProvide
 				azureAccount: account.key.accountId,
 				azureTenantId: databaseServer.tenant,
 				azureResourceId: databaseServer.id,
-				azurePortalEndpoint: account.properties.providerSettings.settings.portalEndpoint
+				azurePortalEndpoint: (account.properties as AzureAccountProperties).providerSettings.settings.portalEndpoint
 			},
 			childProvider: MysqlFlexibleServerTreeDataProvider.MYSQL_FLEXIBLE_SERVER_PROVIDER_ID,
 			type: ExtensionNodeType.Server

--- a/extensions/azurecore/src/azureResource/providers/resourceTreeDataProviderBase.ts
+++ b/extensions/azurecore/src/azureResource/providers/resourceTreeDataProviderBase.ts
@@ -11,6 +11,7 @@ import { AzureResourceErrorMessageUtil } from '../utils';
 import { ResourceGraphClient } from '@azure/arm-resourcegraph';
 import { AzureAccount, azureResource } from 'azurecore';
 import { Logger } from '../../utils/Logger';
+import { ErrorResponse } from '@azure/arm-resourcegraph/esm/models';
 
 export abstract class ResourceTreeDataProviderBase<T extends azureResource.AzureResource> implements azureResource.IAzureResourceTreeDataProvider {
 	public browseConnectionMode: boolean = false;
@@ -78,7 +79,7 @@ export async function queryGraphResources<T extends GraphData>(resourceClient: R
 				skipToken: skipToken
 			}
 		});
-		const resources: T[] = response.data;
+		const resources: T[] = response.data as T[];
 		totalProcessed += resources.length;
 		allResources.push(...resources);
 		if (response.skipToken && totalProcessed < response.totalRecords) {
@@ -91,7 +92,7 @@ export async function queryGraphResources<T extends GraphData>(resourceClient: R
 		try {
 			if (err.response?.body) {
 				// The response object contains more useful error info than the error originally comes back with
-				const response = JSON.parse(err.response.body);
+				const response = JSON.parse(err.response.body) as ErrorResponse;
 				if (response.error?.details && Array.isArray(response.error.details) && response.error.details.length > 0) {
 					if (response.error.details[0].message) {
 						err.message = `${response.error.details[0].message}\n${err.message}`;

--- a/extensions/azurecore/src/azureResource/resourceService.ts
+++ b/extensions/azurecore/src/azureResource/resourceService.ts
@@ -97,7 +97,7 @@ export class AzureResourceService {
 		}
 
 		for (const extension of extensions.all) {
-			const contributes = extension.packageJSON && extension.packageJSON.contributes;
+			const contributes = extension.packageJSON.contributes as { [key: string]: string } | undefined;
 			if (!contributes) {
 				continue;
 			}

--- a/extensions/azurecore/src/test/account-provider/auths/azureAuth.test.ts
+++ b/extensions/azurecore/src/test/account-provider/auths/azureAuth.test.ts
@@ -118,7 +118,7 @@ describe('Azure Authentication', function () {
 			});
 
 			azureAuthCodeGrant.setup(x => x.refreshTokenAdal(mockTenant, provider.settings.ossRdbmsResource!, mockRefreshToken)).returns((): Promise<OAuthTokenResponse> => {
-				const mockToken: AccessToken = JSON.parse(JSON.stringify(mockAccessToken));
+				const mockToken: AccessToken = JSON.parse(JSON.stringify(mockAccessToken)) as AccessToken;
 				delete (mockToken as any).invalidData;
 				return Promise.resolve({
 					accessToken: mockToken
@@ -164,7 +164,7 @@ describe('Azure Authentication', function () {
 				});
 			});
 			azureAuthCodeGrant.setup(x => x.refreshTokenAdal(mockTenant, provider.settings.microsoftResource!, mockRefreshToken)).returns((): Promise<OAuthTokenResponse> => {
-				const mockToken: AccessToken = JSON.parse(JSON.stringify(mockAccessToken));
+				const mockToken: AccessToken = JSON.parse(JSON.stringify(mockAccessToken)) as AccessToken;
 				delete (mockToken as any).invalidData;
 				return Promise.resolve({
 					accessToken: mockToken

--- a/extensions/azurecore/src/utils/Logger.ts
+++ b/extensions/azurecore/src/utils/Logger.ts
@@ -98,6 +98,7 @@ function sanitize(objOrArray: any): string {
 }
 
 function sanitizeImpl(obj: any): string {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	obj = Object.assign({}, obj);
 	delete obj.domains; // very long and not really useful
 	// shorten all tokens since we don't usually need the exact values and there's security concerns if they leaked


### PR DESCRIPTION
To help avoid issues like https://github.com/microsoft/azuredatastudio/issues/22606 and https://github.com/microsoft/azuredatastudio/issues/22631 it would be good to be much stricter on the typing we allow. The [no-unsafe-assignment](https://typescript-eslint.io/rules/no-unsafe-assignment/) eslint rule will help with that as it will prevent assigning any `any` var to a variable. 

If the rule had been enabled  then we would have gotten an error here when assigning the body value : https://github.com/microsoft/azuredatastudio/blob/3f882c5d73e6cbcf58f1c3959c26d9200460e7df/extensions/azurecore/src/azureResource/utils.ts#L399

![image](https://user-images.githubusercontent.com/28519865/230233114-6037f375-31d0-489c-83dd-2987491ad330.png)

which would have told us that we don't actually know what type the body was when it came in. 

But before enabling it we have to fix up all the existing issues - so this is the first part of that. I'm specifically not targeting the auth/httpClient areas since those are being worked on at the moment and I want to avoid causing conflicts with that work. So I'm going to start with other areas which are less likely to be modified.

Generally the fixes will involve just assigning the correct type to the any var. Note that this does NOT guarantee that the type is actually the type being assigned - we'd need to add a runtime check for that (using a typeguard or something being a typical approach) which is a much bigger task. What this does get us though is at least knowing what type we're supposedly dealing with in the code and prevents the usage of any from disabling a lot of the checking that the TS compiler does by default.