### PR TITLE
fix the filter plugin menu size and location issue

### DIFF
--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -101,7 +101,8 @@
 	padding: 4px;
 	z-index: 100000;
 	cursor: default;
-	display: inline-block;
+	display: flex;
+	flex-direction: column;
 	margin: 0;
 	position: absolute;
 }
@@ -118,10 +119,14 @@
 	background: none repeat scroll 0 0 #000000;
 }
 
+.slick-header-menu-image-button-container {
+	flex: 0 0 auto;
+}
+
 .slick-header-menu a.monaco-button.monaco-text-button {
 	width: 60px;
-	margin: 6px 6px 6px 6px;
-	padding: 4px;
+	margin: 5px;
+	padding: 2px;
 }
 
 .slick-header-menu .searchbox-row
@@ -130,6 +135,7 @@
 	align-items: center;
 	padding-left: 5px;
 	margin-top: 5px;
+	flex: 0 0 auto;
 }
 
 .slick-header-menu .searchbox-row .select-all-checkbox
@@ -168,7 +174,6 @@
 {
 	border: 1px solid #BFBDBD;
 	font-size: 8pt;
-	height: 250px;
 	margin-top: 6px;
 	overflow: hidden;
 	padding: 1px;
@@ -176,6 +181,7 @@
 	align-content: flex-start;
 	display: flex;
 	flex-direction: column;
+	flex: 1 1 auto;
 }
 
 .slick-header-menu .filter .filter-option {
@@ -188,6 +194,7 @@
 	display: flex;
 	flex-direction: row;
 	width: 100%;
+	flex: 0 0 auto;
 }
 
 .slick-header-menu .filter-menu-button {


### PR DESCRIPTION
For #22655 
Updated the code to make sure the menu can fit on the screen.


Scenario: Small window size
Before
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/f8007858-66a7-4fa8-833c-8d81ec12ca41)

After:
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/f113940c-455e-4e73-afbb-60ebc509d24d)


Scenario: Normal window size
Before
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/589f9ca4-1f18-43fb-96db-fae92204953a)

After:
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/db82a2ae-45ee-4546-9a00-7231855c8f65)
