### PR TITLE
Register mysql, pgsql with mssql as default 'sql' kernel providers

### DIFF
--- a/src/sql/platform/connection/common/constants.ts
+++ b/src/sql/platform/connection/common/constants.ts
@@ -11,6 +11,7 @@ export const outputChannelName = 'MSSQL';
 export const capabilitiesOptions = 'OPTIONS_METADATA';
 
 export const mssqlProviderName = 'MSSQL';
+export const mysqlProviderName = 'MYSQL';
 export const pgsqlProviderName = 'PGSQL';
 export const anyProviderName = '*';
 export const connectionProviderContextKey = 'connectionProvider';

--- a/src/sql/workbench/services/notebook/browser/interfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/interfaces.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { nb } from 'azdata';
-import { mssqlProviderName } from 'sql/platform/connection/common/constants';
+import { mssqlProviderName, mysqlProviderName, pgsqlProviderName } from 'sql/platform/connection/common/constants';
 import { localize } from 'vs/nls';
 
 export interface FutureInternal extends nb.IFuture {
@@ -14,6 +14,8 @@ export interface FutureInternal extends nb.IFuture {
 export namespace notebookConstants {
 	export const SQL = 'SQL';
 	export const SQL_CONNECTION_PROVIDER = mssqlProviderName;
+	export const MYSQL_CONNECTION_PROVIDER = mysqlProviderName;
+	export const PGSQL_CONNECTION_PROVIDER = pgsqlProviderName;
 	export const sqlKernel: string = localize('sqlKernel', "SQL");
 	export const sqlKernelSpec: nb.IKernelSpec = ({
 		name: sqlKernel,

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -1121,7 +1121,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			// Switching from Kusto to another kernel should set the currentKernelAlias to undefined
 			if (this._selectedKernelDisplayName !== this._currentKernelAlias && this._selectedKernelDisplayName) {
 				this._currentKernelAlias = undefined;
-			} else {
+			} else if (this._currentKernelAlias) {
 				// Adds Kernel Alias and Connection Provider to Map if new Notebook connection contains notebookKernelAlias
 				this._kernelDisplayNameToConnectionProviderIds.set(this._currentKernelAlias, [profile.providerName]);
 			}

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -909,7 +909,11 @@ export class NotebookService extends Disposable implements INotebookService {
 			standardKernels: [{
 				name: notebookConstants.SQL,
 				displayName: notebookConstants.SQL,
-				connectionProviderIds: [notebookConstants.SQL_CONNECTION_PROVIDER],
+				connectionProviderIds: [
+					notebookConstants.SQL_CONNECTION_PROVIDER,
+					notebookConstants.MYSQL_CONNECTION_PROVIDER,
+					notebookConstants.PGSQL_CONNECTION_PROVIDER
+				],
 				supportedLanguages: [notebookConstants.sqlKernelSpec.language]
 			}]
 		});


### PR DESCRIPTION
This PR fixes #21472 

Noticed that all 3 providers are registered for 'sql' kernel when creating new notebook connection, but are not available when reloading ADS with an opened notebook and trying to connect, as explained in the linked issue.