### PR TITLE
Update vscode-mssql.d.ts to match what's in the vscode-mssql repo

### DIFF
--- a/extensions/sql-bindings/src/test/testUtils.ts
+++ b/extensions/sql-bindings/src/test/testUtils.ts
@@ -60,7 +60,7 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 	createConnectionDetails(_: vscodeMssql.IConnectionInfo): vscodeMssql.ConnectionDetails {
 		throw new Error('Method not implemented.');
 	}
-	getServerInfo(_: vscodeMssql.IConnectionInfo): vscodeMssql.ServerInfo {
+	getServerInfo(_: vscodeMssql.IConnectionInfo): vscodeMssql.IServerInfo {
 		throw new Error('Method not implemented.');
 	}
 }
@@ -115,7 +115,8 @@ export function createTestCredentials(): vscodeMssql.IConnectionInfo {
 		multipleActiveResultSets: false,
 		packetSize: 8192,
 		typeSystemVersion: 'Latest',
-		connectionString: ''
+		connectionString: '',
+		commandTimeout: undefined
 	};
 	return creds;
 }

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -742,7 +742,7 @@ export async function fileContainsCreateTableStatement(fullPath: string, project
  * @param serverInfo server information
  * @returns target platform for the database project
  */
-export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.ServerInfo | vscodeMssql.ServerInfo): Promise<SqlTargetPlatform | undefined> {
+export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.ServerInfo | vscodeMssql.IServerInfo): Promise<SqlTargetPlatform | undefined> {
 	const isCloud = serverInfo.isCloud;
 
 	let targetPlatform;

--- a/extensions/sql-database-projects/src/models/connections/connectionService.ts
+++ b/extensions/sql-database-projects/src/models/connections/connectionService.ts
@@ -87,7 +87,8 @@ export class ConnectionService {
 				workstationId: undefined,
 				profileName: profile.profileName,
 				expiresOn: undefined,
-				tenantId: profile.tenantId
+				tenantId: profile.tenantId,
+				commandTimeout: undefined
 			};
 			let connectionUrl = '';
 			try {

--- a/extensions/sql-database-projects/src/test/deploy/azureSqlClient.test.ts
+++ b/extensions/sql-database-projects/src/test/deploy/azureSqlClient.test.ts
@@ -5,7 +5,7 @@
 
 import * as should from 'should';
 import { AzureSqlClient } from '../../models/deploy/azureSqlClient';
-import { AzureAuthType, IAccount, IAzureAccountService, IAzureAccountSession, IAzureResourceService, azure } from 'vscode-mssql';
+import { IAccount, IAzureAccountService, IAzureAccountSession, IAzureResourceService, azure } from 'vscode-mssql';
 
 
 
@@ -24,7 +24,7 @@ export function createContext(): TestContext {
 		key: undefined!,
 		displayInfo: undefined!,
 		properties: {
-			azureAuthType: AzureAuthType.AuthCodeGrant,
+			azureAuthType: 0,
 			providerSettings: {
 				scopes: [],
 				displayName: '',

--- a/extensions/sql-database-projects/src/test/deploy/azureSqlClient.test.ts
+++ b/extensions/sql-database-projects/src/test/deploy/azureSqlClient.test.ts
@@ -5,7 +5,7 @@
 
 import * as should from 'should';
 import { AzureSqlClient } from '../../models/deploy/azureSqlClient';
-import { IAccount, IAzureAccountService, IAzureAccountSession, IAzureResourceService, azure } from 'vscode-mssql';
+import { AzureAuthType, IAccount, IAzureAccountService, IAzureAccountSession, IAzureResourceService, azure } from 'vscode-mssql';
 
 
 
@@ -24,6 +24,33 @@ export function createContext(): TestContext {
 		key: undefined!,
 		displayInfo: undefined!,
 		properties: {
+			azureAuthType: AzureAuthType.AuthCodeGrant,
+			providerSettings: {
+				scopes: [],
+				displayName: '',
+				id: '',
+				clientId: '',
+				loginEndpoint: '',
+				portalEndpoint: '',
+				redirectUri: '',
+				resources: {
+					windowsManagementResource: {
+						id: '',
+						resource: '',
+						endpoint: ''
+					},
+					azureManagementResource: {
+						id: '',
+						resource: '',
+						endpoint: ''
+					}
+				}
+			},
+			isMsAccount: false,
+			owningTenant: {
+				id: '',
+				displayName: ''
+			},
 			tenants: [{
 				id: '',
 				displayName: ''
@@ -69,7 +96,7 @@ export function createContext(): TestContext {
 	};
 }
 
-describe('Azure SQL client', function (): void {
+describe.skip('Azure SQL client', function (): void {
 
 	it('Should return accounts successfully', async function (): Promise<void> {
 		const testContext = createContext();

--- a/extensions/sql-database-projects/src/test/deploy/azureSqlClient.test.ts
+++ b/extensions/sql-database-projects/src/test/deploy/azureSqlClient.test.ts
@@ -96,7 +96,7 @@ export function createContext(): TestContext {
 	};
 }
 
-describe.skip('Azure SQL client', function (): void {
+describe('Azure SQL client', function (): void {
 
 	it('Should return accounts successfully', async function (): Promise<void> {
 		const testContext = createContext();

--- a/extensions/sql-database-projects/src/test/dialogs/testUtils.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/testUtils.ts
@@ -51,7 +51,7 @@ export class MockVscodeMssqlIExtension implements vscodeMssql.IExtension {
 	createConnectionDetails(_: vscodeMssql.IConnectionInfo): vscodeMssql.ConnectionDetails {
 		throw new Error('Method not implemented.');
 	}
-	getServerInfo(_: vscodeMssql.IConnectionInfo): vscodeMssql.ServerInfo {
+	getServerInfo(_: vscodeMssql.IConnectionInfo): vscodeMssql.IServerInfo {
 		throw new Error('Method not implemented.');
 	}
 }
@@ -97,5 +97,6 @@ export const mockConnectionInfo: vscodeMssql.IConnectionInfo = {
 	multipleActiveResultSets: false,
 	packetSize: 8192,
 	typeSystemVersion: 'Latest',
-	connectionString: ''
+	connectionString: '',
+	commandTimeout: undefined
 };

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -1,7 +1,8 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+
 
 declare module 'vscode-mssql' {
 
@@ -125,13 +126,13 @@ declare module 'vscode-mssql' {
 		 * @param connectionInfo connection info of the connection
 		 * @returns server information
 		 */
-		getServerInfo(connectionInfo: IConnectionInfo): ServerInfo
+		getServerInfo(connectionInfo: IConnectionInfo): IServerInfo
 	}
 
 	/**
 	 * Information about a SQL Server instance.
 	 */
-	export interface ServerInfo {
+	export interface IServerInfo {
 		/**
 		 * The major version of the SQL Server instance.
 		 */
@@ -290,10 +291,10 @@ declare module 'vscode-mssql' {
 		expiresOn: number | undefined;
 
 		/**
-		 * Gets or sets a Boolean value that indicates whether SQL Server uses SSL encryption for all data sent between the client and server if
-		 * the server has a certificate installed.
+		 * Gets or sets a string value that indicates whether SQL Server uses SSL encryption for all data sent between the client and server if
+		 * the server has a certificate installed. Accepted values are: Optional, Mandatory (default)
 		 */
-		encrypt: boolean;
+		encrypt: string | boolean;
 
 		/**
 		 * Gets or sets a value that indicates whether the channel will be encrypted while bypassing walking the certificate chain to validate trust.
@@ -301,7 +302,7 @@ declare module 'vscode-mssql' {
 		trustServerCertificate: boolean | undefined;
 
 		/**
-		 * Indicates the host name specified in TLS certificate that will be used by SQL Server to validate server certificate. When not specified, the server name is used by default for certificate validation.
+		 * Gets or sets a string value that provides the host name specified in the certificate chain to be used for trust validation.
 		 */
 		hostNameInCertificate: string | undefined;
 
@@ -315,6 +316,11 @@ declare module 'vscode-mssql' {
 		 * Gets or sets the length of time (in seconds) to wait for a connection to the server before terminating the attempt and generating an error.
 		 */
 		connectTimeout: number | undefined;
+
+		/**
+		 * Gets or sets the length of time (in seconds) to wait for a command to execute before terminating the attempt and generating an error.
+		 */
+		commandTimeout: number | undefined;
 
 		/**
 		 * The number of reconnections attempted after identifying that there was an idle connection failure.
@@ -435,6 +441,14 @@ declare module 'vscode-mssql' {
 	}
 
 	/**
+	 * Error that connect method throws if connection fails because of a fire wall rule error.
+	 */
+	export interface IFireWallRuleError extends Error {
+		connectionUri: string;
+	}
+
+	//////////////////// Azure Types ////////////////////
+	/**
 	 * Interface for working with .sqlproj files
 	 */
 	export interface ISqlProjectsService {
@@ -471,6 +485,19 @@ declare module 'vscode-mssql' {
 		 * @param databaseLiteral Literal name used to reference another database in the same server, if not using SQLCMD variables
 		 */
 		addSystemDatabaseReference(projectUri: string, systemDatabase: SystemDatabase, suppressMissingDependencies: boolean, databaseLiteral?: string): Promise<ResultStatus>;
+
+		/**
+		 * Add a nuget package database reference to a project
+		 * @param projectUri Absolute path of the project, including .sqlproj
+		 * @param packageName Name of the referenced nuget package
+		 * @param packageVersion Version of the referenced nuget package
+		 * @param suppressMissingDependencies Whether to suppress missing dependencies
+		 * @param databaseVariable SQLCMD variable name for specifying the other database this reference is to, if different from that of the current project
+		 * @param serverVariable SQLCMD variable name for specifying the other server this reference is to, if different from that of the current project.
+			 If this is set, DatabaseVariable must also be set.
+		 * @param databaseLiteral Literal name used to reference another database in the same server, if not using SQLCMD variables
+		 */
+		addNugetPackageReference(projectUri: string, packageName: string, packageVersion: string, suppressMissingDependencies: boolean, databaseVariable?: string, serverVariable?: string, databaseLiteral?: string): Promise<ResultStatus>;
 
 		/**
 		 * Delete a database reference from a project
@@ -689,7 +716,7 @@ declare module 'vscode-mssql' {
 		getSqlCmdVariables(projectUri: string): Promise<GetSqlCmdVariablesResult>;
 
 		/**
-		 * getSqlObjectScripts
+		 * Get all the SQL object scripts in a project
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 */
 		getSqlObjectScripts(projectUri: string): Promise<GetScriptsResult>;
@@ -730,105 +757,14 @@ declare module 'vscode-mssql' {
 		moveNoneItem(projectUri: string, destinationPath: string, path: string): Promise<ResultStatus>;
 	}
 
-	export interface GetCrossPlatformCompatibilityResult extends ResultStatus {
-		/**
-		 * Whether the project is cross-platform compatible
-		 */
-		isCrossPlatformCompatible: boolean;
-	}
-
-	export interface GetProjectPropertiesResult extends ResultStatus {
-		/**
-		 * GUID for the SQL project
-		 */
-		projectGuid: string;
-		/**
-		 * Build configuration, defaulted to Debug if not specified
-		 */
-		configuration: string;
-		/**
-		 * Build platform, defaulted to AnyCPU if not specified
-		 */
-		platform: string;
-		/**
-		 * Output path for build, defaulted to "bin/Debug" if not specified.
-			 May be absolute or relative.
-		 */
-		outputPath: string;
-		/**
-		 * Default collation for the project, defaulted to SQL_Latin1_General_CP1_CI_AS if not specified
-		 */
-		defaultCollation: string;
-		/**
-		 * Source of the database schema, used in telemetry
-		 */
-		databaseSource?: string;
-		/**
-		 * Style of the .sqlproj file - SdkStyle or LegacyStyle
-		 */
-		projectStyle: ProjectType;
-		/**
-		 * Database Schema Provider, in the format "Microsoft.Data.Tools.Schema.Sql.SqlXYZDatabaseSchemaProvider"
-		 */
-		databaseSchemaProvider: string
-	}
-
-	export interface GetDatabaseReferencesResult extends ResultStatus {
-		/**
-		 * Array of system database references contained in the project
-		 */
-		systemDatabaseReferences: SystemDatabaseReference[];
-		/**
-		 * Array of dacpac references contained in the project
-		 */
-		dacpacReferences: DacpacReference[];
-		/**
-		 * Array of SQL project references contained in the project
-		 */
-		sqlProjectReferences: SqlProjectReference[];
-	}
-
-	export interface GetFoldersResult extends ResultStatus {
-		/**
-		 * Array of folders contained in the project
-		 */
-		folders: string[];
-	}
-
-	export interface GetSqlCmdVariablesResult extends ResultStatus {
-		/**
-		 * Array of SQLCMD variables contained in the project
-		 */
-		sqlCmdVariables: SqlCmdVariable[];
-	}
-
-	export interface GetScriptsResult extends ResultStatus {
-		/**
-		 * Array of scripts contained in the project
-		 */
-		scripts: string[];
-	}
-
-	export const enum ProjectType {
-		SdkStyle = 0,
-		LegacyStyle = 1
-	}
-
 	/**
 	 * Represents a tenant information for an account.
 	 */
-	export interface Tenant {
+	export interface ITenant {
 		id: string;
 		displayName: string;
 		userId?: string;
 		tenantCategory?: string;
-	}
-
-	/**
-	 * Error that connect method throws if connection fails because of a fire wall rule error.
-	 */
-	export interface IFireWallRuleError extends Error {
-		connectionUri: string;
 	}
 
 	/**
@@ -849,6 +785,15 @@ declare module 'vscode-mssql' {
 		accountVersion?: any;
 	}
 
+	export enum AuthLibrary {
+		ADAL = 'ADAL',
+		MSAL = 'MSAL'
+	}
+
+	export enum AzureAuthType {
+		AuthCodeGrant = 0,
+		DeviceCode = 1
+	}
 
 	export enum AccountType {
 		Microsoft = 'microsoft',
@@ -893,7 +838,7 @@ declare module 'vscode-mssql' {
 		/**
 		 * Custom properties stored with the account
 		 */
-		properties: any;
+		properties: IAzureAccountProperties;
 		/**
 		 * Indicates if the account needs refreshing
 		 */
@@ -904,20 +849,62 @@ declare module 'vscode-mssql' {
 		isSignedIn?: boolean;
 	}
 
-	export interface IAzureAccountSession {
-		subscription: azure.subscription.Subscription,
-		tenantId: string,
-		account: IAccount,
-		token: Token
+	export interface IAzureAccountProperties {
+		/**
+		 * Auth type of azure used to authenticate this account.
+		 */
+		azureAuthType: AzureAuthType;
+
+		providerSettings: IProviderSettings;
+		/**
+		 * Whether or not the account is a Microsoft account
+		 */
+		isMsAccount: boolean;
+		/**
+		 * Represents the tenant that the user would be signing in to. For work and school accounts, the GUID is the immutable tenant ID of the organization that the user is signing in to.
+		 * For sign-ins to the personal Microsoft account tenant (services like Xbox, Teams for Life, or Outlook), the value is 9188040d-6c67-4c5b-b112-36a304b66dad.
+		 */
+		owningTenant: ITenant;
+		/**
+		 * A list of tenants (aka directories) that the account belongs to
+		 */
+		tenants: ITenant[];
 	}
 
-	export interface TokenKey {
+	export interface IProviderSettings {
+		scopes: string[];
+		displayName: string;
+		id: string;
+		clientId: string;
+		loginEndpoint: string;
+		portalEndpoint: string;
+		redirectUri: string;
+		resources: IProviderResources;
+	}
+
+	export interface IProviderResources {
+		windowsManagementResource: IAADResource;
+		azureManagementResource: IAADResource;
+		graphResource?: IAADResource;
+		databaseResource?: IAADResource;
+		ossRdbmsResource?: IAADResource;
+		azureKeyVaultResource?: IAADResource;
+		azureDevopsResource?: IAADResource;
+	}
+
+	export interface IAADResource {
+		id: string;
+		resource: string;
+		endpoint: string;
+	}
+
+	export interface ITokenKey {
 		/**
 		 * Account Key - uniquely identifies an account
 		 */
 		key: string;
 	}
-	export interface AccessToken extends TokenKey {
+	export interface IAccessToken extends ITokenKey {
 		/**
 		 * Access Token
 		 */
@@ -927,11 +914,51 @@ declare module 'vscode-mssql' {
 		 */
 		expiresOn?: number;
 	}
-	export interface Token extends AccessToken {
+
+	export interface IToken extends IAccessToken {
 		/**
 		 * TokenType
 		 */
 		tokenType: string;
+	}
+
+	export interface IRefreshToken extends ITokenKey {
+		/**
+		 * Refresh Token
+		 */
+		token: string;
+	}
+
+	export interface ITokenClaims {
+		aud: string;
+		iss: string;
+		iat: number;
+		idp: string;
+		nbf: number;
+		exp: number;
+		home_oid?: string;
+		c_hash: string;
+		at_hash: string;
+		aio: string;
+		preferred_username: string;
+		email: string;
+		name: string;
+		nonce: string;
+		oid?: string;
+		roles: string[];
+		rh: string;
+		sub: string;
+		tid: string;
+		unique_name: string;
+		uti: string;
+		ver: string;
+	}
+
+	export interface IAzureAccountSession {
+		subscription: azure.subscription.Subscription,
+		tenantId: string,
+		account: IAccount,
+		token: IToken | undefined
 	}
 
 	export interface IAzureAccountService {
@@ -948,7 +975,7 @@ declare module 'vscode-mssql' {
 		/**
 		 * Returns an access token for given user and tenant
 		 */
-		getAccountSecurityToken(account: IAccount, tenantId: string | undefined): Promise<Token>;
+		getAccountSecurityToken(account: IAccount, tenantId: string | undefined): Promise<IToken>;
 
 		/**
 		 * Returns Azure subscriptions with tenant and token for each given account
@@ -1070,7 +1097,7 @@ declare module 'vscode-mssql' {
 		packageFilePath: string;
 		databaseName: string;
 		upgradeExisting: boolean;
-		sqlCommandVariableValues?: Record<string, string>;
+		sqlCommandVariableValues?: Map<string, string>;
 		deploymentOptions?: DeploymentOptions;
 		ownerUri: string;
 		taskExecutionMode: TaskExecutionMode;
@@ -1079,7 +1106,7 @@ declare module 'vscode-mssql' {
 	export interface GenerateDeployScriptParams {
 		packageFilePath: string;
 		databaseName: string;
-		sqlCommandVariableValues?: Record<string, string>;
+		sqlCommandVariableValues?: Map<string, string>;
 		deploymentOptions?: DeploymentOptions;
 		ownerUri: string;
 		taskExecutionMode: TaskExecutionMode;
@@ -1111,7 +1138,7 @@ declare module 'vscode-mssql' {
 		profilePath: string;
 		databaseName: string;
 		connectionString: string;
-		sqlCommandVariableValues?: Record<string, string>;
+		sqlCommandVariableValues?: Map<string, string>;
 		deploymentOptions?: DeploymentOptions;
 	}
 
@@ -1120,22 +1147,249 @@ declare module 'vscode-mssql' {
 	//#region Parameters
 
 	export interface SqlProjectParams {
+		/**
+		 * Absolute path of the project, including .sqlproj
+		 */
 		projectUri: string;
+	}
+
+	export interface SqlProjectScriptParams extends SqlProjectParams {
+		/**
+		 * Path of the script, including .sql, relative to the .sqlproj
+		 */
+		path: string;
+	}
+
+	export interface AddDacpacReferenceParams extends AddUserDatabaseReferenceParams {
+		/**
+		 * Path to the .dacpac file
+		 */
+		dacpacPath: string;
+	}
+
+	export interface AddDatabaseReferenceParams extends SqlProjectParams {
+		/**
+		 * Whether to suppress missing dependencies
+		 */
+		suppressMissingDependencies: boolean;
+		/**
+		 * Literal name used to reference another database in the same server, if not using SQLCMD variables
+		 */
+		databaseLiteral?: string;
+	}
+
+	export interface AddSqlProjectReferenceParams extends AddUserDatabaseReferenceParams {
+		/**
+		 * Path to the referenced .sqlproj file
+		 */
+		projectPath: string;
+		/**
+		 * GUID for the referenced SQL project
+		 */
+		projectGuid: string;
+	}
+
+	export interface AddSystemDatabaseReferenceParams extends AddDatabaseReferenceParams {
+		/**
+		 * Type of system database
+		 */
+		systemDatabase: SystemDatabase;
+	}
+
+	export interface AddNugetPackageReferenceParams extends AddUserDatabaseReferenceParams {
+		/**
+		 * NuGet package name
+		 */
+		packageName: string;
+
+		/**
+		 * NuGet package version
+		 */
+		packageVersion: string;
+	}
+
+	export interface AddUserDatabaseReferenceParams extends AddDatabaseReferenceParams {
+		/**
+		 * SQLCMD variable name for specifying the other database this reference is to, if different from that of the current project
+		 */
+		databaseVariable?: string;
+		/**
+		 * SQLCMD variable name for specifying the other server this reference is to, if different from that of the current project.
+		 * If this is set, DatabaseVariable must also be set.
+		 */
+		serverVariable?: string;
+	}
+
+	export interface DeleteDatabaseReferenceParams extends SqlProjectParams {
+		/**
+		 * Name of the reference to be deleted.  Name of the System DB, path of the sqlproj, or path of the dacpac
+		 */
+		name: string;
+	}
+
+	export interface FolderParams extends SqlProjectParams {
+		/**
+		 * Path of the folder, typically relative to the .sqlproj file
+		 */
+		path: string;
+	}
+
+	export interface CreateSqlProjectParams extends SqlProjectParams {
+		/**
+		 * Type of SQL Project: SDK-style or Legacy
+		 */
+		sqlProjectType: ProjectType;
+		/**
+		 * Database schema provider for the project, in the format
+		 * "Microsoft.Data.Tools.Schema.Sql.SqlXYZDatabaseSchemaProvider".
+		 * Case sensitive.
+		 */
+		databaseSchemaProvider?: string;
+		/**
+		 * Version of the Microsoft.Build.Sql SDK for the project, if overriding the default
+		 */
+		buildSdkVersion?: string;
+	}
+
+	export interface AddSqlCmdVariableParams extends SqlProjectParams {
+		/**
+		 * Name of the SQLCMD variable
+		 */
+		name: string;
+		/**
+		 * Default value of the SQLCMD variable
+		 */
+		defaultValue: string;
+	}
+
+	export interface DeleteSqlCmdVariableParams extends SqlProjectParams {
+		/**
+		 * Name of the SQLCMD variable to be deleted
+		 */
+		name?: string;
+	}
+
+	export interface MoveItemParams extends SqlProjectScriptParams {
+		/**
+		 * Destination path of the file or folder, relative to the .sqlproj
+		 */
+		destinationPath: string;
+	}
+
+	export interface SetDatabaseSourceParams extends SqlProjectParams {
+		/**
+		 * Source of the database schema, used in telemetry
+		 */
+		databaseSource: string;
+	}
+
+	export interface SetDatabaseSchemaProviderParams extends SqlProjectParams {
+		/**
+		 * New DatabaseSchemaProvider value, in the form "Microsoft.Data.Tools.Schema.Sql.SqlXYZDatabaseSchemaProvider"
+		 */
+		databaseSchemaProvider: string;
 	}
 
 	//#endregion
 
 	//#region Results
 
+	export interface GetCrossPlatformCompatibilityResult extends ResultStatus {
+		/**
+		 * Whether the project is cross-platform compatible
+		 */
+		isCrossPlatformCompatible: boolean;
+	}
+
+	export interface GetProjectPropertiesResult extends ResultStatus {
+		/**
+		 * GUID for the SQL project
+		 */
+		projectGuid: string;
+		/**
+		 * Build configuration, defaulted to Debug if not specified
+		 */
+		configuration: string;
+		/**
+		 * Build platform, defaulted to AnyCPU if not specified
+		 */
+		platform: string;
+		/**
+		 * Output path for build, defaulted to "bin/Debug" if not specified.
+			 May be absolute or relative.
+		 */
+		outputPath: string;
+		/**
+		 * Default collation for the project, defaulted to SQL_Latin1_General_CP1_CI_AS if not specified
+		 */
+		defaultCollation: string;
+		/**
+		 * Source of the database schema, used in telemetry
+		 */
+		databaseSource?: string;
+		/**
+		 * Style of the .sqlproj file - SdkStyle or LegacyStyle
+		 */
+		projectStyle: ProjectType;
+		/**
+		 * Database Schema Provider, in the format "Microsoft.Data.Tools.Schema.Sql.SqlXYZDatabaseSchemaProvider"
+		 */
+		databaseSchemaProvider: string
+	}
+
 	export interface GetDatabaseReferencesResult extends ResultStatus {
+		/**
+		 * Array of system database references contained in the project
+		 */
 		systemDatabaseReferences: SystemDatabaseReference[];
-		sqlProjectReferences: SqlProjectReference[];
+		/**
+		 * Array of dacpac references contained in the project
+		 */
 		dacpacReferences: DacpacReference[];
+		/**
+		 * Array of SQL project references contained in the project
+		 */
+		sqlProjectReferences: SqlProjectReference[];
+		/**
+		 * Array of NuGet package references contained in the project
+		 */
+		nugetPackageReferences: NugetPackageReference[];
+	}
+
+	export interface GetFoldersResult extends ResultStatus {
+		/**
+		 * Array of folders contained in the project
+		 */
+		folders: string[];
+	}
+
+	export interface GetSqlCmdVariablesResult extends ResultStatus {
+		/**
+		 * Array of SQLCMD variables contained in the project
+		 */
+		sqlCmdVariables: SqlCmdVariable[];
+	}
+
+	export interface GetScriptsResult extends ResultStatus {
+		/**
+		 * Array of scripts contained in the project
+		 */
+		scripts: string[];
 	}
 
 	//#endregion
 
 	//#region Types
+
+	export const enum ProjectType {
+		SdkStyle = 0,
+		LegacyStyle = 1
+	}
+
+	export const enum SystemDatabase {
+		Master = 0,
+		MSDB = 1
+	}
 
 	export interface DatabaseReference {
 		suppressMissingDependencies: boolean;
@@ -1160,9 +1414,9 @@ declare module 'vscode-mssql' {
 		dacpacPath: string;
 	}
 
-	export const enum SystemDatabase {
-		Master = 0,
-		MSDB = 1
+	export interface NugetPackageReference extends UserDatabaseReference {
+		packageName: string;
+		packageVersion: string;
 	}
 
 	export interface SqlCmdVariable {


### PR DESCRIPTION
Originally I was just going to make the same changes that were made in https://github.com/microsoft/vscode-mssql/pull/17657, but noticed there were several other differences. These files are supposed to stay in sync, so this updates the vscode-mssql.d.ts file in ADS to match the current state of the file in the vscode-mssql repo (pending a small sql projects `NoneItems` change that needs to be added in https://github.com/microsoft/vscode-mssql/pull/17659). 