### PR TITLE
Allow adding new sqlcmd variables to sql project without DefaultValue

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -158,6 +158,7 @@ export const chooseSqlcmdVarsToModify = localize('chooseSqlcmdVarsToModify', "Ch
 export const enterNewValueForVar = (varName: string) => localize('enterNewValueForVar', "Enter new default value for variable '{0}'", varName);
 export const enterNewSqlCmdVariableName = localize('enterNewSqlCmdVariableName', "Enter new SQLCMD Variable name");
 export const enterNewSqlCmdVariableDefaultValue = (varName: string) => localize('enterNewSqlCmdVariableDefaultValue', "Enter default value for SQLCMD variable '{0}'", varName);
+export const addSqlCmdVariableWithoutDefaultValue = (varName: string) => localize('addSqlCmdVariableWithoutDefaultValue', "Add SQLCMD variable '{0}' to project without default value?", varName);
 export const sqlcmdVariableAlreadyExists = localize('sqlcmdVariableAlreadyExists', "A SQLCMD Variable with the same name already exists in this project");
 export const resetAllVars = localize('resetAllVars', "Reset all variables");
 export const createNew = localize('createNew', "Create New");

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -993,14 +993,21 @@ export class ProjectsController {
 			return;
 		}
 
-		const defaultValue = await vscode.window.showInputBox(
+		let defaultValue = await vscode.window.showInputBox(
 			{
 				title: constants.enterNewSqlCmdVariableDefaultValue(variableName),
 				ignoreFocusOut: true
 			});
 
 		if (!defaultValue) {
-			return;
+			// prompt asking if they want to add to add a sqlcmd variable without a default value
+			const result = await vscode.window.showInformationMessage(constants.addSqlCmdVariableWithoutDefaultValue(variableName), constants.yesString, constants.noString);
+
+			if (result === constants.noString) {
+				return;
+			} else {
+				defaultValue = '';
+			}
 		}
 
 		await project.addSqlCmdVariable(variableName, defaultValue);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/azuredatastudio/issues/23135 to allow adding sqlcmd variables without a DefaultValue using through the projects add sqlcmd variable quickpick.
![sqlcmdVarNoDefaultValue](https://github.com/microsoft/azuredatastudio/assets/31145923/39eefd16-71ae-4eb8-a3a9-4835fcc1bed5)
