### PR TITLE
fix aria label for message items

### DIFF
--- a/src/sql/workbench/contrib/query/browser/messagePanel.ts
+++ b/src/sql/workbench/contrib/query/browser/messagePanel.ts
@@ -70,6 +70,15 @@ const TemplateIds = {
 	ERROR: 'error'
 };
 
+function getTimestampDisplayString(message: IResultMessageIntern): string | undefined {
+	if (message.time) {
+		const time = isString(message.time) ? new Date(message.time!) : message.time;
+		return time.toLocaleTimeString();
+	} else {
+		return undefined;
+	}
+}
+
 export class AccessibilityProvider implements IListAccessibilityProvider<IResultMessageIntern> {
 
 	getWidgetAriaLabel(): string {
@@ -77,7 +86,11 @@ export class AccessibilityProvider implements IListAccessibilityProvider<IResult
 	}
 
 	getAriaLabel(element: IResultMessageIntern): string {
-		return element.message;
+		if (element.time && element.range) {
+			return localize('messagePanel.message', "Timestamp: {0}, Message: {1}", getTimestampDisplayString(element), element.message);
+		} else {
+			return element.message;
+		}
 	}
 }
 
@@ -321,10 +334,7 @@ class BatchMessageRenderer implements ITreeRenderer<IResultMessageIntern, void, 
 	}
 
 	renderElement(node: ITreeNode<IResultMessageIntern, void>, index: number, templateData: IBatchTemplate): void {
-		if (isString(node.element.time)) {
-			node.element.time = new Date(node.element.time!);
-		}
-		templateData.timeStamp.innerText = (node.element.time as Date).toLocaleTimeString();
+		templateData.timeStamp.innerText = getTimestampDisplayString(node.element);
 		templateData.message.innerText = node.element.message;
 		if (node.element.range) {
 			templateData.disposable.add(addStandardDisposableGenericMouseDownListener(templateData.message, () => {


### PR DESCRIPTION
For issue: #22673

Add the timestamp information to the aria label when it is available.

the screen capture below shows how NVDA reads it.

![image](https://github.com/microsoft/azuredatastudio/assets/13777222/1f33a699-c272-4fa5-84da-c62788efeb93)


![image](https://github.com/microsoft/azuredatastudio/assets/13777222/823c1848-3be8-4ca7-b4f2-49e633ba2e67)
