### PR TITLE
add objects dialog

### DIFF
--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -976,6 +976,16 @@ declare module 'mssql' {
 		}
 
 		/**
+		 * Base interface for database level security principal object's view information.
+		 */
+		export interface DatabaseLevelPrincipalViewInfo<T extends SecurityPrincipalObject> extends SecurityPrincipalViewInfo<T> {
+			/**
+			 * The schemas in the database.
+			 */
+			schemas: string[];
+		}
+
+		/**
 		 * Server level login.
 		 */
 		export interface Login extends SecurityPrincipalObject {
@@ -1237,7 +1247,7 @@ declare module 'mssql' {
 		/**
 		 * The information required to render the user view.
 		 */
-		export interface UserViewInfo extends SecurityPrincipalViewInfo<User> {
+		export interface UserViewInfo extends DatabaseLevelPrincipalViewInfo<User> {
 			/**
 			 * All user types supported by the database.
 			 */
@@ -1246,10 +1256,6 @@ declare module 'mssql' {
 			 * All languages supported by the database.
 			 */
 			languages: string[];
-			/**
-			 * All schemas in the database.
-			 */
-			schemas: string[];
 			/**
 			 * Name of all the logins in the server.
 			 */
@@ -1313,11 +1319,7 @@ declare module 'mssql' {
 		/**
 		 * Interface representing the information required to render the application role view.
 		 */
-		export interface ApplicationRoleViewInfo extends SecurityPrincipalViewInfo<ApplicationRoleInfo> {
-			/**
-			 * List of all the schemas in the database.
-			 */
-			schemas: string[];
+		export interface ApplicationRoleViewInfo extends DatabaseLevelPrincipalViewInfo<ApplicationRoleInfo> {
 		}
 
 		/**
@@ -1341,11 +1343,7 @@ declare module 'mssql' {
 		/**
 		 * Interface representing the information required to render the database role view.
 		 */
-		export interface DatabaseRoleViewInfo extends SecurityPrincipalViewInfo<DatabaseRoleInfo> {
-			/**
-			 * List of all the schemas in the database.
-			 */
-			schemas: string[];
+		export interface DatabaseRoleViewInfo extends DatabaseLevelPrincipalViewInfo<DatabaseRoleInfo> {
 		}
 
 		/**

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -196,8 +196,10 @@ export const SelectServerRoleMemberDialogTitle = localize('objectManagement.serv
 export const SelectServerRoleOwnerDialogTitle = localize('objectManagement.serverRole.SelectOwnerDialogTitle', "Select Server Role Owner");
 
 // Find Object Dialog
+export const ObjectTypesText = localize('objectManagement.objectTypesLabel', "Object Types");
+export const FilterSectionTitle = localize('objectManagement.filterSectionTitle', "Filters");
 export const ObjectTypeText = localize('objectManagement.objectTypeLabel', "Object Type");
-export const FilterText = localize('objectManagement.filterText', "Filter");
+export const SearchTextLabel = localize('objectManagement.SearchTextLabel', "Search Text");
 export const FindText = localize('objectManagement.findText', "Find");
 export const SelectText = localize('objectManagement.selectText', "Select");
 export const ObjectsText = localize('objectManagement.objectsLabel', "Objects");
@@ -206,8 +208,15 @@ export function LoadingObjectsCompletedText(count: number): string {
 	return localize('objectManagement.loadingObjectsCompletedLabel', "Loading objects completed, {0} objects found", count);
 }
 
-// Util functions
+// ObjectSelectionMethodDialog
+export const ObjectSelectionMethodDialogTitle = localize('objectManagement.objectSelectionMethodDialogTitle', "Add Objects");
+export const ObjectSelectionMethodDialog_TypeLabel = localize('objectManagement.ObjectSelectionMethodDialog_TypeLabel', "How do you want to add objects?");
+export const ObjectSelectionMethodDialog_SpecificObjects = localize('objectManagement.ObjectSelectionMethodDialog_SpecificObjects', "Specific objects…");
+export const ObjectSelectionMethodDialog_AllObjectsOfTypes = localize('objectManagement.ObjectSelectionMethodDialog_AllObjectsOfTypes', "All objects of certain types");
+export const ObjectSelectionMethodDialog_AllObjectsOfSchema = localize('objectManagement.ObjectSelectionMethodDialog_AllObjectsOfSchema', "All objects belonging to a schema");
+export const ObjectSelectionMethodDialog_SelectSchemaDropdownLabel = localize('objectManagement.ObjectSelectionMethodDialog_SelectSchemaDropdownLabel', "Schema");
 
+// Util functions
 export function getNodeTypeDisplayName(type: string, inTitle: boolean = false): string {
 	switch (type) {
 		case ObjectManagement.NodeType.ApplicationRole:

--- a/extensions/mssql/src/objectManagement/ui/applicationRoleDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/applicationRoleDialog.ts
@@ -26,7 +26,7 @@ export class ApplicationRoleDialog extends PrincipalDialogBase<ObjectManagement.
 	private ownedSchemaTable: azdata.TableComponent;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		super(objectManagementService, options, true, false);
+		super(objectManagementService, { ...options, isDatabaseLevelPrincipal: true, supportEffectivePermissions: false });
 	}
 
 	protected override postInitializeData(): void {

--- a/extensions/mssql/src/objectManagement/ui/databaseRoleDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseRoleDialog.ts
@@ -28,7 +28,7 @@ export class DatabaseRoleDialog extends PrincipalDialogBase<ObjectManagement.Dat
 	private memberTable: azdata.TableComponent;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		super(objectManagementService, options, true, false);
+		super(objectManagementService, { ...options, isDatabaseLevelPrincipal: true, supportEffectivePermissions: false });
 	}
 
 	protected override get helpUrl(): string {

--- a/extensions/mssql/src/objectManagement/ui/loginDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/loginDialog.ts
@@ -35,7 +35,7 @@ export class LoginDialog extends PrincipalDialogBase<ObjectManagement.Login, Obj
 	private lockedOutCheckbox: azdata.CheckBoxComponent;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		super(objectManagementService, options, false);
+		super(objectManagementService, { ...options, isDatabaseLevelPrincipal: false, supportEffectivePermissions: true });
 	}
 
 	protected override get helpUrl(): string {

--- a/extensions/mssql/src/objectManagement/ui/objectSelectionMethodDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectSelectionMethodDialog.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import { DefaultMaxTableRowCount, DefaultTableListItemEnabledStateGetter, DialogBase } from '../../ui/dialogBase';
+import * as localizedConstants from '../localizedConstants';
+import { ObjectTypeInfo } from './findObjectDialog';
+
+export enum ObjectSelectionMethod {
+	SpecificObjects,
+	AllObjectsOfTypes,
+	AllObjectsOfSchema
+}
+
+export interface ObjectSelectionMethodDialogOptions {
+	objectTypes: ObjectTypeInfo[];
+	schemas: string[];
+}
+
+export interface ObjectSelectionMethodDialogResult {
+	method: ObjectSelectionMethod;
+	schema: string | undefined;
+	objectTypes: ObjectTypeInfo[];
+}
+
+export class ObjectSelectionMethodDialog extends DialogBase<ObjectSelectionMethodDialogResult> {
+	private specificObjectsRadioButton: azdata.RadioButtonComponent;
+	private allObjectsOfTypesRadioButton: azdata.RadioButtonComponent;
+	private allObjectsOfSchemaRadioButton: azdata.RadioButtonComponent;
+	private objectTypesTable: azdata.TableComponent;
+	private schemaRow: azdata.FlexContainer;
+	private result: ObjectSelectionMethodDialogResult;
+
+	constructor(private readonly options: ObjectSelectionMethodDialogOptions) {
+		super(localizedConstants.ObjectSelectionMethodDialogTitle, 'ObjectSelectionMethodDialog');
+		this.result = {
+			method: ObjectSelectionMethod.SpecificObjects,
+			schema: undefined,
+			objectTypes: []
+		};
+	}
+
+	protected override async initialize(): Promise<void> {
+		const radioGroupName = 'objectSelectionMethodRadioGroup';
+		this.specificObjectsRadioButton = this.createRadioButton(localizedConstants.ObjectSelectionMethodDialog_SpecificObjects, radioGroupName, true, async (checked) => { await this.handleTypeChange(checked); });
+		this.allObjectsOfTypesRadioButton = this.createRadioButton(localizedConstants.ObjectSelectionMethodDialog_AllObjectsOfTypes, radioGroupName, false, async (checked) => { await this.handleTypeChange(checked); });
+		this.allObjectsOfSchemaRadioButton = this.createRadioButton(localizedConstants.ObjectSelectionMethodDialog_AllObjectsOfSchema, radioGroupName, false, async (checked) => { await this.handleTypeChange(checked); });
+
+		const typeGroup = this.createGroup(localizedConstants.ObjectSelectionMethodDialog_TypeLabel, [this.specificObjectsRadioButton, this.allObjectsOfTypesRadioButton, this.allObjectsOfSchemaRadioButton], false);
+		this.objectTypesTable = this.createTableList<ObjectTypeInfo>(localizedConstants.ObjectTypeText,
+			[localizedConstants.ObjectTypesText],
+			this.options.objectTypes,
+			this.result.objectTypes,
+			DefaultMaxTableRowCount,
+			DefaultTableListItemEnabledStateGetter, (item) => {
+				return [item.displayName];
+			}, (item1, item2) => {
+				return item1.name === item2.name;
+			});
+
+		const schemaDropdown = this.createDropdown(localizedConstants.ObjectSelectionMethodDialog_SelectSchemaDropdownLabel, async (newValue) => {
+			this.result.schema = newValue;
+		}, this.options.schemas, this.options.schemas[0]);
+		this.schemaRow = this.createLabelInputContainer(localizedConstants.ObjectSelectionMethodDialog_SelectSchemaDropdownLabel, schemaDropdown);
+		await this.setComponentsVisibility(false, false);
+		this.formContainer.addItems([typeGroup, this.schemaRow, this.objectTypesTable], this.getSectionItemLayout());
+	}
+
+	private async handleTypeChange(checked: boolean): Promise<void> {
+		let method: ObjectSelectionMethod = ObjectSelectionMethod.SpecificObjects;
+		let showSchema = false;
+		let showObjectTypes = false;
+		await this.setComponentsVisibility(showObjectTypes, showSchema);
+		if (this.allObjectsOfTypesRadioButton.checked) {
+			method = ObjectSelectionMethod.AllObjectsOfTypes;
+			showSchema = false;
+			showObjectTypes = true;
+		} else if (this.allObjectsOfSchemaRadioButton.checked) {
+			method = ObjectSelectionMethod.AllObjectsOfSchema;
+			showSchema = true;
+			showObjectTypes = false;
+		}
+		this.result.method = method;
+		await this.setComponentsVisibility(showObjectTypes, showSchema);
+	}
+
+	private async setComponentsVisibility(showObjectTypes: boolean, showSchema: boolean): Promise<void> {
+		await this.schemaRow.updateCssStyles({ display: showSchema ? 'flex' : 'none' });
+		await this.objectTypesTable.updateCssStyles({ display: showObjectTypes ? 'block' : 'none' });
+	}
+
+	protected override get dialogResult(): ObjectSelectionMethodDialogResult | undefined {
+		return this.result;
+	}
+
+	protected override async onFormFieldChange(): Promise<void> {
+		this.dialogObject.okButton.enabled = this.result.method !== ObjectSelectionMethod.AllObjectsOfTypes || this.result.objectTypes.length > 0;
+	}
+}

--- a/extensions/mssql/src/objectManagement/ui/principalDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/principalDialogBase.ts
@@ -8,13 +8,19 @@ import * as mssql from 'mssql';
 import * as localizedConstants from '../localizedConstants';
 
 import { ObjectManagementDialogBase, ObjectManagementDialogOptions } from './objectManagementDialogBase';
-import { FindObjectDialog } from './findObjectDialog';
+import { FindObjectDialog, FindObjectDialogResult } from './findObjectDialog';
 import { deepClone } from '../../util/objects';
 import { DefaultTableWidth, getTableHeight } from '../../ui/dialogBase';
+import { ObjectSelectionMethod, ObjectSelectionMethodDialog } from './objectSelectionMethodDialog';
 
 const GrantColumnIndex = 2;
 const WithGrantColumnIndex = 3;
 const DenyColumnIndex = 4;
+
+export interface PrincipalDialogOptions extends ObjectManagementDialogOptions {
+	isDatabaseLevelPrincipal: boolean;
+	supportEffectivePermissions: boolean;
+}
 
 /**
  * Base class for security principal dialogs such as user, role, etc.
@@ -28,8 +34,8 @@ export abstract class PrincipalDialogBase<ObjectInfoType extends mssql.ObjectMan
 	protected effectivePermissionTableLabel: azdata.TextComponent;
 	private securablePermissions: mssql.ObjectManagement.SecurablePermissions[] = [];
 
-	constructor(objectManagementService: mssql.IObjectManagementService, options: ObjectManagementDialogOptions, private readonly showSchemaColumn: boolean, private readonly supportEffectivePermissions: boolean = true) {
-		super(objectManagementService, options);
+	constructor(objectManagementService: mssql.IObjectManagementService, private readonly dialogOptions: PrincipalDialogOptions) {
+		super(objectManagementService, dialogOptions);
 	}
 
 	protected override async initializeUI(): Promise<void> {
@@ -40,12 +46,12 @@ export abstract class PrincipalDialogBase<ObjectInfoType extends mssql.ObjectMan
 	private initializeSecurableSection(): void {
 		const items: azdata.Component[] = [];
 		const securableTableColumns = [localizedConstants.NameText, localizedConstants.ObjectTypeText];
-		if (this.showSchemaColumn) {
+		if (this.dialogOptions.isDatabaseLevelPrincipal) {
 			securableTableColumns.splice(1, 0, localizedConstants.SchemaText);
 		}
 		this.securableTable = this.createTable(localizedConstants.SecurablesText, securableTableColumns, this.getSecurableTableData());
 		const buttonContainer = this.addButtonsForTable(this.securableTable, localizedConstants.AddSecurableAriaLabel, localizedConstants.RemoveSecurableAriaLabel,
-			() => this.onAddSecurableButtonClicked(), () => this.onRemoveSecurableButtonClicked());
+			(button) => this.onAddSecurableButtonClicked(button), () => this.onRemoveSecurableButtonClicked());
 		this.disposables.push(this.securableTable.onRowSelected(async () => {
 			await this.updatePermissionsTable();
 		}));
@@ -115,19 +121,40 @@ export abstract class PrincipalDialogBase<ObjectInfoType extends mssql.ObjectMan
 		this.securableSection = this.createGroup(localizedConstants.SecurablesText, items, true, true);
 	}
 
-	private async onAddSecurableButtonClicked(): Promise<void> {
-		const dialog = new FindObjectDialog(this.objectManagementService, {
-			objectTypes: this.viewInfo.supportedSecurableTypes,
-			selectAllObjectTypes: false,
-			multiSelect: true,
-			contextId: this.contextId,
-			title: localizedConstants.SelectSecurablesDialogTitle,
-			showSchemaColumn: this.showSchemaColumn
-		});
-		await dialog.open();
-		const result = await dialog.waitForClose();
-		if (result && result.selectedObjects.length > 0) {
-			result.selectedObjects.forEach(obj => {
+	private async onAddSecurableButtonClicked(button: azdata.ButtonComponent): Promise<void> {
+		const selectedObjects: mssql.ObjectManagement.SearchResultItem[] = [];
+		if (this.dialogOptions.isDatabaseLevelPrincipal) {
+			const methodDialog = new ObjectSelectionMethodDialog({
+				objectTypes: this.viewInfo.supportedSecurableTypes,
+				schemas: (<mssql.ObjectManagement.DatabaseLevelPrincipalViewInfo<mssql.ObjectManagement.SecurityPrincipalObject>><unknown>this.viewInfo).schemas,
+			});
+			await methodDialog.open();
+			const methodResult = await methodDialog.waitForClose();
+			if (methodResult) {
+				switch (methodResult.method) {
+					case ObjectSelectionMethod.AllObjectsOfTypes:
+						selectedObjects.push(... await this.searchForObjects(methodResult.objectTypes.map(item => item.name)));
+						break;
+					case ObjectSelectionMethod.AllObjectsOfSchema:
+						selectedObjects.push(... await this.searchForObjects(this.viewInfo.supportedSecurableTypes.map(item => item.name), methodResult.schema));
+						break;
+					default:
+						const objectsResult = await this.openFindObjectsDialog();
+						if (objectsResult) {
+							selectedObjects.push(...objectsResult.selectedObjects);
+						}
+						break;
+				}
+			}
+		} else {
+			const result = await this.openFindObjectsDialog();
+			if (result) {
+				selectedObjects.push(...result.selectedObjects);
+			}
+		}
+
+		if (selectedObjects.length > 0) {
+			selectedObjects.forEach(obj => {
 				if (this.securablePermissions.find(securable => securable.type === obj.type && securable.name === obj.name && securable.schema === obj.schema)) {
 					return;
 				}
@@ -150,6 +177,27 @@ export abstract class PrincipalDialogBase<ObjectInfoType extends mssql.ObjectMan
 			const data = this.getSecurableTableData();
 			await this.setTableData(this.securableTable, data);
 		}
+		await button.focus();
+	}
+
+	private async searchForObjects(objectTypes: string[], schema: string = undefined): Promise<mssql.ObjectManagement.SearchResultItem[]> {
+		this.updateLoadingStatus(true);
+		const result = await this.objectManagementService.search(this.contextId, objectTypes, undefined, schema);
+		this.updateLoadingStatus(false);
+		return result;
+	}
+
+	private async openFindObjectsDialog(): Promise<FindObjectDialogResult> {
+		const dialog = new FindObjectDialog(this.objectManagementService, {
+			objectTypes: this.viewInfo.supportedSecurableTypes,
+			selectAllObjectTypes: false,
+			multiSelect: true,
+			contextId: this.contextId,
+			title: localizedConstants.SelectSecurablesDialogTitle,
+			showSchemaColumn: this.dialogOptions.isDatabaseLevelPrincipal
+		});
+		await dialog.open();
+		return await dialog.waitForClose();
 	}
 
 	private async onRemoveSecurableButtonClicked(): Promise<void> {
@@ -164,7 +212,7 @@ export abstract class PrincipalDialogBase<ObjectInfoType extends mssql.ObjectMan
 	private getSecurableTableData(): string[][] {
 		return this.securablePermissions.map(securable => {
 			const row = [securable.name, this.getSecurableTypeDisplayName(securable.type)];
-			if (this.showSchemaColumn) {
+			if (this.dialogOptions.isDatabaseLevelPrincipal) {
 				row.splice(1, 0, securable.schema);
 			}
 			return row;
@@ -223,6 +271,6 @@ export abstract class PrincipalDialogBase<ObjectInfoType extends mssql.ObjectMan
 	}
 
 	private get showEffectivePermissions(): boolean {
-		return !this.options.isNewObject && this.supportEffectivePermissions;
+		return !this.dialogOptions.isNewObject && this.dialogOptions.supportEffectivePermissions;
 	}
 }

--- a/extensions/mssql/src/objectManagement/ui/serverRoleDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverRoleDialog.ts
@@ -28,7 +28,7 @@ export class ServerRoleDialog extends PrincipalDialogBase<ObjectManagement.Serve
 
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		super(objectManagementService, options, false, false);
+		super(objectManagementService, { ...options, isDatabaseLevelPrincipal: false, supportEffectivePermissions: false });
 	}
 
 	protected override get helpUrl(): string {

--- a/extensions/mssql/src/objectManagement/ui/userDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/userDialog.ts
@@ -32,7 +32,7 @@ export class UserDialog extends PrincipalDialogBase<ObjectManagement.User, Objec
 	private membershipTable: azdata.TableComponent;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		super(objectManagementService, options, true);
+		super(objectManagementService, { ...options, isDatabaseLevelPrincipal: true, supportEffectivePermissions: true });
 	}
 
 	protected override get helpUrl(): string {

--- a/extensions/mssql/src/ui/scriptableDialogBase.ts
+++ b/extensions/mssql/src/ui/scriptableDialogBase.ts
@@ -68,8 +68,8 @@ export abstract class ScriptableDialogBase<OptionsType extends ScriptableDialogO
 		await this.initializeUI();
 	}
 
-	protected override onLoadingStatusChanged(isLoading: boolean): void {
-		super.onLoadingStatusChanged(isLoading);
+	protected override updateLoadingStatus(isLoading: boolean): void {
+		super.updateLoadingStatus(isLoading);
 		this._helpButton.enabled = !isLoading;
 		this.dialogObject.okButton.enabled = this._scriptButton.enabled = isLoading ? false : this.isDirty;
 	}
@@ -80,7 +80,7 @@ export abstract class ScriptableDialogBase<OptionsType extends ScriptableDialogO
 	protected abstract generateScript(): Promise<string>;
 
 	private async onScriptButtonClick(): Promise<void> {
-		this.onLoadingStatusChanged(true);
+		this.updateLoadingStatus(true);
 		try {
 			const isValid = await this.runValidation();
 			if (!isValid) {
@@ -104,7 +104,7 @@ export abstract class ScriptableDialogBase<OptionsType extends ScriptableDialogO
 				level: azdata.window.MessageLevel.Error
 			};
 		} finally {
-			this.onLoadingStatusChanged(false);
+			this.updateLoadingStatus(false);
 		}
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/groupContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/groupContainer.component.ts
@@ -22,9 +22,10 @@ import { ILogService } from 'vs/platform/log/common/log';
 	selector: 'modelview-groupContainer',
 	template: `
 		<div *ngIf="hasHeader()" [class]="getHeaderClass()" (click)="changeState()" (keydown)="onKeyDown($event)" [tabindex]="isCollapsible()? 0 : -1" [attr.role]="isCollapsible() ? 'button' : null" [attr.aria-expanded]="isCollapsible() ? !collapsed : null">
-				{{_containerLayout.header}}
+				{{header}}
 		</div>
 		<!-- This extra div is needed so that the expanded state of the header is updated correctly. See https://github.com/microsoft/azuredatastudio/pull/16499 for more details -->
+		<fieldset [attr.aria-label]="header" class="modelview-group-fieldset">
 		<div>
 			<div #container *ngIf="items" class="modelview-group-container" [ngStyle]="CSSStyles">
 				<ng-container *ngFor="let item of items">
@@ -37,6 +38,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 				</ng-container>
 			</div>
 		</div>
+		</fieldset>
 	`
 })
 export default class GroupContainer extends ContainerBase<GroupLayout, GroupContainerProperties> implements IComponent, OnDestroy, AfterViewInit {
@@ -93,6 +95,10 @@ export default class GroupContainer extends ContainerBase<GroupLayout, GroupCont
 
 	public get collapsed(): boolean {
 		return this.getPropertyOrDefault<boolean>((props) => props.collapsed, false);
+	}
+
+	public get header(): string {
+		return this._containerLayout?.header;
 	}
 
 	private hasHeader(): boolean {

--- a/src/sql/workbench/browser/modelComponents/media/groupLayout.css
+++ b/src/sql/workbench/browser/modelComponents/media/groupLayout.css
@@ -9,6 +9,13 @@
 	box-sizing: border-box;
 }
 
+.modelview-group-fieldset {
+	border: none;
+	margin-inline: 0px;
+	padding-inline: 0px;
+	padding-block: 0px;
+}
+
 .modelview-group-row {
 	display: table-row;
 }


### PR DESCRIPTION
1. New dialog to add database level serurables.
2. Add search text field to the FindObjects dialog.
3. This PR fixes #23240


specific objects
![specific-objects](https://github.com/microsoft/azuredatastudio/assets/13777222/9dfee165-4955-4722-96e4-1d590db916b7)

all objects of certain types
![by-types](https://github.com/microsoft/azuredatastudio/assets/13777222/dddd29d4-2a0d-4301-a4d4-90e7b44556ad)

all objects of a schema
![by-schema](https://github.com/microsoft/azuredatastudio/assets/13777222/8aa2e33f-a308-4228-872e-557429d775fb)
