### PR TITLE
rename table commands

### DIFF
--- a/src/sql/workbench/contrib/table/browser/table.contribution.ts
+++ b/src/sql/workbench/contrib/table/browser/table.contribution.ts
@@ -13,9 +13,9 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { HybridDataProvider } from 'sql/base/browser/ui/table/hybridDataProvider';
 import { IComponentContextService } from 'sql/workbench/services/componentContext/browser/componentContextService';
 
-export const RESIZE_COLUMN_COMMAND_ID = 'table.resizeColumn';
-export const SHOW_COLUMN_MENU_COMMAND_ID = 'table.showColumnMenu';
-export const SORT_COLUMN_COMMAND_ID = 'table.sortColumn';
+export const RESIZE_COLUMN_COMMAND_ID = 'grid.resizeColumn';
+export const SHOW_COLUMN_MENU_COMMAND_ID = 'grid.showColumnMenu';
+export const SORT_COLUMN_COMMAND_ID = 'grid.sortColumn';
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: RESIZE_COLUMN_COMMAND_ID,


### PR DESCRIPTION
these commands were introduced to address accessibility bugs recently, it's unlikely being used by users. I am changing the command name from `table.xxx` to `grid.xxx` to make it consistent with the other commands.