### PR TITLE
SQL-Migration, fix tenant selection, multi-tenant issue

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
@@ -10,7 +10,7 @@
   "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.41.0"
+    "azdata": ">=1.44.1"
   },
   "activationEvents": [
     "onDashboardOpen",

--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -468,7 +468,7 @@ export function getAzureTenants(account?: Account): Tenant[] {
 	return account?.properties.tenants || [];
 }
 
-export async function getAzureSubscriptions(account?: Account): Promise<azureResource.AzureResourceSubscription[]> {
+export async function getAzureSubscriptions(account?: Account, tenantId?: string): Promise<azureResource.AzureResourceSubscription[]> {
 	let subscriptions: azureResource.AzureResourceSubscription[] = [];
 	try {
 		subscriptions = account && !isAccountTokenStale(account)
@@ -477,8 +477,9 @@ export async function getAzureSubscriptions(account?: Account): Promise<azureRes
 	} catch (e) {
 		logError(TelemetryViews.Utils, 'utils.getAzureSubscriptions', e);
 	}
-	subscriptions.sort((a, b) => a.name.localeCompare(b.name));
-	return subscriptions;
+	const filtered = subscriptions.filter(subscription => subscription.tenant === tenantId);
+	filtered.sort((a, b) => a.name.localeCompare(b.name));
+	return filtered;
 }
 
 export async function getAzureSubscriptionsDropdownValues(subscriptions: azureResource.AzureResourceSubscription[]): Promise<CategoryValue[]> {
@@ -1166,4 +1167,9 @@ export function createRegistrationInstructions(view: ModelView, testConnectionBu
 	).withLayout({
 		flexFlow: 'column'
 	}).component();
+}
+
+export function clearDropDown(dropDown: DropDownComponent): void {
+	dropDown.values = [];
+	dropDown.value = undefined;
 }

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureAccount } from 'azurecore';
 import * as nls from 'vscode-nls';
 import { EOL } from 'os';
 import { MigrationSourceAuthenticationType } from '../models/stateMachine';
@@ -506,21 +505,6 @@ export function accountLinkedMessage(count: number): string {
 	return count === 1 ? localize('sql.migration.wizard.account.count.single.message', '{0} account linked', count) : localize('sql.migration.wizard.account.count.multiple.message', '{0} accounts linked', count);
 }
 export const AZURE_TENANT = localize('sql.migration.azure.tenant', "Azure AD tenant");
-export function ACCOUNT_STALE_ERROR(account: AzureAccount) {
-	return localize(
-		'azure.accounts.accountStaleError',
-		"The access token for selected account '{0}' and tenant '{1}' is no longer valid. Select 'Link account' and refresh the account, or select a different account.",
-		`${account?.displayInfo?.displayName} (${account?.displayInfo?.userId})`,
-		`${account?.properties?.tenants[0]?.displayName} (${account?.properties?.tenants[0]?.userId})`);
-}
-export function ACCOUNT_ACCESS_ERROR(account: AzureAccount, error: Error) {
-	return localize(
-		'azure.accounts.accountAccessError',
-		"An error occurred while accessing the selected account '{0}' and tenant '{1}'. Select 'Link account' and refresh the account, or select a different account. Error '{2}'",
-		`${account?.displayInfo?.displayName} (${account?.displayInfo?.userId})`,
-		`${account?.properties?.tenants[0]?.displayName} (${account?.properties?.tenants[0]?.userId})`,
-		error.message);
-}
 export function MI_NOT_READY_ERROR(miName: string, state: string): string {
 	return localize('sql.migration.mi.not.ready', "The managed instance '{0}' is unavailable for migration because it is currently in the '{1}' state. To continue, select an available managed instance.", miName, state);
 }

--- a/extensions/sql-migration/src/dialog/restartMigration/restartMigrationDialog.ts
+++ b/extensions/sql-migration/src/dialog/restartMigration/restartMigrationDialog.ts
@@ -50,7 +50,7 @@ export class RestartMigrationDialog {
 
 			// TargetSelection
 			azureAccount: serviceContext.azureAccount!,
-			azureTenant: serviceContext.azureAccount!.properties.tenants[0]!,
+			azureTenant: serviceContext.tenant!,
 			subscription: serviceContext.subscription!,
 			location: location,
 			resourceGroup: {

--- a/extensions/sql-migration/src/dialog/tdeConfiguration/tdeMigrationDialog.ts
+++ b/extensions/sql-migration/src/dialog/tdeConfiguration/tdeMigrationDialog.ts
@@ -297,7 +297,7 @@ export class TdeMigrationDialog {
 			this._updateProgressText();
 
 			//Get access token
-			const accessToken = await azdata.accounts.getAccountSecurityToken(this._model._azureAccount, this._model._azureAccount.properties.tenants[0].id, azdata.AzureResource.ResourceManagement);
+			const accessToken = await azdata.accounts.getAccountSecurityToken(this._model._azureAccount, this._model._azureTenant.id, azdata.AzureResource.ResourceManagement);
 
 			const operationResult = await this._model.startTdeMigration(accessToken!.token, this._updateTableResultRow.bind(this));
 

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -1142,7 +1142,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 						TelemetryAction.StartMigration,
 						{
 							'sessionId': this._sessionId,
-							'tenantId': this._azureAccount.properties.tenants[0].id,
+							'tenantId': this._azureTenant?.id,
 							'subscriptionId': this._sqlMigrationServiceSubscription?.id,
 							'resourceGroup': this._sqlMigrationServiceResourceGroup?.name,
 							'location': this._location.name,

--- a/extensions/sql-migration/src/telemetry.ts
+++ b/extensions/sql-migration/src/telemetry.ts
@@ -98,7 +98,8 @@ export function sendSqlMigrationActionEvent(telemetryView: TelemetryViews, telem
 }
 
 export function getTelemetryProps(migrationStateModel: MigrationStateModel): TelemetryEventProperties {
-	const tenantId = migrationStateModel._azureAccount?.properties?.tenants?.length > 0
+	const tenantId = migrationStateModel._azureTenant?.id ??
+		migrationStateModel._azureAccount?.properties?.tenants?.length > 0
 		? migrationStateModel._azureAccount?.properties?.tenants[0]?.id
 		: '';
 	return {

--- a/extensions/sql-migration/src/wizard/integrationRuntimePage.ts
+++ b/extensions/sql-migration/src/wizard/integrationRuntimePage.ts
@@ -327,6 +327,8 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 				} else {
 					this.migrationStateModel._sqlMigrationServiceSubscription = undefined!;
 				}
+
+				utils.clearDropDown(this._resourceGroupDropdown);
 				await this.loadResourceGroupDropdown();
 			}));
 
@@ -370,6 +372,7 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 					else {
 						this.migrationStateModel._sqlMigrationServiceResourceGroup = undefined!;
 					}
+					utils.clearDropDown(this._dmsDropdown);
 					this.loadDmsDropdown();
 				}));
 
