### PR TITLE
Move stringifying of request body for azure REST calls

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/httpClient.ts
+++ b/extensions/azurecore/src/account-provider/auths/httpClient.ts
@@ -286,7 +286,7 @@ const networkRequestViaHttps = <T>(
 	const isPostRequest = httpMethod === HttpMethod.POST;
 	const isPutRequest = httpMethod === HttpMethod.PUT;
 	// Note: Text Encoder is necessary here because otherwise it was not able to handle Chinese characters in table names.
-	const body = (new TextEncoder()).encode(JSON.stringify(options?.body || ''));
+	const body = (new TextEncoder()).encode(options?.body || '');
 	const url = new URL(urlString);
 	const optionHeaders = options?.headers || {} as Record<string, string>;
 	let customOptions: https.RequestOptions = {
@@ -366,7 +366,7 @@ const networkRequestViaHttps = <T>(
 };
 
 /**
- * Check if extra parsing is needed on the response from the server
+ * Check if extra parsing is needed on the repsonse from the server
  * @param statusCode {number} the status code of the response from the server
  * @param statusMessage {string | undefined} the status message of the response from the server
  * @param headers {Record<string, string>} the headers of the response from the server

--- a/extensions/azurecore/src/account-provider/auths/httpClient.ts
+++ b/extensions/azurecore/src/account-provider/auths/httpClient.ts
@@ -366,7 +366,7 @@ const networkRequestViaHttps = <T>(
 };
 
 /**
- * Check if extra parsing is needed on the repsonse from the server
+ * Check if extra parsing is needed on the response from the server
  * @param statusCode {number} the status code of the response from the server
  * @param statusMessage {string | undefined} the status message of the response from the server
  * @param headers {Record<string, string>} the headers of the response from the server

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -20,6 +20,7 @@ import * as Constants from '../constants';
 import { getProxyEnabledHttpClient } from '../utils';
 import { HttpClient } from '../account-provider/auths/httpClient';
 import { NetworkRequestOptions } from '@azure/msal-common';
+import { TextEncoder } from 'util';
 
 const localize = nls.loadMessageBundle();
 
@@ -396,9 +397,10 @@ export async function makeHttpRequest(account: AzureAccount, subscription: azure
 		...requestHeaders
 	}
 
+	const body = JSON.stringify(requestBody || '');
 	let networkRequestOptions: NetworkRequestOptions = {
 		headers: reqHeaders,
-		body: requestBody
+		body
 	};
 
 	// Adding '/' if path does not begin with it.

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -20,7 +20,6 @@ import * as Constants from '../constants';
 import { getProxyEnabledHttpClient } from '../utils';
 import { HttpClient } from '../account-provider/auths/httpClient';
 import { NetworkRequestOptions } from '@azure/msal-common';
-import { TextEncoder } from 'util';
 
 const localize = nls.loadMessageBundle();
 


### PR DESCRIPTION
This fixes an no-unsafe-assignment issue on line 403 of utils.ts. The incoming body is typed as `any`, but we're assigning it to NetworkRequestOptions which expects it to be `string | undefined`. @cssuh originally fixed this by having the HttpClient handle stringifying it, but that's unnecessary in most cases since the makeHttpRequest function is the only place that we're passing in something that isn't already a string.

I'd like to remove the `any` from the body parameter too - but unfortunately we expose that in the azurecore API which is used heavily by the sql-migration extension. So to avoid breaking them like we did recently (because of mismatched ADS/extension versions) we'll just leave it as any for now and then just make sure we handle the any appropriately later on. 