### PR TITLE
Cleanup mssql dialog base

### DIFF
--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -78,7 +78,7 @@ export abstract class DialogBase<DialogResult> {
 		try {
 			this.onLoadingStatusChanged(true);
 			const initializeDialogPromise = new Promise<void>((async resolve => {
-				await this.dialogObject.registerContent(async view => {
+				this.dialogObject.registerContent(async view => {
 					this._modelView = view;
 					this._formContainer = this.createFormContainer([]);
 					this._loadingComponent = view.modelBuilder.loadingComponent().withItem(this._formContainer).withProps({
@@ -236,7 +236,7 @@ export abstract class DialogBase<DialogResult> {
 		return table;
 	}
 
-	protected addButtonsForTable(table: azdata.TableComponent, addButtonAriaLabel: string, removeButtonAriaLabel: string, addHandler: () => Promise<void>, removeHandler: () => void): azdata.FlexContainer {
+	protected addButtonsForTable(table: azdata.TableComponent, addButtonAriaLabel: string, removeButtonAriaLabel: string, addHandler: () => Promise<void>, removeHandler: () => Promise<void>): azdata.FlexContainer {
 		let addButton: azdata.ButtonComponent;
 		let removeButton: azdata.ButtonComponent;
 		const updateButtons = () => {


### PR DESCRIPTION
Noticed a few small things while working on some other stuff: 

1. Unnecessary await on registerContent
2. removeHandler wasn't defined as returning a Promise but was having await called on it. It makes sense for it to return a Promise for callers to implement async handlers so just fixing the parameter typing