### PR TITLE
Remove publisher link and fix license link

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -908,12 +908,15 @@ export class ExtensionEditor extends EditorPane {
 		if (extension.repository) {
 			resources.push([localize('repository', "Repository"), URI.parse(extension.repository)]);
 		}
-		if (extension.url && extension.licenseUrl) {
+		// {{SQL CARBON EDIT}} Our gallery doesn't have marketplace URLs so skip that check so we show the license link
+		if (/*extension.url &&*/ extension.licenseUrl) {
 			resources.push([localize('license', "License"), URI.parse(extension.licenseUrl)]);
 		}
+		/* {{SQL CARBON EDIT}} Our gallery doesn't have publisher links since we don't have a publicly-viewable gallery
 		if (extension.publisherUrl) {
 			resources.push([extension.publisherDisplayName, extension.publisherUrl]);
 		}
+		*/
 		if (resources.length || extension.publisherSponsorLink) {
 			const extensionResourcesContainer = append(container, $('.resources-container.additional-details-element'));
 			append(extensionResourcesContainer, $('.additional-details-title', undefined, localize('resources', "Extension Resources")));


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/22901
Fixes https://github.com/microsoft/azuredatastudio/issues/22902

Removes broken publisher link (we don't have anything useful to link to for publishers since we don't have a public UI for the gallery) and fixes the License link not showing up. 

With fixes : 
![image](https://user-images.githubusercontent.com/28519865/235266902-4302bee9-77d3-43a3-853a-69bba99b8a52.png)

Extension without license (only a couple of those)

![image](https://user-images.githubusercontent.com/28519865/235266866-ac7e380e-bd8a-40e0-bd08-bc360f963745.png)
