### PR TITLE
Add check for extension READMEs to have license header

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1546,15 +1546,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/extensions/azdata-sanddance/sanddance-logo.png"
+									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/main/extensions/azdata-sanddance/sanddance-logo.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/extensions/azdata-sanddance/README.md"
+									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/main/extensions/azdata-sanddance/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/extensions/azdata-sanddance/package.json"
+									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/main/extensions/azdata-sanddance/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -4295,7 +4295,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/22349.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4356,7 +4356,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/22349.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4421,7 +4421,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/23110.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/LICENSE.rtf"
 								}
 							],
 							"properties": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1546,15 +1546,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/extensions/azdata-sanddance/sanddance-logo.png"
+									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/main/extensions/azdata-sanddance/sanddance-logo.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/extensions/azdata-sanddance/README.md"
+									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/main/extensions/azdata-sanddance/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/extensions/azdata-sanddance/package.json"
+									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/main/extensions/azdata-sanddance/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -4295,7 +4295,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/22349.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/net-6-runtime/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4356,7 +4356,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/22349.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/azuredatastudio-oracle/LICENSE.rtf"
 								}
 							],
 							"properties": [
@@ -4421,7 +4421,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/23110.1/LICENSE.rtf"
+									"source": "https://dsct.blob.core.windows.net/extensions/dsct-oracle-to-ms-sql/LICENSE.rtf"
 								}
 							],
 							"properties": [

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -334,7 +334,10 @@ const extensionsToSkipLicenseHeaderCheck = [
     'mark carrington.azuredatastudio-sql4cds',
     'azuredatastudio-select-top-n',
     'schema-visualization',
-    'plan-explorer'
+    'plan-explorer',
+    // TODO: These should have licenses, following up with team
+    'azuredatastudio-oracle',
+    'net-6-runtime'
 ];
 
 /**

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -275,7 +275,7 @@ async function validateVersion(galleryFilePath, extensionName, extensionJson, ex
         throw new Error(`${galleryFilePath} - ${extensionName} - Invalid version files\n${JSON.stringify(extensionVersionJson)}`)
     }
 
-    validateHasRequiredAssets(galleryFilePath, extensionName, extensionVersionJson.files);
+    await validateHasRequiredAssets(galleryFilePath, extensionName, extensionVersionJson.files);
 
     for (const file of extensionVersionJson.files) {
         await validateExtensionFile(galleryFilePath, extensionName, extensionJson, file);
@@ -306,6 +306,37 @@ function parseVersion(galleryFilePath, extensionName, version) {
     return parsedVersion;
 }
 
+// Simple regex to search for license header within an extensions' README
+const licenseHeaderRegex = new RegExp('#+\\s*License', 'm')
+
+// List of extensions that don't have the expected license header, but as they are 3rd party
+// will ignore them for now. All future extensions will be expected to have a proper license
+// header in their readme.
+const extensionsToSkipLicenseHeaderCheck = [
+    'mssql-db-insights',
+    'alwayson-insights',
+    'sqlops-combine-scripts',
+    'newdatabase',
+    'mssql-instance-insights',
+    'sp_executesqlToSQL',
+    'tsqlchecker',
+    'ADS-add-columns',
+    'sql-server-diagnostic-book',
+    'sql-prompt',
+    'sql-search',
+    'simple-data-scripter',
+    'delete-database',
+    'db-snapshot-creator',
+    'poor-sql-formatter',
+    'vscode-wakatime',
+    'extra-sql-script-as',
+    'column-aligner-ads',
+    'mark carrington.azuredatastudio-sql4cds',
+    'azuredatastudio-select-top-n',
+    'schema-visualization',
+    'plan-explorer'
+];
+
 /**
  * Validates that an extension version has the expected files for displaying in the gallery.
  * There are some existing 3rd party extensions that don't have all the files, but that's ok for now.
@@ -314,7 +345,7 @@ function parseVersion(galleryFilePath, extensionName, version) {
  * @param {string} extensionName
  * @param {IRawGalleryExtensionFile[]} filesJson
  */
-function validateHasRequiredAssets(galleryFilePath, extensionName, filesJson) {
+async function validateHasRequiredAssets(galleryFilePath, extensionName, filesJson) {
     // VSIXPackage or DownloadPage
     const vsixFile = filesJson.find(file => file.assetType === MICROSOFT_VISUALSTUDIO_SERVICES_VSIXPACKAGE);
     const downloadPageFile = filesJson.find(file => file.assetType === MICROSOFT_SQLOPS_DOWNLOADPAGE);
@@ -335,6 +366,20 @@ function validateHasRequiredAssets(galleryFilePath, extensionName, filesJson) {
     const detailsFile = filesJson.find(file => file.assetType === 'Microsoft.VisualStudio.Services.Content.Details');
     if (!detailsFile) {
         throw new Error(`${galleryFilePath} - ${extensionName} - Must have a details file (README)`);
+    }
+
+    // For any non-skipped extensions check that they have a license header in their README. This is a very simple check
+    // (we don't actually check that the content is accurate) - but is enough for now.
+    let readmeBody;
+    if (!extensionsToSkipLicenseHeaderCheck.includes(extensionName)) {
+        try {
+            readmeBody = (await got.get(detailsFile.source)).body;
+        } catch (err) {
+            throw new Error(`${galleryFilePath} - ${extensionName} - Error checking README for license header. ${err}`);
+        }
+        if (!licenseHeaderRegex.test(readmeBody)) {
+            throw new Error(`${galleryFilePath} - ${extensionName} - README is missing License header. Extensions must contain a License section with details about the license for this extension.`);
+        }
     }
 
     // Manifest


### PR DESCRIPTION
Going forward we'll require that extensions not only have a license file linked in their metadata, but that the README also contains a license section. Adding the check for that now - with a number of 3rd party extensions that currently don't have this added to a skip list since we don't control those.

Currently there's still a number of 1st party extensions that need to be fixed - will keep this PR open until they can be addressed.

- [x] pastetheplan @dzsquared https://github.com/dzsquared/sqlops-pastetheplan/pull/1
- [x] sql-dw @Charles-Gagnon @WilliamDAssafMSFT
- [x] hcq--high-color-queries- @dzsquared https://github.com/dzsquared/high-color-queries/pull/9
- [x] firstresponderkit @dzsquared https://github.com/dzsquared/sqlops-firstresponderkit/pull/35
- [x] server-report @Charles-Gagnon 
- [x] demo-mode @dzsquared https://github.com/dzsquared/demo-mode/pull/14
- [x] whoisactive @Charles-Gagnon 
- [x] managed-instance-dashboard @Charles-Gagnon @JocaPC 
- [ ] net-6-runtime @Charles-Gagnon @sergten
- [ ] azuredatastudio-oracle @Charles-Gagnon @sergten 
- [x] azdata-sanddance @Charles-Gagnon @danmarshall
- [x] qpi @Charles-Gagnon @JocaPC
- [x] azure-cosmosdb-ads-extension @Charles-Gagnon @languy 

@dzsquared For the ones that you own, are you planning on keeping those around? We can help with getting them updated if so, just want to make sure we couldn't just remove them if they aren't useful anymore. 