### PR TITLE
Fix Azure rest calls not working

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -29,7 +29,7 @@ import { HttpClient } from './httpClient';
 import { getProxyEnabledHttpClient, getTenantIgnoreList, updateTenantIgnoreList } from '../../utils';
 import { errorToPromptFailedResult } from './networkUtils';
 import { MsalCachePluginProvider } from '../utils/msalCachePlugin';
-import { AzureListOperationResponse, ErrorResponseBodyWithError, isErrorResponseBody as isErrorResponseBodyWithError } from '../../azureResource/utils';
+import { AzureListOperationResponse, ErrorResponseBodyWithError, isErrorResponseBodyWithError } from '../../azureResource/utils';
 const localize = nls.loadMessageBundle();
 
 export abstract class AzureAuth implements vscode.Disposable {

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -287,13 +287,6 @@ declare module 'azurecore' {
 		status: number;
 	};
 
-	export interface HttpClientResponse<B> {
-		body: B;
-		headers: any;
-		status: Number;
-		error: any;
-	}
-
 	export interface IExtension {
 		/**
 		 * Gets the list of subscriptions for the specified AzureAccount


### PR DESCRIPTION
These were broken in https://github.com/microsoft/azuredatastudio/pull/22828 - I wrapped the results one too many times which ended up causing an error to be thrown when making some API calls. Unfortunately, this kind of thing is hard to catch with just static analysis since we're doing all our own custom requests - so if a mistake like this gets in then it won't show up until runtime. 

I went through and verified all the public API calls seem to be working correctly after this fix so we should be good now, and going forward this should be avoided by making sure to properly test new calls as they're added. 