### PR TITLE
SQL-Migration: improve SQL DB table selection ux to include missing tables

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -807,7 +807,9 @@ export function sortResourceArrayByName(resourceArray: SortableAzureResources[])
 export function getMigrationTargetId(migration: DatabaseMigration): string {
 	// `${targetServerId}/providers/Microsoft.DataMigration/databaseMigrations/${targetDatabaseName}?api-version=${DMSV2_API_VERSION}`
 	const paths = migration.id.split('/providers/Microsoft.DataMigration/', 1);
-	return paths[0];
+	return paths?.length > 0
+		? paths[0]
+		: '';
 }
 
 export function getMigrationTargetName(migration: DatabaseMigration): string {

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -667,6 +667,8 @@ export const SELECT_RESOURCE_GROUP_PROMPT = localize('sql.migration.blob.resourc
 export const SELECT_STORAGE_ACCOUNT = localize('sql.migration.blob.storageAccount.select', "Select a storage account value first.");
 export const SELECT_BLOB_CONTAINER = localize('sql.migration.blob.container.select', "Select a blob container value first.");
 
+
+export const MISSING_TABLE_NAME_COLUMN = localize('sql.migration.missing.table.name.column', "Table name");
 export function SELECT_DATABASE_TABLES_TITLE(targetDatabaseName: string): string {
 	return localize('sql.migration.table.select.label', "Select tables for {0}", targetDatabaseName);
 }
@@ -679,9 +681,10 @@ export function TABLE_SELECTED_COUNT(selectedCount: number, rowCount: number): s
 	return localize('sql.migration.table.selected.count', "{0} of {1} tables selected", selectedCount, rowCount);
 }
 export function MISSING_TARGET_TABLES_COUNT(tables: number): string {
-	return localize('sql.migration.table.missing.count', "Missing target tables excluded from list: {0}", tables);
+	return localize('sql.migration.table.missing.count', "Tables missing on target: {0}", formatNumber(tables));
 }
-export const DATABASE_MISSING_TABLES = localize('sql.migration.database.missing.tables', "0 tables found.");
+export const SELECT_TABLES_FOR_MIGRATION = localize('sql.migration.select.migration.tables', "Select tables for migration");
+export const DATABASE_MISSING_TABLES = localize('sql.migration.database.missing.tables', "0 tables found on source database.");
 export const DATABASE_LOADING_TABLES = localize('sql.migration.database.loading.tables', "Loading tables list...");
 export const TABLE_SELECTION_FILTER = localize('sql.migration.table.selection.filter', "Filter tables");
 export const TABLE_SELECTION_UPDATE_BUTTON = localize('sql.migration.table.selection.update.button', "Update");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -675,10 +675,10 @@ export function SELECT_DATABASE_TABLES_TITLE(targetDatabaseName: string): string
 export const TABLE_SELECTION_EDIT = localize('sql.migration.table.selection.edit', "Edit");
 
 export function TABLE_SELECTION_COUNT(selectedCount: number, rowCount: number): string {
-	return localize('sql.migration.table.selection.count', "{0} of {1}", selectedCount, rowCount);
+	return localize('sql.migration.table.selection.count', "{0} of {1}", formatNumber(selectedCount), formatNumber(rowCount));
 }
 export function TABLE_SELECTED_COUNT(selectedCount: number, rowCount: number): string {
-	return localize('sql.migration.table.selected.count', "{0} of {1} tables selected", selectedCount, rowCount);
+	return localize('sql.migration.table.selected.count', "{0} of {1} tables selected", formatNumber(selectedCount), formatNumber(rowCount));
 }
 export function MISSING_TARGET_TABLES_COUNT(tables: number): string {
 	return localize('sql.migration.table.missing.count', "Tables missing on target: {0}", formatNumber(tables));
@@ -935,7 +935,9 @@ export const AZURE_STORAGE_ACCOUNT_TO_UPLOAD_BACKUPS = localize('sql.migration.a
 export const SHIR = localize('sql.migration.shir', "Self-hosted integration runtime node");
 export const DATABASE_TO_BE_MIGRATED = localize('sql.migration.database.to.be.migrated', "Database to be migrated");
 export function COUNT_DATABASES(count: number): string {
-	return (count === 1) ? localize('sql.migration.count.database.single', "{0} database", count) : localize('sql.migration.count.database.multiple', "{0} databases", count);
+	return (count === 1)
+		? localize('sql.migration.count.database.single', "{0} database", count)
+		: localize('sql.migration.count.database.multiple', "{0} databases", formatNumber(count));
 }
 export function TOTAL_TABLES_SELECTED(selected: number, total: number): string {
 	return localize('total.tables.selected.of.total', "{0} of {1}", formatNumber(selected), formatNumber(total));

--- a/extensions/sql-migration/src/dialog/createSqlMigrationService/createSqlMigrationServiceDialog.ts
+++ b/extensions/sql-migration/src/dialog/createSqlMigrationService/createSqlMigrationServiceDialog.ts
@@ -401,7 +401,11 @@ export class CreateSqlMigrationServiceDialog {
 				constants.RESOURCE_GROUP_NOT_FOUND);
 
 			const selectedResourceGroupValue = this.migrationServiceResourceGroupDropdown.values.find(v => v.name.toLowerCase() === this._resourceGroupPreset.toLowerCase());
-			this.migrationServiceResourceGroupDropdown.value = (selectedResourceGroupValue) ? selectedResourceGroupValue : this.migrationServiceResourceGroupDropdown.values[0];
+			this.migrationServiceResourceGroupDropdown.value = (selectedResourceGroupValue)
+				? selectedResourceGroupValue
+				: this.migrationServiceResourceGroupDropdown.values?.length > 0
+					? this.migrationServiceResourceGroupDropdown.values[0]
+					: '';
 		} finally {
 			this.migrationServiceResourceGroupDropdown.loading = false;
 		}

--- a/extensions/sql-migration/src/telemetry.ts
+++ b/extensions/sql-migration/src/telemetry.ts
@@ -97,12 +97,15 @@ export function sendSqlMigrationActionEvent(telemetryView: TelemetryViews, telem
 }
 
 export function getTelemetryProps(migrationStateModel: MigrationStateModel): TelemetryEventProperties {
+	const tenantId = migrationStateModel._azureAccount?.properties?.tenants?.length > 0
+		? migrationStateModel._azureAccount?.properties?.tenants[0]?.id
+		: '';
 	return {
 		'sessionId': migrationStateModel._sessionId,
 		'subscriptionId': migrationStateModel._targetSubscription?.id,
 		'resourceGroup': migrationStateModel._resourceGroup?.name,
 		'targetType': migrationStateModel._targetType,
-		'tenantId': migrationStateModel._azureAccount?.properties?.tenants[0]?.id,
+		'tenantId': tenantId,
 	};
 }
 

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -897,14 +897,16 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 				this._sqlSourceUsernameInput.value = username;
 				this._sqlSourcePassword.value = (await getSourceConnectionCredentials()).password;
 
-				this._windowsUserAccountText.value =
-					this.migrationStateModel._databaseBackup.networkShares[0]?.windowsUser
-					?? this.migrationStateModel.savedInfo?.networkShares[0]?.windowsUser
-					?? '';
-				this._passwordText.value =
-					this.migrationStateModel._databaseBackup.networkShares[0]?.password
-					?? this.migrationStateModel.savedInfo?.networkShares[0]?.password
-					?? '';
+				const networkShares = this.migrationStateModel._databaseBackup?.networkShares?.length > 0
+					? this.migrationStateModel._databaseBackup?.networkShares
+					: this.migrationStateModel.savedInfo?.networkShares ?? [];
+
+				const networkShare = networkShares?.length > 0
+					? networkShares[0]
+					: undefined;
+
+				this._windowsUserAccountText.value = networkShare?.windowsUser ?? '';
+				this._passwordText.value = networkShare?.password ?? '';
 
 				this._networkShareTargetDatabaseNames = [];
 				this._networkShareLocations = [];
@@ -1379,13 +1381,15 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 						break;
 					case NetworkContainerType.NETWORK_SHARE:
 						// All network share migrations use the same storage account
-						const storageAccount = this.migrationStateModel._databaseBackup.networkShares[0]?.storageAccount;
-						const storageKey = (await getStorageAccountAccessKeys(
-							this.migrationStateModel._azureAccount,
-							this.migrationStateModel._databaseBackup.subscription,
-							storageAccount)).keyName1;
-						for (let i = 0; i < this.migrationStateModel._databaseBackup.networkShares.length; i++) {
-							this.migrationStateModel._databaseBackup.networkShares[i].storageKey = storageKey;
+						if (this.migrationStateModel._databaseBackup.networkShares?.length > 0) {
+							const storageAccount = this.migrationStateModel._databaseBackup.networkShares[0]?.storageAccount;
+							const storageKey = (await getStorageAccountAccessKeys(
+								this.migrationStateModel._azureAccount,
+								this.migrationStateModel._databaseBackup.subscription,
+								storageAccount)).keyName1;
+							for (let i = 0; i < this.migrationStateModel._databaseBackup.networkShares.length; i++) {
+								this.migrationStateModel._databaseBackup.networkShares[i].storageKey = storageKey;
+							}
 						}
 						break;
 				}

--- a/extensions/sql-migration/src/wizard/summaryPage.ts
+++ b/extensions/sql-migration/src/wizard/summaryPage.ts
@@ -6,7 +6,7 @@
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import { MigrationWizardPage } from '../models/migrationWizardPage';
-import { MigrationMode, MigrationStateModel, NetworkContainerType, StateChangeEvent } from '../models/stateMachine';
+import { MigrationMode, MigrationStateModel, NetworkContainerType, NetworkShare, StateChangeEvent } from '../models/stateMachine';
 import * as constants from '../constants/strings';
 import { createHeadingTextComponent, createInformationRow, createLabelTextComponent } from './wizardController';
 import { getResourceGroupFromId } from '../api/azure';
@@ -185,7 +185,10 @@ export class SummaryPage extends MigrationWizardPage {
 			.withLayout({ flexFlow: 'column' })
 			.component();
 
-		const networkShare = this.migrationStateModel._databaseBackup.networkShares[0];
+		const networkShare = this.migrationStateModel._databaseBackup.networkShares?.length > 0
+			? this.migrationStateModel._databaseBackup.networkShares[0]
+			: <NetworkShare>{};
+
 		switch (this.migrationStateModel._databaseBackup.networkContainerType) {
 			case NetworkContainerType.NETWORK_SHARE:
 				flexContainer.addItems([


### PR DESCRIPTION
This PR:
- improves the SQL DB table selection user experience by adding a refresh button, error handling and missing target tables list.  
- adds error handling around loading from previously saved migration states.

New table view loading:
![image](https://user-images.githubusercontent.com/61598682/230662076-852d97b4-040a-408c-b673-d0ae74bfba42.png)

tables loaded w/missing targets
![image](https://user-images.githubusercontent.com/61598682/230662131-0129dee6-dd74-4d4a-bc1e-5c2c49cf045e.png)

missing tables tab
![image](https://user-images.githubusercontent.com/61598682/230663172-90eef916-9f63-4db6-b40d-3c9a860fd5cc.png)

load table list error:
![image](https://user-images.githubusercontent.com/61598682/230663469-a1060898-3a55-4759-89ab-997861d546ec.png)

lots of missing target tables
![image](https://user-images.githubusercontent.com/61598682/230663528-3c433914-8534-4153-b209-aa0de0d14674.png)

missing source tables
![image](https://user-images.githubusercontent.com/61598682/230663584-942474ef-41f9-4d4d-a604-7415177b89ea.png)

source and target schema match:
![image](https://user-images.githubusercontent.com/61598682/230665356-75a8c643-31a4-4222-b729-539349fea1b6.png)
