### PR TITLE
Respect 'showDashboard' disabled by default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -269,23 +269,6 @@
 			}
 		},
 		{
-			"type": "pwa-chrome",
-			"request": "attach",
-			"name": "Attach to VS Code",
-			"browserAttachLocation": "workspace",
-			"port": 9222,
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"presentation": {
-				"group": "2_attach"
-			},
-			"resolveSourceMapLocations": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"perScriptSourcemaps": "yes"
-		},
-		{
 			"type": "node",
 			"request": "launch",
 			"name": "Run Smoke Tests",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -269,6 +269,23 @@
 			}
 		},
 		{
+			"type": "pwa-chrome",
+			"request": "attach",
+			"name": "Attach to VS Code",
+			"browserAttachLocation": "workspace",
+			"port": 9222,
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"presentation": {
+				"group": "2_attach"
+			},
+			"resolveSourceMapLocations": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"perScriptSourcemaps": "yes"
+		},
+		{
 			"type": "node",
 			"request": "launch",
 			"name": "Run Smoke Tests",

--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -172,7 +172,6 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 			await this._connectionManagementService.connectAndSaveProfile(connectionProfile, undefined, {
 				saveTheConnection: isUndefinedOrNull(connectionCompletionOptions.saveConnection) ? true : connectionCompletionOptions.saveConnection,
 				showDashboard: isUndefinedOrNull(connectionCompletionOptions.showDashboard) ? false : connectionCompletionOptions.showDashboard,
-				params: undefined,
 				showConnectionDialogOnError: isUndefinedOrNull(connectionCompletionOptions.showConnectionDialogOnError) ? true : connectionCompletionOptions.showConnectionDialogOnError,
 				showFirewallRuleOnError: isUndefinedOrNull(connectionCompletionOptions.showFirewallRuleOnError) ? true : connectionCompletionOptions.showFirewallRuleOnError
 			});
@@ -248,7 +247,6 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 		return this._connectionManagementService.connectAndSaveProfile(profile, undefined, {
 			saveTheConnection: saveConnection,
 			showDashboard: showDashboard,
-			params: undefined,
 			showConnectionDialogOnError: true,
 			showFirewallRuleOnError: true
 		}).then((result) => {

--- a/src/sql/workbench/browser/actions.ts
+++ b/src/sql/workbench/browser/actions.ts
@@ -47,7 +47,7 @@ export class ManageAction extends Action {
 
 	override async run(actionContext: ManageActionContext): Promise<void> {
 		if (actionContext.profile) {
-			await this._connectionManagementService.connect(actionContext.profile, actionContext.uri, { showDashboard: true, saveTheConnection: false, params: undefined, showConnectionDialogOnError: false, showFirewallRuleOnError: true });
+			await this._connectionManagementService.connect(actionContext.profile, actionContext.uri, { showDashboard: true, saveTheConnection: false, showConnectionDialogOnError: false, showFirewallRuleOnError: true });
 			this._angularEventingService.sendAngularEvent(actionContext.uri, AngularEventType.NAV_DATABASE);
 		}
 	}

--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -123,7 +123,12 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 		let showConnectDialogOnStartup: boolean = this._configurationService.getValue('workbench.showConnectDialogOnStartup');
 		if (showConnectDialogOnStartup && !commandName && !profile && !this._connectionManagementService.hasRegisteredServers()) {
 			// prompt the user for a new connection on startup if no profiles are registered
-			await this._connectionManagementService.showConnectionDialog();
+			await this._connectionManagementService.showConnectionDialog(undefined, {
+				showDashboard: true,
+				saveTheConnection: true,
+				showConnectionDialogOnError: true,
+				showFirewallRuleOnError: true
+			});
 			return;
 		}
 		let connectedContext: azdata.ConnectedContext = undefined;
@@ -234,7 +239,13 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 			}
 
 			const connectionProfile = this.readProfileFromArgs(args);
-			await this._connectionManagementService.showConnectionDialog(undefined, undefined, connectionProfile);
+			await this._connectionManagementService.showConnectionDialog(undefined, {
+				saveTheConnection: true,
+				showDashboard: true,
+				params: undefined,
+				showConnectionDialogOnError: true,
+				showFirewallRuleOnError: true
+			}, connectionProfile);
 		} catch (err) {
 			this._notificationService.error(localize('errConnectUrl', "Could not open URL due to error {0}", getErrorMessage(err)));
 		}

--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -242,7 +242,6 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 			await this._connectionManagementService.showConnectionDialog(undefined, {
 				saveTheConnection: true,
 				showDashboard: true,
-				params: undefined,
 				showConnectionDialogOnError: true,
 				showFirewallRuleOnError: true
 			}, connectionProfile);

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -139,7 +139,7 @@ suite('commandLineService tests', () => {
 		const connectionManagementService: TypeMoq.Mock<IConnectionManagementService>
 			= TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService, TypeMoq.MockBehavior.Strict);
 
-		connectionManagementService.setup((c) => c.showConnectionDialog())
+		connectionManagementService.setup((c) => c.showConnectionDialog(undefined, TypeMoq.It.isAny()))
 			.returns(() => new Promise<void>((resolve, reject) => { resolve(); }))
 			.verifiable();
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => false);

--- a/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
@@ -152,7 +152,13 @@ CommandsRegistry.registerCommand('azdata.connect',
 				showFirewallRuleOnError: true
 			});
 		} else {
-			connectionManagementService.showConnectionDialog();
+			connectionManagementService.showConnectionDialog(undefined, {
+				saveTheConnection: true,
+				showDashboard: true,
+				params: undefined,
+				showConnectionDialogOnError: true,
+				showFirewallRuleOnError: true
+			});
 		}
 	});
 

