### PR TITLE
Hide tenant dropdown until account is refreshed

### DIFF
--- a/src/sql/platform/accounts/common/accountActions.ts
+++ b/src/sql/platform/accounts/common/accountActions.ts
@@ -123,7 +123,7 @@ export class ApplyFilterAction extends Action {
  */
 export class RefreshAccountAction extends Action {
 	public static ID = 'account.refresh';
-	public static LABEL = localize('refreshAccount', "Reenter your credentials");
+	public static LABEL = localize('refreshAccount', "Refresh your credentials");
 	public account?: azdata.Account;
 
 	constructor(

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
@@ -256,7 +256,9 @@ export class AccountPicker extends Disposable {
 
 	private onAccountSelectionChange(account: azdata.Account | undefined) {
 		this.viewModel.selectedAccount = account;
-		if (account && account.isStale) {
+		if (!account) {
+			DOM.hide(this._tenantContainer!);
+		} else if (account && account.isStale) {
 			this._refreshAccountAction!.account = account;
 			DOM.show(this._refreshContainer!);
 			DOM.hide(this._tenantContainer!);

--- a/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountPickerImpl.ts
@@ -259,6 +259,7 @@ export class AccountPicker extends Disposable {
 		if (account && account.isStale) {
 			this._refreshAccountAction!.account = account;
 			DOM.show(this._refreshContainer!);
+			DOM.hide(this._tenantContainer!);
 		} else if (account) {
 			DOM.hide(this._refreshContainer!);
 


### PR DESCRIPTION
Fixes #11856 

![Firewall tenant](https://github.com/microsoft/azuredatastudio/assets/13396919/149d12c1-fdd5-4c06-92f4-f8fed20e29f2)
