### PR TITLE
fix error message steal focus issue

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -612,8 +612,11 @@ export abstract class Modal extends Disposable implements IThemable {
 	protected set messagesElementVisible(visible: boolean) {
 		if (visible) {
 			if (this._useDefaultMessageBoxLocation) {
-				DOM.prepend(this._modalContent!, this._messageElement!);
-				this.setInitialFocusedElement();
+				// only do the append when the messageElement doesn't have parent element.
+				if (!this._messageElement!.parentNode) {
+					DOM.prepend(this._modalContent!, this._messageElement!);
+					this.setInitialFocusedElement();
+				}
 			}
 		} else {
 			// only do the removal when the messageElement has parent element.

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -612,7 +612,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	protected set messagesElementVisible(visible: boolean) {
 		if (visible) {
 			if (this._useDefaultMessageBoxLocation) {
-				// only do the append when the messageElement doesn't have parent element.
+				// To avoid stealing focus from the user, only reset the keyboard focus when the message is not currently visible.
 				if (!this._messageElement!.parentNode) {
 					DOM.prepend(this._modalContent!, this._messageElement!);
 					this.setInitialFocusedElement();


### PR DESCRIPTION
This PR fixes #22777

introduced in https://github.com/microsoft/azuredatastudio/pull/22743.
the fix is to only reset the focus if the message area was previously not visible.