### PR TITLE
Remove vs code engine version for whoisactive extension

### DIFF
--- a/samples/sp_whoIsActive/package.json
+++ b/samples/sp_whoIsActive/package.json
@@ -6,7 +6,7 @@
   "publisher": "Microsoft",
   "preview": true,
   "engines": {
-    "vscode": "^1.26.0",
+    "vscode": "*",
     "azdata": "^1.11.0"
   },
   "icon": "images/extension.png",


### PR DESCRIPTION
Since this doesn't match the typings we import the VSCE tool complains when we try to package it up. This engine version isn't actually necessary so just removing it. 