### PR TITLE
fix warning in console when drag and dropping in sql projects

### DIFF
--- a/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
+++ b/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
@@ -16,8 +16,8 @@ import Logger from './logger';
  * Tree data provider for the workspace main view
  */
 export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<WorkspaceTreeItem>, vscode.TreeDragAndDropController<WorkspaceTreeItem> {
-	dropMimeTypes = ['application/vnd.code.tree.WorkspaceTreeDataProvider'];
-	dragMimeTypes = []; // The recommended mime type of the tree (`application/vnd.code.tree.WorkspaceTreeDataProvider`) is automatically added.
+	dropMimeTypes = ['application/vnd.code.tree.workspacetreedataprovider'];
+	dragMimeTypes = ['application/vnd.code.tree.workspacetreedataprovider'];
 
 	constructor(private _workspaceService: IWorkspaceService) {
 		this._workspaceService.onDidWorkspaceProjectsChange(() => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/azuredatastudio/issues/22989. I didn't add `application/vnd.code.tree.workspacetreedataprovider` to the `dragMimeTypes` originally because the doc comments say it's automatically added and it was working as expected, but adding it now since it's causing a warning in the console. 
https://github.com/microsoft/azuredatastudio/blob/e7d3d047ec5ac8bdade3d40ea5ab0b0a085c1f1a/src/vscode-dts/vscode.d.ts#L10223-L10229