### PR TITLE
Validating connectionProfile for missing server before attempting to connect

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseQuickpick.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as constants from '../common/constants';
-import { exists, getVscodeMssqlApi, isValidBasenameErrorMessage, sanitizeStringForFilename } from '../common/utils';
+import { exists, getVscodeMssqlApi, isValidBasenameErrorMessage, sanitizeStringForFilename, getErrorMessage } from '../common/utils';
 import { IConnectionInfo } from 'vscode-mssql';
 import { defaultProjectNameFromDb, defaultProjectSaveLocation } from '../tools/newProjectTool';
 import { ImportDataModel } from '../models/api/import';
@@ -40,10 +40,10 @@ export async function createNewProjectFromDatabaseWithQuickpick(connectionInfo?:
 				connectionUri = await vscodeMssqlApi.connect(connectionProfile);
 				dbs = (await vscodeMssqlApi.listDatabases(connectionUri))
 					.filter(db => !constants.systemDbs.includes(db)); // Filter out system dbs
-			} catch {
-				// The mssql extension handles showing the error to the user.
+			} catch (err) {
 				// Prompt the user for a new connection and then go and try getting the DBs again
 				isValidProfile = false;
+				console.error(getErrorMessage(err));
 			}
 		} else {
 			connectionProfile = await vscodeMssqlApi.promptForConnection(true);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23057

https://github.com/microsoft/vscode-mssql/pull/17676 already fixed the error showing up in the console, but that should be preempted by the sqlproj extension before it calls into the mssql.