### PR TITLE
handle long text cells

### DIFF
--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -66,20 +66,25 @@ export function isCssIconCellValue(obj: any | undefined): obj is CssIconCellValu
 export function hyperLinkFormatter(row: number | undefined, cell: any | undefined, value: any, columnDef: any | undefined, dataContext: any | undefined): string {
 	let cellClasses = 'grid-cell-value-container';
 	let valueToDisplay: string = '';
-
+	let isHyperlink: boolean = false;
 	if (DBCellValue.isDBCellValue(value)) {
 		valueToDisplay = 'NULL';
 		if (!value.isNull) {
 			valueToDisplay = getCellDisplayValue(value.displayValue);
-			return `<a class="${cellClasses}">${valueToDisplay}</a>`;
+			isHyperlink = true;
 		} else {
 			cellClasses += ' missing-value';
 		}
 	} else if (isHyperlinkCellValue(value)) {
 		valueToDisplay = getCellDisplayValue(value.displayText);
-		return `<a class="${cellClasses}" title="${valueToDisplay}">${valueToDisplay}</a>`;
+		isHyperlink = true;
 	}
-	return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
+
+	if (isHyperlink) {
+		return `<a class="${cellClasses}" title="${valueToDisplay}">${valueToDisplay}</a>`;
+	} else {
+		return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
+	}
 }
 
 /**
@@ -131,10 +136,11 @@ export function textFormatter(row: number | undefined, cell: any | undefined, va
 	return formattedValue;
 }
 
-function getCellDisplayValue(cellValue: string): string {
+export function getCellDisplayValue(cellValue: string): string {
+	let valueToDisplay = cellValue.length > 250 ? cellValue.slice(0, 250) + '...' : cellValue;
 	// allow-any-unicode-next-line
-	let valueToDisplay = cellValue.replace(/(\r\n|\n|\r)/g, '↵');
-	return escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
+	valueToDisplay = valueToDisplay.replace(/(\r\n|\n|\r)/g, '↵');
+	return escape(valueToDisplay);
 }
 
 

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -17,7 +17,7 @@ import { IGridActionContext, SaveResultAction, CopyResultAction, SelectAllGridAc
 import { CellSelectionModel } from 'sql/base/browser/ui/table/plugins/cellSelectionModel.plugin';
 import { RowNumberColumn } from 'sql/base/browser/ui/table/plugins/rowNumberColumn.plugin';
 import { escape } from 'sql/base/common/strings';
-import { DBCellValue, hyperLinkFormatter, textFormatter } from 'sql/base/browser/ui/table/formatters';
+import { DBCellValue, getCellDisplayValue, hyperLinkFormatter, textFormatter } from 'sql/base/browser/ui/table/formatters';
 import { AdditionalKeyBindings } from 'sql/base/browser/ui/table/plugins/additionalKeyBindings.plugin';
 
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
@@ -925,9 +925,11 @@ export abstract class GridTableBase<T> extends Disposable implements IView, IQue
 				let dataWithSchema = {};
 				// skip the first column since its a number column
 				for (let i = 1; i < this.columns.length; i++) {
+					const displayValue = r[i - 1].displayValue ?? '';
+					const ariaLabel = getCellDisplayValue(displayValue);
 					dataWithSchema[this.columns[i].field] = {
-						displayValue: r[i - 1].displayValue,
-						ariaLabel: escape(r[i - 1].displayValue),
+						displayValue: displayValue,
+						ariaLabel: ariaLabel,
 						isNull: r[i - 1].isNull,
 						invariantCultureDisplayValue: r[i - 1].invariantCultureDisplayValue
 					};


### PR DESCRIPTION
this PR fixes #304

1. When inspecting the cells, I realized that the aria-label has the full value which is adding a lot of content to the DOM tree.
2. Refactor the formatter method

before
![xml-before](https://github.com/microsoft/azuredatastudio/assets/13777222/6f1430cc-f7c1-4bfb-8994-462848c66184)


after
![xml-after](https://github.com/microsoft/azuredatastudio/assets/13777222/65e95b33-b7e4-4b1d-b1e0-ebc3a091bd90)
