### PR TITLE
Use System.AccessToken instead of github-distro-mixin-password

### DIFF
--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -14,26 +14,10 @@ steps:
     inputs:
       versionSpec: "16.x"
 
-  - task: AzureKeyVault@1
-    displayName: "Azure Key Vault: Get Secrets"
-    inputs:
-      azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
-      SecretsFilter: "github-distro-mixin-password"
-
   - script: |
       set -e
 
-      cat << EOF > ~/.netrc
-      machine github.com
-      login vscode
-      password $(github-distro-mixin-password)
-      EOF
-
-      git config user.email "vscode@microsoft.com"
-      git config user.name "VSCode"
-
-      git remote add distro "https://github.com/$VSCODE_MIXIN_REPO.git"
+      git remote add distro "https://$(System_AccessToken)@github.com/$VSCODE_MIXIN_REPO.git"
       git fetch distro
 
       # Push main branch into oss/main
@@ -45,3 +29,5 @@ steps:
       git merge $(node -p "require('./package.json').distro")
 
     displayName: Sync & Merge Distro
+    env:
+      System_AccessToken: $(System.AccessToken)

--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -7,6 +7,9 @@ trigger:
 pr: none
 
 steps:
+  - checkout: self
+    persistCredentials: true
+
   - task: NodeTool@0
     inputs:
       versionSpec: "16.x"

--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -7,17 +7,30 @@ trigger:
 pr: none
 
 steps:
-  - checkout: self
-    persistCredentials: true
-
   - task: NodeTool@0
     inputs:
       versionSpec: "16.x"
 
+  - task: AzureKeyVault@1
+    displayName: "Azure Key Vault: Get Secrets"
+    inputs:
+      azureSubscription: "vscode-builds-subscription"
+      KeyVaultName: vscode
+      SecretsFilter: "github-distro-mixin-password"
+
   - script: |
       set -e
 
-      git remote add distro "https://$(System_AccessToken)@github.com/$VSCODE_MIXIN_REPO.git"
+      cat << EOF > ~/.netrc
+      machine github.com
+      login vscode
+      password $(github-distro-mixin-password)
+      EOF
+
+      git config user.email "vscode@microsoft.com"
+      git config user.name "VSCode"
+
+      git remote add distro "https://github.com/$VSCODE_MIXIN_REPO.git"
       git fetch distro
 
       # Push main branch into oss/main
@@ -29,5 +42,3 @@ steps:
       git merge $(node -p "require('./package.json').distro")
 
     displayName: Sync & Merge Distro
-    env:
-      System_AccessToken: $(System.AccessToken)

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -4,6 +4,16 @@ resources:
     image: sqltoolscontainers.azurecr.io/linux-build-agent:6
     endpoint: SqlToolsContainers
 
+  repositories:
+  - repository: azuredatastudio-release
+    type: github
+    endpoint: CrossPlatBuildScripts
+    name: microsoft/azuredatastudio-release
+  - repository: azuredatastudio
+    type: github
+    endpoint: CrossPlatBuildScripts
+    name: microsoft/azuredatastudio
+
 stages:
   - stage: Compile
     jobs:

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -18,7 +18,7 @@ steps:
 - script: |
     dir $(Build.SourcesDirectory)
     set -e
-    git merge $(Build.SourcesDirectory)/azuredatastudio-release $(Build.SourcesDirectory)/azuredatastudio
+    git merge $(Build.SourcesDirectory)/azuredatastudio-release.git $(Build.SourcesDirectory)/azuredatastudio.git
   displayName: Merge distro
 
 - script: |

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -22,7 +22,8 @@ steps:
     echo "azuredatastudio"
     dir $(Build.SourcesDirectory)/azuredatastudio
     set -e
-    git merge $(Build.SourcesDirectory)/azuredatastudio-release.git $(Build.SourcesDirectory)/azuredatastudio.git
+    cd $(Build.SourcesDirectory)/azuredatastudio-release
+    git merge $(Build.SourcesDirectory)/azuredatastudio
   displayName: Merge distro
 
 - script: |

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -16,14 +16,17 @@ steps:
   displayName: Prepare tooling
 
 - script: |
-    dir $(Build.SourcesDirectory)
-    echo "azuredatastudio-release"
-    dir $(Build.SourcesDirectory)/azuredatastudio-release
-    echo "azuredatastudio"
-    dir $(Build.SourcesDirectory)/azuredatastudio
+    # dir $(Build.SourcesDirectory)
+    # echo "azuredatastudio-release"
+    # dir $(Build.SourcesDirectory)/azuredatastudio-release
+    # echo "azuredatastudio"
+    # dir $(Build.SourcesDirectory)/azuredatastudio
     set -e
