### PR TITLE
remove the rename db context menu

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -510,7 +510,7 @@
         },
         {
           "command": "mssql.renameObject",
-          "when": "connectionProvider == MSSQL && nodeType =~ /^(Database|ServerLevelLogin|User|Table|View|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|Table|View|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
           "group": "0_query@3"
         },
         {
@@ -555,7 +555,7 @@
         },
         {
           "command": "mssql.renameObject",
-          "when": "connectionProvider == MSSQL && nodeType =~ /^(Database|ServerLevelLogin|User|Table|View|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|Table|View|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
           "group": "connection@3"
         },
         {


### PR DESCRIPTION
This PR fixes #22866
I accidentally added rename support for database but missed adding it to STS side, since @corivera has already started working on full feature support (create/update/rename/delete) for database object type, I am going to remove it and let Cory handle it when it is ready.
