### PR TITLE
fix build errors introduced by sql projects test file

### DIFF
--- a/extensions/sql-database-projects/src/test/testUtils.ts
+++ b/extensions/sql-database-projects/src/test/testUtils.ts
@@ -13,9 +13,8 @@ import should = require('should');
 import { AssertionError } from 'assert';
 import { Project } from '../models/project';
 import { Uri } from 'vscode';
-import { exists, getAzdataApi, getSqlProjectsService } from '../common/utils';
+import { exists, getSqlProjectsService } from '../common/utils';
 import * as mssql from 'mssql';
-import * as vscodeMssql from 'vscode-mssql';
 
 export async function shouldThrowSpecificError(block: Function, expectedMessage: string, details?: string) {
 	let succeeded = false;


### PR DESCRIPTION
Fix build errors introduced by https://github.com/microsoft/azuredatastudio/pull/22847 for unused imports.
![image](https://user-images.githubusercontent.com/31145923/235218699-e98a3333-6d6c-479d-8ef9-1c3f738bb3ab.png)
