### PR TITLE
[SQL Migration] Remove noisy telemetry error event

### DIFF
--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -659,7 +659,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 
 				void vscode.window.showInformationMessage(constants.AZURE_RECOMMENDATION_START_POPUP);
 
-				await this.startSkuTimers(page, this.refreshPerfDataCollectionFrequency);
+				await this.startSkuTimers(page);
 			}
 		}
 		catch (error) {
@@ -688,7 +688,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 		}
 	}
 
-	public async startSkuTimers(page: SKURecommendationPage, refreshIntervalInMs: number): Promise<void> {
+	public async startSkuTimers(page: SKURecommendationPage): Promise<void> {
 		const classVariable = this;
 
 		if (!this._autoRefreshPerfDataCollectionHandle) {
@@ -701,7 +701,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 							await page.refreshSkuRecommendationComponents();	// update timer
 						}
 					},
-					refreshIntervalInMs);
+					this.refreshPerfDataCollectionFrequency);
 			}
 		}
 

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -773,7 +773,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			}
 		}
 		catch (error) {
-			logError(TelemetryViews.DataCollectionWizard, 'RefreshDataCollectionFailed', error);
+			console.log(error);		// use console.log() instead of logError() to avoid spamming telemetry with this error, which can be frequent
 		}
 
 		return true;

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -558,6 +558,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 					if (this.migrationStateModel._perfDataCollectionIsCollecting) {
 						// user started collecting data, ensure the collector is still running
 						await this.migrationStateModel.startSkuTimers(this);
+						await this.refreshSkuRecommendationComponents();
 					} else {
 						// user started collecting data, but collector is stopped
 						// set stop date to some date value

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -556,12 +556,8 @@ export class SKURecommendationPage extends MigrationWizardPage {
 					// check if collector is still running
 					await this.migrationStateModel.refreshPerfDataCollection();
 					if (this.migrationStateModel._perfDataCollectionIsCollecting) {
-						// user started collecting data, and the collector is still running
-						const collectionStartTime = new Date(this.migrationStateModel._perfDataCollectionStartDate!);
-						const expectedRefreshTime = new Date(collectionStartTime.getTime() + this.migrationStateModel.refreshGetSkuRecommendationFrequency);
-						const timeLeft = Math.abs(new Date().getTime() - expectedRefreshTime.getTime());
-						await this.migrationStateModel.startSkuTimers(this, timeLeft);
-
+						// user started collecting data, ensure the collector is still running
+						await this.migrationStateModel.startSkuTimers(this);
 					} else {
 						// user started collecting data, but collector is stopped
 						// set stop date to some date value


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

During performance data collection for SKU recommendation in the SQL Migration extension, the source instance is periodically (default: every 30 seconds, but configurable) queried, but if that fails for whatever reason (e.g. source instance is temporarily unavailable, etc.) then an error event is emitted (`RefreshDataCollectionFailed`). However, this event is quite noisy and can be removed, considering:
- any errors during data collection are shown to the user as a toast in ADS anyways, so having them in telemetry doesn't really help
- data collection is a long running ongoing process, so there isn't a need to potentially constantly re-emit the same errors over and over
- we still have separate telemetry/error events for actually generating the recommendations (e.g. `GetMISkuRecommendation`, etc.), which is much less frequent and is the part that matters anyways

This PR removes this error event and redirects the message to console output instead. No downstream telemetry/reporting changes should be needed. Also identified and fixed an issue that may have been the root cause of this error event being spammed (timer being incorrectly created). 