### PR TITLE
Fix validation errors in package.json when clause

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -515,7 +515,7 @@
         },
         {
           "command": "mssql.renameObject",
-          "when": "connectionProvider == MSSQL && nodeType == Column && config.workbench.enablePreviewFeatures && nodePath =~ /^.*\/Tables\/.*\/Columns\/.*$",
+          "when": "connectionProvider == MSSQL && nodeType == Column && config.workbench.enablePreviewFeatures && nodePath =~ /^.*\\/Tables\\/.*\\/Columns\\/.*$/",
           "group": "0_query@3"
         },
         {
@@ -560,7 +560,7 @@
         },
         {
           "command": "mssql.renameObject",
-          "when": "connectionProvider == MSSQL && nodeType == Column && config.workbench.enablePreviewFeatures && nodePath =~ /^.*\/Tables\/.*\/Columns\/.*$",
+          "when": "connectionProvider == MSSQL && nodeType == Column && config.workbench.enablePreviewFeatures && nodePath =~ /^.*\\/Tables\\/.*\\/Columns\\/.*$/",
           "group": "connection@3"
         },
         {


### PR DESCRIPTION
Noticed these - and while the errors don't seem to actually matter for some reason the reason they're outlined makes sense (we should be escaping the backslash so that it reduces down to just a single backslash for the regex). And then I'm also closing out the regex properly with a /.

I believe the backslashes work currently because `\/` isn't a valid escape sequence so it just ignores it and leaves it in.

![image](https://user-images.githubusercontent.com/28519865/236343578-53325b72-6b80-4e89-b5eb-2b34fec005ff.png)

Menus after fix:

Table columns:

![image](https://user-images.githubusercontent.com/28519865/236343649-c9acc31d-64d0-44a3-9498-9abecb0ff710.png)

View columns:

![image](https://user-images.githubusercontent.com/28519865/236343711-43c1d4dc-679b-4dd7-a2e0-d44a9f97f163.png)
