### PR TITLE
fix tab style in hc mode

### DIFF
--- a/src/sql/base/browser/ui/panel/panel.component.ts
+++ b/src/sql/base/browser/ui/panel/panel.component.ts
@@ -439,10 +439,18 @@ export class PanelComponent extends Disposable implements IThemable {
 
 			if (styles.selectedTabContrastBorder) {
 				content.push(`
+				.tabbedPanel > .title .tabList .tab-header:focus,
 				.tabbedPanel > .title .tabList .tab-header.selected {
-					outline: 1px solid;
+					outline-width: 1px;
 					outline-offset: -3px;
 					outline-color: ${styles.selectedTabContrastBorder};
+				}
+				.tabbedPanel > .title .tabList .tab-header.selected {
+					outline-style: dashed;
+				}
+				.tabbedPanel > .title .tabList .tab-header:focus,
+				.tabbedPanel > .title .tabList .tab-header.selected:focus {
+					outline-style: solid;
 				}
 			`);
 			}


### PR DESCRIPTION
For #22694 

followed the example of vscode to differentiate the selected vs focused item by using dashed and solid outline style.

VSCode
![vscode](https://user-images.githubusercontent.com/13777222/236373495-37b3e075-280e-4956-bc04-f415ce8a164d.gif)


High Contrast Light
![hc-light-theme](https://user-images.githubusercontent.com/13777222/236373200-fcec3efb-a6d2-4261-a4db-3e7c36cf8ae2.gif)

High Contrast Dark
![hc-dark-theme](https://user-images.githubusercontent.com/13777222/236373202-6cca27f9-c611-431e-9aaa-117a310aaba7.gif)

Dark Theme - No Change
![dark-theme](https://user-images.githubusercontent.com/13777222/236373204-a19305ad-ab8c-42d5-a4ea-b7182109c896.gif)

Light Theme - No Change
![light-theme](https://user-images.githubusercontent.com/13777222/236373207-ba4554a0-1e20-4595-8b94-31cb5a77d9fc.gif)
