### PR TITLE
Delete both cache files on decryption failure

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -870,10 +870,15 @@ export abstract class AzureAuth implements vscode.Disposable {
 	protected toBase64UrlEncoding(base64string: string): string {
 		return base64string.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_'); // Need to use base64url encoding
 	}
+
 	public async deleteAllCacheMsal(): Promise<void> {
 		this.clientApplication.clearCache();
-		await this.msalCacheProvider.clearLocalCache();
+
+		// unlink both cache files
+		await this.msalCacheProvider.unlinkMsalCache();
+		await this.msalCacheProvider.unlinkLocalCache();
 	}
+
 	public async deleteAllCacheAdal(): Promise<void> {
 		const results = await this.tokenCache.findCredentials('');
 

--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -152,7 +152,9 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 				try {
 					// Fetch cached token from local cache if token is available and valid.
 					let accessToken = await this.msalCacheProvider.getTokenFromLocalCache(account.key.accountId, tenantId, resource);
-					if (this.isValidToken(accessToken)) {
+					if (this.isValidToken(accessToken) &&
+						// Ensure MSAL Cache contains user account
+						(await this.clientApplication.getAllAccounts()).find((accountInfo) => accountInfo.homeAccountId === account.key.accountId)) {
 						return accessToken;
 					} // else fallback to fetching a new token.
 				} catch (e) {

--- a/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
+++ b/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
@@ -173,10 +173,17 @@ export class MsalCachePluginProvider {
 	}
 
 	/**
-	 * Clears local access token cache.
+	 * Deletes Msal access token cache file
 	 */
-	public async clearLocalCache(): Promise<void> {
-		await this.writeCache(JSON.stringify({ tokens: [] }), this._localCacheConfiguration);
+	public async unlinkMsalCache(): Promise<void> {
+		await fsPromises.unlink(this._msalCacheConfiguration.cacheFilePath);
+	}
+
+	/**
+	 * Deletes local access token cache file.
+	 */
+	public async unlinkLocalCache(): Promise<void> {
+		await fsPromises.unlink(this._localCacheConfiguration.cacheFilePath);
 	}
 
 	//#region Private helper methods


### PR DESCRIPTION
Addresses #23286 

When reading from local/MSAL cache, if decryption fails we currently were only resetting current cache file, and not the other. This leads to other cache file causing malfunctions and unwanted errors when due to any reason IV/KEY encryption keys go bad (edge case scenario). The changes make sure both cache files are cleared in such an event and users are able to transparently reconnect.
