### PR TITLE
Fix resetting tenant values when dropdown is not visible

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -813,7 +813,10 @@ export class ConnectionWidget extends lifecycle.Disposable {
 
 		} else {
 			if (selectedAccount && selectedAccount.properties.tenants && selectedAccount.properties.tenants.length === 1) {
+				let options = selectedAccount.properties.tenants.map(tenant => tenant.displayName);
+				this._azureTenantDropdown.setOptions(options);
 				this._azureTenantId = selectedAccount.properties.tenants[0].id;
+				this.onAzureTenantSelected(0);
 			}
 			this._tableContainer.classList.add(hideTenantsClassName);
 		}


### PR DESCRIPTION
Fixes a minor edge case that happens when switching accounts - if the selected account has single tenant, the dropdown doesn't get updated with new tenant and connection leads to an error as the selected tenant still points to previously selected tenant from last account selection.