### PR TITLE
Fix table designer parameter typings

### DIFF
--- a/src/sql/workbench/browser/editor/tableDesigner/tableDesignerInput.ts
+++ b/src/sql/workbench/browser/editor/tableDesigner/tableDesignerInput.ts
@@ -39,7 +39,7 @@ export class TableDesignerInput extends EditorInput {
 		private _provider: TableDesignerProvider,
 		tableInfo: azdata.designers.TableInfo,
 		telemetryInfo: { [key: string]: string },
-		objectExplorerContext: azdata.ObjectExplorerContext,
+		objectExplorerContext: azdata.ObjectExplorerContext | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@INotificationService private readonly _notificationService: INotificationService) {
 		super();

--- a/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
+++ b/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
@@ -56,7 +56,7 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 	constructor(private readonly _provider: TableDesignerProvider,
 		public tableInfo: azdata.designers.TableInfo,
 		private _telemetryInfo: ITelemetryEventProperties,
-		private _objectExplorerContext: azdata.ObjectExplorerContext,
+		private _objectExplorerContext: azdata.ObjectExplorerContext | undefined,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IAdsTelemetryService readonly _adsTelemetryService: IAdsTelemetryService,
 		@IQueryEditorService private readonly _queryEditorService: IQueryEditorService,


### PR DESCRIPTION
Added in https://github.com/microsoft/azuredatastudio/pull/23370 - this parameter is optional so should be defined as such. We can't make the actual parameter optional because the injected service parameters are non-optional and required to be last, but in this case we just need to update the type to be `| undefined` since we can guarantee we'll always be passing a value.

(the public API will stay as optional to make it simpler for extensions to call if they don't have an OE context)

It's important for us to try and keep our typings correct - it helps make sure that we're handling them correctly and eventually we want to be able to enable strict null checking and incorrect typings like this would cause that to fail. 