### PR TITLE
fix macros not getting replaced in sql project item scripts

### DIFF
--- a/extensions/sql-database-projects/src/templates/templates.ts
+++ b/extensions/sql-database-projects/src/templates/templates.ts
@@ -65,7 +65,7 @@ export function macroExpansion(template: string, macroDict: Map<string, string>)
 	const macroIndicator = '@@';
 	let output = template;
 
-	for (const macro in macroDict) {
+	for (const macro of macroDict.keys()) {
 		// check if value contains the macroIndicator, which could break expansion for successive macros
 		if (macroDict.get(macro)!.includes(macroIndicator)) {
 			throw new Error(`Macro value ${macroDict.get(macro)} is invalid because it contains ${macroIndicator}`);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/22944. This broke when records were switched to maps in https://github.com/microsoft/azuredatastudio/pull/22758.

before:
![objectName](https://user-images.githubusercontent.com/31145923/235978833-6bc87ca2-eecc-4fd5-a3d8-bd523d57740f.gif)

fixed:
![objectNameFixed](https://user-images.githubusercontent.com/31145923/235984798-e95968d4-3af3-46d9-a23a-18180bf39414.gif)