-    cd $(Build.SourcesDirectory)/azuredatastudio-release
-    git merge $(Build.SourcesDirectory)/azuredatastudio
+    git remote add distro "https://github.com/$(VSCODE_MIXIN_REPO).git"
+    git fetch distro
+    git merge $(node -p "require('./package.json').distro")
+    # cd $(Build.SourcesDirectory)/azuredatastudio-release
+    # git merge $(Build.SourcesDirectory)/azuredatastudio
   displayName: Merge distro
 
 - script: |

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -15,7 +15,7 @@ steps:
 
 - script: |
     set -e
-    git remote add distro "https://$(System_AccessToken)@github.com/$VSCODE_MIXIN_REPO.git"
+    git remote add distro "https://$System_AccessToken@github.com/$VSCODE_MIXIN_REPO.git"
     git fetch distro
     git merge $(node -p "require('./package.json').distro")
   displayName: Merge distro

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -16,17 +16,10 @@ steps:
   displayName: Prepare tooling
 
 - script: |
-    # dir $(Build.SourcesDirectory)
-    # echo "azuredatastudio-release"
-    # dir $(Build.SourcesDirectory)/azuredatastudio-release
-    # echo "azuredatastudio"
-    # dir $(Build.SourcesDirectory)/azuredatastudio
     set -e
     git remote add distro "https://github.com/$(VSCODE_MIXIN_REPO).git"
     git fetch distro
     git merge $(node -p "require('./package.json').distro")
-    # cd $(Build.SourcesDirectory)/azuredatastudio-release
-    # git merge $(Build.SourcesDirectory)/azuredatastudio
   displayName: Merge distro
 
 - script: |

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -1,15 +1,3 @@
-resources:
-  repositories:
-  - repository: azuredatastudio-release
-    type: github
-    endpoint: CrossPlatBuildScripts
-    name: microsoft/azuredatastudio-release
-  - repository: azuredatastudio
-    type: github
-    endpoint: CrossPlatBuildScripts
-    name: microsoft/azuredatastudio
-
-
 steps:
 - checkout: self
   persistCredentials: true

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -17,8 +17,10 @@ steps:
 
 - script: |
     dir $(Build.SourcesDirectory)
+    echo "azuredatastudio-release"
     dir $(Build.SourcesDirectory)/azuredatastudio-release
-    $(Build.SourcesDirectory)/azuredatastudio
+    echo "azuredatastudio"
+    dir $(Build.SourcesDirectory)/azuredatastudio
     set -e
     git merge $(Build.SourcesDirectory)/azuredatastudio-release.git $(Build.SourcesDirectory)/azuredatastudio.git
   displayName: Merge distro

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -1,4 +1,7 @@
 steps:
+- checkout: self
+  persistCredentials: true
+
 - task: NodeTool@0
   inputs:
     versionSpec: "16.x"
@@ -7,30 +10,17 @@ steps:
   inputs:
     versionSpec: "1.x"
 
-- task: AzureKeyVault@1
-  displayName: 'Azure Key Vault: Get Secrets'
-  inputs:
-    azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
-    KeyVaultName: ado-secrets
-
 - script: |
-    set -e
-    cat << EOF > ~/.netrc
-    machine github.com
-    login azuredatastudio
-    password $(github-distro-mixin-password)
-    EOF
-
-    git config user.email "sqltools@service.microsoft.com"
-    git config user.name "AzureDataStudio"
   displayName: Prepare tooling
 
 - script: |
     set -e
-    git remote add distro "https://github.com/$(VSCODE_MIXIN_REPO).git"
+    git remote add distro "https://$(System_AccessToken)@github.com/$VSCODE_MIXIN_REPO.git"
     git fetch distro
     git merge $(node -p "require('./package.json').distro")
   displayName: Merge distro
+  env:
+    System_AccessToken: $(System.AccessToken)
 
 - script: |
     mkdir -p .build

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -1,6 +1,20 @@
+resources:
+  repositories:
+  - repository: azuredatastudio-release # The name used to reference this repository in the checkout step
+    type: github
+    endpoint: CrossPlatBuildScripts
+    name: microsoft/azuredatastudio-release
+  - repository: azuredatastudio
+    type: github
+    endpoint: CrossPlatBuildScripts
+    name: microsoft/azuredatastudio
+
+
 steps:
 - checkout: self
   persistCredentials: true
