### PR TITLE
[SQL Migration] Release v1.4.5 to Worldwide

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.4",
-							"lastUpdated": "04/25/2023",
+							"version": "1.4.5",
+							"lastUpdated": "05/24/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.4.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.5.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the wolrdwide extension gallery to the latest version of the SQL Migration extension. 
This version was already released to insiders via PR:  https://github.com/microsoft/azuredatastudio/pull/23119