### PR TITLE
Populate Project in Update project from db UI

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -536,6 +536,9 @@ export class UpdateProjectFromDatabaseDialog {
 			connection.password = connection.options.password = credentials.password;
 		}
 
+		const projectFilePath = this.projectFileDropdown!.value! as string;
+		this.project = await Project.openProject(projectFilePath);
+
 		const connectionDetails: azdata.IConnectionProfile = {
 			id: connection.connectionId,
 			userName: connection.userName,
@@ -569,10 +572,10 @@ export class UpdateProjectFromDatabaseDialog {
 
 		const targetEndpointInfo: mssql.SchemaCompareEndpointInfo = {
 			endpointType: mssql.SchemaCompareEndpointType.Project,
-			projectFilePath: this.projectFileDropdown!.value! as string,
+			projectFilePath: projectFilePath,
 			extractTarget: mapExtractTargetEnum(<string>this.folderStructureDropDown!.value),
 			targetScripts: [],
-			dataSchemaProvider: this.project!.getProjectTargetVersion(),
+			dataSchemaProvider: this.project.getProjectTargetVersion(),
 			connectionDetails: connectionDetails,
 			databaseName: '',
 			serverDisplayName: '',

--- a/extensions/sql-database-projects/src/test/dialogs/updateProjectFromDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/updateProjectFromDatabaseDialog.test.ts
@@ -114,8 +114,9 @@ describe('Update Project From Database Dialog', () => {
 		sinon.stub(azdata.connection, 'getUriForConnection').resolves('MockUri');
 		sinon.stub(azdata.connection, 'getCredentials').resolves({ ['credentials']: 'credentials' });
 
+		const projectFilePath = project.projectFilePath.toLowerCase();
 		const profile = mockConnectionProfile;
-		mockURIList.unshift(vscode.Uri.file(project.projectFilePath));
+		mockURIList.unshift(vscode.Uri.file(projectFilePath));
 		const dialog = new UpdateProjectFromDatabaseDialog(profile, undefined, mockURIList);
 		await dialog.openDialog();
 		await dialog.populatedInputsPromise;
@@ -128,7 +129,7 @@ describe('Update Project From Database Dialog', () => {
 		// verify the handleUpdateButtonClick method goes through successfully
 		let model: UpdateProjectDataModel;
 		const testProjectEndpointInfo: mssql.SchemaCompareEndpointInfo = { ...mockProjectEndpointInfo };
-		testProjectEndpointInfo.projectFilePath = project.projectFilePath;
+		testProjectEndpointInfo.projectFilePath = projectFilePath;
 		const expectedUpdateProjectDataModel: UpdateProjectDataModel = {
 			sourceEndpointInfo: mockDatabaseEndpointInfo,
 			targetEndpointInfo: testProjectEndpointInfo,

--- a/extensions/sql-database-projects/src/test/dialogs/updateProjectFromDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/updateProjectFromDatabaseDialog.test.ts
@@ -6,11 +6,14 @@
 import * as azdata from 'azdata';
 import * as should from 'should';
 import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as mssql from 'mssql';
 import * as baselines from '../baselines/baselines';
 import * as testUtils from '../testUtils';
 
 import { UpdateProjectFromDatabaseDialog } from '../../dialogs/updateProjectFromDatabaseDialog';
-import { mockConnectionProfile, mockURIList } from '../testContext';
+import { mockConnectionProfile, mockDatabaseEndpointInfo, mockProjectEndpointInfo, mockURIList } from '../testContext';
+import { UpdateProjectDataModel } from '../../models/api/updateProject';
 
 describe('Update Project From Database Dialog', () => {
 	before(async function (): Promise<void> {
@@ -81,5 +84,59 @@ describe('Update Project From Database Dialog', () => {
 		should.equal(dialog.projectFileDropdown!.value, project.projectFilePath, `Project file dropdown should be the sqlproj path (${project.projectFilePath}), but instead was "${dialog.projectFileDropdown!.value}".`);
 		should.deepEqual(dialog.projectFileDropdown!.values, uriList, `Project file dropdown list should be the sqlproj path (${mockURIList}), but instead was "${dialog.projectFileDropdown!.values}".`);
 		should.equal(dialog.dialog.okButton.enabled, true, 'Okay button should be enabled when dialog is complete.');
+	});
+
+	it('Should populate endpoints correctly when Connection context and workspace with projects is provided', async function (): Promise<void> {
+		sinon.stub(azdata.connection, 'getConnections').resolves([<azdata.connection.ConnectionProfile><unknown>mockConnectionProfile]);
+		sinon.stub(azdata.connection, 'listDatabases').resolves([mockConnectionProfile.databaseName!]);
+
+		const profile = mockConnectionProfile;
+		const dialog = new UpdateProjectFromDatabaseDialog(profile, undefined, mockURIList);
+		await dialog.openDialog();
+		await dialog.populatedInputsPromise;
+
+		let uriList: string[] = [];
+		mockURIList.forEach(projectUri => {
+			uriList.push(projectUri.fsPath as string);
+		});
+
+		should.equal((<any>dialog.serverDropdown!.value).displayName, profile.options['connectionName'], `Server dropdown should be "${profile.options['connectionName']}", but instead was "${(<any>dialog.serverDropdown!.value).displayName}".`);
+		should.equal(dialog.databaseDropdown!.value, profile.databaseName, `Database dropdown should as "${profile.databaseName}", but instead was "${dialog.databaseDropdown!.value}".`);
+		should.equal(dialog.projectFileDropdown!.value, uriList[0], `Project file dropdown should be the first project listed in the workspace URI list (${uriList[0]}), but instead was "${dialog.projectFileDropdown!.value}".`);
+		should.deepEqual(dialog.projectFileDropdown!.values, uriList, `Project file dropdown list should be the workspace URI list (${mockURIList}), but instead was "${dialog.projectFileDropdown!.values}".`);
+		should.equal(dialog.dialog.okButton.enabled, true, 'Okay button should be enabled when dialog is complete.');
+	});
+
+	it('Should successfully complete the handleUpdateButtonClick method call and connect to appropriate call back properties when Connection context and workspace with projects is provided', async function (): Promise<void> {
+		const project = await testUtils.createTestProject(this.test, baselines.openProjectFileBaseline);
+		sinon.stub(azdata.connection, 'getConnections').resolves([<azdata.connection.ConnectionProfile><unknown>mockConnectionProfile]);
+		sinon.stub(azdata.connection, 'listDatabases').resolves([mockConnectionProfile.databaseName!]);
+		sinon.stub(azdata.connection, 'getUriForConnection').resolves('MockUri');
+		sinon.stub(azdata.connection, 'getCredentials').resolves({ ['credentials']: 'credentials' });
+
+		const profile = mockConnectionProfile;
+		mockURIList.unshift(vscode.Uri.file(project.projectFilePath));
+		const dialog = new UpdateProjectFromDatabaseDialog(profile, undefined, mockURIList);
+		await dialog.openDialog();
+		await dialog.populatedInputsPromise;
+
+		let uriList: string[] = [];
+		mockURIList.forEach(projectUri => {
+			uriList.push(projectUri.fsPath as string);
+		});
+
+		// verify the handleUpdateButtonClick method goes through successfully
+		let model: UpdateProjectDataModel;
+		const testProjectEndpointInfo: mssql.SchemaCompareEndpointInfo = { ...mockProjectEndpointInfo };
+		testProjectEndpointInfo.projectFilePath = project.projectFilePath;
+		const expectedUpdateProjectDataModel: UpdateProjectDataModel = {
+			sourceEndpointInfo: mockDatabaseEndpointInfo,
+			targetEndpointInfo: testProjectEndpointInfo,
+			action: 0
+		};
+		dialog.updateProjectFromDatabaseCallback = (m) => { model = m; };
+		await dialog.handleUpdateButtonClick();
+
+		should(model!).deepEqual(expectedUpdateProjectDataModel);
 	});
 });

--- a/extensions/sql-database-projects/src/test/dialogs/updateProjectFromDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/updateProjectFromDatabaseDialog.test.ts
@@ -101,7 +101,7 @@ describe('Update Project From Database Dialog', () => {
 		});
 
 		should.equal((<any>dialog.serverDropdown!.value).displayName, profile.options['connectionName'], `Server dropdown should be "${profile.options['connectionName']}", but instead was "${(<any>dialog.serverDropdown!.value).displayName}".`);
-		should.equal(dialog.databaseDropdown!.value, profile.databaseName, `Database dropdown should as "${profile.databaseName}", but instead was "${dialog.databaseDropdown!.value}".`);
+		should.equal(dialog.databaseDropdown!.value, profile.databaseName, `Database dropdown should be "${profile.databaseName}", but instead was "${dialog.databaseDropdown!.value}".`);
 		should.equal(dialog.projectFileDropdown!.value, uriList[0], `Project file dropdown should be the first project listed in the workspace URI list (${uriList[0]}), but instead was "${dialog.projectFileDropdown!.value}".`);
 		should.deepEqual(dialog.projectFileDropdown!.values, uriList, `Project file dropdown list should be the workspace URI list (${mockURIList}), but instead was "${dialog.projectFileDropdown!.values}".`);
 		should.equal(dialog.dialog.okButton.enabled, true, 'Okay button should be enabled when dialog is complete.');

--- a/extensions/sql-database-projects/src/test/testContext.ts
+++ b/extensions/sql-database-projects/src/test/testContext.ts
@@ -139,3 +139,55 @@ export const mockURIList: vscode.Uri[] = [
 	vscode.Uri.file('/test/folder/folder1/abc1.sqlproj'),
 	vscode.Uri.file('/test/folder/folder2/abc2.sqlproj')
 ];
+
+export const mockConnectionInfo = {
+	id: undefined,
+	userName: 'My User',
+	password: 'My Pwd',
+	serverName: 'My Server',
+	databaseName: 'My Database',
+	connectionName: 'My Connection',
+	providerName: undefined,
+	groupId: 'My GroupId',
+	groupFullName: 'My groupName',
+	authenticationType: azdata.connection.AuthenticationType.SqlLogin,
+	savePassword: false,
+	saveProfile: true,
+	options: {
+		server: 'My Server',
+		database: 'My Database',
+		user: 'My User',
+		password: 'My Pwd',
+		authenticationType: 'SqlLogin',
+		connectionName: 'My Connection Name'
+	}
+};
+
+export const mockProjectEndpointInfo: mssql.SchemaCompareEndpointInfo = {
+	endpointType: mssql.SchemaCompareEndpointType.Project,
+	projectFilePath: '',
+	extractTarget: mssql.ExtractTarget.schemaObjectType,
+	targetScripts: [],
+	dataSchemaProvider: '150',
+	connectionDetails: mockConnectionInfo,
+	databaseName: '',
+	serverDisplayName: '',
+	serverName: '',
+	ownerUri: '',
+	packageFilePath: ''
+};
+
+export const mockDatabaseEndpointInfo: mssql.SchemaCompareEndpointInfo = {
+	endpointType: mssql.SchemaCompareEndpointType.Database,
+	databaseName: 'My Database',
+	serverDisplayName: 'My Connection Name',
+	serverName: 'My Server',
+	connectionDetails: mockConnectionInfo,
+	ownerUri: 'MockUri',
+	projectFilePath: '',
+	extractTarget: mssql.ExtractTarget.schemaObjectType,
+	targetScripts: [],
+	dataSchemaProvider: '',
+	packageFilePath: '',
+	connectionName: 'My Connection Name'
+};


### PR DESCRIPTION
This PR fixes #23160.
When a user tries to update project from database, it populates various parameters to get the target project information. But in the scenario where the Update Project UI doesn't start from the project context, the code never pulled the project details. After https://github.com/microsoft/azuredatastudio/pull/22938 change went in, the code looked up for version information of the project. For the scenario where Update project was started from db context (non-project context), it didn't have the project information, and the code was failed. This PR fixes it by opening project from the chosen project filepath, before accessing the project information.