### PR TITLE
[SQL Migration] Release v1.4.5 to Insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.4",
-							"lastUpdated": "04/19/2023",
+							"version": "1.4.5",
+							"lastUpdated": "05/12/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.4.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.5.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the insiders extension gallery to the latest version 1.4.5 of the SQL Migration extension.  sql-migration-1.4.5.vsix

Link to Azure Data Studio - Product Build (nightly) pipeline run off main 

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=199880&view=artifacts&pathAsName=false&type=publishedArtifacts
-> sql-migration-1.4.5.vsix