### PR TITLE
Fixing duplicate connections in Async sever tree

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -228,7 +228,12 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			if (this._tree instanceof AsyncServerTree) {
 				const connectionParentGroup = this._tree.getElementById(newConnection.groupId) as ConnectionProfileGroup;
 				if (connectionParentGroup) {
-					connectionParentGroup.connections.push(newConnection);
+					const matchingConnectionIndex = connectionParentGroup.connections.findIndex((connection) => connection.matches(newConnection));
+					if (matchingConnectionIndex !== -1) {
+						connectionParentGroup.connections[matchingConnectionIndex] = newConnection;
+					} else {
+						connectionParentGroup.connections.push(newConnection);
+					}
 					newConnection.parent = connectionParentGroup;
 					newConnection.groupId = connectionParentGroup.id;
 					await this._tree.updateChildren(connectionParentGroup);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #22668 
In case of new connections, I am checking if the connection already exists in the group and then replace the connection instead of appending it to the end.

@smartguest can you please verify if the fix works.