### PR TITLE
fix sqlcmd table var table in publish dialog

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -882,7 +882,7 @@ export class PublishDatabaseDialog {
 
 	private convertSqlCmdVarsToTableFormat(sqlCmdVars: Map<string, string>): azdataType.DeclarativeTableCellValue[][] {
 		let data = [];
-		for (let [key, value] of sqlCmdVars) {
+		for (const [key, value] of sqlCmdVars) {
 			data.push([{ value: key }, { value: value! }]);
 		}
 

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -655,7 +655,7 @@ export class PublishDatabaseDialog {
 	}
 
 	private createSqlCmdTable(view: azdataType.ModelView): azdataType.DeclarativeTableComponent {
-		this.sqlCmdVars = { ...this.project.sqlCmdVariables };
+		this.sqlCmdVars = this.project.sqlCmdVariables;
 
 		const table = view.modelBuilder.declarativeTable().withProps({
 			ariaLabel: constants.sqlCmdVariables,
@@ -706,9 +706,9 @@ export class PublishDatabaseDialog {
 		}).component();
 
 		loadSqlCmdVarsButton.onDidClick(async () => {
-			for (const varName in this.sqlCmdVars) {
+			for (const [key, _value] of this.sqlCmdVars!) {
 
-				this.sqlCmdVars.set(varName, this.getDefaultSqlCmdValue(varName));
+				this.sqlCmdVars!.set(key, this.getDefaultSqlCmdValue(key));
 			}
 
 			const data = this.convertSqlCmdVarsToTableFormat(this.sqlCmdVars!);
@@ -882,8 +882,8 @@ export class PublishDatabaseDialog {
 
 	private convertSqlCmdVarsToTableFormat(sqlCmdVars: Map<string, string>): azdataType.DeclarativeTableCellValue[][] {
 		let data = [];
-		for (let key in sqlCmdVars) {
-			data.push([{ value: key }, { value: sqlCmdVars.get(key)! }]);
+		for (let [key, value] of sqlCmdVars) {
+			data.push([{ value: key }, { value: value! }]);
 		}
 
 		return data;
@@ -900,8 +900,8 @@ export class PublishDatabaseDialog {
 
 		let revertButtonEnabled = false;
 
-		for (const varName in this.sqlCmdVars) {
-			if (this.sqlCmdVars!.get(varName) !== this.getDefaultSqlCmdValue(varName)) {
+		for (const [key, _value] of this.sqlCmdVars!) {
+			if (this.sqlCmdVars!.get(key) !== this.getDefaultSqlCmdValue(key)) {
 				revertButtonEnabled = true;
 				break;
 			}

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -706,7 +706,7 @@ export class PublishDatabaseDialog {
 		}).component();
 
 		loadSqlCmdVarsButton.onDidClick(async () => {
-			for (const [key, _value] of this.sqlCmdVars!) {
+			for (const key of this.sqlCmdVars!.keys()) {
 
 				this.sqlCmdVars!.set(key, this.getDefaultSqlCmdValue(key));
 			}
@@ -900,7 +900,7 @@ export class PublishDatabaseDialog {
 
 		let revertButtonEnabled = false;
 
-		for (const [key, _value] of this.sqlCmdVars!) {
+		for (const key of this.sqlCmdVars!.keys()) {
 			if (this.sqlCmdVars!.get(key) !== this.getDefaultSqlCmdValue(key)) {
 				revertButtonEnabled = true;
 				break;


### PR DESCRIPTION
After the record to map swap in https://github.com/microsoft/azuredatastudio/pull/22758, the sqlcmd table in the publish dialog no longer was showing as expected.

before: 
![image](https://user-images.githubusercontent.com/31145923/232898752-c86859b2-9516-45bb-9ad9-2282cfe515f7.png)

fixed:
![sqlcmdTableFixed](https://user-images.githubusercontent.com/31145923/232900692-2aad4be6-8bfa-4e8e-8eee-4c442dac4d40.gif)

