### PR TITLE
Reverting changes to actions folder

### DIFF
--- a/build/actions/api/testbed.js
+++ b/build/actions/api/testbed.js
@@ -7,15 +7,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.TestbedIssue = exports.Testbed = void 0;
 class Testbed {
     constructor(config) {
+        var _a, _b, _c, _d, _e;
         this.config = {
-            globalLabels: config?.globalLabels ?? [],
-            configs: config?.configs ?? {},
-            writers: config?.writers ?? [],
-            releasedCommits: config?.releasedCommits ?? [],
-            queryRunner: config?.queryRunner ??
-                async function* () {
-                    yield [];
-                },
+            globalLabels: (_a = config === null || config === void 0 ? void 0 : config.globalLabels) !== null && _a !== void 0 ? _a : [],
+            configs: (_b = config === null || config === void 0 ? void 0 : config.configs) !== null && _b !== void 0 ? _b : {},
+            writers: (_c = config === null || config === void 0 ? void 0 : config.writers) !== null && _c !== void 0 ? _c : [],
+            releasedCommits: (_d = config === null || config === void 0 ? void 0 : config.releasedCommits) !== null && _d !== void 0 ? _d : [],
+            queryRunner: (_e = config === null || config === void 0 ? void 0 : config.queryRunner) !== null && _e !== void 0 ? _e : async function* () {
+                yield [];
+            },
         };
     }
     async *query(query) {
@@ -48,15 +48,16 @@ class Testbed {
 exports.Testbed = Testbed;
 class TestbedIssue extends Testbed {
     constructor(globalConfig, issueConfig) {
+        var _a, _b, _c;
         super(globalConfig);
-        issueConfig = issueConfig ?? {};
-        issueConfig.comments = issueConfig?.comments ?? [];
-        issueConfig.labels = issueConfig?.labels ?? [];
+        issueConfig = issueConfig !== null && issueConfig !== void 0 ? issueConfig : {};
+        issueConfig.comments = (_a = issueConfig === null || issueConfig === void 0 ? void 0 : issueConfig.comments) !== null && _a !== void 0 ? _a : [];
+        issueConfig.labels = (_b = issueConfig === null || issueConfig === void 0 ? void 0 : issueConfig.labels) !== null && _b !== void 0 ? _b : [];
         issueConfig.issue = {
             author: { name: 'JacksonKearl' },
             body: 'issue body',
             locked: false,
-            numComments: issueConfig?.comments?.length || 0,
+            numComments: ((_c = issueConfig === null || issueConfig === void 0 ? void 0 : issueConfig.comments) === null || _c === void 0 ? void 0 : _c.length) || 0,
             number: 1,
             open: true,
             title: 'issue title',
@@ -90,7 +91,7 @@ class TestbedIssue extends Testbed {
     }
     async postComment(body, author) {
         this.issueConfig.comments.push({
-            author: { name: author ?? 'bot' },
+            author: { name: author !== null && author !== void 0 ? author : 'bot' },
             body,
             id: Math.random(),
             timestamp: +new Date(),

--- a/build/actions/auto-labeler/index.js
+++ b/build/actions/auto-labeler/index.js
@@ -8,15 +8,15 @@ const core = require("@actions/core");
 const github_1 = require("@actions/github");
 const octokit_1 = require("../api/octokit");
 const utils_1 = require("../utils/utils");
-const token = (0, utils_1.getRequiredInput)('token');
-const label = (0, utils_1.getRequiredInput)('label');
+const token = utils_1.getRequiredInput('token');
+const label = utils_1.getRequiredInput('label');
 async function main() {
     const pr = new octokit_1.OctoKitIssue(token, github_1.context.repo, { number: github_1.context.issue.number });
     pr.addLabel(label);
 }
 main()
-    .then(() => (0, utils_1.logRateLimit)(token))
+    .then(() => utils_1.logRateLimit(token))
     .catch(async (error) => {
     core.setFailed(error.message);
-    await (0, utils_1.logErrorToIssue)(error.message, true, token);
+    await utils_1.logErrorToIssue(error.message, true, token);
 });

--- a/build/actions/utils/utils.js
+++ b/build/actions/utils/utils.js
@@ -9,11 +9,9 @@ const core = require("@actions/core");
 const github_1 = require("@actions/github");
 const axios_1 = require("axios");
 const octokit_1 = require("../api/octokit");
-const getInput = (name) => core.getInput(name) || undefined;
-exports.getInput = getInput;
-const getRequiredInput = (name) => core.getInput(name, { required: true });
-exports.getRequiredInput = getRequiredInput;
-const normalizeIssue = (issue) => {
+exports.getInput = (name) => core.getInput(name) || undefined;
+exports.getRequiredInput = (name) => core.getInput(name, { required: true });
+exports.normalizeIssue = (issue) => {
     const { body, title } = issue;
     const isBug = body.includes('bug_report_template') || /Issue Type:.*Bug.*/.test(body);
     const isFeatureRequest = body.includes('feature_request_template') || /Issue Type:.*Feature Request.*/.test(body);
@@ -36,25 +34,20 @@ const normalizeIssue = (issue) => {
         issueType: isBug ? 'bug' : isFeatureRequest ? 'feature_request' : 'unknown',
     };
 };
-exports.normalizeIssue = normalizeIssue;
-const loadLatestRelease = async (quality) => (await axios_1.default.get(`https://vscode-update.azurewebsites.net/api/update/darwin/${quality}/latest`)).data;
-exports.loadLatestRelease = loadLatestRelease;
-const daysAgoToTimestamp = (days) => +new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-exports.daysAgoToTimestamp = daysAgoToTimestamp;
-const daysAgoToHumanReadbleDate = (days) => new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().replace(/\.\d{3}\w$/, '');
-exports.daysAgoToHumanReadbleDate = daysAgoToHumanReadbleDate;
-const logRateLimit = async (token) => {
+exports.loadLatestRelease = async (quality) => (await axios_1.default.get(`https://vscode-update.azurewebsites.net/api/update/darwin/${quality}/latest`)).data;
+exports.daysAgoToTimestamp = (days) => +new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+exports.daysAgoToHumanReadbleDate = (days) => new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().replace(/\.\d{3}\w$/, '');
+exports.logRateLimit = async (token) => {
     const usageData = (await new github_1.GitHub(token).rateLimit.get()).data.resources;
     ['core', 'graphql', 'search'].forEach(async (category) => {
         const usage = 1 - usageData[category].remaining / usageData[category].limit;
         const message = `Usage at ${usage} for ${category}`;
         if (usage > 0.5) {
-            await (0, exports.logErrorToIssue)(message, false, token);
+            await exports.logErrorToIssue(message, false, token);
         }
     });
 };
-exports.logRateLimit = logRateLimit;
-const logErrorToIssue = async (message, ping, token) => {
+exports.logErrorToIssue = async (message, ping, token) => {
     // Attempt to wait out abuse detection timeout if present
     await new Promise((resolve) => setTimeout(resolve, 10000));
     const dest = github_1.context.repo.repo === 'vscode-internalbacklog'
@@ -75,4 +68,3 @@ ${JSON.stringify(github_1.context, null, 2).replace(/<!--/gu, '<@--').replace(/-
 -->
 `);
 };
-exports.logErrorToIssue = logErrorToIssue;


### PR DESCRIPTION
It seems port labeler runs on 'main' branch (affecting multiple port PRs), I'm rebuilding actions folder from it's root to resolve errors, as compiling from build\ leads to different output. Need to investigate later why compilation results in different output for both folders.

Opened issue #23050 to track improvements to build\actions code.