### PR TITLE
fix sqlcmd variables not getting loaded correctly in vscode

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -159,9 +159,7 @@ export async function getPublishDatabaseSettings(project: ISqlProject, promptFor
 	}
 
 	// 4. Modify sqlcmd vars
-	// If a publish profile is provided then the values from there will overwrite the ones in the
-	// project file (if they exist)
-	let sqlCmdVariables = Object.assign({}, project.sqlCmdVariables, publishProfile?.sqlCmdVariables);
+	let sqlCmdVariables: Map<string, string> = getInitialSqlCmdVariables(project, publishProfile);
 
 	if (sqlCmdVariables.size > 0) {
 		// Continually loop here, allowing the user to modify SQLCMD variables one
@@ -170,13 +168,14 @@ export async function getPublishDatabaseSettings(project: ISqlProject, promptFor
 		// as many times as they wish - with an option to reset all the variables
 		// to their starting values being provided as well.
 		while (true) {
-			const quickPickItems = Object.keys(sqlCmdVariables).map(key => {
-				return {
+			let quickPickItems = [];
+			for (const key of sqlCmdVariables.keys()) {
+				quickPickItems.push({
 					label: key,
 					description: sqlCmdVariables.get(key),
 					key: key
-				} as vscode.QuickPickItem & { key?: string, isResetAllVars?: boolean, isDone?: boolean };
-			});
+				} as vscode.QuickPickItem & { key?: string, isResetAllVars?: boolean, isDone?: boolean })
+			}
 			quickPickItems.push({ label: `$(refresh) ${constants.resetAllVars}`, isResetAllVars: true });
 			quickPickItems.unshift({ label: `$(check) ${constants.done}`, isDone: true });
 			const sqlCmd = await vscode.window.showQuickPick(
@@ -200,7 +199,7 @@ export async function getPublishDatabaseSettings(project: ISqlProject, promptFor
 					sqlCmdVariables.set(sqlCmd.key, newValue);
 				}
 			} else if (sqlCmd.isResetAllVars) {
-				sqlCmdVariables = Object.assign({}, project.sqlCmdVariables, publishProfile?.sqlCmdVariables);
+				sqlCmdVariables = getInitialSqlCmdVariables(project, publishProfile);
 			} else if (sqlCmd.isDone) {
 				break;
 			}
@@ -218,6 +217,24 @@ export async function getPublishDatabaseSettings(project: ISqlProject, promptFor
 		profileUsed: !!publishProfile
 	};
 	return settings;
+}
+
+/**
+ * Loads the sqlcmd variables from a sql projects. If a publish profile is provided then the values from there will overwrite the ones in the project file (if they exist)
+ * @param project
+ * @param publishProfile
+ * @returns Map of sqlcmd variables
+ */
+function getInitialSqlCmdVariables(project: ISqlProject, publishProfile?: PublishProfile): Map<string, string> {
+	// create a copy of the sqlcmd variable map so that the original ones don't get overwritten
+	let sqlCmdVariables = new Map(project.sqlCmdVariables);
+	if (publishProfile?.sqlCmdVariables) {
+		for (const [key, value] of publishProfile.sqlCmdVariables) {
+			sqlCmdVariables.set(key, value);
+		}
+	}
+
+	return sqlCmdVariables;
 }
 
 export async function launchPublishTargetOption(project: Project): Promise<constants.PublishTargetType | undefined> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This addresses https://github.com/microsoft/vscode-mssql/issues/17682. This was caused by the Record to Map swap in https://github.com/microsoft/azuredatastudio/pull/22758. 

https://github.com/microsoft/vscode-mssql/pull/17683 was only part of the fix, but these other changes had to be made for this to functionally work as expected. Generate script was failing with the error `object is not iterable (cannot read property Symbol(Symbol.iterator))` when trying to convert the sqlcmd variables [here](https://github.com/microsoft/vscode-mssql/blob/0c2b2ed75710e326bdf0d9356f78f12b0308b1e8/src/services/dacFxService.ts#L114) because the quickpick wasn't passing it the object it expected.

before (generate script broken):
![vscodeGenerateScriptBroken](https://github.com/microsoft/azuredatastudio/assets/31145923/54fdf53f-baf8-4624-8be0-abd84b1fd854)

Project w/sqlcmd variables:
![sqlcmdVarVscode](https://github.com/microsoft/azuredatastudio/assets/31145923/5abbd1f1-4d59-4795-8ad7-49d9ba6f6582)


Project w/o sqlcmd variables:
![vscodeGenerateScript](https://github.com/microsoft/azuredatastudio/assets/31145923/f420f93b-163e-4e4c-a925-21701dc627a1)
