### PR TITLE
Fixing issue where "delete" would also show up for database reference root node

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -452,7 +452,7 @@
         },
         {
           "command": "sqlDatabaseProjects.delete",
-          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/ || viewItem =~ /^databaseProject.itemType.reference/ || viewItem == databaseProject.itemType.sqlcmdVariable",
+          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/ || viewItem == databaseProject.itemType.reference || viewItem == databaseProject.itemType.reference.sqlProject || viewItem == databaseProject.itemType.sqlcmdVariable",
           "group": "9_dbProjectsLast@2"
         },
         {


### PR DESCRIPTION
Fixing https://github.com/microsoft/azuredatastudio/issues/23308

Before:
![image](https://github.com/microsoft/azuredatastudio/assets/1609827/d28805ea-c648-4cd9-963c-0d0f175280be)

After:
![image](https://github.com/microsoft/azuredatastudio/assets/1609827/48955819-8b06-4443-a3ce-4aaffef31895)
![image](https://github.com/microsoft/azuredatastudio/assets/1609827/181adc49-22b0-41b6-985d-55e26fe48d63)
![image](https://github.com/microsoft/azuredatastudio/assets/1609827/17c00cc4-1827-4b64-8020-ccfa01dfc7b9)
