### PR TITLE
Finish up no-unsafe-assignment fixes in azurecore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@
 **/extensions/**/*.d.ts
 **/extensions/**/build/**
 **/extensions/**/colorize-fixtures/**
+**/extensions/azurecore/extension.webpack.config.js
 **/extensions/css-language-features/server/test/pathCompletionFixtures/**
 **/extensions/html-language-features/server/lib/jquery.d.ts
 **/extensions/html-language-features/server/src/test/pathCompletionFixtures/**

--- a/extensions/azurecore/.eslintrc.json
+++ b/extensions/azurecore/.eslintrc.json
@@ -11,6 +11,7 @@
 			}
 		],
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "error"
 	}
 }

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -30,7 +30,6 @@ import { getProxyEnabledHttpClient, getTenantIgnoreList, updateTenantIgnoreList 
 import { errorToPromptFailedResult } from './networkUtils';
 import { MsalCachePluginProvider } from '../utils/msalCachePlugin';
 import { AzureListOperationResponse, ErrorResponseBodyWithError, isErrorResponseBody as isErrorResponseBodyWithError } from '../../azureResource/utils';
-import { ErrorResponseBody } from '@azure/arm-subscriptions/esm/models';
 const localize = nls.loadMessageBundle();
 
 export abstract class AzureAuth implements vscode.Disposable {

--- a/extensions/azurecore/src/account-provider/auths/httpClient.ts
+++ b/extensions/azurecore/src/account-provider/auths/httpClient.ts
@@ -233,10 +233,14 @@ const networkRequestViaProxy = <T>(
 
 					// check if the value of the header is supposed to be a JSON object
 					try {
+						// TODO: Investigate this - https://github.com/microsoft/azuredatastudio/issues/22835
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 						const object = JSON.parse(headerValue);
 
 						// if it is, then convert it from a string to a JSON object
 						if (object && (typeof object === 'object')) {
+							// TODO: Investigate this - https://github.com/microsoft/azuredatastudio/issues/22835
+							// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 							headerValue = object;
 						}
 					} catch (e) {

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -28,6 +28,7 @@ const localize = nls.loadMessageBundle();
  * Specialized version of the ErrorResponseBody that is required to have the error
  * information for easier typing support, without it how do we know it's an error
  * response?
+ * https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/subscription/arm-subscriptions/src/models/index.ts#L180
  */
 export type ErrorResponseBodyWithError = Required<ErrorResponseBody>;
 

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -20,14 +20,32 @@ import * as Constants from '../constants';
 import { getProxyEnabledHttpClient } from '../utils';
 import { HttpClient } from '../account-provider/auths/httpClient';
 import { NetworkRequestOptions } from '@azure/msal-common';
+import { ErrorResponseBody } from '@azure/arm-subscriptions/esm/models';
 
 const localize = nls.loadMessageBundle();
+
+/**
+ * Specialized version of the ErrorResponseBody that is required to have the error
+ * information for easier typing support, without it how do we know it's an error
+ * response?
+ */
+export type ErrorResponseBodyWithError = Required<ErrorResponseBody>;
+
+/**
+ * Checks if the body object given is an error response, that is has a non-undefined
+ * property named error which contains detailed about the error.
+ * @param body The body object to check
+ * @returns True if the body is an ErrorResponseBodyWithError
+ */
+export function isErrorResponseBody(body: any): body is ErrorResponseBodyWithError {
+	return 'error' in body && body.error;
+}
 
 /**
  * Shape of list operation responses
  * e.g. https://learn.microsoft.com/en-us/rest/api/storagerp/srp_json_list_operations#response-body
  */
-declare type AzureListOperationResponse<T> = {
+export declare type AzureListOperationResponse<T> = {
 	value: T;
 }
 


### PR DESCRIPTION
Finished the last few of these. The error responses seem like something we should build into all the Azure REST calls...I'm assuming that's a possible response from any of these. But that's out of the scope of this work here.

I did disable the check for the header conversion stuff - I have no idea what's going on with that so I just opened an issue to look into this (which I would recommend doing since right now this could easily cause something to break at runtime if a header is converted into an object unexpectedly...) https://github.com/microsoft/azuredatastudio/issues/22835