### PR TITLE
Fix missing placeholder warning for infoboxes

### DIFF
--- a/src/sql/workbench/browser/modelComponents/infoBox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/infoBox.component.ts
@@ -78,8 +78,8 @@ export default class InfoBoxComponent extends ComponentBase<azdata.InfoBoxCompon
 			this._container.nativeElement.style.height = this.getHeight();
 			this._infoBox.announceText = this.announceText;
 			this._infoBox.infoBoxStyle = this.style;
-			this._infoBox.links = this.links;
 			this._infoBox.text = this.text;
+			this._infoBox.links = this.links;
 			this._infoBox.isClickable = this.isClickable;
 			this._infoBox.clickableButtonAriaLabel = this.clickableButtonAriaLabel;
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/22628

Turns out we were setting the links first, which triggered the check and warning to be displayed since the text hadn't been set. 