### PR TITLE
Fixing OE nodes error handling.

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -23,7 +23,7 @@ import { IConnectionManagementService } from 'sql/platform/connection/common/con
 import { TreeCreationUtils } from 'sql/workbench/services/objectExplorer/browser/treeCreationUtils';
 import { TreeUpdateUtils } from 'sql/workbench/services/objectExplorer/browser/treeUpdateUtils';
 import { TreeSelectionHandler } from 'sql/workbench/services/objectExplorer/browser/treeSelectionHandler';
-import { IObjectExplorerService, IServerTreeView, ServerTreeViewView } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
+import { ERROR_NODE_TYPE, IObjectExplorerService, IServerTreeView, ServerTreeViewView } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { Button } from 'sql/base/browser/ui/button/button';
 import { TreeNode, TreeItemCollapsibleState } from 'sql/workbench/services/objectExplorer/common/treeNode';
@@ -931,7 +931,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 
 		// In case of error node, we need to show the error message
 		if (node instanceof TreeNode) {
-			if (node.objectType === 'error') {
+			if (node.objectType === ERROR_NODE_TYPE) {
 				this.showError(node.label);
 			}
 		}

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -928,6 +928,13 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				}
 			}
 		}
+
+		// In case of error node, we need to show the error message
+		if (node instanceof TreeNode) {
+			if (node.objectType === 'error') {
+				this.showError(node.label);
+			}
+		}
 	}
 
 	public getActionContext(element: ServerTreeElement): any {

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -38,6 +38,8 @@ export const enum ServerTreeViewView {
 	active = 'active'
 }
 
+export const ERROR_NODE_TYPE = 'error';
+
 export interface IServerTreeView {
 	readonly tree: ITree | AsyncServerTree;
 	readonly onSelectionOrFocusChange: Event<void>;
@@ -588,7 +590,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 			objectType: 'error',
 			label: 'Error',
 			errorMessage: '',
-			nodeType: 'error',
+			nodeType: ERROR_NODE_TYPE,
 			isLeaf: true,
 			nodeSubType: '',
 			nodeStatus: '',

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -583,7 +583,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		};
 		let allNodes: azdata.NodeInfo[] = [];
 		let errorNode: azdata.NodeInfo = {
-			nodePath: nodePath,
+			nodePath: '',
 			parentNodePath: '',
 			objectType: 'error',
 			label: 'Error',


### PR DESCRIPTION
Previously (error nodes looked like the parent node). 

![image](https://github.com/microsoft/azuredatastudio/assets/6816294/1d15302c-1f0a-493e-b97a-64ff4ec34cb3)

Now:
![image](https://github.com/microsoft/azuredatastudio/assets/6816294/90ce7525-7798-4716-a578-e7941b964454)

Double clicking the node will open the error message in an error dialog
![azuredatastudio_3FSW4wXX0r](https://github.com/microsoft/azuredatastudio/assets/6816294/bfe1972b-aa38-4a3d-b618-eb4b070e3e9a)
