### PR TITLE
Remove Preview tag from Sql database projects extension

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3481,7 +3481,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": ""
 				},
 				{
 					"extensionId": "71",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3481,7 +3481,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": ""
+					"flags": "preview"
 				},
 				{
 					"extensionId": "71",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4445,7 +4445,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": ""
 				},
 				{
 					"extensionId": "88",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3481,7 +3481,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": ""
 				},
 				{
 					"extensionId": "71",
@@ -4445,7 +4445,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": ""
+					"flags": "preview"
 				},
 				{
 					"extensionId": "88",


### PR DESCRIPTION
This PR removes the "Preview" tag from Sql Database projects extension, since it is GAing with this release.