@@ -523,7 +526,8 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 		try {
 			this._subscriptionDropdown.loading = true;
 			this.migrationStateModel._subscriptions = await utils.getAzureSubscriptions(
-				this.migrationStateModel._azureAccount);
+				this.migrationStateModel._azureAccount,
+				this.migrationStateModel._azureTenant?.id);
 
 			const sub = this.migrationStateModel._sqlMigrationServiceSubscription
 				?? this.migrationStateModel._targetSubscription;

--- a/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
@@ -374,10 +374,11 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 			this._azureAccountsDropdown.onValueChanged(async (value) => {
 				if (value && value !== 'undefined') {
 					const selectedAccount = this.migrationStateModel._azureAccounts.find(account => account.displayInfo.displayName === value);
-					this.migrationStateModel._azureAccount = (selectedAccount)
+					this.migrationStateModel._azureAccount = selectedAccount
 						? utils.deepClone(selectedAccount)!
 						: undefined!;
 				}
+				utils.clearDropDown(this._accountTenantDropdown);
 				await this.populateTenantsDropdown();
 			}));
 
@@ -425,16 +426,12 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 		this._disposables.push(
 			this._accountTenantDropdown.onValueChanged(async (value) => {
 				if (value && value !== 'undefined') {
-					/**
-					 * Replacing all the tenants in azure account with the tenant user has selected.
-					 * All azure requests will only run on this tenant from now on
-					 */
-					const selectedTenant = this.migrationStateModel._accountTenants.find(tenant => tenant.displayName === value);
-					if (selectedTenant) {
-						this.migrationStateModel._azureTenant = utils.deepClone(selectedTenant)!;
-						this.migrationStateModel._azureAccount.properties.tenants = [this.migrationStateModel._azureTenant];
-					}
+					const selectedTenant = this.migrationStateModel._accountTenants?.find(tenant => tenant.displayName === value);
+					this.migrationStateModel._azureTenant = selectedTenant
+						? utils.deepClone(selectedTenant)
+						: undefined!;
 				}
+				utils.clearDropDown(this._azureSubscriptionDropdown);
 				await this.populateSubscriptionDropdown();
 			}));
 
