### PR TITLE
Update default folder structure option in VSCode

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseQuickpick.ts
@@ -127,7 +127,7 @@ export async function createNewProjectFromDatabaseWithQuickpick(connectionInfo?:
 
 	// 5: Prompt for folder structure
 	const folderStructure = await vscode.window.showQuickPick(
-		[constants.file, constants.flat, constants.objectType, constants.schema, constants.schemaObjectType],
+		[constants.schemaObjectType, constants.file, constants.flat, constants.objectType, constants.schema],
 		{ title: constants.selectFolderStructure, ignoreFocusOut: true, });
 	if (!folderStructure) {
 		// User cancelled


### PR DESCRIPTION
This PR fixes #22995.
The first option in the showQuickPick becomes the default value. So updating the folder structure default by resequencing "Schema/Object Type" to the top.

Before:
![image](https://user-images.githubusercontent.com/57200045/236577302-7224602d-7f30-4e00-83ba-f0e14d4f5de9.png)

After:
![image](https://user-images.githubusercontent.com/57200045/236577130-6ac9eded-30e2-4ca7-9e4a-11d5608c9f18.png)


