### PR TITLE
[SQL Migration] Release v1.4.6 to Insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.5",
-							"lastUpdated": "05/12/2023",
+							"version": "1.4.6",
+							"lastUpdated": "06/08/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.5.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.6.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4073,7 +4073,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.41.0"
+									"value": ">=1.44.1"
 								}
 							]
 						}


### PR DESCRIPTION
This PR updates the insiders extension gallery to the latest version 1.4.6 of the SQL Migration extension. sql-migration-1.4.6.vsix

Link to Azure Data Studio - Extensions Product pipeline run off main:
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=202526&view=artifacts&pathAsName=false&type=publishedArtifacts
