### PR TITLE
Adding option to open referenced project from SQL Project reference item

### DIFF
--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -81,7 +81,7 @@ export class WorkspaceService implements IWorkspaceService {
 			vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders?.length || 0, undefined, ...(newWorkspaceFolders.map(folder => ({ uri: vscode.Uri.file(folder) }))));
 		}
 
-		// 2. Compare projcets being added against prior (cached) list of projects in the workspace
+		// 2. Compare projects being added against prior (cached) list of projects in the workspace
 
 		const previousProjects: string[] = (await this.getProjectsInWorkspace(undefined, false)).map(p => p.path);
 		let newProjectAdded: boolean = false;

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -164,6 +164,11 @@
         "category": "%sqlDatabaseProjects.displayName%"
       },
       {
+        "command": "sqlDatabaseProjects.openReferencedSqlProject",
+        "title": "%sqlDatabaseProjects.openReferencedSqlProject%",
+        "category": "%sqlDatabaseProjects.displayName%"
+      },
+      {
         "command": "sqlDatabaseProjects.validateExternalStreamingJob",
         "title": "%sqlDatabaseProjects.validateExternalStreamingJob%",
         "category": "%sqlDatabaseProjects.displayName%"
@@ -301,6 +306,10 @@
           "when": "false"
         },
         {
+          "command": "sqlDatabaseProjects.openReferencedSqlProject",
+          "when": "false"
+        },
+        {
           "command": "sqlDatabaseProjects.validateExternalStreamingJob",
           "when": "false"
         },
