### PR TITLE
Add launch config for VS Code selfhost test provider

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -279,7 +279,8 @@
 				"${workspaceFolder}/out/**/*.js"
 			],
 			"presentation": {
-				"group": "2_attach"
+				"group": "2_attach",
+				"hidden": true
 			},
 			"resolveSourceMapLocations": [
 				"${workspaceFolder}/out/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -269,6 +269,24 @@
 			}
 		},
 		{
+			/* Added for "VS Code Selfhost Test Provider" extension support */
+			"type": "pwa-chrome",
+			"request": "attach",
+			"name": "Attach to VS Code",
+			"browserAttachLocation": "workspace",
+			"port": 9222,
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"presentation": {
+				"group": "2_attach"
+			},
+			"resolveSourceMapLocations": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"perScriptSourcemaps": "yes"
+		},
+		{
 			"type": "node",
 			"request": "launch",
 			"name": "Run Smoke Tests",


### PR DESCRIPTION
Adds launch configuration "Attach to VS Code" for test run/debug support with "[VS Code Selfhost test provider](https://github.com/microsoft/vscode-selfhost-test-provider)" extension.