### PR TITLE
Remove advanced options for table designer and notebook Actions title

### DIFF
--- a/extensions/mssql/src/tableDesigner/tableDesigner.ts
+++ b/extensions/mssql/src/tableDesigner/tableDesigner.ts
@@ -26,18 +26,11 @@ export function registerTableDesignerCommands(appContext: AppContext) {
 			if (!connectionString) {
 				throw new Error(FailedToGetConnectionStringError);
 			}
-			let titleString = `${context.connectionProfile!.serverName} - ${context.connectionProfile!.databaseName} - ${NewTableText}`;
-			// append non default options to end to let users know exact connection.
-			let nonDefaultOptions = await azdata.connection.getEditorConnectionProfileTitle(context.connectionProfile, true);
-			nonDefaultOptions = nonDefaultOptions.replace('(', '[').replace(')', ']');
-			if (nonDefaultOptions !== '') {
-				titleString += `${nonDefaultOptions}`;
-			}
 			const tableIcon = context.nodeInfo!.nodeSubType as azdata.designers.TableIcon;
 			const telemetryInfo = await getTelemetryInfo(context, tableIcon);
 			await azdata.designers.openTableDesigner(sqlProviderName, {
 				title: NewTableText,
-				tooltip: titleString,
+				tooltip: `${context.connectionProfile!.serverName} - ${context.connectionProfile!.databaseName} - ${NewTableText}`,
 				server: context.connectionProfile!.serverName,
 				database: context.connectionProfile!.databaseName,
 				isNewTable: true,
@@ -63,18 +56,11 @@ export function registerTableDesignerCommands(appContext: AppContext) {
 			if (!connectionString) {
 				throw new Error(FailedToGetConnectionStringError);
 			}
-			let titleString = `${server} - ${database} - ${schema}.${name}`;
-			// append non default options to end to let users know exact connection.
-			let nonDefaultOptions = await azdata.connection.getEditorConnectionProfileTitle(context.connectionProfile, true);
-			nonDefaultOptions = nonDefaultOptions.replace('(', '[').replace(')', ']');
-			if (nonDefaultOptions !== '') {
-				titleString += `${nonDefaultOptions}`;
-			}
 			const tableIcon = context.nodeInfo!.nodeSubType as azdata.designers.TableIcon;
 			const telemetryInfo = await getTelemetryInfo(context, tableIcon);
 			await azdata.designers.openTableDesigner(sqlProviderName, {
 				title: `${schema}.${name}`,
-				tooltip: titleString,
+				tooltip: `${server} - ${database} - ${schema}.${name}`,
 				server: server,
 				database: database,
 				isNewTable: false,

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -731,10 +731,7 @@ export class AttachToDropdown extends SelectBox {
 		} else {
 			let connections: string[] = [];
 			if (model.context && model.context.title && (connProviderIds.includes(this.model.context.providerName))) {
-				let textResult = model.context.title;
-				let fullTitleText = this._connectionManagementService.getEditorConnectionProfileTitle(model.context);
-				textResult = fullTitleText.length !== 0 ? fullTitleText : textResult;
-				connections.push(textResult);
+				connections.push(model.context.title);
 			} else if (this._configurationService.getValue(saveConnectionNameConfigName) && model.savedConnectionName) {
 				connections.push(model.savedConnectionName);
 			} else {


### PR DESCRIPTION
In response to feedback and upon reflection, it is determined that the use of advanced options in these contexts are unnecessary for the operation and that they usually only display one title at a time. This PR removes the advanced titles for Table Designer and Attach To for notebook Actions, but query editor is still kept unchanged as users may make queries to multiple similarly named connections on the same session. (It is reasonably expected the user will know which connection they have picked for Notebook and table designer as they have to connect to the clearly labeled connection from the start).

Companion PR for STS: https://github.com/microsoft/sqltoolsservice/pull/2025