### PR TITLE
Added changes and fixes for feat/connectionuri

### DIFF
--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -91,7 +91,6 @@ export class ConnectionConfig {
 				if (match && (matcher.toString() !== ConnectionProfile.matchesProfile.toString())) {
 					firstMatchProfile = value;
 				}
-				providerConnectionProfile.dispose();
 				return match;
 			});
 
@@ -107,7 +106,6 @@ export class ConnectionConfig {
 				let matchesExistingProfile = profiles.find(value => {
 					const providerConnectionProfile = ConnectionProfile.createFromStoredProfile(value, this._capabilitiesService);
 					const match = ConnectionProfile.matchesProfile(providerConnectionProfile, connectionProfile);
-					providerConnectionProfile.dispose();
 					return match;
 				});
 
@@ -373,7 +371,6 @@ export class ConnectionConfig {
 	private checkIfNonDefaultOptionsMatch(profileStore: IConnectionProfileStore, profile: ConnectionProfile): boolean {
 		let tempProfile = ConnectionProfile.createFromStoredProfile(profileStore, this._capabilitiesService);
 		let result = profile.getNonDefaultOptionsString() === tempProfile.getNonDefaultOptionsString();
-		tempProfile.dispose();
 		return result;
 	}
 

--- a/src/sql/platform/connection/common/providerConnectionInfo.ts
+++ b/src/sql/platform/connection/common/providerConnectionInfo.ts
@@ -161,7 +161,7 @@ export class ProviderConnectionInfo implements azdata.ConnectionInfo {
 			}
 		}
 		// The provider capabilities are registered at the same time at load time, we can assume all providers are registered as long as the collection is not empty.
-		else if (Object.keys(this.capabilitiesService.providers).length > 0) {
+		else if (this.hasLoaded()) {
 			return localize('connection.unsupported', "Unsupported connection");
 		} else {
 			return localize('loading', "Loading...");
@@ -171,6 +171,10 @@ export class ProviderConnectionInfo implements azdata.ConnectionInfo {
 
 	public hasServerCapabilities(): boolean {
 		return (this.serverCapabilities !== undefined);
+	}
+
+	public hasLoaded(): boolean {
+		return Object.keys(this.capabilitiesService.providers).length > 0;
 	}
 
 	public get serverInfo(): string {

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -237,6 +237,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 					newConnection.parent = connectionParentGroup;
 					newConnection.groupId = connectionParentGroup.id;
 					await this._tree.updateChildren(connectionParentGroup);
+					await this.refreshConnectionTreeTitles();
 					await this._tree.revealSelectFocusElement(newConnection);
 					await this._tree.expand(newConnection);
 				}
@@ -251,6 +252,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 					await this._tree.rerender(connectionInTree);
 					await this._tree.revealSelectFocusElement(connectionInTree);
 					await this._tree.updateChildren(connectionInTree);
+					await this.refreshConnectionTreeTitles();
 					await this._tree.expand(connectionInTree);
 				}
 			}
@@ -263,6 +265,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				if (parentGroup) {
 					parentGroup.connections = parentGroup.connections.filter(c => c.id !== e.id);
 					await this._tree.updateChildren(parentGroup);
+					await this.refreshConnectionTreeTitles();
 					await this._tree.revealSelectFocusElement(parentGroup);
 				}
 			}
@@ -282,6 +285,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 					e.profile.parent = newProfileParent;
 					e.profile.groupId = newProfileParent.id;
 					await this._tree.updateChildren(newProfileParent);
+					this.refreshConnectionTreeTitles();
 					await this._tree.revealSelectFocusElement(e.profile);
 					await this._tree.expand(e.profile);
 				} else {
@@ -289,7 +293,8 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 					oldProfileParent.connections[oldProfileParent.connections.findIndex(c => c.id === e.oldProfileId)] = e.profile;
 					e.profile.parent = oldProfileParent;
 					e.profile.groupId = oldProfileParent.id;
-					await this._tree.updateChildren(oldProfileParent)
+					await this._tree.updateChildren(oldProfileParent);
+					this.refreshConnectionTreeTitles();
 					await this._tree.revealSelectFocusElement(e.profile);
 					await this._tree.expand(e.profile);
 				}
@@ -313,6 +318,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 					movedConnection.groupId = newParent.id;
 					await this._tree.updateChildren(newParent);
 				}
+				this.refreshConnectionTreeTitles();
 				const newConnection = this._tree.getElementById(movedConnection.id);
 				if (newConnection) {
 					await this._tree.revealSelectFocusElement(newConnection);
@@ -327,6 +333,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				const parent = <ConnectionProfileGroup>this._tree.getElementById(e.parentId);
 				parent.children = parent.children.filter(c => c.id !== e.id);
 				await this._tree.updateChildren(parent);
+				this.refreshConnectionTreeTitles();
 				await this._tree.revealSelectFocusElement(parent);
 			}
 		}));
@@ -341,6 +348,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				e.parent = parent;
 				e.parentId = parent.id;
 				await this._tree.updateChildren(parent);
