### PR TITLE
Fix .publish.xml file extension not being used on mac

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -851,7 +851,7 @@ export class PublishDatabaseDialog {
 		saveProfileAsButton.onDidClick(async () => {
 			const filePath = await vscode.window.showSaveDialog(
 				{
-					defaultUri: this.publishProfileUri ?? vscode.Uri.file(path.join(this.project.projectFolderPath, `${this.project.projectFileName}_1`)),
+					defaultUri: this.publishProfileUri ?? vscode.Uri.file(path.join(this.project.projectFolderPath, `${this.project.projectFileName}_1.publish.xml`)),
 					saveLabel: constants.save,
 					filters: {
 						'Publish Settings Files': ['publish.xml'],
@@ -868,6 +868,7 @@ export class PublishDatabaseDialog {
 				const targetDatabaseName = this.targetDatabaseName ?? '';
 				const deploymentOptions = await this.getDeploymentOptions();
 				await this.savePublishProfile(filePath.fsPath, targetDatabaseName, targetConnectionString, this.getSqlCmdVariablesForPublish(), deploymentOptions);
+
 				TelemetryReporter.sendActionEvent(TelemetryViews.SqlProjectPublishDialog, TelemetryActions.profileSaved);
 			}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/azuredatastudio/issues/22931. On windows, the `.publish.xml` file extension is correctly appended to the publish profile file name, but on mac only `.xml` was getting added. The vscode `showSaveDialog` api opens the native save dialog and passes along the options, so it looks like this is a limitation on mac. 

As a fix for this, this adds the `.publish.xml` file extension to the defaultUri and now the correct file extension is used for saving the publish profile on both mac and windows.

### Before:
mac
![image](https://user-images.githubusercontent.com/31145923/235785977-176fce33-4e4f-4052-992b-cffbc62d4168.png)

windows
![image](https://user-images.githubusercontent.com/31145923/235786006-3692f746-2d3e-44e2-9498-bcedd38ba0ff.png)

### After:
mac
![image](https://user-images.githubusercontent.com/31145923/235812733-9ed852de-82bc-43e0-8b9b-eb4fe710a76f.png)

windows
![image](https://user-images.githubusercontent.com/31145923/235812681-9ebfad88-8ed1-4947-b8cb-300b879c9543.png)


