### PR TITLE
Handle no matching account scenario

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -967,15 +967,18 @@ export class ConnectionWidget extends lifecycle.Disposable {
 					if (accountName) {
 						// For backwards compatibility with ADAL, we need to check if the account ID matches with tenant Id or just the account ID
 						// The OR case can be removed once we no longer support ADAL
-						account = this._azureAccountList.find(account => account.key.accountId === this.getModelValue(accountName)
+						account = this._azureAccountList?.find(account => account.key.accountId === this.getModelValue(accountName)
 							|| account.key.accountId.split('.')[0] === this.getModelValue(accountName));
-						this._azureAccountDropdown.selectWithOptionName(account.key.accountId);
-					} else {
+						if (account) {
+							this._azureAccountDropdown.selectWithOptionName(account.key.accountId);
+						}
+					}
+					if (!account) {
 						// If account was not filled in from received configuration, select the first account.
 						this._azureAccountDropdown.select(0);
 						account = this._azureAccountList[0];
 						if (this._azureAccountList.length > 0) {
-							accountName = account.key.accountId;
+							accountName = account?.key?.accountId;
 						} else {
 							this._logService.debug('fillInConnectionInputs: No accounts available');
 						}


### PR DESCRIPTION
Minor change to only select account when found.

Addresses below error in log:

`[renderer1] [error] Unexpected error populating initial Azure Account options : TypeError: Cannot read properties of undefined (reading 'key')`