### PR TITLE
Support advanced options in command line arguments

### DIFF
--- a/src/sql/platform/capabilities/test/common/testCapabilitiesService.ts
+++ b/src/sql/platform/capabilities/test/common/testCapabilitiesService.ts
@@ -97,10 +97,24 @@ export class TestCapabilitiesService implements ICapabilitiesService {
 				valueType: ServiceOptionType.string
 			}
 		];
+		let mssqlAdvancedOptions: azdata.ConnectionOption[] = [
+			{
+				name: 'trustServerCertificate',
+				displayName: undefined!,
+				description: undefined!,
+				groupName: undefined!,
+				categoryValues: undefined!,
+				defaultValue: 'false',
+				isIdentity: false,
+				isRequired: false,
+				specialValueType: undefined!,
+				valueType: ServiceOptionType.boolean
+			}
+		];
 		let msSQLCapabilities = {
 			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
-			connectionOptions: connectionProvider,
+			connectionOptions: connectionProvider.concat(mssqlAdvancedOptions),
 		};
 		let pgSQLCapabilities = {
 			providerId: this.pgsqlProviderName,

--- a/src/sql/platform/connection/common/providerConnectionInfo.ts
+++ b/src/sql/platform/connection/common/providerConnectionInfo.ts
@@ -202,6 +202,27 @@ export class ProviderConnectionInfo implements azdata.ConnectionInfo {
 	 * Example: "providerName:MSSQL|authenticationType:|databaseName:database|serverName:server3|userName:user|group:testid"
 	 */
 	public getOptionsKey(): string {
+		let idNames = this.getOptionKeyIdNames();
+		idNames = idNames.filter(x => x !== undefined);
+
+		//Sort to make sure using names in the same order every time otherwise the ids would be different
+		idNames.sort();
+
+		let idValues: string[] = [];
+		for (let index = 0; index < idNames.length; index++) {
+			let value = this.options[idNames[index]!];
+			value = value ? value : '';
+			idValues.push(`${idNames[index]}${ProviderConnectionInfo.nameValueSeparator}${value}`);
+		}
+
+		return ProviderConnectionInfo.ProviderPropertyName + ProviderConnectionInfo.nameValueSeparator +
+			this.providerName + ProviderConnectionInfo.idSeparator + idValues.join(ProviderConnectionInfo.idSeparator);
+	}
+
+	/**
+	 * @returns Array of option key names
+	 */
+	public getOptionKeyIdNames(): string[] {
 		let idNames = [];
 		if (this.serverCapabilities) {
 			idNames = this.serverCapabilities.connectionOptions.map(o => {
@@ -217,21 +238,7 @@ export class ProviderConnectionInfo implements azdata.ConnectionInfo {
 			// This should never happen but just incase the serverCapabilities was not ready at this time
 			idNames = ['authenticationType', 'database', 'server', 'user'];
 		}
-
-		idNames = idNames.filter(x => x !== undefined);
-
-		//Sort to make sure using names in the same order every time otherwise the ids would be different
-		idNames.sort();
-
-		let idValues: string[] = [];
-		for (let index = 0; index < idNames.length; index++) {
-			let value = this.options[idNames[index]!];
-			value = value ? value : '';
-			idValues.push(`${idNames[index]}${ProviderConnectionInfo.nameValueSeparator}${value}`);
-		}
-
-		return ProviderConnectionInfo.ProviderPropertyName + ProviderConnectionInfo.nameValueSeparator +
-			this.providerName + ProviderConnectionInfo.idSeparator + idValues.join(ProviderConnectionInfo.idSeparator);
+		return idNames;
 	}
 
 	public static getProviderFromOptionsKey(optionsKey: string) {

--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -85,7 +85,7 @@ export interface SqlArgs {
 	 *  Supports providing advanced connection properties that providers support.
 	 *  Value must be a json object containing key-value pairs in format: '{"key1":"value1","key2":"value2",...}'
 	 */
-	properties?: string;
+	connectionProperties?: string;
 }
 
 //#region decorators
@@ -369,7 +369,7 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 		profile.setOptionValue('databaseDisplayName', profile.databaseName);
 		profile.setOptionValue('groupId', profile.groupId);
 		// Set all advanced options
-		let advancedOptions = this.getAdvancedOptions(args.properties, profile.getOptionKeyIdNames());
+		let advancedOptions = this.getAdvancedOptions(args.connectionProperties, profile.getOptionKeyIdNames());
 		advancedOptions.forEach((v, k) => {
 			profile.setOptionValue(k, v);
 		});
@@ -387,7 +387,7 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 					}
 				});
 			} catch (e) {
-				throw new Error(localize('commandline.propertiesFormatError', 'Advanced connection properties could be parsed as JSON. Received properties value: {0}', options));
+				throw new Error(localize('commandline.propertiesFormatError', 'Advanced connection properties could not be parsed as JSON, error occurred: {0} Received properties value: {1}', e, options));
 			}
 		}
 		return advancedOptionsMap;

--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -381,6 +381,8 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 		let advancedOptionsMap = new Map<string, string>();
 		if (options) {
 			try {
+				// Decode options if they contain any encoded URL characters
+				options = decodeURI(options);
 				JSON.parse(options, (k, v) => {
 					if (!(k in ignoredProperties)) {
 						advancedOptionsMap.set(k, v);

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -96,6 +96,7 @@ class TestParsedArgs implements NativeParsedArgs, SqlArgs {
 	waitMarkerFilePath?: string;
 	authenticationType?: string;
 	applicationName?: string;
+	properties?: string;
 }
 suite('commandLineService tests', () => {
 
@@ -229,8 +230,8 @@ suite('commandLineService tests', () => {
 		args.user = 'myuser';
 		args.authenticationType = Constants.AuthenticationType.SqlLogin;
 		args.applicationName = 'myapplication';
-		// Pass advanced option
-		args.options = `{"trustServerCertificate":"true"}`;
+		// Pass advanced connection properties
+		args.properties = `{"trustServerCertificate":"true"}`;
 
 		connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -96,7 +96,7 @@ class TestParsedArgs implements NativeParsedArgs, SqlArgs {
 	waitMarkerFilePath?: string;
 	authenticationType?: string;
 	applicationName?: string;
-	properties?: string;
+	connectionProperties?: string;
 }
 suite('commandLineService tests', () => {
 
@@ -231,7 +231,7 @@ suite('commandLineService tests', () => {
 		args.authenticationType = Constants.AuthenticationType.SqlLogin;
 		args.applicationName = 'myapplication';
 		// Pass advanced connection properties
-		args.properties = `{"trustServerCertificate":"true"}`;
+		args.connectionProperties = `{"trustServerCertificate":"true"}`;
 
 		connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());


### PR DESCRIPTION
Addresses #23081 
This came as an internal request from Cosmos DB team.

With this PR, Command Line Arguments will support passing advanced connection properties in JSON format: `{"key1":"value1","key2":"value2",...}` pairs to be able to pass these to respective provider.

e.g. `azuredatastudio://connect?server=*****&user=*****&authenticationType=*****&connectionProperties={"key1":"value1"}`
or `azuredatastudio --server localhost --provider mssql --user sa --connectionProperties '{"key1":"value1"}'`

cc @languy @sevoku 