### PR TITLE
fix accessibility issue for open dialog location radio button

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -85,6 +85,7 @@ export const GitRepoUrlTitle = localize('dataworkspace.gitRepoUrlTitle', "Git re
 export const GitRepoUrlPlaceholder = localize('dataworkspace.gitRepoUrlPlaceholder', "Enter remote git repository URL");
 export const LocalClonePathTitle = localize('dataworkspace.localClonePathTitle', "Local clone path");
 export const LocalClonePathPlaceholder = localize('dataworkspace.localClonePathPlaceholder', "Select location to clone repository locally");
+export const ProjectFileTitle = localize('dataworkspace.projectFileTitle', "Project file");
 
 // Workspace settings for saving new projects
 export const ProjectConfigurationKey = 'projects';

--- a/extensions/data-workspace/src/dialogs/openExistingDialog.ts
+++ b/extensions/data-workspace/src/dialogs/openExistingDialog.ts
@@ -119,7 +119,6 @@ export class OpenExistingDialog extends DialogBase {
 
 		this.locationRadioButtonFormComponent = {
 			title: constants.LocationSelectorTitle,
-			required: true,
 			component: view.modelBuilder.flexContainer()
 				.withItems([this.localRadioButton, this.remoteGitRepoRadioButton], { flex: '0 0 auto', CSSStyles: { 'margin-right': '15px' } })
 				.withProps({ ariaRole: 'radiogroup' })
@@ -212,9 +211,10 @@ export class OpenExistingDialog extends DialogBase {
 		this.register(localProjectBrowseFolderButton.onDidClick(() => this.onBrowseButtonClick()));
 
 		const flexContainer = this.createHorizontalContainer(view, [this.filePathTextBox, localProjectBrowseFolderButton]);
-		void flexContainer.updateCssStyles({ 'margin-top': '-10px' });
 		this.filePathAndButtonComponent = {
-			component: flexContainer
+			component: flexContainer,
+			title: constants.ProjectFileTitle,
+			required: true
 		};
 
 		this.formBuilder = view.modelBuilder.formContainer().withFormItems([

--- a/extensions/data-workspace/src/dialogs/openExistingDialog.ts
+++ b/extensions/data-workspace/src/dialogs/openExistingDialog.ts
@@ -191,7 +191,7 @@ export class OpenExistingDialog extends DialogBase {
 		};
 
 		this.filePathTextBox = view.modelBuilder.inputBox().withProps({
-			ariaLabel: constants.LocationSelectorTitle,
+			ariaLabel: constants.ProjectFileTitle,
 			placeHolder: constants.ProjectFilePlaceholder,
 			required: true,
 			width: constants.DefaultInputWidth


### PR DESCRIPTION
This addresses the last of the many issues in #22127, "Open existing Project - Location : Voiceover is not announcing as required for location radio group". Because it's a radio button, it doesn't need the required attribute since one of them is always selected. I added a title to the project file input box and made that required since that needs to be filled out.

open dialog before:
![Screen Shot 2023-04-20 at 3 57 25 PM](https://user-images.githubusercontent.com/31145923/233505534-7f3d806e-77c4-4b4d-9f4e-b33062b9b99d.png)

open dialog after:
![Screen Shot 2023-04-20 at 3 57 00 PM](https://user-images.githubusercontent.com/31145923/233505545-0426ab3a-0fb7-422e-98e3-4fa85b57aed9.png)

open dialog git repo option (not changed):
![Screen Shot 2023-04-20 at 3 57 10 PM](https://user-images.githubusercontent.com/31145923/233505537-c5289a35-90ab-4d27-a99e-8bf3dfc840f3.png)

gif showing voiceover announcing required for the project location input box:
![locationRequired](https://user-images.githubusercontent.com/31145923/233505526-3c84a644-e572-45a4-a326-c21b2bde1937.gif)