### PR TITLE
query result selection summary improvement (both perf and usability)

### DIFF
--- a/src/sql/base/common/gridRange.ts
+++ b/src/sql/base/common/gridRange.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IGridPosition, GridPosition } from 'sql/base/common/gridPosition';
+import { IRange } from 'vs/base/common/range';
 import { isNumber } from 'vs/base/common/types';
 
 /**
@@ -26,20 +27,6 @@ export interface IGridRange {
 	 * Column on which the range ends in line `endRow`.
 	 */
 	readonly endColumn: number;
-}
-
-/**
- * An one dimensional range
- */
-export interface OneDimensionalRange {
-	/**
-	 * Start position
-	 */
-	start: number;
-	/**
-	 * End position
-	 */
-	end: number;
 }
 
 /**
@@ -397,15 +384,15 @@ export class GridRange {
 	 * @param ranges the ranges to be merged
 	 * @param mergeRows whether to merge the rows or columns.
 	 */
-	private static mergeRanges(ranges: IGridRange[], mergeRows: boolean): OneDimensionalRange[] {
-		let sourceRanges: OneDimensionalRange[] = ranges.map(r => {
+	private static mergeRanges(ranges: IGridRange[], mergeRows: boolean): IRange[] {
+		let sourceRanges: IRange[] = ranges.map(r => {
 			if (mergeRows) {
 				return { start: r.startRow, end: r.endRow };
 			} else {
 				return { start: r.startColumn, end: r.endColumn };
 			}
 		});
-		const mergedRanges: OneDimensionalRange[] = [];
+		const mergedRanges: IRange[] = [];
 		sourceRanges = sourceRanges.sort((s1, s2) => { return s1.start - s2.start; });
 		sourceRanges.forEach(range => {
 			let merged = false;
@@ -427,14 +414,14 @@ export class GridRange {
 	/**
 	 * Gets the unique row ranges.
 	 */
-	public static getUniqueRows(ranges: IGridRange[]): OneDimensionalRange[] {
+	public static getUniqueRows(ranges: IGridRange[]): IRange[] {
 		return GridRange.mergeRanges(ranges, true);
 	}
 
 	/**
 	 * Gets the unique column ranges.
 	 */
-	public static getUniqueColumns(ranges: IGridRange[]): OneDimensionalRange[] {
+	public static getUniqueColumns(ranges: IGridRange[]): IRange[] {
 		return GridRange.mergeRanges(ranges, false);
 	}
 }

--- a/src/sql/base/common/gridRange.ts
+++ b/src/sql/base/common/gridRange.ts
@@ -29,6 +29,20 @@ export interface IGridRange {
 }
 
 /**
+ * An one dimensional range
+ */
+export interface OneDimensionalRange {
+	/**
+	 * Start position
+	 */
+	start: number;
+	/**
+	 * End position
+	 */
+	end: number;
+}
+
+/**
  * A range in a grid. (startRow,startColumn) is <= (endRow,endColumn)
  */
 export class GridRange {
@@ -357,5 +371,70 @@ export class GridRange {
 	 */
 	public static spansMultipleLines(range: IGridRange): boolean {
 		return range.endRow > range.startRow;
+	}
+
+	/**
+	 * Create an instance of IGridRange from Slick.Range.
+	 */
+	public static fromSlickRange(range: Slick.Range): IGridRange {
+		return {
+			startRow: range.fromRow,
+			endRow: range.toRow,
+			startColumn: range.fromCell,
+			endColumn: range.toCell
+		};
+	}
+
+	/**
+	 * Create a list IGridRange from a list of Slick.Range.
+	 */
+	public static fromSlickRanges(ranges: Slick.Range[]): IGridRange[] {
+		return ranges.map(r => GridRange.fromSlickRange(r));
+	}
+
+	/**
+	 * Merge the ranges by row or column and return merged ranges
+	 * @param ranges the ranges to be merged
+	 * @param mergeRows whether to merge the rows or columns.
+	 */
+	private static mergeRanges(ranges: IGridRange[], mergeRows: boolean): OneDimensionalRange[] {
+		let sourceRanges: OneDimensionalRange[] = ranges.map(r => {
+			if (mergeRows) {
+				return { start: r.startRow, end: r.endRow };
+			} else {
+				return { start: r.startColumn, end: r.endColumn };
+			}
+		});
+		const mergedRanges: OneDimensionalRange[] = [];
+		sourceRanges = sourceRanges.sort((s1, s2) => { return s1.start - s2.start; });
+		sourceRanges.forEach(range => {
+			let merged = false;
+			for (let i = 0; i < mergedRanges.length; i++) {
+				const mergedRange = mergedRanges[i];
+				if (range.start <= mergedRange.end) {
+					mergedRange.end = Math.max(range.end, mergedRange.end);
+					merged = true;
+					break;
+				}
+			}
+			if (!merged) {
+				mergedRanges.push(range);
+			}
+		});
+		return mergedRanges;
+	}
+
+	/**
+	 * Gets the unique row ranges.
+	 */
+	public static getUniqueRows(ranges: IGridRange[]): OneDimensionalRange[] {
+		return GridRange.mergeRanges(ranges, true);
+	}
+
+	/**
+	 * Gets the unique column ranges.
+	 */
+	public static getUniqueColumns(ranges: IGridRange[]): OneDimensionalRange[] {
+		return GridRange.mergeRanges(ranges, false);
 	}
 }

--- a/src/sql/platform/query/common/query.ts
+++ b/src/sql/platform/query/common/query.ts
@@ -32,6 +32,7 @@ export interface IQueryEditorConfiguration {
 		readonly openAfterSave: boolean;
 		readonly showActionBar: boolean;
 		readonly preferProvidersCopyHandler: boolean;
+		readonly promptForLargeRowSelection: boolean;
 	},
 	readonly messages: {
 		readonly showBatchTime: boolean;

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -868,7 +868,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView, IQue
 				}
 			]);
 		} else {
-			runAction(true);
+			await runAction(true);
 		}
 	}
 

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -870,7 +870,6 @@ export abstract class GridTableBase<T> extends Disposable implements IView, IQue
 		} else {
 			runAction(true);
 		}
-		// todo test the restore page scenario
 	}
 
 	private async onTableClick(event: ITableMouseEvent) {

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -424,6 +424,11 @@ const queryEditorConfiguration: IConfigurationNode = {
 			'description': localize('queryEditor.results.showActionBar', "Whether to show the action bar in the query results view"),
 			'default': true
 		},
+		'queryEditor.results.promptForLargeRowSelection': {
+			'type': 'boolean',
+			'default': true,
+			'description': localize('queryEditor.results.promptForLargeRowSelection', "Whether to show the a confirmation when user has selected rows that are more than the value specified in the 'inMemoryDataProcessingThreshold' setting. The default value is true.")
+		},
 		'queryEditor.messages.showBatchTime': {
 			'type': 'boolean',
 			'description': localize('queryEditor.messages.showBatchTime', "Should execution time be shown for individual batches"),

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -427,7 +427,7 @@ const queryEditorConfiguration: IConfigurationNode = {
 		'queryEditor.results.promptForLargeRowSelection': {
 			'type': 'boolean',
 			'default': true,
-			'description': localize('queryEditor.results.promptForLargeRowSelection', "Whether to show the a confirmation when user has selected rows that are more than the value specified in the 'inMemoryDataProcessingThreshold' setting. The default value is true.")
+			'description': localize('queryEditor.results.promptForLargeRowSelection', "When cells are selected in the results grid, ADS will calculate the summary for them, This setting controls whether to show the a confirmation when the number of rows selected is larger than the value specified in the 'inMemoryDataProcessingThreshold' setting. The default value is true.")
 		},
 		'queryEditor.messages.showBatchTime': {
 			'type': 'boolean',

--- a/src/sql/workbench/contrib/query/browser/statusBarItems.ts
+++ b/src/sql/workbench/contrib/query/browser/statusBarItems.ts
@@ -316,10 +316,12 @@ export class QueryResultSelectionSummaryStatusBarContribution extends Disposable
 		const nullCount = selectedCells.filter(cell => cell.isNull).length;
 		let summaryText, tooltipText;
 		if (numericValues.length >= 2) {
-			const sum = numericValues.reduce((previous, current, idx, array) => previous + current);
+			const sum = numericValues.reduce((previous, current) => previous + current);
+			const min = numericValues.reduce((previous, current) => Math.min(previous, current));
+			const max = numericValues.reduce((previous, current) => Math.max(previous, current));
 			summaryText = localize('status.query.summaryText', "Average: {0}  Count: {1}  Sum: {2}", Number((sum / numericValues.length).toFixed(3)), selectedCells.length, sum);
 			tooltipText = localize('status.query.summaryTooltip', "Average: {0}  Count: {1}  Distinct Count: {2}  Max: {3}  Min: {4}  Null Count: {5}  Sum: {6}",
-				Number((sum / numericValues.length).toFixed(3)), selectedCells.length, distinctValues.size, Math.max(...numericValues), Math.min(...numericValues), nullCount, sum);
+				Number((sum / numericValues.length).toFixed(3)), selectedCells.length, distinctValues.size, max, min, nullCount, sum);
 		} else {
 			summaryText = summaryText = localize('status.query.summaryTextNonNumeric', "Count: {0}  Distinct Count: {1}  Null Count: {2}", selectedCells.length, distinctValues.size, nullCount);
 		}

--- a/src/sql/workbench/services/query/common/gridDataProvider.ts
+++ b/src/sql/workbench/services/query/common/gridDataProvider.ts
@@ -53,10 +53,9 @@ export interface IGridDataProvider {
 	serializeResults(format: SaveFormat, selection: Slick.Range[]): Thenable<void>;
 }
 
-export async function executeCopyWithNotification(notificationService: INotificationService, selections: Slick.Range[], copyHandler: (notification: INotificationHandle, rowCount: number) => Promise<void>, cancellationToken?: CancellationTokenSource): Promise<void> {
+export async function executeCopyWithNotification(notificationService: INotificationService, selections: Slick.Range[], copyHandler: (notification: INotificationHandle, rowCount: number) => Promise<void>, cancellationTokenSource?: CancellationTokenSource): Promise<void> {
 	const rowRanges = GridRange.getUniqueRows(GridRange.fromSlickRanges(selections));
 	const rowCount = rowRanges.map(range => range.end - range.start + 1).reduce((p, c) => p + c);
-	let isCanceled = false;
 	const notificationHandle = notificationService.notify({
 		message: nls.localize('gridDataProvider.copying', "Copying..."),
 		severity: Severity.Info,
@@ -64,13 +63,12 @@ export async function executeCopyWithNotification(notificationService: INotifica
 			infinite: true
 		},
 		actions: {
-			primary: cancellationToken ? [
+			primary: cancellationTokenSource ? [
 				toAction({
 					id: 'cancelCopyResults',
 					label: nls.localize('gridDataProvider.cancelCopyResults', "Cancel"),
 					run: () => {
-						isCanceled = true;
-						cancellationToken.cancel();
+						cancellationTokenSource.cancel();
 						notificationHandle.close();
 					}
 				})] : []
@@ -78,7 +76,7 @@ export async function executeCopyWithNotification(notificationService: INotifica
 	});
 	try {
 		await copyHandler(notificationHandle, rowCount);
-		if (!isCanceled) {
+		if (cancellationTokenSource === undefined || !cancellationTokenSource.token.isCancellationRequested) {
 			notificationHandle.progress.done();
 			notificationHandle.updateActions({
 				primary: [

--- a/src/sql/workbench/services/query/common/gridDataProvider.ts
+++ b/src/sql/workbench/services/query/common/gridDataProvider.ts
@@ -11,6 +11,8 @@ import { INotificationHandle, INotificationService, Severity } from 'vs/platform
 import * as nls from 'vs/nls';
 import { toAction } from 'vs/base/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
+import { GridRange } from 'sql/base/common/gridRange';
 
 export interface IGridDataProvider {
 
@@ -19,7 +21,7 @@ export interface IGridDataProvider {
 	 * @param rowStart 0-indexed start row to retrieve data from
 	 * @param numberOfRows total number of rows of data to retrieve
 	 */
-	getRowData(rowStart: number, numberOfRows: number): Thenable<ResultSetSubset>;
+	getRowData(rowStart: number, numberOfRows: number, cancellationToken?: CancellationToken, onProgressCallback?: (availableRows: number) => void): Thenable<ResultSetSubset>;
 
 	/**
 	 * Sends a copy request to copy data to the clipboard
@@ -51,36 +53,8 @@ export interface IGridDataProvider {
 	serializeResults(format: SaveFormat, selection: Slick.Range[]): Thenable<void>;
 }
 
-interface Range {
-	start: number;
-	end: number;
-}
-
-/**
- * Merge the ranges and get the sorted ranges.
- */
-function mergeRanges(ranges: Range[]): Range[] {
-	const mergedRanges: Range[] = [];
-	const orderedRanges = ranges.sort((s1, s2) => { return s1.start - s2.start; });
-	orderedRanges.forEach(range => {
-		let merged = false;
-		for (let i = 0; i < mergedRanges.length; i++) {
-			const mergedRange = mergedRanges[i];
-			if (range.start <= mergedRange.end) {
-				mergedRange.end = Math.max(range.end, mergedRange.end);
-				merged = true;
-				break;
-			}
-		}
-		if (!merged) {
-			mergedRanges.push(range);
-		}
-	});
-	return mergedRanges;
-}
-
-export async function executeCopyWithNotification(notificationService: INotificationService, selections: Slick.Range[], isCancelable: boolean, copyHandler: (notification: INotificationHandle, rowCount: number) => Promise<void>, onCanceled?: () => void): Promise<void> {
-	const rowRanges: Range[] = mergeRanges(selections.map(selection => { return { start: selection.fromRow, end: selection.toRow }; }));
+export async function executeCopyWithNotification(notificationService: INotificationService, selections: Slick.Range[], copyHandler: (notification: INotificationHandle, rowCount: number) => Promise<void>, cancellationToken?: CancellationTokenSource): Promise<void> {
+	const rowRanges = GridRange.getUniqueRows(GridRange.fromSlickRanges(selections));
 	const rowCount = rowRanges.map(range => range.end - range.start + 1).reduce((p, c) => p + c);
 	let isCanceled = false;
 	const notificationHandle = notificationService.notify({
@@ -90,13 +64,13 @@ export async function executeCopyWithNotification(notificationService: INotifica
 			infinite: true
 		},
 		actions: {
-			primary: isCancelable ? [
+			primary: cancellationToken ? [
 				toAction({
 					id: 'cancelCopyResults',
 					label: nls.localize('gridDataProvider.cancelCopyResults', "Cancel"),
 					run: () => {
 						isCanceled = true;
-						onCanceled!();
+						cancellationToken.cancel();
 						notificationHandle.close();
 					}
 				})] : []
@@ -124,16 +98,16 @@ export async function executeCopyWithNotification(notificationService: INotifica
 }
 
 export async function copySelectionToClipboard(clipboardService: IClipboardService, notificationService: INotificationService, provider: IGridDataProvider, selections: Slick.Range[], includeHeaders?: boolean, tableView?: IDisposableDataProvider<Slick.SlickData>): Promise<void> {
-	let isCanceled = false;
-	await executeCopyWithNotification(notificationService, selections, true, async (notificationHandle, rowCount) => {
-		const batchSize = 100;
+	const cancellationTokenSource = new CancellationTokenSource()
+	await executeCopyWithNotification(notificationService, selections, async (notificationHandle, rowCount) => {
 		const eol = provider.getEolString();
 		const valueSeparator = '\t';
 		const shouldRemoveNewLines = provider.shouldRemoveNewLines();
 
-		// Merge the selections to get the columns and rows.
-		const columnRanges: Range[] = mergeRanges(selections.map(selection => { return { start: selection.fromCell, end: selection.toCell }; }));
-		const rowRanges: Range[] = mergeRanges(selections.map(selection => { return { start: selection.fromRow, end: selection.toRow }; }));
+		// Merge the selections to get the unique columns and unique rows.
+		const gridRanges = GridRange.fromSlickRanges(selections);
+		const columnRanges = GridRange.getUniqueColumns(gridRanges);
+		const rowRanges = GridRange.getUniqueRows(gridRanges);
 
 		let processedRows = 0;
 		const getMessageText = (): string => {
@@ -151,57 +125,41 @@ export async function copySelectionToClipboard(clipboardService: IClipboardServi
 			resultString = Array.from(headers.values()).join(valueSeparator).concat(eol);
 		}
 
-		const batchResult: string[] = [];
+		const rowValues: string[] = [];
 		for (const range of rowRanges) {
+			let rows: ICellValue[][];
+			let processedRowsSnapshot = processedRows;
+			const rangeLength = range.end - range.start + 1;
 			if (tableView && tableView.isDataInMemory) {
-				const rangeLength = range.end - range.start + 1;
 				// If the data is sorted/filtered in memory, we need to get the data that is currently being displayed
 				const tableData = await tableView.getRangeAsync(range.start, rangeLength);
-				const rowSet = tableData.map(item => Object.keys(item).map(key => item[key]));
-				batchResult.push(getStringValueForRowSet(rowSet, columnRanges, selections, range.start, eol, valueSeparator, shouldRemoveNewLines));
+				rows = tableData.map(item => Object.keys(item).map(key => item[key]));
 				processedRows += rangeLength;
 				notificationHandle.updateMessage(getMessageText());
 			} else {
-				let start = range.start;
-				do {
-					const end = Math.min(start + batchSize - 1, range.end);
-					const batchLength = end - start + 1
-					const rowSet = (await provider.getRowData(start, batchLength)).rows;
-					batchResult.push(getStringValueForRowSet(rowSet, columnRanges, selections, range.start, eol, valueSeparator, shouldRemoveNewLines));
-					start = end + 1;
-					processedRows = processedRows + batchLength;
-					if (!isCanceled) {
-						notificationHandle.updateMessage(getMessageText());
-					}
-				} while (start < range.end && !isCanceled)
+				rows = (await provider.getRowData(range.start, rangeLength, cancellationTokenSource.token, (fetchedRows) => {
+					processedRows = processedRowsSnapshot + fetchedRows;
+					notificationHandle.updateMessage(getMessageText());
+				})).rows;
 			}
+			rows.forEach((values, index) => {
+				const rowIndex = index + range.start;
+				const columnValues = [];
+				columnRanges.forEach(cr => {
+					for (let i = cr.start; i <= cr.end; i++) {
+						if (selections.some(selection => selection.contains(rowIndex, i))) {
+							columnValues.push(shouldRemoveNewLines ? removeNewLines(values[i].displayValue) : values[i].displayValue);
+						}
+					}
+				});
+				rowValues.push(columnValues.join(valueSeparator));
+			});
 		}
-		if (!isCanceled) {
-			resultString += batchResult.join(eol);
+		if (!cancellationTokenSource.token.isCancellationRequested) {
+			resultString += rowValues.join(eol);
 			await clipboardService.writeText(resultString);
 		}
-	}, () => {
-		isCanceled = true;
-	});
-}
-
-function getStringValueForRowSet(rows: ICellValue[][], columnRanges: Range[], selections: Slick.Range[], rowSetStartIndex: number, eol: string, valueSeparator: string, shouldRemoveNewLines: boolean): string {
-	let rowStrings: string[] = [];
-	rows.forEach((values, index) => {
-		const rowIndex = index + rowSetStartIndex;
-		const rowValues = [];
-		columnRanges.forEach(cr => {
-			for (let i = cr.start; i <= cr.end; i++) {
-				if (selections.some(selection => selection.contains(rowIndex, i))) {
-					rowValues.push(shouldRemoveNewLines ? removeNewLines(values[i].displayValue) : values[i].displayValue);
-				} else {
-					rowValues.push('');
-				}
-			}
-		});
-		rowStrings.push(rowValues.join(valueSeparator));
-	});
-	return rowStrings.join(eol);
+	}, cancellationTokenSource);
 }
 
 export function getTableHeaderString(provider: IGridDataProvider, selection: Slick.Range[]): string {

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -18,6 +18,7 @@ import { ResultSetSubset } from 'sql/workbench/services/query/common/query';
 import { isUndefined } from 'vs/base/common/types';
 import { ILogService } from 'vs/platform/log/common/log';
 import * as nls from 'vs/nls';
+import { CancellationToken } from 'vs/base/common/cancellation';
 
 export const SERVICE_ID = 'queryManagementService';
 
@@ -50,7 +51,7 @@ export interface IQueryManagementService {
 	runQueryString(ownerUri: string, queryString: string): Promise<void>;
 	runQueryAndReturn(ownerUri: string, queryString: string): Promise<azdata.SimpleExecuteResult>;
 	parseSyntax(ownerUri: string, query: string): Promise<azdata.SyntaxParseResult>;
-	getQueryRows(rowData: azdata.QueryExecuteSubsetParams): Promise<ResultSetSubset>;
+	getQueryRows(rowData: azdata.QueryExecuteSubsetParams, cancellationToken?: CancellationToken, onProgressCallback?: (availableRows: number) => void): Promise<ResultSetSubset>;
 	disposeQuery(ownerUri: string): Promise<void>;
 	changeConnectionUri(newUri: string, oldUri: string): Promise<void>;
 	saveResults(requestParams: azdata.SaveResultsRequestParams): Promise<azdata.SaveResultRequestResult>;
@@ -271,9 +272,38 @@ export class QueryManagementService implements IQueryManagementService {
 		});
 	}
 
-	public async getQueryRows(rowData: azdata.QueryExecuteSubsetParams): Promise<ResultSetSubset> {
-		return this._runAction(rowData.ownerUri, (runner) => {
-			return runner.getQueryRows(rowData).then(r => r.resultSubset);
+	public async getQueryRows(rowData: azdata.QueryExecuteSubsetParams, cancellationToken?: CancellationToken, onProgressCallback?: (availableRows: number) => void): Promise<ResultSetSubset> {
+		const pageSize = 500;
+		return this._runAction(rowData.ownerUri, async (runner): Promise<ResultSetSubset> => {
+			const result = [];
+			let start = rowData.rowsStartIndex;
+			this._logService.trace(`Getting ${rowData.rowsCount} rows starting from index: ${rowData.rowsStartIndex}.`);
+			do {
+				const rowCount = Math.min(pageSize, rowData.rowsStartIndex + rowData.rowsCount - start);
+				this._logService.trace(`Paged Fetch - Getting ${rowCount} rows starting from index: ${start}.`);
+				const rowSet = await runner.getQueryRows({
+					ownerUri: rowData.ownerUri,
+					batchIndex: rowData.batchIndex,
+					resultSetIndex: rowData.resultSetIndex,
+					rowsCount: rowCount,
+					rowsStartIndex: start
+				});
+				this._logService.trace(`Paged Fetch - Received ${rowSet.resultSubset.rows} rows starting from index: ${start}.`);
+				result.push(...rowSet.resultSubset.rows);
+				start += rowCount;
+				if (onProgressCallback) {
+					onProgressCallback(start - rowData.rowsStartIndex);
+				}
+			} while (start < rowData.rowsStartIndex + rowData.rowsCount && (!!cancellationToken || !cancellationToken.isCancellationRequested));
+			if (cancellationToken?.isCancellationRequested) {
+				this._logService.trace(`Stop getting more rows since cancellation has been requested.`);
+			} else {
+				this._logService.trace(`Successfully fetched ${result.length} rows. Expected Rows: ${rowData.rowsCount}.`);
+			}
+			return {
+				rows: result,
+				rowCount: result.length
+			};
 		});
 	}
 

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -294,7 +294,7 @@ export class QueryManagementService implements IQueryManagementService {
 				if (onProgressCallback) {
 					onProgressCallback(start - rowData.rowsStartIndex);
 				}
-			} while (start < rowData.rowsStartIndex + rowData.rowsCount && (!!cancellationToken || !cancellationToken.isCancellationRequested));
+			} while (start < rowData.rowsStartIndex + rowData.rowsCount && (cancellationToken === undefined || !cancellationToken.isCancellationRequested));
 			if (cancellationToken?.isCancellationRequested) {
 				this._logService.trace(`Stop getting more rows since cancellation has been requested.`);
 			} else {

--- a/src/sql/workbench/services/query/test/common/queryRunner.test.ts
+++ b/src/sql/workbench/services/query/test/common/queryRunner.test.ts
@@ -59,7 +59,7 @@ suite('Query Runner', () => {
 		const getRowStub = sinon.stub().returns(Promise.resolve(rowResults));
 		(instantiationService as TestInstantiationService).stub(IQueryManagementService, 'getQueryRows', getRowStub);
 		const resultReturn = await runner.getQueryRows(0, 100, 0, 0);
-		assert(getRowStub.calledWithExactly({ ownerUri: uri, batchIndex: 0, resultSetIndex: 0, rowsStartIndex: 0, rowsCount: 100 }));
+		assert(getRowStub.calledWithExactly({ ownerUri: uri, batchIndex: 0, resultSetIndex: 0, rowsStartIndex: 0, rowsCount: 100 }, undefined, undefined));
 		assert.deepStrictEqual(resultReturn, rowResults);
 		// batch complete
 		const batchComplete: CompleteBatchSummary = { ...batch, executionEnd: 'endstring', executionElapsed: 'elapsedstring' };

--- a/src/sql/workbench/services/query/test/common/testQueryManagementService.ts
+++ b/src/sql/workbench/services/query/test/common/testQueryManagementService.ts
@@ -10,6 +10,7 @@ import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 import * as azdata from 'azdata';
 import { IRange } from 'vs/editor/common/core/range';
 import { ResultSetSubset } from 'sql/workbench/services/query/common/query';
+import { CancellationToken } from 'vs/base/common/cancellation';
 
 export class TestQueryManagementService implements IQueryManagementService {
 	_serviceBrand: undefined;
@@ -50,7 +51,7 @@ export class TestQueryManagementService implements IQueryManagementService {
 	parseSyntax(ownerUri: string, query: string): Promise<azdata.SyntaxParseResult> {
 		throw new Error('Method not implemented.');
 	}
-	getQueryRows(rowData: azdata.QueryExecuteSubsetParams): Promise<ResultSetSubset> {
+	getQueryRows(rowData: azdata.QueryExecuteSubsetParams, cancellationToken?: CancellationToken, onProgressCallback?: (availableRows: number) => void): Promise<ResultSetSubset> {
 		throw new Error('Method not implemented.');
 	}
 	async disposeQuery(ownerUri: string): Promise<void> {


### PR DESCRIPTION
1. This PR fixes #23377
    Problem: Similar to the original copy result issue, a request is send to retrieve all the rows.
    Fix:  
        a. paginate the fetch result request.
        b. show a confirmation when user selected more than a certain number of rows. user can choose to do not show this dialog again.
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/ebe9f12b-2d01-4c41-84a7-1640f33c6d79)
        c. show user a prompt so that the user is aware of the work in progress (only when it is taking more than 1 second) and can cancel it.
![e2e-selection](https://github.com/microsoft/azuredatastudio/assets/13777222/0ba1b05b-ece7-4e17-a205-afb418ea798e)
![user-cancellation](https://github.com/microsoft/azuredatastudio/assets/13777222/5a79268b-c8a4-4036-8ea6-3670d23d3649)
        d. any new selection request will cancel the currently running request.
![auto-cancellation](https://github.com/microsoft/azuredatastudio/assets/13777222/7f07c829-1ce8-4c97-9c92-91cf425ea848)
        e. when the selection is small, user wouldn't notice any difference.
![small-selection](https://github.com/microsoft/azuredatastudio/assets/13777222/3b011bc4-d66f-43ad-bc07-c0a9cb31c61a)

2. This PR fixes #22807 
    Problem: Cells that appear in multiple selection ranges were calculated multiple times. 
    Fix: Merge the selection ranges and only go through each cell once.
3. Fix an issue when there are too many cells selected, the selection summary will fail with max callstack size exceeded. The issue is caused by the use of Math.max(...array), when there are too many items in the array, the error would occur, the fix is to use .reduce to find out the min or max.
4. Refactoring the code
    a. Move the pagination logic to the query management service to make sure no other places in the entire code base could make the same mistake of retrieving the data all at once.
    b. Use cancellation token instead of a boolean flag.
    c. Move the range merge logic to sql/base directory where we already have a similar class.