### PR TITLE
Remove skipped license checks in validate galleries check

### DIFF
--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -335,9 +335,6 @@ const extensionsToSkipLicenseHeaderCheck = [
     'azuredatastudio-select-top-n',
     'schema-visualization',
     'plan-explorer',
-    // TODO: These should have licenses, following up with team
-    'azuredatastudio-oracle',
-    'net-6-runtime'
 ];
 
 /**


### PR DESCRIPTION
These have been updated with the new content so no longer need to be skipped