### PR TITLE
Fix schema comparison failure for Azure synapse dedicated pool

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -726,7 +726,12 @@ export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.
 	let targetPlatform;
 	if (isCloud) {
 		const engineEdition = serverInfo.engineEditionId;
-		targetPlatform = engineEdition === vscodeMssql.DatabaseEngineEdition.SqlDataWarehouse ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;
+		const azdataApi = getAzdataApi();
+		if (azdataApi) {
+			targetPlatform = engineEdition === azdataApi.DatabaseEngineEdition.SqlDataWarehouse ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;
+		} else {
+			targetPlatform = engineEdition === vscodeMssql.DatabaseEngineEdition.SqlDataWarehouse ? SqlTargetPlatform.sqlDW : SqlTargetPlatform.sqlAzure;
+		}
 	} else {
 		const serverMajorVersion = serverInfo.serverMajorVersion;
 		targetPlatform = serverMajorVersion ? constants.onPremServerVersionToTargetPlatform.get(serverMajorVersion) : undefined;

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -572,7 +572,7 @@ export class UpdateProjectFromDatabaseDialog {
 			projectFilePath: this.projectFileDropdown!.value! as string,
 			extractTarget: mapExtractTargetEnum(<string>this.folderStructureDropDown!.value),
 			targetScripts: [],
-			dataSchemaProvider: '',
+			dataSchemaProvider: this.project!.getProjectTargetVersion(),
 			connectionDetails: connectionDetails,
 			databaseName: '',
 			serverDisplayName: '',


### PR DESCRIPTION
This PR fixes #22923  (and #20363).
Two problems fixed in this PR:
1. In a prior PR (https://github.com/microsoft/azuredatastudio/pull/20607), target platform was getting incorrectly set (just considers the vscode version, and doesn't read the ADS version of the enum values used). Updated assignment in this one.
2. Target platform wasn't getting set in the Schema Compare object that was been sent from Update database from projects codeflow. Because of this, the code was using the default target platform of 160 (Sql Server 2022), hence the comparison failed. Assignment added in this PR.

Tested scenarios:
- Create project from database sets correct target platform for Azure and DW databases.
- Update project from database and Schema comparison workflows complete successfully for Azure Synapse dedicated SQL pool.
- Schema comparison fails when Azure database and DW platform project are compared (expected behavior) [and the other way round].