### PR TITLE
Add more error handling for python installation

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -470,14 +470,14 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 						.catch(err => {
 							let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
 							op.updateStatus(azdata.TaskStatus.Failed, errorMsg);
-							this._installCompletion.reject(errorMsg);
+							this._installCompletion.reject(new Error(errorMsg));
 							this._installInProgress = false;
 						});
 				}
 			});
 		} catch (err) {
 			let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
-			this._installCompletion.reject(errorMsg);
+			this._installCompletion.reject(new Error(errorMsg));
 			this._installInProgress = false;
 		}
 		return this._installCompletion.promise;

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -430,51 +430,56 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 
 		this._installInProgress = true;
 		this._installCompletion = new Deferred<void>();
+		try {
+			this._pythonInstallationPath = installSettings.installPath;
+			this._usingExistingPython = installSettings.existingPython;
+			await this.configurePackagePaths();
 
-		this._pythonInstallationPath = installSettings.installPath;
-		this._usingExistingPython = installSettings.existingPython;
-		await this.configurePackagePaths();
+			azdata.tasks.startBackgroundOperation({
+				displayName: msgTaskName,
+				description: msgTaskName,
+				isCancelable: false,
+				operation: op => {
+					this.installDependencies(op, forceInstall, installSettings.packages)
+						.then(async () => {
+							let notebookConfig = vscode.workspace.getConfiguration(constants.notebookConfigKey);
+							await notebookConfig.update(constants.pythonPathConfigKey, this._pythonInstallationPath, vscode.ConfigurationTarget.Global);
+							await notebookConfig.update(constants.existingPythonConfigKey, this._usingExistingPython, vscode.ConfigurationTarget.Global);
+							await this.configurePackagePaths();
 
-		azdata.tasks.startBackgroundOperation({
-			displayName: msgTaskName,
-			description: msgTaskName,
-			isCancelable: false,
-			operation: op => {
-				this.installDependencies(op, forceInstall, installSettings.packages)
-					.then(async () => {
-						let notebookConfig = vscode.workspace.getConfiguration(constants.notebookConfigKey);
-						await notebookConfig.update(constants.pythonPathConfigKey, this._pythonInstallationPath, vscode.ConfigurationTarget.Global);
-						await notebookConfig.update(constants.existingPythonConfigKey, this._usingExistingPython, vscode.ConfigurationTarget.Global);
-						await this.configurePackagePaths();
+							this._installCompletion.resolve();
+							this._installInProgress = false;
+							if (this._upgradeInProcess) {
+								// Pass in false for restartJupyterServer parameter since the jupyter server has already been shutdown
+								// when removing the old Python version on Windows.
+								if (process.platform === constants.winPlatform) {
+									await vscode.commands.executeCommand('notebook.action.restartJupyterNotebookSessions', false);
+								} else {
+									await vscode.commands.executeCommand('notebook.action.restartJupyterNotebookSessions');
+								}
+								if (this._oldUserInstalledPipPackages.length !== 0) {
+									await this.createInstallPipPackagesHelpNotebook(this._oldUserInstalledPipPackages);
+								}
 
-						this._installCompletion.resolve();
-						this._installInProgress = false;
-						if (this._upgradeInProcess) {
-							// Pass in false for restartJupyterServer parameter since the jupyter server has already been shutdown
-							// when removing the old Python version on Windows.
-							if (process.platform === constants.winPlatform) {
-								await vscode.commands.executeCommand('notebook.action.restartJupyterNotebookSessions', false);
-							} else {
+								await fs.remove(this._oldPythonInstallationPath);
+								this._upgradeInProcess = false;
+							} else if (!installSettings.packageUpgradeOnly) {
 								await vscode.commands.executeCommand('notebook.action.restartJupyterNotebookSessions');
 							}
-							if (this._oldUserInstalledPipPackages.length !== 0) {
-								await this.createInstallPipPackagesHelpNotebook(this._oldUserInstalledPipPackages);
-							}
-
-							await fs.remove(this._oldPythonInstallationPath);
-							this._upgradeInProcess = false;
-						} else if (!installSettings.packageUpgradeOnly) {
-							await vscode.commands.executeCommand('notebook.action.restartJupyterNotebookSessions');
-						}
-					})
-					.catch(err => {
-						let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
-						op.updateStatus(azdata.TaskStatus.Failed, errorMsg);
-						this._installCompletion.reject(errorMsg);
-						this._installInProgress = false;
-					});
-			}
-		});
+						})
+						.catch(err => {
+							let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
+							op.updateStatus(azdata.TaskStatus.Failed, errorMsg);
+							this._installCompletion.reject(errorMsg);
+							this._installInProgress = false;
+						});
+				}
+			});
+		} catch (err) {
+			let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
+			this._installCompletion.reject(errorMsg);
+			this._installInProgress = false;
+		}
 		return this._installCompletion.promise;
 	}
 


### PR DESCRIPTION
Some of the python setup calls will fail if the python executable is in a folder that requires admin access. This was causing installs to get stuck in a halfway state because we weren't clearing the installInProgress flag on error.

This PR fixes #22391
