### PR TITLE
replace deprecated onDidClick() handler in sql projects

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -206,8 +206,10 @@ export class AddDatabaseReferenceDialog {
 				label: constants.projectLabel
 			}).component();
 
-		this.projectRadioButton.onDidClick(() => {
-			this.projectRadioButtonClick();
+		this.projectRadioButton.onDidChangeCheckedState((checked) => {
+			if (checked) {
+				this.projectRadioButtonClick();
+			}
 		});
 
 		this.systemDatabaseRadioButton = this.view!.modelBuilder.radioButton()
@@ -216,8 +218,10 @@ export class AddDatabaseReferenceDialog {
 				label: constants.systemDatabase
 			}).component();
 
-		this.systemDatabaseRadioButton.onDidClick(() => {
-			this.systemDbRadioButtonClick();
+		this.systemDatabaseRadioButton.onDidChangeCheckedState((checked) => {
+			if (checked) {
+				this.systemDbRadioButtonClick();
+			}
 		});
 
 		const dacpacRadioButton = this.view!.modelBuilder.radioButton()
@@ -226,8 +230,10 @@ export class AddDatabaseReferenceDialog {
 				label: constants.dacpacText
 			}).component();
 
-		dacpacRadioButton.onDidClick(() => {
-			this.dacpacRadioButtonClick();
+		dacpacRadioButton.onDidChangeCheckedState((checked) => {
+			if (checked) {
+				this.dacpacRadioButtonClick();
+			}
 		});
 
 		if (this.projectDropdown?.values?.length) {

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -481,14 +481,18 @@ export class UpdateProjectFromDatabaseDialog {
 		await this.compareActionRadioButton.updateProperties({ checked: true });
 		this.action = UpdateProjectAction.Compare;
 
-		this.compareActionRadioButton.onDidClick(async () => {
-			this.action = UpdateProjectAction.Compare;
-			this.tryEnableUpdateButton();
+		this.compareActionRadioButton.onDidChangeCheckedState((checked) => {
+			if (checked) {
+				this.action = UpdateProjectAction.Compare;
+				this.tryEnableUpdateButton();
+			}
 		});
 
-		this.updateActionRadioButton.onDidClick(async () => {
-			this.action = UpdateProjectAction.Update;
-			this.tryEnableUpdateButton();
+		this.updateActionRadioButton.onDidChangeCheckedState((checked) => {
+			if (checked) {
+				this.action = UpdateProjectAction.Update;
+				this.tryEnableUpdateButton();
+			}
 		});
 
 		let radioButtons = view.modelBuilder.flexContainer()


### PR DESCRIPTION
`onDidClick()` for radio buttons was deprecated a while ago, so this updates the places in sql projects that were still using it to to use `onDidChangeCheckedState()` instead.