+- checkout: azuredatastudio-release
+- checkout: azuredatastudio
 
 - task: NodeTool@0
   inputs:
@@ -15,9 +29,7 @@ steps:
 
 - script: |
     set -e
-    git remote add distro "https://$(System.AccessToken)@github.com/$(VSCODE_MIXIN_REPO).git"
-    git fetch distro
-    git merge $(node -p "require('./package.json').distro")
+    git merge $(Build.SourcesDirectory)/azuredatastudio-release $(Build.SourcesDirectory)/azuredatastudio
   displayName: Merge distro
   env:
     System_AccessToken: $(System.AccessToken)

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -17,6 +17,8 @@ steps:
 
 - script: |
     dir $(Build.SourcesDirectory)
+    dir $(Build.SourcesDirectory)/azuredatastudio-release
+    $(Build.SourcesDirectory)/azuredatastudio
     set -e
     git merge $(Build.SourcesDirectory)/azuredatastudio-release.git $(Build.SourcesDirectory)/azuredatastudio.git
   displayName: Merge distro

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -15,7 +15,7 @@ steps:
 
 - script: |
     set -e
-    git remote add distro "https://github.com/$VSCODE_MIXIN_REPO.git.extraheader 'AUTHORIZATION: bearer $System.AccessToken'"
+    git remote add distro "https://$System.AccessToken@github.com/$VSCODE_MIXIN_REPO.git"
     git fetch distro
     git merge $(node -p "require('./package.json').distro")
   displayName: Merge distro

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -15,7 +15,7 @@ steps:
 
 - script: |
     set -e
-    git remote add distro "https://$System.AccessToken@github.com/$VSCODE_MIXIN_REPO.git"
+    git remote add distro "https://$(System.AccessToken)@github.com/$VSCODE_MIXIN_REPO.git"
     git fetch distro
     git merge $(node -p "require('./package.json').distro")
   displayName: Merge distro

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -15,7 +15,7 @@ steps:
 
 - script: |
     set -e
-    git remote add distro "https://$(System.AccessToken)@github.com/$VSCODE_MIXIN_REPO.git"
+    git remote add distro "https://$(System.AccessToken)@github.com/$(VSCODE_MIXIN_REPO).git"
     git fetch distro
     git merge $(node -p "require('./package.json').distro")
   displayName: Merge distro

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -1,6 +1,6 @@
 resources:
   repositories:
-  - repository: azuredatastudio-release # The name used to reference this repository in the checkout step
+  - repository: azuredatastudio-release
     type: github
     endpoint: CrossPlatBuildScripts
     name: microsoft/azuredatastudio-release
@@ -31,8 +31,6 @@ steps:
     set -e
     git merge $(Build.SourcesDirectory)/azuredatastudio-release $(Build.SourcesDirectory)/azuredatastudio
   displayName: Merge distro
-  env:
-    System_AccessToken: $(System.AccessToken)
 
 - script: |
     mkdir -p .build

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -16,6 +16,7 @@ steps:
   displayName: Prepare tooling
 
 - script: |
+    dir $(Build.SourcesDirectory)
     set -e
     git merge $(Build.SourcesDirectory)/azuredatastudio-release $(Build.SourcesDirectory)/azuredatastudio
   displayName: Merge distro

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -15,7 +15,7 @@ steps:
 
 - script: |
     set -e
-    git remote add distro "https://$System_AccessToken@github.com/$VSCODE_MIXIN_REPO.git"
+    git remote add distro "https://github.com/$VSCODE_MIXIN_REPO.git.extraheader AUTHORIZATION: bearer $System.AccessToken"
     git fetch distro
     git merge $(node -p "require('./package.json').distro")
   displayName: Merge distro

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -15,7 +15,7 @@ steps:
 
 - script: |
     set -e
-    git remote add distro "https://github.com/$VSCODE_MIXIN_REPO.git.extraheader AUTHORIZATION: bearer $System.AccessToken"
+    git remote add distro "https://github.com/$VSCODE_MIXIN_REPO.git.extraheader 'AUTHORIZATION: bearer $System.AccessToken'"
     git fetch distro
     git merge $(node -p "require('./package.json').distro")
   displayName: Merge distro


### PR DESCRIPTION
We have a dependency on PATs (Personal Access Tokens) which causes issues when people leave the team / these PATs expire.  This replaces the PATs with the System.AccessToken.  I am testing the behavior with this singular yml file and will replace the remaining build ymls if this works well.