### PR TITLE
Reset IV/Key if MSAL cache file decryption fails

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -715,7 +715,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 	//#region data modeling
 
 	public createAccount(tokenClaims: TokenClaims, key: string, tenants: Tenant[]): AzureAccount {
-		Logger.verbose(`Token Claims acccount: ${tokenClaims.name}, TID: ${tokenClaims.tid}`);
+		Logger.verbose(`Token Claims acccount: ${tokenClaims.preferred_username}, TID: ${tokenClaims.tid}`);
 		tenants.forEach((tenant) => {
 			Logger.verbose(`Tenant ID: ${tenant.id}, Tenant Name: ${tenant.displayName}`);
 		});

--- a/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
+++ b/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
@@ -53,8 +53,8 @@ export class MsalCachePluginProvider {
 				} catch (e) {
 					// Handle deserialization error in cache file in case file gets corrupted.
 					// Clearing cache here will ensure account is marked stale so re-authentication can be triggered.
-					Logger.verbose(`MsalCachePlugin: Error occurred when trying to read cache file, file contents will be cleared: ${e.message}`);
-					await fsPromises.writeFile(this._msalFilePath, '', { encoding: 'utf8' });
+					Logger.verbose(`MsalCachePlugin: Error occurred when trying to read cache file, file will be deleted: ${e.message}`);
+					await fsPromises.unlink(this._msalFilePath);
 				}
 				Logger.verbose(`MsalCachePlugin: Token read from cache successfully.`);
 			} catch (e) {
@@ -64,8 +64,9 @@ export class MsalCachePluginProvider {
 				}
 				else {
 					Logger.error(`MsalCachePlugin: Failed to read from cache file: ${e}`);
-					Logger.verbose(`MsalCachePlugin: Error occurred when trying to read cache file, file contents will be cleared: ${e.message}`);
-					await fsPromises.writeFile(this._msalFilePath, '', { encoding: 'utf8' });
+					Logger.verbose(`MsalCachePlugin: Error occurred when trying to read cache file, file will be deleted: ${e.message}`);
+					await fsPromises.unlink(this._msalFilePath);
+					// await fsPromises.writeFile(this._msalFilePath, '', { encoding: 'utf8' });
 				}
 			} finally {
 				lockFile.unlockSync(lockFilePath);

--- a/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
+++ b/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
@@ -66,7 +66,6 @@ export class MsalCachePluginProvider {
 					Logger.error(`MsalCachePlugin: Failed to read from cache file: ${e}`);
 					Logger.verbose(`MsalCachePlugin: Error occurred when trying to read cache file, file will be deleted: ${e.message}`);
 					await fsPromises.unlink(this._msalFilePath);
-					// await fsPromises.writeFile(this._msalFilePath, '', { encoding: 'utf8' });
 				}
 			} finally {
 				lockFile.unlockSync(lockFilePath);


### PR DESCRIPTION
Fixes #22716 that may occur if IV/KEY is corrupted due to any reason.
The best action here is to reset IV/KEY combination to allow resetting cache.

Fix verified with log:

```log
[Verbose]: Initialized Azure account extension storage. - []
[Verbose]: FileEncryptionHelper: Fired encryption keys updated event. - []
[Verbose]: Initializing stored accounts [] - []
[Information]: [Fri, 14 Apr 2023 17:21:04 GMT] : @azure/msal-node@1.16.0 : Info - getTokenCache called - []
[Verbose]: [Fri, 14 Apr 2023 17:21:04 GMT] : @azure/msal-node@1.16.0 : Trace - getAllAccounts called - []
[Error]: FileEncryptionHelper: Error occurred when decrypting data, IV/KEY will be reset: Error: error:1e00007b:Cipher functions:OPENSSL_internal:WRONG_FINAL_BLOCK_LENGTH - []
[Information]: FileEncryptionHelper: Successfully saved encryption key accessTokenCache-iv for MSAL persistent cache encryption in system credential store. - []
[Information]: FileEncryptionHelper: Successfully saved encryption key accessTokenCache-key for MSAL persistent cache encryption in system credential store. - []
[Verbose]: FileEncryptionHelper: Fired encryption keys updated event. - []
[Error]: MsalCachePlugin: Failed to read from cache file: Error: Decryption failed with error: Error: error:1e00007b:Cipher functions:OPENSSL_internal:WRONG_FINAL_BLOCK_LENGTH - []
[Verbose]: MsalCachePlugin: Error occurred when trying to read cache file, file will be deleted: Decryption failed with error: Error: error:1e00007b:Cipher functions:OPENSSL_internal:WRONG_FINAL_BLOCK_LENGTH - []
[Verbose]: [Fri, 14 Apr 2023 17:21:05 GMT] : @azure/msal-node@1.16.0 : Trace - Retrieving all cache keys - []
[Verbose]: [Fri, 14 Apr 2023 17:21:05 GMT] : @azure/msal-node@1.16.0 : Trace - Getting cache key-value store - []
[Information]: [Fri, 14 Apr 2023 17:21:05 GMT] : @azure/msal-node@1.16.0 : Info - getTokenCache called - []
[Verbose]: [Fri, 14 Apr 2023 17:21:05 GMT] : @azure/msal-node@1.16.0 : Trace - getAllAccounts called - []
[Verbose]: MsalCachePlugin: Cache file not found on disk: ENOENT - []
```

Account can now be added/refreshed successfully, as cache file will be created when content is to be written.