### PR TITLE
Adding telemetry to ads OE filter

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1798,6 +1798,10 @@ declare module 'azdata' {
 
 	export interface NodeFilterProperty {
 		/**
+		 * The name of the filter property
+		 */
+		name: string;
+		/**
 		 * The name of the filter property displayed to the user
 		 */
 		displayName: string;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1798,7 +1798,7 @@ declare module 'azdata' {
 
 	export interface NodeFilterProperty {
 		/**
-		 * The name of the filter property
+		 * The non-localized name of the filter property
 		 */
 		name: string;
 		/**

--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -50,7 +50,8 @@ export const enum TelemetryView {
 	ResultsPanel = 'ResultsPanel',
 	Shell = 'Shell',
 	SqlAssessment = 'SqlAssessment',
-	TableDesigner = 'TableDesigner'
+	TableDesigner = 'TableDesigner',
+	ObjectExplorer = 'ObjectExplorer'
 }
 
 export const enum TelemetryError {
@@ -98,6 +99,8 @@ export const enum TelemetryAction {
 	MoveServerGroup = 'MoveServerGroup',
 	NewQuery = 'NewQuery',
 	ObjectExplorerExpand = 'ObjectExplorerExpand',
+	ObjectExplorerFilter = 'ObjectExplorerFilter',
+	ObjectExplorerRemoveFilter = 'ObjectExplorerRemoveFilter',
 	Open = 'Open',
 	OpenQuery = 'OpenQuery',
 	OpenExecutionPlanProperties = 'OpenExecutionPlanProperties',

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -625,7 +625,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 
 					this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.ObjectExplorer, TelemetryKeys.TelemetryAction.ObjectExplorerFilter)
 						.withAdditionalProperties({
-							filterPropertyNames: JSON.stringify(filters.map(f => node.filterProperties.find(p => f.displayName === p.displayName).name)),
+							filterPropertyNames: JSON.stringify(filters.map(f => node.filterProperties.find(p => f.displayName === p.displayName)?.name)),
 							filterCount: filters.length,
 							objectType: node.objectType
 						}).send();

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -627,7 +627,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 						.withAdditionalProperties({
 							filterPropertyNames: JSON.stringify(filters.map(f => f.displayName)),
 							filterCount: filters.length,
-							nodeName: node.objectType
+							objectType: node.objectType
 						}).send();
 				}
 				return;

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -625,7 +625,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 
 					this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.ObjectExplorer, TelemetryKeys.TelemetryAction.ObjectExplorerFilter)
 						.withAdditionalProperties({
-							properties: JSON.stringify(filters.map(f => f.displayName)),
+							filterPropertyNames: JSON.stringify(filters.map(f => f.displayName)),
 							filterCount: filters.length,
 							nodeName: node.objectType
 						}).send();

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -625,7 +625,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 
 					this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.ObjectExplorer, TelemetryKeys.TelemetryAction.ObjectExplorerFilter)
 						.withAdditionalProperties({
-							filterPropertyNames: JSON.stringify(filters.map(f => f.displayName)),
+							filterPropertyNames: JSON.stringify(filters.map(f => node.filterProperties.find(p => f.displayName === p.displayName).name)),
 							filterCount: filters.length,
 							objectType: node.objectType
 						}).send();

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -48,6 +48,8 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { USE_ASYNC_SERVER_TREE_CONFIG } from 'sql/workbench/contrib/objectExplorer/common/serverGroup.contribution';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { FilterDialog } from 'sql/workbench/services/objectExplorer/browser/filterDialog/filterDialog';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 
 export const CONTEXT_SERVER_TREE_VIEW = new RawContextKey<ServerTreeViewView>('serverTreeView.view', ServerTreeViewView.all);
 export const CONTEXT_SERVER_TREE_HAS_CONNECTIONS = new RawContextKey<boolean>('serverTreeView.hasConnections', false);
@@ -79,7 +81,8 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 		@IKeybindingService private _keybindingService: IKeybindingService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IHostService private _hostService: IHostService,
-		@INotificationService private _notificationService: INotificationService
+		@INotificationService private _notificationService: INotificationService,
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		super();
 		this._hasConnectionsKey = CONTEXT_SERVER_TREE_HAS_CONNECTIONS.bindTo(contextKeyService);
@@ -619,6 +622,13 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 					if (errorListener) {
 						errorListener.dispose();
 					}
+
+					this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.ObjectExplorer, TelemetryKeys.TelemetryAction.ObjectExplorerFilter)
+						.withAdditionalProperties({
+							properties: JSON.stringify(filters.map(f => f.displayName)),
+							filterCount: filters.length,
+							nodeName: node.objectType
+						}).send();
 				}
 				return;
 			},

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
@@ -39,7 +39,7 @@ suite('ServerTreeView onAddConnectionProfile handler tests', () => {
 		);
 		mockConnectionManagementService.setup(x => x.getConnectionGroups()).returns(x => []);
 		mockConnectionManagementService.setup(x => x.hasRegisteredServers()).returns(() => true);
-		serverTreeView = new ServerTreeView(mockConnectionManagementService.object, instantiationService, undefined, new TestThemeService(), undefined, new TestConfigurationService(), capabilitiesService, undefined, undefined, new MockContextKeyService(), undefined, undefined);
+		serverTreeView = new ServerTreeView(mockConnectionManagementService.object, instantiationService, undefined, new TestThemeService(), undefined, new TestConfigurationService(), capabilitiesService, undefined, undefined, new MockContextKeyService(), undefined, undefined, undefined);
 		mockTree = TypeMoq.Mock.ofType<ITree>(TestTree);
 		(serverTreeView as any)._tree = mockTree.object;
 		mockRefreshTreeMethod = TypeMoq.Mock.ofType(Function);

--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -365,6 +365,11 @@ export class RemoveFilterAction extends Action {
 			await this._tree.refresh(nodeToRefresh);
 			await this._tree.expand(nodeToRefresh);
 		}
-		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.ObjectExplorer, TelemetryKeys.TelemetryAction.ObjectExplorerRemoveFilter)
+		this._telemetryService.createActionEvent(
+			TelemetryKeys.TelemetryView.ObjectExplorer,
+			TelemetryKeys.TelemetryAction.ObjectExplorerRemoveFilter
+		).withAdditionalProperties({
+			objectType: node.objectType
+		}).send();
 	}
 }

--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -21,6 +21,8 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { AsyncServerTree, ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
 import { SqlIconId } from 'sql/base/common/codicons';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 
 export interface IServerView {
 	showFilteredTree(filter: string): void;
@@ -338,7 +340,8 @@ export class RemoveFilterAction extends Action {
 		private _node: TreeNode,
 		private _tree: AsyncServerTree | ITree,
 		private _profile: ConnectionProfile | undefined,
-		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService
+		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService,
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		super(id, label);
 	}
@@ -362,5 +365,6 @@ export class RemoveFilterAction extends Action {
 			await this._tree.refresh(nodeToRefresh);
 			await this._tree.expand(nodeToRefresh);
 		}
+		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.ObjectExplorer, TelemetryKeys.TelemetryAction.ObjectExplorerRemoveFilter)
 	}
 }


### PR DESCRIPTION
Adding telemetry to ads oe filtering

Sample event:
```js
{
  filterCount: 2
  filterPropertyNames: "[\"Name\",\"Create Date\"]"
  objectType: "Databases"
}
```