### PR TITLE
fix duplicate required indicator

### DIFF
--- a/src/sql/workbench/browser/modal/dialogHelper.ts
+++ b/src/sql/workbench/browser/modal/dialogHelper.ts
@@ -9,8 +9,7 @@ import { append, $ } from 'vs/base/browser/dom';
 import * as types from 'vs/base/common/types';
 import * as azdata from 'azdata';
 import { wrapStringWithNewLine } from 'sql/workbench/common/sqlWorkbenchUtils';
-
-export const requiredIndicatorSpan = 'span.required-indicator';
+import { RequiredIndicatorClassName } from 'sql/base/browser/ui/label/label';
 
 export function appendRow(container: HTMLElement, label: string, labelClass: string, cellContainerClass: string, rowContainerClass?: string | Array<string>, showRequiredIndicator: boolean = false, title?: string, titleMaxWidth?: number): HTMLElement {
 	let rowContainer = append(container, $('tr'));
@@ -31,7 +30,7 @@ export function appendRow(container: HTMLElement, label: string, labelClass: str
 
 	append(labelContainer, $('div')).innerText = label;
 	if (showRequiredIndicator) {
-		appendRequiredIndicator(labelContainer);
+		labelContainer.classList.add(RequiredIndicatorClassName);
 	}
 	let inputCellContainer = append(rowContainer, $(`td.${cellContainerClass}`));
 
@@ -79,14 +78,6 @@ export function getCategoryName(categories: azdata.CategoryValue[], categoryDisp
 		}
 	});
 	return categoryName;
-}
-
-export function appendRequiredIndicator(labelContainer: HTMLElement): HTMLElement {
-	const indicator = append(labelContainer, $(requiredIndicatorSpan));
-	indicator.innerText = '*';
-	indicator.style.color = 'red';
-	indicator.style.marginLeft = '5px';
-	return indicator;
 }
 
 export function getOptionContainerByName(parentContainer: HTMLElement, optionName: string): HTMLElement | undefined {

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -32,6 +32,7 @@ import { GroupHeaderBackground } from 'sql/platform/theme/common/colorRegistry';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfiguration';
 import { AdsWidget } from 'sql/base/browser/ui/adsWidget';
 import { Actions } from 'sql/platform/connection/common/constants';
+import { RequiredIndicatorClassName } from 'sql/base/browser/ui/label/label';
 
 export interface IOptionsDialogOptions extends IModalOptions {
 	cancelLabel?: string;
@@ -246,7 +247,7 @@ export class OptionsDialog extends Modal {
 						let element = DialogHelper.getOptionContainerByName(container, optionAction.optionName) as HTMLElement;
 						// Append required indicator when not present.
 						if (element && element.childElementCount === 1) {
-							DialogHelper.appendRequiredIndicator(element);
+							element.classList.add(RequiredIndicatorClassName);
 						}
 					}
 					// Force selection event if option value is available.
@@ -274,7 +275,7 @@ export class OptionsDialog extends Modal {
 				let element = DialogHelper.getOptionContainerByName(container, optionAction.optionName) as HTMLElement;
 				// Append required indicator when not present.
 				if (element && element.childElementCount === 1) {
-					DialogHelper.appendRequiredIndicator(element);
+					element.classList.add(RequiredIndicatorClassName);
 				}
 			}
 		} else {

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -43,6 +43,7 @@ import { AdsWidget } from 'sql/base/browser/ui/adsWidget';
 import { createCSSRule } from 'vs/base/browser/dom';
 import { AuthLibrary, getAuthLibrary } from 'sql/workbench/services/accountManagement/utils';
 import { adjustForMssqlAppName } from 'sql/platform/connection/common/utils';
+import { RequiredIndicatorClassName } from 'sql/base/browser/ui/label/label';
 
 const ConnectionStringText = localize('connectionWidget.connectionString', "Connection string");
 
@@ -362,7 +363,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 			if (optionAction.required) {
 				let element = DialogHelper.getOptionContainerByName(this._tableContainer, optionAction.optionName);
 				if (element) {
-					DialogHelper.appendRequiredIndicator(element);
+					element.classList.add(RequiredIndicatorClassName);
 				}
 			}
 		} else {


### PR DESCRIPTION
Introduced by this PR https://github.com/microsoft/azuredatastudio/pull/22971, The class name is used in other places, caused duplicate required indicators. I've check and made sure no other places are using the class name.

Before:
![image](https://user-images.githubusercontent.com/13777222/236376407-beacc051-4e09-4d8e-bfc5-9a0c4c646801.png)


After:
![image](https://user-images.githubusercontent.com/13777222/236376228-b5b0ec61-43ff-4432-894c-41964e0c39cf.png)
