### PR TITLE
Enable proposed APIs for copilot

### DIFF
--- a/product.json
+++ b/product.json
@@ -86,6 +86,16 @@
 		"ms-dotnettools.dotnet-interactive-vscode",
 		"ms-toolsai.jupyter"
 	],
+	"extensionEnabledApiProposals": {
+		"GitHub.copilot": [
+			"inlineCompletionsAdditions",
+			"terminalDataWriteEvent"
+		],
+		"GitHub.copilot-nightly": [
+			"inlineCompletionsAdditions",
+			"terminalDataWriteEvent"
+		]
+	},
 	"extensionsGallery": {
 		"version": "0.0.76",
 		"serviceUrl": "https://sqlopsextensions.blob.core.windows.net/marketplace/v1/extensionsGallery.json"


### PR DESCRIPTION
These APIs are required to enabled embedded suggestions in the editor.  Otherwise, only the Copilot suggestion document scenario is working.

![image](https://user-images.githubusercontent.com/599935/233471707-df2201f3-e448-4573-937d-608019e9aa87.png)
