### PR TITLE
Few more no-unsafe-assignment cleanups

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -402,6 +402,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 		const tokenUrl = `${this.loginEndpointUrl}${tenant.id}/oauth2/token`;
 		const response = await this.makePostRequest(tokenUrl, postData);
 
+		// ADAL is being deprecated so just ignoring these for now
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		Logger.piiSanitized('Token: ', [{ name: 'access token', objOrArray: response.data }, { name: 'refresh token', objOrArray: response.data }], []);
 		if (response.data.error === 'interaction_required') {
 			return this.handleInteractionRequiredAdal(tenant, resource);
@@ -410,8 +412,12 @@ export abstract class AzureAuth implements vscode.Disposable {
 			Logger.error(`Response returned error : ${response.data}`);
 			throw new AzureAuthError(localize('azure.responseError', "Token retrieval failed with an error. [Open developer tools]({0}) for more details.", 'command:workbench.action.toggleDevTools'), 'Token retrieval failed', undefined);
 		}
+		// ADAL is being deprecated so just ignoring these for now
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const accessTokenString = response.data.access_token;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const refreshTokenString = response.data.refresh_token;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const expiresOnString = response.data.expires_on;
 		return this.getTokenHelperAdal(tenant, resource, accessTokenString, refreshTokenString, expiresOnString);
 	}
@@ -530,6 +536,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 				Logger.error(`Headers: ${JSON.stringify(tenantResponse.headers)}`);
 				throw new Error('Error with tenant response');
 			}
+			// ADAL is being deprecated so just ignoring these for now
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			const tenants: Tenant[] = tenantResponse.data.value.map((tenantInfo: TenantResponse) => {
 				if (tenantInfo.displayName) {
 					tenantList.push(tenantInfo.displayName);
@@ -792,6 +800,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 		// Intercept response and print out the response for future debugging
 		const response = await axios.post(url, qs.stringify(postData), config);
+		// ADAL is being deprecated so just ignoring these for now
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		Logger.piiSanitized('POST request ', [{ name: 'data', objOrArray: postData }, { name: 'response', objOrArray: response.data }], [], url);
 		return response;
 	}
@@ -806,6 +816,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 		};
 
 		const response = await axios.get(url, config);
+		// ADAL is being deprecated so just ignoring these for now
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		Logger.piiSanitized('GET request ', [{ name: 'response', objOrArray: response.data.value ?? response.data }], [], url,);
 		return response;
 	}

--- a/extensions/azurecore/src/account-provider/auths/azureDeviceCode.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureDeviceCode.ts
@@ -92,7 +92,7 @@ export class AzureDeviceCode extends AzureAuth {
 
 		const postResult = await this.makePostRequest(uri, postData);
 
-		const initialDeviceLogin: DeviceCodeLogin = postResult.data;
+		const initialDeviceLogin: DeviceCodeLogin = postResult.data as DeviceCodeLogin;
 
 		await azdata.accounts.beginAutoOAuthDeviceCode(this.metadata.id, this.pageTitle, initialDeviceLogin.message, initialDeviceLogin.user_code, initialDeviceLogin.verification_url);
 
@@ -154,7 +154,7 @@ export class AzureDeviceCode extends AzureAuth {
 			};
 
 			const postResult = await this.makePostRequest(uri, postData);
-			const result: DeviceCodeLoginResult = postResult.data;
+			const result: DeviceCodeLoginResult = postResult.data as DeviceCodeLoginResult;
 
 			return result;
 		} catch (ex) {

--- a/extensions/azurecore/src/account-provider/auths/httpClient.ts
+++ b/extensions/azurecore/src/account-provider/auths/httpClient.ts
@@ -366,7 +366,7 @@ const networkRequestViaHttps = <T>(
 };
 
 /**
- * Check if extra parsing is needed on the repsonse from the server
+ * Check if extra parsing is needed on the response from the server
  * @param statusCode {number} the status code of the response from the server
  * @param statusMessage {string | undefined} the status message of the response from the server
  * @param headers {Record<string, string>} the headers of the response from the server
@@ -382,7 +382,7 @@ const parseBody = (statusCode: number, statusMessage: string | undefined, header
 	 * Server error responses (500 - 599)
 	 */
 
-	let parsedBody;
+	let parsedBody: unknown;
 	try {
 		parsedBody = JSON.parse(body);
 	} catch (error) {


### PR DESCRIPTION
Couple simple fixes, mostly just disabling the warning for stuff that's going to go away before too long. Doing these in smaller chunks to make them easier to review. 