@@ -470,12 +467,14 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 		this._disposables.push(
 			this._azureSubscriptionDropdown.onValueChanged(async (value) => {
 				if (value && value !== 'undefined' && value !== constants.NO_SUBSCRIPTIONS_FOUND) {
-					const selectedSubscription = this.migrationStateModel._subscriptions.find(subscription => `${subscription.name} - ${subscription.id}` === value);
+					const selectedSubscription = this.migrationStateModel._subscriptions?.find(
+						subscription => `${subscription.name} - ${subscription.id}` === value);
 					this.migrationStateModel._targetSubscription = (selectedSubscription)
 						? utils.deepClone(selectedSubscription)!
 						: undefined!;
-					this.migrationStateModel.refreshDatabaseBackupPage = true;
 				}
+				this.migrationStateModel.refreshDatabaseBackupPage = true;
+				utils.clearDropDown(this._azureLocationDropdown);
 				await this.populateLocationDropdown();
 			}));
 
@@ -506,6 +505,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 						: undefined!;
 				}
 				this.migrationStateModel.refreshDatabaseBackupPage = true;
+				utils.clearDropDown(this._azureResourceGroupDropdown);
 				await this.populateResourceGroupDropdown();
 			}));
 
@@ -733,6 +733,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 						? utils.deepClone(selectedResourceGroup)!
 						: undefined!;
 				}
+				utils.clearDropDown(this._azureResourceDropdown);
 				await this.populateResourceInstanceDropdown();
 			}));
 
@@ -778,7 +779,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 								this.wizard.message = { text: '' };
 
 								// validate power state from VM instance view
-								const runningState = 'PowerState/running'.toLowerCase();
+								const runningState = 'powerstate/running';
 								if (!this.migrationStateModel._vmInstanceView.statuses.some(status => status.code.toLowerCase() === runningState)) {
 									this.wizard.message = {
 										text: constants.VM_NOT_READY_POWER_STATE_ERROR(this.migrationStateModel._targetServerInstance.name),
@@ -787,7 +788,7 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 								}
 
 								// validate IaaS extension mode
-								const fullMode = 'Full'.toLowerCase();
+								const fullMode = 'full';
 								if (this.migrationStateModel._targetServerInstance.properties.sqlManagement.toLowerCase() !== fullMode) {
 									this.wizard.message = {
 										text: constants.VM_NOT_READY_IAAS_EXTENSION_ERROR(this.migrationStateModel._targetServerInstance.name, this.migrationStateModel._targetServerInstance.properties.sqlManagement),
@@ -910,7 +911,10 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 	private async populateSubscriptionDropdown(): Promise<void> {
 		try {
 			this._azureSubscriptionDropdown.loading = true;
-			this.migrationStateModel._subscriptions = await utils.getAzureSubscriptions(this.migrationStateModel._azureAccount);
+			this.migrationStateModel._subscriptions = await utils.getAzureSubscriptions(
+				this.migrationStateModel._azureAccount,
+				this.migrationStateModel._azureTenant?.id);
+
 			this._azureSubscriptionDropdown.values = await utils.getAzureSubscriptionsDropdownValues(this.migrationStateModel._subscriptions);
 		} catch (e) {
 			console.log(e);


### PR DESCRIPTION
Fix issue with migration wizard selecting a default tenant and preventing tenant selection to change again.
Typically tenant selection is hidden if only one tenant is available.  In this case the tenants array was overwritten with the selected tenant, thus hiding and preventing further selection or change.