### PR TITLE
Removed parent override when adding connection profiles to groups 

### DIFF
--- a/src/sql/platform/connection/common/connectionProfileGroup.ts
+++ b/src/sql/platform/connection/common/connectionProfileGroup.ts
@@ -126,8 +126,6 @@ export class ConnectionProfileGroup extends Disposable implements IConnectionPro
 	public getChildren(): (ConnectionProfile | ConnectionProfileGroup)[] {
 		let allChildren: (ConnectionProfile | ConnectionProfileGroup)[] = [];
 		this._childConnections.forEach((conn) => {
-			conn.parent = this;
-			conn.groupId = this.id;
 			allChildren.push(conn);
 		});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes issue #22616 

Whenever a new connection profile was added to a connection group, I used to enforce a parent to ensure that we can easily identify the group to which the connectionProfile's parent belongs, and refresh it when the connection is established. However, this approach had an issue: when a connection was created from the connection dialog, which did not belong to the tree, the connection profile's uri returned to the extension had group as undefined. Despite this, the connection was added to the group in OE, which necessitated assigning a parent to it. This resulted in the version of the connection URI in the extension being different from the version of URI in ads core.