### PR TITLE
fix schema compare diff editor colors not being reversed after merge

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1150,8 +1150,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		const foreignModified = this._modifiedEditorState.getForeignViewZones(this._modifiedEditor.getWhitespaces());
 
 		// {{SQL CARBON EDIT}}
-		// const diffDecorations = this._strategy.getEditorsDiffDecorations(lineChanges, this._options.ignoreTrimWhitespace, this._options.renderIndicators, foreignOriginal, foreignModified, this._originalEditor, this._modifiedEditor, this._options.reverse); // {{ SQL CARBON TODO }} - The last 3 args are different in the updated version below.
-		const diffDecorations = this._strategy.getEditorsDiffDecorations(lineChanges, this._options.ignoreTrimWhitespace, this._options.renderIndicators, this._options.renderMarginRevertIcon, foreignOriginal, foreignModified);
+		const diffDecorations = this._strategy.getEditorsDiffDecorations(lineChanges, this._options.ignoreTrimWhitespace, this._options.renderIndicators, this._options.renderMarginRevertIcon, foreignOriginal, foreignModified, this._options.reverse);
 
 		try {
 			this._currentlyChangingViewZones = true;


### PR DESCRIPTION
Fixes #22850. After the latest merge, the schema compare diff colors weren't swapped like they're supposed to be because the `reverse` parameter wasn't getting passed in. 

before:
![image](https://user-images.githubusercontent.com/31145923/234415641-5a05ee1b-6688-4425-b7a8-15dc3311b95c.png)

after:
![image](https://user-images.githubusercontent.com/31145923/234415626-a771149f-dfae-43c7-b459-727b9411c6c2.png)
