### PR TITLE
Firewall Dialog Account/Tenant Selection

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/accountPicker.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPicker.ts
@@ -12,6 +12,7 @@ export const IAccountPickerService = createDecorator<IAccountPickerService>('Acc
 export interface IAccountPickerService {
 	_serviceBrand: undefined;
 	renderAccountPicker(rootContainer: HTMLElement): void;
+	setAccountSelection(account: string): void;
 	addAccountCompleteEvent: Event<void>;
 	addAccountErrorEvent: Event<string>;
 	addAccountStartEvent: Event<void>;

--- a/src/sql/workbench/services/accountManagement/browser/accountPicker.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPicker.ts
@@ -12,7 +12,7 @@ export const IAccountPickerService = createDecorator<IAccountPickerService>('Acc
 export interface IAccountPickerService {
 	_serviceBrand: undefined;
 	renderAccountPicker(rootContainer: HTMLElement): void;
-	setAccountSelection(account: string): void;
+	setInitialAccountTenant(account: string, tenant: string): void;
 	addAccountCompleteEvent: Event<void>;
 	addAccountErrorEvent: Event<string>;
 	addAccountStartEvent: Event<void>;

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
@@ -176,6 +176,7 @@ export class AccountPicker extends Disposable {
 		actionBar.push(this._refreshAccountAction, { icon: false, label: true });
 
 		if (this._accountList.length > 0) {
+			// Should set account list selection to accout selected in the connection dialog instead of setting to [0]
 			this._accountList.setSelection([0]);
 			this.onAccountSelectionChange(this._accountList.getSelectedElements()[0]);
 		} else {
@@ -198,6 +199,25 @@ export class AccountPicker extends Disposable {
 			this._accountList.dispose();
 		}
 	}
+
+	// public setInitialAccount()
+
+	public setAccountSelection(account: string): void {
+		let index = 0;
+		// find index
+		while (account !== this._accountList.view.items[index].element.key.accountId) {
+			index++
+		}
+		this._accountList.setSelection([index]);
+	}
+
+	// public setTenantSelection(tenant: string): void {
+	// 	let index = 0;
+	// 	while (tenant !== this._tenantList[index].id) {
+	// 		index++
+	// 	}
+	// 	this._tenantList.setSelection([index]);
+	// }
 
 	// PRIVATE HELPERS /////////////////////////////////////////////////////
 
@@ -316,6 +336,7 @@ export class AccountPicker extends Disposable {
 			if (selectedIndex && selectedIndex !== -1) {
 				this._accountList!.setSelection([selectedIndex]);
 			} else {
+				// Should set account list selection to account selected in the connection dialog instead of setting to [0]
 				this._accountList!.setSelection([0]);
 			}
 		} else {

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
@@ -176,7 +176,6 @@ export class AccountPicker extends Disposable {
 		actionBar.push(this._refreshAccountAction, { icon: false, label: true });
 
 		if (this._accountList.length > 0) {
-			// Should set account list selection to accout selected in the connection dialog instead of setting to [0]
 			this._accountList.setSelection([0]);
 			this.onAccountSelectionChange(this._accountList.getSelectedElements()[0]);
 		} else {
@@ -200,8 +199,6 @@ export class AccountPicker extends Disposable {
 		}
 	}
 
-	// public setInitialAccount()
-
 	public setAccountSelection(account: string): void {
 		let index = 0;
 		// find index
@@ -210,14 +207,6 @@ export class AccountPicker extends Disposable {
 		}
 		this._accountList.setSelection([index]);
 	}
-
-	// public setTenantSelection(tenant: string): void {
-	// 	let index = 0;
-	// 	while (tenant !== this._tenantList[index].id) {
-	// 		index++
-	// 	}
-	// 	this._tenantList.setSelection([index]);
-	// }
 
 	// PRIVATE HELPERS /////////////////////////////////////////////////////
 
@@ -336,7 +325,6 @@ export class AccountPicker extends Disposable {
 			if (selectedIndex && selectedIndex !== -1) {
 				this._accountList!.setSelection([selectedIndex]);
 			} else {
-				// Should set account list selection to account selected in the connection dialog instead of setting to [0]
 				this._accountList!.setSelection([0]);
 			}
 		} else {

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
@@ -202,7 +202,7 @@ export class AccountPicker extends Disposable {
 	public setAccountSelection(account: string): void {
 		let index = 0;
 		// find index
-		while (account !== this._accountList.view.items[index].element.key.accountId) {
+		while (account !== this._accountList.element(index).key.accountId) {
 			index++
 		}
 		this._accountList.setSelection([index]);

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
@@ -204,7 +204,6 @@ export class AccountPicker extends Disposable {
 		}
 	}
 
-
 	public setInitialTenant(tenant: string): void {
 		this.initialTenant = tenant;
 	}
@@ -213,7 +212,9 @@ export class AccountPicker extends Disposable {
 		this.initialAccount = account;
 	}
 
-	public setAccountSelection(): void {
+	// PRIVATE HELPERS /////////////////////////////////////////////////////
+
+	private setAccountSelection(): void {
 		let index = 0;
 		let accountFound = false;
 		while (index < this._accountList.length) {
@@ -228,7 +229,7 @@ export class AccountPicker extends Disposable {
 		}
 	}
 
-	public setTenantSelection(): void {
+	private setTenantSelection(): void {
 		let index = 0;
 		let tenantFound = false;
 		while (index < this._tenantList.length) {
@@ -242,8 +243,6 @@ export class AccountPicker extends Disposable {
 			this._tenantList.setSelection([index]);
 		}
 	}
-
-	// PRIVATE HELPERS /////////////////////////////////////////////////////
 
 	private createLabelElement(content: string, isHeader?: boolean) {
 		let className = 'dialog-label';

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
@@ -30,6 +30,8 @@ export class AccountPicker extends Disposable {
 	public static ACCOUNTPICKERLIST_HEIGHT = 47;
 	public static ACCOUNTTENANTLIST_HEIGHT = 32;
 	public viewModel: AccountPickerViewModel;
+	public initialAccount: string;
+	public initialTenant: string;
 	private _accountList?: List<azdata.Account>;
 	private _rootContainer?: HTMLElement;
 
@@ -189,6 +191,9 @@ export class AccountPicker extends Disposable {
 		this.viewModel.initialize()
 			.then((accounts: azdata.Account[]) => {
 				this.updateAccountList(accounts);
+				// Need to set account selection after account list has been updated
+				this.setAccountSelection();
+				this.setTenantSelection();
 			});
 	}
 
@@ -199,13 +204,43 @@ export class AccountPicker extends Disposable {
 		}
 	}
 
-	public setAccountSelection(account: string): void {
+
+	public setInitialTenant(tenant: string): void {
+		this.initialTenant = tenant;
+	}
+
+	public setInitialAccount(account: string): void {
+		this.initialAccount = account;
+	}
+
+	public setAccountSelection(): void {
 		let index = 0;
-		// find index
-		while (account !== this._accountList.element(index).key.accountId) {
+		let accountFound = false;
+		while (index < this._accountList.length) {
+			if (this.initialAccount === this._accountList.element(index).key.accountId) {
+				accountFound = true;
+				break;
+			}
 			index++
 		}
-		this._accountList.setSelection([index]);
+		if (accountFound) {
+			this._accountList.setSelection([index]);
+		}
+	}
+
+	public setTenantSelection(): void {
+		let index = 0;
+		let tenantFound = false;
+		while (index < this._tenantList.length) {
+			if (this.initialTenant === this._tenantList.element(index).id) {
+				tenantFound = true;
+				break;
+			}
+			index++
+		}
+		if (tenantFound) {
+			this._tenantList.setSelection([index]);
+		}
 	}
 
 	// PRIVATE HELPERS /////////////////////////////////////////////////////

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerService.ts
@@ -59,6 +59,7 @@ export class AccountPickerService implements IAccountPickerService {
 		if (this._accountPicker) {
 			this._accountPicker.setInitialAccount(account);
 			this._accountPicker.setInitialTenant(tenant);
+			this._logService.info(`Set initial account: ${account} and tenant: ${tenant}`)
 		} else {
 			this._logService.error('Account Picker was undefined. Could not set initial account/tenant for firewall dialog.');
 		}

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerService.ts
@@ -9,6 +9,7 @@ import * as azdata from 'azdata';
 
 import { IAccountPickerService } from 'sql/workbench/services/accountManagement/browser/accountPicker';
 import { AccountPicker } from 'sql/workbench/services/accountManagement/browser/accountPickerImpl';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export class AccountPickerService implements IAccountPickerService {
 	_serviceBrand: undefined;
@@ -32,7 +33,8 @@ export class AccountPickerService implements IAccountPickerService {
 	public get onTenantSelectionChangeEvent(): Event<string | undefined> { return this._onTenantSelectionChangeEvent.event; }
 
 	constructor(
-		@IInstantiationService private _instantiationService: IInstantiationService
+		@IInstantiationService private _instantiationService: IInstantiationService,
+		@ILogService private readonly _logService: ILogService
 	) {
 		// Create event emitters
 		this._addAccountCompleteEmitter = new Emitter<void>();
@@ -53,12 +55,12 @@ export class AccountPickerService implements IAccountPickerService {
 		}
 	}
 
-	public setAccountSelection(account: string): void {
+	public setInitialAccountTenant(account: string, tenant: string): void {
 		if (this._accountPicker) {
-			this._accountPicker.setAccountSelection(account);
+			this._accountPicker.setInitialAccount(account);
+			this._accountPicker.setInitialTenant(tenant);
 		} else {
-			// log could not set account selection
-			return undefined;
+			this._logService.error('Account Picker was undefined. Could not set initial account/tenant for firewall dialog.');
 		}
 	}
 

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerService.ts
@@ -53,6 +53,16 @@ export class AccountPickerService implements IAccountPickerService {
 		}
 	}
 
+	public setAccountSelection(account: string): void {
+		if (this._accountPicker) {
+			this._accountPicker.setAccountSelection(account);
+		} else {
+			// log could not set account selection
+			return undefined;
+		}
+	}
+
+
 	/**
 	 * Render account picker
 	 */

--- a/src/sql/workbench/services/accountManagement/test/browser/accountPickerService.test.ts
+++ b/src/sql/workbench/services/accountManagement/test/browser/accountPickerService.test.ts
@@ -14,6 +14,7 @@ import { TestAccountManagementService } from 'sql/platform/accounts/test/common/
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 import { AccountPickerService } from 'sql/workbench/services/accountManagement/browser/accountPickerService';
+import { NullLogService } from 'vs/platform/log/common/log';
 
 // SUITE STATE /////////////////////////////////////////////////////////////
 let mockAddAccountCompleteEmitter: Emitter<void>;
@@ -37,9 +38,10 @@ suite('Account picker service tests', () => {
 		// Setup:
 		// ... Create instantiation service
 		let instantiationService = createInstantiationService();
+		let logService = new NullLogService();
 
-		// ... Create instance of the service and reder account picker
-		let service = new AccountPickerService(instantiationService, undefined);
+		// ... Create instance of the service and render account picker
+		let service = new AccountPickerService(instantiationService, logService);
 		service.renderAccountPicker(TypeMoq.It.isAny());
 
 		// Then:

--- a/src/sql/workbench/services/accountManagement/test/browser/accountPickerService.test.ts
+++ b/src/sql/workbench/services/accountManagement/test/browser/accountPickerService.test.ts
@@ -39,7 +39,7 @@ suite('Account picker service tests', () => {
 		let instantiationService = createInstantiationService();
 
 		// ... Create instance of the service and reder account picker
-		let service = new AccountPickerService(instantiationService);
+		let service = new AccountPickerService(instantiationService, undefined);
 		service.renderAccountPicker(TypeMoq.It.isAny());
 
 		// Then:

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
@@ -326,7 +326,6 @@ export class FirewallRuleDialog extends Modal {
 		this._accountPickerService.setInitialAccountTenant(account, tenant);
 	}
 
-
 	public onAccountSelectionChange(account: azdata.Account | undefined): void {
 		this.viewModel.selectedAccount = account;
 		if (account && !account.isStale) {

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
@@ -322,6 +322,11 @@ export class FirewallRuleDialog extends Modal {
 		}
 	}
 
+	public setAccountSelection(account: string) {
+		this._accountPickerService.setAccountSelection(account);
+	}
+
+
 	public onAccountSelectionChange(account: azdata.Account | undefined): void {
 		this.viewModel.selectedAccount = account;
 		if (account && !account.isStale) {
@@ -330,6 +335,11 @@ export class FirewallRuleDialog extends Modal {
 			this._createButton!.enabled = false;
 		}
 	}
+
+	public setTenantSelection(tenantId: string) {
+
+	}
+
 
 	public onTenantSelectionChange(tenantId: string): void {
 		this.viewModel.selectedTenantId = tenantId;

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
@@ -322,8 +322,8 @@ export class FirewallRuleDialog extends Modal {
 		}
 	}
 
-	public setAccountSelection(account: string) {
-		this._accountPickerService.setAccountSelection(account);
+	public setInitialAccountTenant(account: string, tenant: string) {
+		this._accountPickerService.setInitialAccountTenant(account, tenant);
 	}
 
 

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
@@ -336,11 +336,6 @@ export class FirewallRuleDialog extends Modal {
 		}
 	}
 
-	public setTenantSelection(tenantId: string) {
-
-	}
-
-
 	public onTenantSelectionChange(tenantId: string): void {
 		this.viewModel.selectedTenantId = tenantId;
 	}

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController.ts
@@ -49,6 +49,7 @@ export class FirewallRuleDialogController {
 		this._resourceProviderId = resourceProviderId;
 		this._firewallRuleDialog.viewModel.updateDefaultValues(ipAddress);
 		this._firewallRuleDialog.open();
+		this._firewallRuleDialog.setAccountSelection(connection.azureAccount);
 		this._deferredPromise = new Deferred();
 		return this._deferredPromise.promise;
 	}

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController.ts
@@ -49,7 +49,7 @@ export class FirewallRuleDialogController {
 		this._resourceProviderId = resourceProviderId;
 		this._firewallRuleDialog.viewModel.updateDefaultValues(ipAddress);
 		this._firewallRuleDialog.open();
-		this._firewallRuleDialog.setAccountSelection(connection.azureAccount);
+		this._firewallRuleDialog.setInitialAccountTenant(connection.azureAccount, connection.azureTenantId);
 		this._deferredPromise = new Deferred();
 		return this._deferredPromise.promise;
 	}

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController.ts
@@ -48,8 +48,8 @@ export class FirewallRuleDialogController {
 		this._connection = connection;
 		this._resourceProviderId = resourceProviderId;
 		this._firewallRuleDialog.viewModel.updateDefaultValues(ipAddress);
-		this._firewallRuleDialog.open();
 		this._firewallRuleDialog.setInitialAccountTenant(connection.azureAccount, connection.azureTenantId);
+		this._firewallRuleDialog.open();
 		this._deferredPromise = new Deferred();
 		return this._deferredPromise.promise;
 	}


### PR DESCRIPTION
Pre-select Firewall Dialog Account & Tenant based on details selected by the user in the Connection Dialog.  I noticed the account was not being selected correctly (even though the issue only mentions the tenant behavior) so I have fixed that as well.

Previous Behavior: The first account & tenant in their respective lists were selected.

New Behavior: The account & tenant are matched to the account & tenant selected in the connection dialog page, and pre-selected for the user. 

This PR fixes #22300
