### PR TITLE
Update default values for Owner and Collation in Create Database dialog

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.8.0.16",
+	"version": "4.8.0.17",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -35,6 +35,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<ObjectManagement.
 		containers.push(this.createLabelInputContainer(localizedConstants.NameText, this._nameInput));
 
 		if (this.viewInfo.loginNames?.length > 0) {
+			this.objectInfo.owner = this.viewInfo.loginNames[0];
 			let ownerDropbox = this.createDropdown(localizedConstants.OwnerText, async () => {
 				this.objectInfo.owner = ownerDropbox.value as string;
 			}, this.viewInfo.loginNames, this.viewInfo.loginNames[0]);
@@ -47,6 +48,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<ObjectManagement.
 	private initializeOptionsSection(): azdata.GroupContainer {
 		let containers: azdata.Component[] = [];
 		if (this.viewInfo.collationNames?.length > 0) {
+			this.objectInfo.collationName = this.viewInfo.collationNames[0];
 			let collationDropbox = this.createDropdown(localizedConstants.CollationText, async () => {
 				this.objectInfo.collationName = collationDropbox.value as string;
 			}, this.viewInfo.collationNames, this.viewInfo.collationNames[0]);


### PR DESCRIPTION
Previously we were using "<default>" for those fields to match SSMS, but after some team discussion we decided having actual values in those fields was better. These changes mostly come SQL Tools Service.

SQL Tools changes in this version bump:
![SqlToolsVersionBump](https://github.com/microsoft/azuredatastudio/assets/12820011/bee240bf-72df-4efc-93e3-f9a557be9a91)
