### PR TITLE
Fixing add server group icon when azure viewlet is disabled. 

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/media/serverTreeActions.css
+++ b/src/sql/workbench/contrib/objectExplorer/browser/media/serverTreeActions.css
@@ -15,8 +15,8 @@
 	background-image: url('add_server_inverse.svg') !important;
 }
 
-.monaco-workbench .dataExplorer-viewlet .actions-container .action-label.add-server-group-action,
-.monaco-workbench.hc-light .dataExplorer-viewlet .actions-container .action-label.add-server-group-action {
+.monaco-workbench .actions-container .action-label.add-server-group-action,
+.monaco-workbench.hc-light .actions-container .action-label.add-server-group-action {
 	background-image: url('new_servergroup.svg') !important;
 }
 


### PR DESCRIPTION
This PR fixes #22941 

Now:
![image](https://github.com/microsoft/azuredatastudio/assets/6816294/13b4dd72-73dc-48ce-b998-ab707a03001a)
Before:
![image](https://github.com/microsoft/azuredatastudio/assets/6816294/ee638f78-137b-47c8-b284-8ded870ddd33)