--- a/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
@@ -147,7 +147,6 @@ CommandsRegistry.registerCommand('azdata.connect',
 			connectionManagementService.connect(connectionProfile, undefined, {
 				saveTheConnection: true,
 				showDashboard: true,
-				params: undefined,
 				showConnectionDialogOnError: true,
 				showFirewallRuleOnError: true
 			});
@@ -155,7 +154,6 @@ CommandsRegistry.registerCommand('azdata.connect',
 			connectionManagementService.showConnectionDialog(undefined, {
 				saveTheConnection: true,
 				showDashboard: true,
-				params: undefined,
 				showConnectionDialogOnError: true,
 				showFirewallRuleOnError: true
 			});

--- a/src/sql/workbench/contrib/dashboard/browser/dashboardActions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboardActions.ts
@@ -38,7 +38,6 @@ CommandsRegistry.registerCommand({
 				let options = {
 					showDashboard: true,
 					saveTheConnection: false,
-					params: undefined,
 					showConnectionDialogOnError: true,
 					showFirewallRuleOnError: true
 				};
@@ -122,7 +121,6 @@ export class OEManageConnectionAction extends Action {
 		}
 
 		let options: IConnectionCompletionOptions = {
-			params: undefined,
 			saveTheConnection: false,
 			showConnectionDialogOnError: true,
 			showDashboard: true,

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -186,7 +186,12 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			connectButton.label = localize('serverTree.newConnection', "New Connection");
 			this._register(attachButtonStyler(connectButton, this._themeService));
 			this._register(connectButton.onDidClick(() => {
-				this._connectionManagementService.showConnectionDialog();
+				this._connectionManagementService.showConnectionDialog(undefined, {
+					showDashboard: true,
+					saveTheConnection: true,
+					showConnectionDialogOnError: true,
+					showFirewallRuleOnError: true
+				});
 			}));
 		}
 

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -877,7 +877,6 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			if (node instanceof ConnectionProfile) {
 				connectionProfile = node;
 				await TreeUpdateUtils.connectAndCreateOeSession(connectionProfile, {
-					params: undefined,
 					saveTheConnection: true,
 					showConnectionDialogOnError: true,
 					showFirewallRuleOnError: true,

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
@@ -285,11 +285,10 @@ suite('SQL Connection Tree Action tests', () => {
 
 	test('AddServerAction - test if show connection dialog is called', () => {
 		let connectionManagementService = createConnectionManagementService(true, undefined);
-
 		let connectionTreeAction: AddServerAction = new AddServerAction(AddServerAction.ID, AddServerAction.LABEL, connectionManagementService.object);
 		let conProfGroup = new ConnectionProfileGroup('testGroup', undefined, 'testGroup', undefined, undefined);
 		return connectionTreeAction.run(conProfGroup).then((value) => {
-			connectionManagementService.verify(x => x.showConnectionDialog(undefined, undefined, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			connectionManagementService.verify(x => x.showConnectionDialog(undefined, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 	});
 

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
@@ -283,13 +283,14 @@ suite('SQL Connection Tree Action tests', () => {
 		});
 	});
 
-	test('AddServerAction - test if show connection dialog is called', () => {
+	test('AddServerAction - test if show connection dialog is called', async () => {
 		let connectionManagementService = createConnectionManagementService(true, undefined);
+		connectionManagementService.setup(x => x.showConnectionDialog(undefined, TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(
+			() => new Promise<void>((resolve, reject) => resolve()));
 		let connectionTreeAction: AddServerAction = new AddServerAction(AddServerAction.ID, AddServerAction.LABEL, connectionManagementService.object);
 		let conProfGroup = new ConnectionProfileGroup('testGroup', undefined, 'testGroup', undefined, undefined);
-		return connectionTreeAction.run(conProfGroup).then((value) => {
-			connectionManagementService.verify(x => x.showConnectionDialog(undefined, TypeMoq.It.isAny()), TypeMoq.Times.once());
-		});
+		await connectionTreeAction.run(conProfGroup);
+		connectionManagementService.verify(x => x.showConnectionDialog(undefined, TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
 	test('ActiveConnectionsFilterAction - test if view is called to display filtered results', () => {

--- a/src/sql/workbench/contrib/profiler/browser/profilerActions.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerActions.ts
@@ -278,7 +278,6 @@ export class NewProfilerAction extends Task {
 		let profilerInput = accessor.get<IInstantiationService>(IInstantiationService).createInstance(ProfilerInput, profile);
 		await accessor.get<IEditorService>(IEditorService).openEditor(profilerInput, { pinned: true }, ACTIVE_GROUP);
 		let options: IConnectionCompletionOptions = {
-			params: undefined,
 			saveTheConnection: false,
 			showConnectionDialogOnError: true,
 			showDashboard: false,

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -265,7 +265,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		let options: IConnectionCompletionOptions = this._options || {
 			params: params,
 			saveTheConnection: !isTemporaryConnection,
-			showDashboard: params && params.showDashboard !== undefined ? params.showDashboard : !fromEditor && !isTemporaryConnection,
+			showDashboard: params && params.showDashboard !== undefined ? params.showDashboard : false,
 			showConnectionDialogOnError: false,
 			showFirewallRuleOnError: true
 		};

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -265,7 +265,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		let options: IConnectionCompletionOptions = this._options || {
 			params: params,
 			saveTheConnection: !isTemporaryConnection,
-			showDashboard: params && params.showDashboard !== undefined ? params.showDashboard : false,
+			showDashboard: params?.showDashboard ?? false,
 			showConnectionDialogOnError: false,
 			showFirewallRuleOnError: true
 		};

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -492,7 +492,6 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				saveTheConnection: saveConnection,
 				showConnectionDialogOnError: true,
 				showDashboard: purpose === 'dashboard',
-				params: undefined,
 				showFirewallRuleOnError: true,
 			};
 			return this.connect(connection, ownerUri, options).then(connectionResult => {
@@ -524,7 +523,6 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			options = {
 				saveTheConnection: true,
 				showDashboard: false,
-				params: undefined,
 				showConnectionDialogOnError: false,
 				showFirewallRuleOnError: true
 			};
@@ -574,7 +572,6 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			options = {
 				saveTheConnection: false,
 				showDashboard: false,
-				params: undefined,
 				showConnectionDialogOnError: false,
 				showFirewallRuleOnError: true
 			};

--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -179,7 +179,12 @@ export class AddServerAction extends Action {
 			saveProfile: true,
 			id: element.id!
 		} as Partial<IConnectionProfile>;
-		await this._connectionManagementService.showConnectionDialog(undefined, undefined, connection);
+		await this._connectionManagementService.showConnectionDialog(undefined, {
+			showDashboard: true,
+			saveTheConnection: true,
+			showConnectionDialogOnError: true,
+			showFirewallRuleOnError: true
+		}, connection);
 	}
 }
 

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
@@ -87,7 +87,7 @@ export class OEShimService extends Disposable implements IOEShimService {
 
 	private async connectOrPrompt(connProfile: ConnectionProfile): Promise<ConnectionProfile> {
 		connProfile = await new Promise(async (resolve, reject) => {
-			let result = await this.cm.connect(connProfile, undefined, { showConnectionDialogOnError: true, showFirewallRuleOnError: true, saveTheConnection: false, showDashboard: false, params: undefined }, {
+			let result = await this.cm.connect(connProfile, undefined, { showConnectionDialogOnError: true, showFirewallRuleOnError: true, saveTheConnection: false, showDashboard: false }, {
 				onConnectSuccess: async (e, profile) => {
 					let existingConnection = this.cm.findExistingConnection(profile);
 					connProfile = new ConnectionProfile(this.capabilities, existingConnection);

--- a/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeSelectionHandler.ts
@@ -142,7 +142,6 @@ export class TreeSelectionHandler {
 					doubleClickHandler(selectedNode);
 				} else if (selectedNode instanceof ConnectionProfile) {
 					let options: IConnectionCompletionOptions = {
-						params: undefined,
 						saveTheConnection: true,
 						showConnectionDialogOnError: true,
 						showFirewallRuleOnError: true,

--- a/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
@@ -305,7 +305,6 @@ export class TreeUpdateUtils {
 				return rootNode.children ?? [];
 			} else {
 				const options: IConnectionCompletionOptions = {
-					params: undefined,
 					saveTheConnection: true,
 					showConnectionDialogOnError: true,
 					showFirewallRuleOnError: true,


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/22869

`ShowDashboard` should be not enabled by default for any connection type, as it fails its purpose if connection type is not defined. This PR enables 'showDashboard' where it should be visible, and retains the public API promise to not show dashboard unless specified.