### PR TITLE
fix find object dialog type display name issue

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -5,6 +5,7 @@
 
 import * as nls from 'vscode-nls';
 import { ObjectManagement } from 'mssql';
+import { ObjectTypeInfo } from './ui/findObjectDialog';
 const localize = nls.loadMessageBundle();
 
 // Object Types
@@ -272,4 +273,13 @@ export function getUserTypeByDisplayName(displayName: string): ObjectManagement.
 			return key;
 	}
 	throw new Error(`Unknown user type display name: ${displayName}`);
+}
+
+export function getObjectTypeInfo(typeNames: string[]): ObjectTypeInfo[] {
+	return typeNames.map(typeName => {
+		return {
+			name: typeName,
+			displayName: getNodeTypeDisplayName(typeName, true)
+		};
+	});
 }

--- a/extensions/mssql/src/objectManagement/ui/databaseRoleDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseRoleDialog.ts
@@ -54,7 +54,11 @@ export class DatabaseRoleDialog extends PrincipalDialogBase<ObjectManagement.Dat
 		}, this.objectInfo.owner, true, 'text', 210);
 		const browseOwnerButton = this.createButton(localizedConstants.BrowseText, localizedConstants.BrowseOwnerButtonAriaLabel, async () => {
 			const dialog = new FindObjectDialog(this.objectManagementService, {
-				objectTypes: [ObjectManagement.NodeType.ApplicationRole, ObjectManagement.NodeType.DatabaseRole, ObjectManagement.NodeType.User],
+				objectTypes: localizedConstants.getObjectTypeInfo([
+					ObjectManagement.NodeType.ApplicationRole,
+					ObjectManagement.NodeType.DatabaseRole,
+					ObjectManagement.NodeType.User
+				]),
 				selectAllObjectTypes: true,
 				multiSelect: false,
 				contextId: this.contextId,
@@ -78,7 +82,10 @@ export class DatabaseRoleDialog extends PrincipalDialogBase<ObjectManagement.Dat
 		const buttonContainer = this.addButtonsForTable(this.memberTable, localizedConstants.AddMemberAriaLabel, localizedConstants.RemoveMemberAriaLabel,
 			async () => {
 				const dialog = new FindObjectDialog(this.objectManagementService, {
-					objectTypes: [ObjectManagement.NodeType.DatabaseRole, ObjectManagement.NodeType.User],
+					objectTypes: localizedConstants.getObjectTypeInfo([
+						ObjectManagement.NodeType.DatabaseRole,
+						ObjectManagement.NodeType.User
+					]),
 					selectAllObjectTypes: true,
 					multiSelect: true,
 					contextId: this.contextId,

--- a/extensions/mssql/src/objectManagement/ui/findObjectDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/findObjectDialog.ts
@@ -9,10 +9,13 @@ import { DefaultTableListItemEnabledStateGetter, DefaultMaxTableRowCount, Dialog
 import * as localizedConstants from '../localizedConstants';
 import { getErrorMessage } from '../../utils';
 
-type ObjectType = string | { name: string, displayName: string };
+export interface ObjectTypeInfo {
+	name: string;
+	displayName: string;
+}
 
 export interface FindObjectDialogOptions {
-	objectTypes: ObjectType[];
+	objectTypes: ObjectTypeInfo[];
 	selectAllObjectTypes: boolean;
 	multiSelect: boolean;
 	contextId: string;
@@ -37,7 +40,7 @@ export class FindObjectDialog extends DialogBase<FindObjectDialogResult> {
 	private objectsTable: azdata.TableComponent;
 	private objectsLoadingComponent: azdata.LoadingComponent;
 	private result: FindObjectDialogResult;
-	private selectedObjectTypes: ObjectType[] = [];
+	private selectedObjectTypes: ObjectTypeInfo[] = [];
 	private allObjects: mssql.ObjectManagement.SearchResultItem[] = [];
 
 	constructor(private readonly objectManagementService: mssql.IObjectManagementService, private readonly options: FindObjectDialogOptions) {
@@ -49,25 +52,17 @@ export class FindObjectDialog extends DialogBase<FindObjectDialogResult> {
 		this.selectedObjectTypes = options.selectAllObjectTypes ? [...options.objectTypes] : [];
 	}
 
-	private getObjectTypeName(objectType: ObjectType): string {
-		return typeof objectType === 'string' ? objectType : objectType.name;
-	}
-
-	private getObjectTypeDisplayName(objectType: ObjectType): string {
-		return typeof objectType === 'string' ? localizedConstants.getNodeTypeDisplayName(objectType, true) : objectType.displayName;
-	}
-
 	protected override async initialize(): Promise<void> {
 		this.dialogObject.okButton.enabled = false;
-		this.objectTypesTable = this.createTableList<ObjectType>(localizedConstants.ObjectTypeText,
+		this.objectTypesTable = this.createTableList<ObjectTypeInfo>(localizedConstants.ObjectTypeText,
 			[localizedConstants.ObjectTypeText],
 			this.options.objectTypes,
 			this.selectedObjectTypes,
 			DefaultMaxTableRowCount,
 			DefaultTableListItemEnabledStateGetter, (item) => {
-				return [this.getObjectTypeDisplayName(item)];
+				return [item.displayName];
 			}, (item1, item2) => {
-				return this.getObjectTypeName(item1) === this.getObjectTypeName(item2);
+				return item1.name === item2.name;
 			});
 		this.findButton = this.createButton(localizedConstants.FindText, localizedConstants.FindText, async () => {
 			await this.onFindObjectButtonClick();
@@ -118,7 +113,7 @@ export class FindObjectDialog extends DialogBase<FindObjectDialogResult> {
 		this.objectsLoadingComponent.loading = true;
 		this.findButton.enabled = false;
 		try {
-			const results = await this.objectManagementService.search(this.options.contextId, this.selectedObjectTypes.map(item => this.getObjectTypeName(item)));
+			const results = await this.objectManagementService.search(this.options.contextId, this.selectedObjectTypes.map(item => item.name));
 			this.allObjects.splice(0, this.allObjects.length, ...results);
 			let data;
 			if (this.options.multiSelect) {
@@ -147,7 +142,8 @@ export class FindObjectDialog extends DialogBase<FindObjectDialogResult> {
 	}
 
 	private getObjectRowValue(item: mssql.ObjectManagement.SearchResultItem): string[] {
-		const row = [item.name, this.getObjectTypeName(item.type)];
+		const objectType = this.options.objectTypes.find(type => type.name === item.type);
+		const row = [item.name, objectType?.displayName];
 		if (this.options.showSchemaColumn) {
 			row.splice(1, 0, item.schema);
 		}

--- a/extensions/mssql/src/objectManagement/ui/serverRoleDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverRoleDialog.ts
@@ -59,7 +59,10 @@ export class ServerRoleDialog extends PrincipalDialogBase<ObjectManagement.Serve
 		}, this.objectInfo.owner, !this.viewInfo.isFixedRole, 'text', 210);
 		const browseOwnerButton = this.createButton(localizedConstants.BrowseText, localizedConstants.BrowseOwnerButtonAriaLabel, async () => {
 			const dialog = new FindObjectDialog(this.objectManagementService, {
-				objectTypes: [ObjectManagement.NodeType.ServerLevelLogin, ObjectManagement.NodeType.ServerLevelServerRole],
+				objectTypes: localizedConstants.getObjectTypeInfo([
+					ObjectManagement.NodeType.ServerLevelLogin,
+					ObjectManagement.NodeType.ServerLevelServerRole
+				]),
 				selectAllObjectTypes: true,
 				multiSelect: false,
 				contextId: this.contextId,
@@ -84,7 +87,10 @@ export class ServerRoleDialog extends PrincipalDialogBase<ObjectManagement.Serve
 		const buttonContainer = this.addButtonsForTable(this.memberTable, localizedConstants.AddMemberAriaLabel, localizedConstants.RemoveMemberAriaLabel,
 			async () => {
 				const dialog = new FindObjectDialog(this.objectManagementService, {
-					objectTypes: [ObjectManagement.NodeType.ServerLevelLogin, ObjectManagement.NodeType.ServerLevelServerRole],
+					objectTypes: localizedConstants.getObjectTypeInfo([
+						ObjectManagement.NodeType.ServerLevelLogin,
+						ObjectManagement.NodeType.ServerLevelServerRole
+					]),
 					selectAllObjectTypes: true,
 					multiSelect: true,
 					contextId: this.contextId,


### PR DESCRIPTION
Issue: In the following scenarios, the type is displayed with underlying type name instead of display name:
1. Add Server Role Member
2. Browse database role owner
3. Add database role member

Fix:
Enforce the full object type so that the Find Object Dialog doesn't need to handle special cases.

Before
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/c8650983-a88a-461c-af21-516bb0420ffd)

After
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/927f0018-6498-4c53-8f7e-d1413b4eabf8)