+				this.refreshConnectionTreeTitles();
 				await this._tree.revealSelectFocusElement(e);
 			}
 		}));
@@ -351,6 +359,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				if (newParent) {
 					newParent.children[newParent.children.findIndex(c => c.id === e.id)] = e;
 					await this._tree.updateChildren(newParent);
+					this.refreshConnectionTreeTitles();
 					await this._tree.revealSelectFocusElement(e);
 				}
 			}
@@ -369,6 +378,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				(<ConnectionProfileGroup>movedGroup).parent = newParent;
 				(<ConnectionProfileGroup>movedGroup).parentId = newParent.id;
 				await this._tree.updateChildren(newParent);
+				this.refreshConnectionTreeTitles();
 				await this._tree.revealSelectFocusElement(movedGroup);
 				// Expanding the previously expanded children of the moved group after the move.
 				this._tree.expandElements(profileExpandedState);
@@ -608,6 +618,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			if (this._tree instanceof AsyncServerTree) {
 				await this._tree.setInput(treeInput!);
 				await this._tree.updateChildren(treeInput!);
+				this.refreshConnectionTreeTitles();
 				return;
 			}
 			await this._tree.setInput(treeInput!);
@@ -868,5 +879,12 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			actionContext = element;
 		}
 		return actionContext;
+	}
+
+	private async refreshConnectionTreeTitles(): Promise<void> {
+		let treeInput = TreeUpdateUtils.getTreeInput(this._connectionManagementService);
+		let treeArray = TreeUpdateUtils.alterTreeChildrenTitles([treeInput]);
+		treeInput = treeArray[0];
+		await this._tree!.setInput(treeInput);
 	}
 }

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -721,7 +721,6 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			else {
 				result = tempProfile.getNonDefaultOptionsString();
 			}
-			tempProfile.dispose();
 		}
 		return result;
 	}

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -1017,13 +1017,11 @@ suite('SQL ConnectionManagementService tests', () => {
 		connectionStore.setup(x => x.isDuplicateEdit(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((inputProfile, matcher) => {
 			let newProfile = ConnectionProfile.fromIConnectionProfile(new TestCapabilitiesService(), inputProfile);
 			let result = newProfile.getOptionsKey() === originalProfileKey;
-			newProfile.dispose();
 			return Promise.resolve(result);
 		});
 		await connect(uri1, options, true, profile);
 		let originalProfile = ConnectionProfile.fromIConnectionProfile(new TestCapabilitiesService(), connectionProfile);
 		originalProfileKey = originalProfile.getOptionsKey();
-		originalProfile.dispose();
 		let newProfile = Object.assign({}, connectionProfile);
 		newProfile.connectionName = newname;
 		options.params.isEditConnection = true;
@@ -1096,14 +1094,12 @@ suite('SQL ConnectionManagementService tests', () => {
 		connectionStore.setup(x => x.isDuplicateEdit(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((inputProfile, matcher) => {
 			let newProfile = ConnectionProfile.fromIConnectionProfile(new TestCapabilitiesService(), inputProfile);
 			let result = newProfile.getOptionsKey() === originalProfileKey;
-			newProfile.dispose();
 			return Promise.resolve(result)
 		});
 
 		await connect(uri1, options, true, profile);
 		let originalProfile = ConnectionProfile.fromIConnectionProfile(new TestCapabilitiesService(), connectionProfile);
 		originalProfileKey = originalProfile.getOptionsKey();
-		originalProfile.dispose();
 		let newProfile = Object.assign({}, connectionProfile);
 		options.params.isEditConnection = true;
 		try {
@@ -2141,7 +2137,6 @@ test('getEditorConnectionProfileTitle should return a correctly formatted title 
 	// We should expect that the string contains the connection name and the server info (with all non default options appended).
 	let generatedProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesService, profile);
 	let profileServerInfo = generatedProfile.serverInfo;
-	generatedProfile.dispose();
 	result = connectionManagementService.getEditorConnectionProfileTitle(profile);
 
 	assert.strictEqual(result, `${profile.connectionName}: ${profileServerInfo}`, `getEditorConnectionProfileTitle does not return the correct string for ${profile.connectionName}`);

--- a/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
@@ -405,7 +405,7 @@ export class TreeUpdateUtils {
 		// Map the indices of profiles that share the same connection name.
 		for (let i = 0; i < inputList.length; i++) {
 			// do not add if the profile is still loading as that will result in erroneous entries.
-			if (inputList[i].hasServerCapabilities) {
+			if (inputList[i].hasServerCapabilities && inputList[i].hasLoaded()) {
 				let titleKey = inputList[i].getOriginalTitle();
 				if (profileListMap.has(titleKey)) {
 					let profilesForKey = profileListMap.get(titleKey);


### PR DESCRIPTION
This PR addresses the connection titles not updating for the async server tree, and also removes the dispose function for the connection profile since it's no longer needed. 

Additionally I am unable to reproduce the SQL Migration bug with a built version of my STS branch, so I assume that's an issue only with the debug version.