### PR TITLE
Append Endpoint suffix to storage blob connection string

### DIFF
--- a/build/azure-pipelines/common/publish.js
+++ b/build/azure-pipelines/common/publish.js
@@ -153,7 +153,7 @@ async function publish(commit, quality, platform, type, name, version, _isUpdate
     const blobName = commit + '/' + name;
     const storageAccount = process.env['AZURE_STORAGE_ACCOUNT_2'];
     const storageKey = process.env['AZURE_STORAGE_ACCESS_KEY_2'];
-    const connectionString = `DefaultEndpointsProtocol=https;AccountName=${storageAccount};AccountKey=${storageKey}`;
+    const connectionString = `DefaultEndpointsProtocol=https;AccountName=${storageAccount};AccountKey=${storageKey};EndpointSuffix=core.windows.net`;
     let blobServiceClient = storage_blob_1.BlobServiceClient.fromConnectionString(connectionString, {
         retryOptions: {
             maxTries: 20,

--- a/build/azure-pipelines/common/publish.ts
+++ b/build/azure-pipelines/common/publish.ts
@@ -188,7 +188,7 @@ async function publish(commit: string, quality: string, platform: string, type: 
 	const blobName = commit + '/' + name;
 	const storageAccount = process.env['AZURE_STORAGE_ACCOUNT_2']!;
 	const storageKey = process.env['AZURE_STORAGE_ACCESS_KEY_2']!;
-	const connectionString = `DefaultEndpointsProtocol=https;AccountName=${storageAccount};AccountKey=${storageKey}`;
+	const connectionString = `DefaultEndpointsProtocol=https;AccountName=${storageAccount};AccountKey=${storageKey};EndpointSuffix=core.windows.net`;
 
 	let blobServiceClient = BlobServiceClient.fromConnectionString(connectionString, {
 		retryOptions: {


### PR DESCRIPTION
Fixes publish issues due to missing endpoint suffix.
Verified connection string from Azure Portal for storage account, validated with local testing.