### PR TITLE
Fixing OE disconnecting connections when other types of connections are disconnected

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -226,10 +226,10 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 		}));
 
 		this._register(this._connectionManagementService.onDisconnect(async (connectionParams) => {
-			if (this._tree instanceof AsyncServerTree) {
-				await this.disconnectConnection(<ConnectionProfile>connectionParams.connectionProfile);
-			} else {
-				if (this.isObjectExplorerConnectionUri(connectionParams.connectionUri)) {
+			if (this.isObjectExplorerConnectionUri(connectionParams.connectionUri)) {
+				if (this._tree instanceof AsyncServerTree) {
+					await this.disconnectConnection(<ConnectionProfile>connectionParams.connectionProfile);
+				} else {
 					this.deleteObjectExplorerNodeAndRefreshTree(connectionParams.connectionProfile).catch(errors.onUnexpectedError);
 				}
 			}


### PR DESCRIPTION
Adding back the check to async server tree that ignores disconnections from other areas of ads. 

This PR fixes #22686, fixes #22709, fixes #23074