### PR TITLE
fix project listed twice when using multi root workspaces

### DIFF
--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -170,7 +170,7 @@ export class WorkspaceService implements IWorkspaceService {
 			const projectPromises = vscode.workspace.workspaceFolders?.map(f => this.getAllProjectsInFolder(f.uri)) ?? [];
 			const allProjects = (await Promise.all(projectPromises)).reduce((prev, curr) => prev.concat(curr), []);
 
-			// convert to set to make sure all the fsPaths are unique so projects aren't listed multiple times if they are included by multiple workspace folders.
+			// convert to Set to make sure all the fsPaths are unique so projects aren't listed multiple times if they are included by multiple workspace folders.
 			// Need to use fsPath for the set to be able to filter out duplicates because it's a string, rather than the vscode.Uri
 			const uniqueProjects = [...new Set(allProjects.map(p => p.fsPath))];
 			this.openedProjects = uniqueProjects.map(p => vscode.Uri.file(p));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #22517.

Example of a workspace where two of the workspace folders include the same project:
![image](https://user-images.githubusercontent.com/31145923/231604580-e187d7f0-7dd1-4bc2-a0cc-572debcfa870.png)

before:
![image](https://user-images.githubusercontent.com/31145923/231604710-8f086f58-e2c4-4cb6-9cbf-82453c783762.png)

fixed:
![image](https://user-images.githubusercontent.com/31145923/231604655-1f187d71-819d-423b-ab64-2775eef0f6f4.png)

