### PR TITLE
Update workbench file and fix relative link not working in markdown

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -16,7 +16,8 @@
     "Programming Languages"
   ],
   "enabledApiProposals": [
-    "documentPaste"
+    "documentPaste",
+    "notebookEditor"
   ],
   "activationEvents": [
     "onLanguage:markdown",

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -27,7 +27,7 @@ export class LinkHandlerDirective {
 		@Inject(INotebookService) private readonly notebookService: INotebookService,
 		@Inject(IFileService) private readonly fileService: IFileService
 	) {
-		this.workbenchFilePath = URI.parse(require.toUrl('vs/code/electron-browser/workbench/workbench.html'));
+		this.workbenchFilePath = URI.parse(require.toUrl('vs/code/electron-sandbox/workbench/workbench.html'));
 	}
 
 	@HostListener('click', ['$event'])


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/23100

The workbench file path was changed from electron-browser to electron-sandbox. Also, I noticed that some of the markdown links in preview mode were not working properly and saw these errors in console:
<img width="417" alt="image" src="https://github.com/microsoft/azuredatastudio/assets/34872381/6781590a-4bcc-47f3-b66a-63f0e48a64ed">
Adding the notebookEditor fixed the issue.


