### PR TITLE
Fix backup/restore dialog titles not updating

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -661,7 +661,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	/**
 	 * Set the title of the modal
 	 */
-	protected set title(title: string) {
+	public set title(title: string) {
 		this._title = title;
 		if (this._modalTitle) {
 			this._modalTitle.innerText = title;
@@ -671,7 +671,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		}
 	}
 
-	protected get title(): string {
+	public get title(): string {
 		return this._title;
 	}
 

--- a/src/sql/workbench/contrib/backup/browser/backupUiService.ts
+++ b/src/sql/workbench/contrib/backup/browser/backupUiService.ts
@@ -77,8 +77,9 @@ export class BackupUiService implements IBackupUiService {
 			backupDialog.render();
 			this._backupDialogs[this._currentProvider] = backupDialog;
 		} else if (backupOptions) {
-			// Update the title for non-MSSQL backups each time so they show the correct database name
-			(backupDialog as OptionsDialog).title = backupDialogTitle;
+			// Update the title for non-MSSQL restores each time so they show the correct database name since those
+			// use just a basic OptionsDialog which doesn't get updated on every open
+			backupDialog.title = backupDialogTitle;
 		}
 
 		let uri = this._connectionManagementService.getConnectionUri(connection)

--- a/src/sql/workbench/contrib/backup/browser/backupUiService.ts
+++ b/src/sql/workbench/contrib/backup/browser/backupUiService.ts
@@ -17,6 +17,7 @@ import { BackupDialog } from 'sql/workbench/contrib/backup/browser/backupDialog'
 import { OptionsDialog } from 'sql/workbench/browser/modal/optionsDialog';
 import { IBackupService, TaskExecutionMode } from 'sql/platform/backup/common/backupService';
 import { IBackupUiService } from 'sql/workbench/contrib/backup/common/backupUiService';
+import { localize } from 'vs/nls';
 
 export class BackupUiService implements IBackupUiService {
 	public _serviceBrand: undefined;
@@ -62,11 +63,12 @@ export class BackupUiService implements IBackupUiService {
 		this._connectionUri = ConnectionUtils.generateUri(connection);
 		this._currentProvider = connection.providerName;
 		let backupDialog = this._backupDialogs[this._currentProvider];
+		const backupDialogTitle = localize('backupDialogTitle', 'Backup database - {0}:{1}', connection.serverName, connection.databaseName);
+		const backupOptions = this.getOptions(this._currentProvider);
 		if (!backupDialog) {
-			let backupOptions = this.getOptions(this._currentProvider);
 			if (backupOptions) {
 				backupDialog = this._instantiationService.createInstance(
-					OptionsDialog, 'Backup database - ' + connection.serverName + ':' + connection.databaseName, 'BackupOptions', undefined);
+					OptionsDialog, backupDialogTitle, 'BackupOptions', undefined);
 				backupDialog.onOk(() => this.handleOptionDialogClosed());
 			}
 			else {
@@ -74,9 +76,11 @@ export class BackupUiService implements IBackupUiService {
 			}
 			backupDialog.render();
 			this._backupDialogs[this._currentProvider] = backupDialog;
+		} else if (backupOptions) {
+			// Update the title for non-MSSQL backups each time so they show the correct database name
+			(backupDialog as OptionsDialog).title = backupDialogTitle;
 		}
 
-		let backupOptions = this.getOptions(this._currentProvider);
 		let uri = this._connectionManagementService.getConnectionUri(connection)
 			+ ProviderConnectionInfo.idSeparator
 			+ ConnectionUtils.ConnectionUriBackupIdAttributeName

--- a/src/sql/workbench/services/restore/browser/restoreServiceImpl.ts
+++ b/src/sql/workbench/services/restore/browser/restoreServiceImpl.ts
@@ -320,8 +320,9 @@ export class RestoreDialogController implements IRestoreDialogController {
 						newRestoreDialog.render();
 						this._restoreDialogs[this._currentProvider] = newRestoreDialog;
 					} else if (this._currentProvider !== ConnectionConstants.mssqlProviderName) {
-						// Update the title for non-MSSQL restores each time so they show the correct database name
-						(this._restoreDialogs[this._currentProvider] as RestoreDialog).title = dialogTitle;
+						// Update the title for non-MSSQL restores each time so they show the correct database name since those
+						// use just a basic OptionsDialog which doesn't get updated on every open
+						this._restoreDialogs[this._currentProvider].title = dialogTitle;
 					}
 
 					if (this._currentProvider === ConnectionConstants.mssqlProviderName) {

--- a/src/sql/workbench/services/restore/browser/restoreServiceImpl.ts
+++ b/src/sql/workbench/services/restore/browser/restoreServiceImpl.ts
@@ -24,6 +24,7 @@ import { invalidProvider } from 'sql/base/common/errors';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { DatabaseEngineEdition } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { localize } from 'vs/nls';
 
 export class RestoreService implements IRestoreService {
 
@@ -300,6 +301,7 @@ export class RestoreDialogController implements IRestoreDialogController {
 				this._connectionService.connect(connection, this._ownerUri).then(connectionResult => {
 					this._sessionId = undefined;
 					this._currentProvider = this.getCurrentProviderId();
+					const dialogTitle = localize('restoreDialogTitle', 'Restore database - {0}:{1}', connection.serverName, connection.databaseName);
 					if (!this._restoreDialogs[this._currentProvider]) {
 						let newRestoreDialog: RestoreDialog | OptionsDialog;
 						if (this._currentProvider === ConnectionConstants.mssqlProviderName) {
@@ -311,12 +313,15 @@ export class RestoreDialogController implements IRestoreDialogController {
 							newRestoreDialog.onDatabaseListFocused(() => this.fetchDatabases(provider));
 						} else {
 							newRestoreDialog = this._instantiationService.createInstance(
-								OptionsDialog, 'Restore database - ' + connection.serverName + ':' + connection.databaseName, 'RestoreOptions', undefined);
+								OptionsDialog, dialogTitle, 'RestoreOptions', undefined);
 							newRestoreDialog.onOk(() => this.handleOnRestore());
 						}
 						newRestoreDialog.onCloseEvent(() => this.handleOnClose());
 						newRestoreDialog.render();
 						this._restoreDialogs[this._currentProvider] = newRestoreDialog;
+					} else if (this._currentProvider !== ConnectionConstants.mssqlProviderName) {
+						// Update the title for non-MSSQL restores each time so they show the correct database name
+						(this._restoreDialogs[this._currentProvider] as RestoreDialog).title = dialogTitle;
 					}
 
 					if (this._currentProvider === ConnectionConstants.mssqlProviderName) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23158

For non-MSSQL backups/restores we were storing the dialog instances on a per-provider basis but then never updating the title, which meant it would always have the title of the first dialog opened. 

This doesn't affect MSSQL backup/restores since it sets the title when the dialog is opened. 