### PR TITLE
Books Unstable Test Potential Fix

### DIFF
--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -22,6 +22,7 @@ import { NavigationProviders } from '../../common/constants';
 import { openFileError } from '../../common/localizedConstants';
 import * as sinon from 'sinon';
 import { AppContext } from '../../common/appContext';
+import { sleep } from '../common/testUtils';
 
 export interface IExpectedBookItem {
 	title: string;
@@ -730,6 +731,7 @@ describe('BooksTreeViewTests', function () {
 				afterEach(async function (): Promise<void> {
 					sinon.restore();
 					await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+					await sleep(500);
 				});
 
 				it('should add book and initialize book on openBook', async () => {


### PR DESCRIPTION
Leaving this as draft for now since I don't have the root cause and this is not-terribly-educated guess. I did run the ad-hoc pipeline a number of times after this change and it did not fail.

Found one interesting nugget in the logs when the test fails, we see the following:

```
The selector "notebookeditor-component_4" did not match any elements
```

This didn't make a lot of sense to me for a few reasons. One theory that I had was that the "close all editors" command wasn't actually complete, so there was a race condition when trying to create a new editor. No proof of this, of course. Just an idea 😄 