@@ -432,13 +441,18 @@
           "group": "6_dbProjects_openInDesigner"
         },
         {
+          "command": "sqlDatabaseProjects.openReferencedSqlProject",
+          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.reference.sqlProject",
+          "group": "8_dbProjects_openReferencedSqlProject"
+        },
+        {
           "command": "sqlDatabaseProjects.exclude",
           "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/",
           "group": "9_dbProjectsLast@1"
         },
         {
           "command": "sqlDatabaseProjects.delete",
-          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/ || viewItem == databaseProject.itemType.reference || viewItem == databaseProject.itemType.sqlcmdVariable",
+          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/ || viewItem =~ /^databaseProject.itemType.reference/ || viewItem == databaseProject.itemType.sqlcmdVariable",
           "group": "9_dbProjectsLast@2"
         },
         {

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -38,6 +38,7 @@
 	"sqlDatabaseProjects.generateProjectFromOpenApiSpec": "Generate SQL Project from OpenAPI/Swagger spec (Preview)",
 	"sqlDatabaseProjects.convertToSdkStyleProject": "Convert to SDK-style project",
 	"sqlDatabaseProjects.openInDesigner": "Open in Designer",
+	"sqlDatabaseProjects.openReferencedSqlProject": "Open project",
 
 	"sqlDatabaseProjects.Settings": "Database Projects",
 	"sqlDatabaseProjects.dotnetInstallLocation": "Full path to .NET SDK on the machine. For example, if dotnet.exe is located at C:\\folder1\\dotnet\\dotnet.exe, set the path for this setting to C:\\folder1\\dotnet",

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -572,6 +572,7 @@ export enum DatabaseProjectItemType {
 	table = 'databaseProject.itemType.file.table',
 	referencesRoot = 'databaseProject.itemType.referencesRoot',
 	reference = 'databaseProject.itemType.reference',
+	sqlProjectReference = 'databaseProject.itemType.reference.sqlProject',
 	dataSourceRoot = 'databaseProject.itemType.dataSourceRoot',
 	sqlcmdVariablesRoot = 'databaseProject.itemType.sqlcmdVariablesRoot',
 	sqlcmdVariable = 'databaseProject.itemType.sqlcmdVariable',

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -81,6 +81,7 @@ export default class MainController implements vscode.Disposable {
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.newPublishProfile', async (node: WorkspaceTreeItem) => { return this.projectsController.addItemPromptFromNode(node, ItemType.publishProfile); }));
 
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.addDatabaseReference', async (node: WorkspaceTreeItem) => { return this.projectsController.addDatabaseReference(node); }));
+		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.openReferencedSqlProject', async (node: WorkspaceTreeItem) => { return this.projectsController.openReferencedSqlProject(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.openContainingFolder', async (node: WorkspaceTreeItem) => { return this.projectsController.openContainingFolder(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.editProjectFile', async (node: WorkspaceTreeItem) => { return this.projectsController.editProjectFile(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.delete', async (node: WorkspaceTreeItem) => { return this.projectsController.delete(node); }));

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1028,6 +1028,10 @@ export class ProjectsController {
 		await vscode.commands.executeCommand(constants.revealFileInOsCommand, vscode.Uri.file(project.projectFilePath));
 	}
 
+	/**
+	 * Open the project indicated by `context` in the workspace
+	 * @param context a SqlProjectReferenceTreeItem in the project's tree
+	 */
 	public async openReferencedSqlProject(context: dataworkspace.WorkspaceTreeItem): Promise<void> {
 		const node = context.element as BaseProjectTreeItem;
 		const project = await this.getProjectFromContext(node);

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -28,7 +28,7 @@ import { BuildHelper } from '../tools/buildHelper';
 import { readPublishProfile, promptForSavingProfile, savePublishProfile } from '../models/publishProfile/publishProfile';
 import { AddDatabaseReferenceDialog } from '../dialogs/addDatabaseReferenceDialog';
 import { ISystemDatabaseReferenceSettings, IDacpacReferenceSettings, IProjectReferenceSettings, INugetPackageReferenceSettings } from '../models/IDatabaseReferenceSettings';
-import { DatabaseReferenceTreeItem } from '../models/tree/databaseReferencesTreeItem';
+import { DatabaseReferenceTreeItem, SqlProjectReferenceTreeItem } from '../models/tree/databaseReferencesTreeItem';
 import { CreateProjectFromDatabaseDialog } from '../dialogs/createProjectFromDatabaseDialog';
 import { UpdateProjectFromDatabaseDialog } from '../dialogs/updateProjectFromDatabaseDialog';
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from '../common/telemetry';
@@ -1026,6 +1026,20 @@ export class ProjectsController {
 	public async openContainingFolder(context: dataworkspace.WorkspaceTreeItem): Promise<void> {
 		const project = await this.getProjectFromContext(context);
 		await vscode.commands.executeCommand(constants.revealFileInOsCommand, vscode.Uri.file(project.projectFilePath));
+	}
+
+	public async openReferencedSqlProject(context: dataworkspace.WorkspaceTreeItem): Promise<void> {
+		const node = context.element as BaseProjectTreeItem;
+		const project = await this.getProjectFromContext(node);
+
+		if (!(node instanceof SqlProjectReferenceTreeItem)) {
+			return;
+		}
+
+		console.log(`opening referenced project ${node.entryKey}`);
+		const absolutePath = path.normalize(path.join(project.projectFolderPath, node.reference.fsUri.fsPath));
+
+		await this.openProjectInWorkspace(absolutePath);
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1036,9 +1036,7 @@ export class ProjectsController {
 			return;
 		}
 
-		console.log(`opening referenced project ${node.entryKey}`);
 		const absolutePath = path.normalize(path.join(project.projectFolderPath, node.reference.fsUri.fsPath));
-
 		await this.openProjectInWorkspace(absolutePath);
 	}
 

--- a/extensions/sql-database-projects/src/models/tree/databaseReferencesTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/databaseReferencesTreeItem.ts
@@ -10,6 +10,7 @@ import * as constants from '../../common/constants';
 import { BaseProjectTreeItem } from './baseTreeItem';
 import { IconPathHelper } from '../../common/iconHelper';
 import { IDatabaseReferenceProjectEntry } from 'sqldbproj';
+import { SqlProjectReferenceProjectEntry } from '../projectEntry';
 
 /**
  * Folder for containing references nodes in the tree
@@ -35,7 +36,9 @@ export class DatabaseReferencesTreeItem extends BaseProjectTreeItem {
 		}
 
 		for (const reference of databaseReferences) {
-			this.references.push(new DatabaseReferenceTreeItem(reference, this.relativeProjectUri, this.projectFileUri));
+			this.references.push(reference instanceof SqlProjectReferenceProjectEntry
+				? new SqlProjectReferenceTreeItem(reference, this.relativeProjectUri, this.projectFileUri)
+				: new DatabaseReferenceTreeItem(reference, this.relativeProjectUri, this.projectFileUri));
 		}
 	}
 
@@ -57,7 +60,7 @@ export class DatabaseReferencesTreeItem extends BaseProjectTreeItem {
 }
 
 export class DatabaseReferenceTreeItem extends BaseProjectTreeItem {
-	constructor(private reference: IDatabaseReferenceProjectEntry, referencesNodeRelativeProjectUri: vscode.Uri, sqlprojUri: vscode.Uri) {
+	constructor(public readonly reference: IDatabaseReferenceProjectEntry, referencesNodeRelativeProjectUri: vscode.Uri, sqlprojUri: vscode.Uri) {
 		super(vscode.Uri.file(path.join(referencesNodeRelativeProjectUri.fsPath, reference.referenceName)), sqlprojUri);
 		this.entryKey = this.friendlyName;
 	}
@@ -77,5 +80,11 @@ export class DatabaseReferenceTreeItem extends BaseProjectTreeItem {
 		refItem.iconPath = IconPathHelper.referenceDatabase;
 
 		return refItem;
+	}
+}
+
+export class SqlProjectReferenceTreeItem extends DatabaseReferenceTreeItem {
+	public override get type(): constants.DatabaseProjectItemType {
+		return constants.DatabaseProjectItemType.sqlProjectReference;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23170

I thought ADS used to cascade opening referenced projects, but it appears SSDT doesn't either.  Instead of opening the full tree of project references automatically, I opted to add a hook to open referenced projects in ADS.

https://github.com/microsoft/azuredatastudio/assets/1609827/49e20d03-a405-4ba7-983a-0f38bf0142a7

