### PR TITLE
add copy results to query provider

### DIFF
--- a/extensions/import/src/test/utils.test.ts
+++ b/extensions/import/src/test/utils.test.ts
@@ -78,6 +78,9 @@ export class TestQueryProvider implements azdata.QueryProvider {
 	saveResults(requestParams: azdata.SaveResultsRequestParams): Thenable<azdata.SaveResultRequestResult> {
 		throw new Error('Method not implemented.');
 	}
+	copyResults(requestParams: azdata.CopyResultsRequestParams): Thenable<azdata.CopyResultsRequestResult> {
+		throw new Error('Method not implemented.');
+	}
 	setQueryExecutionOptions(ownerUri: string, options: azdata.QueryExecutionOptions): Thenable<void> {
 		throw new Error('Method not implemented.');
 	}

--- a/extensions/import/src/test/utils.test.ts
+++ b/extensions/import/src/test/utils.test.ts
@@ -78,7 +78,7 @@ export class TestQueryProvider implements azdata.QueryProvider {
 	saveResults(requestParams: azdata.SaveResultsRequestParams): Thenable<azdata.SaveResultRequestResult> {
 		throw new Error('Method not implemented.');
 	}
-	copyResults(requestParams: azdata.CopyResultsRequestParams): Thenable<azdata.CopyResultsRequestResult> {
+	copyResults(requestParams: azdata.CopyResultsRequestParams): Thenable<void> {
 		throw new Error('Method not implemented.');
 	}
 	setQueryExecutionOptions(ownerUri: string, options: azdata.QueryExecutionOptions): Thenable<void> {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -873,11 +873,11 @@ declare module 'azdata' {
 		/**
 		 * Notify clients that the URI for a connection has been changed.
 		 */
-		connectionUriChanged(newUri: string, oldUri: string): Thenable<void>;
+		connectionUriChanged?(newUri: string, oldUri: string): Thenable<void>;
 		/**
 		 * Copy the selected data to the clipboard.
 		 */
-		copyResults(requestParams: CopyResultsRequestParams): Thenable<CopyResultsRequestResult>;
+		copyResults?(requestParams: CopyResultsRequestParams): Thenable<CopyResultsRequestResult>;
 	}
 
 	export enum DataProviderType {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -823,11 +823,61 @@ declare module 'azdata' {
 		parentTypeName?: string;
 	}
 
+	/**
+	 * Represents a selected range in the result grid.
+	 */
+	export interface SelectionRange {
+		fromRow: number;
+		toRow: number;
+		fromCell: number;
+		toCell: number;
+	}
+
+	/**
+	 * Parameters for the copy results request.
+	 */
+	export interface CopyResultsRequestParams {
+		/**
+		 * ownerUri of the editor
+		 */
+		ownerUri: string;
+		/**
+		 * Index of the batch.
+		 */
+		batchIndex: number;
+		/**
+		 * Index of the result set.
+		 */
+		resultSetIndex: number;
+		/**
+		 * Whether to include the column headers.
+		 */
+		includeHeaders: boolean
+		/**
+		 * Whether to remove line breaks from the cell value.
+		 */
+		removeNewLines: boolean;
+		/**
+		 * The selected ranges to be copied.
+		 */
+		selections: SelectionRange[];
+	}
+
+	/**
+	 * The result of copy results request.
+	 */
+	export interface CopyResultsRequestResult {
+	}
+
 	export interface QueryProvider {
 		/**
 		 * Notify clients that the URI for a connection has been changed.
 		 */
 		connectionUriChanged(newUri: string, oldUri: string): Thenable<void>;
+		/**
+		 * Copy the selected data to the clipboard.
+		 */
+		copyResults(requestParams: CopyResultsRequestParams): Thenable<CopyResultsRequestResult>;
 	}
 
 	export enum DataProviderType {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -838,7 +838,7 @@ declare module 'azdata' {
 	 */
 	export interface CopyResultsRequestParams {
 		/**
-		 * ownerUri of the editor
+		 * URI of the editor.
 		 */
 		ownerUri: string;
 		/**

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -829,8 +829,8 @@ declare module 'azdata' {
 	export interface SelectionRange {
 		fromRow: number;
 		toRow: number;
-		fromCell: number;
-		toCell: number;
+		fromColumn: number;
+		toColumn: number;
 	}
 
 	/**
@@ -863,12 +863,6 @@ declare module 'azdata' {
 		selections: SelectionRange[];
 	}
 
-	/**
-	 * The result of copy results request.
-	 */
-	export interface CopyResultsRequestResult {
-	}
-
 	export interface QueryProvider {
 		/**
 		 * Notify clients that the URI for a connection has been changed.
@@ -876,8 +870,11 @@ declare module 'azdata' {
 		connectionUriChanged?(newUri: string, oldUri: string): Thenable<void>;
 		/**
 		 * Copy the selected data to the clipboard.
+		 * This is introduced to address the performance issue of large amount of data to ADS side.
+		 * ADS will use this if 'supportCopyResultsToClipboard' property is set to true in the provider contribution point in extension's package.json.
+		 * Otherwise, The default handler will load all the selected data to ADS and perform the copy operation.
 		 */
-		copyResults?(requestParams: CopyResultsRequestParams): Thenable<CopyResultsRequestResult>;
+		copyResults?(requestParams: CopyResultsRequestParams): Thenable<void>;
 	}
 
 	export enum DataProviderType {


### PR DESCRIPTION
add copyResults to query provider definition, this is needed to improve the performance of copying large amount of data.

follow up PRs will be send in dataprotocol-client repo and sts repo, eventually in ADS again.