### PR TITLE
sort table by keyboard

### DIFF
--- a/src/sql/workbench/contrib/table/browser/table.contribution.ts
+++ b/src/sql/workbench/contrib/table/browser/table.contribution.ts
@@ -11,9 +11,11 @@ import { KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/co
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { HeaderFilter } from 'sql/base/browser/ui/table/plugins/headerFilter.plugin';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { HybridDataProvider } from 'sql/base/browser/ui/table/hybridDataProvider';
 
 export const RESIZE_COLUMN_COMMAND_ID = 'table.resizeColumn';
 export const SHOW_COLUMN_MENU_COMMAND_ID = 'table.showColumnMenu';
+export const SORT_COLUMN_COMMAND_ID = 'table.sortColumn';
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: RESIZE_COLUMN_COMMAND_ID,
@@ -37,6 +39,46 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 			let plugin = table.grid.getPlugins().find(p => p instanceof HeaderFilter) as HeaderFilter<any>;
 			if (plugin) {
 				await plugin.showMenu();
+			}
+		});
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: SORT_COLUMN_COMMAND_ID,
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: InTable,
+	primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KeyO,
+	handler: async (accessor) => {
+		await handleTableCommand(accessor, async (table) => {
+			const activeCell = table.grid.getActiveCell();
+			if (activeCell && activeCell.cell >= 0) {
+				const column = table.grid.getColumns()[activeCell.cell];
+				if (column.sortable) {
+					table.grid.sortColumnByActiveCell();
+				} else if (table.getData() instanceof HybridDataProvider) {
+					// For query editor/notebook, we don't use the slickgrid's builtin sorting, so handle it separately here.
+					let columnState = table.grid.getSortColumns().find(c => c.columnId === column.id);
+					if (columnState) {
+						columnState.sortAsc = !columnState.sortAsc;
+					} else {
+						columnState = {
+							columnId: column.id,
+							sortAsc: true
+						};
+					}
+					table.grid.setSortColumn(columnState.columnId, columnState.sortAsc);
+
+					const dataProvider = table.getData() as HybridDataProvider<Slick.SlickData>;
+					await dataProvider.sort({
+						grid: table.grid,
+						multiColumnSort: false,
+						sortCol: column,
+						sortAsc: columnState.sortAsc
+					});
+					table.rerenderGrid();
+					table.setActiveCell(activeCell.row, activeCell.cell);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
this PR fixes #12822
and https://msdata.visualstudio.com/Data%20Studio/_workitems/edit/1654903

add a keyboard shortcut to sort the columns. the default binding is SHIFT+ALT+O

![sort-keyboard](https://github.com/microsoft/azuredatastudio/assets/13777222/dfe29520-eb78-44c3-bf8a-0f00302ee12b)
