### PR TITLE
[SQL Migration] Release v1.4.4 to Insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.3",
-							"lastUpdated": "04/11/2023",
+							"version": "1.4.4",
+							"lastUpdated": "04/19/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.3.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.4.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the insiders extension gallery to the latest version of the SQL Migration extension.

Very recently we released v1.4.3 to Insiders, however that build still contained changes from https://github.com/microsoft/azuredatastudio/pull/22525, meaning it was not backwards compatible across both stable and Insiders ADS. Since this was recently reverted in https://github.com/microsoft/azuredatastudio/pull/22761, this means that v1.4.3 will no longer work in insiders ADS. 

With the latest changes pulled in, our updated vsix now works on both insiders and stable ADS.

Link to `Azure Data Studio - Extensions` pipeline run off main containing vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=197623&view=results