### PR TITLE
Add vscode support for System database package references for SDK-style sql projects

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1166,19 +1166,19 @@ export class ProjectsController {
 	public async addDatabaseReference(context: Project | dataworkspace.WorkspaceTreeItem): Promise<AddDatabaseReferenceDialog | undefined> {
 		const project = await this.getProjectFromContext(context);
 
-		// if (utils.getAzdataApi()) {
-		// 	const addDatabaseReferenceDialog = this.getAddDatabaseReferenceDialog(project);
-		// 	addDatabaseReferenceDialog.addReference = async (proj, settings) => await this.addDatabaseReferenceCallback(proj, settings, context as dataworkspace.WorkspaceTreeItem);
+		if (utils.getAzdataApi()) {
+			const addDatabaseReferenceDialog = this.getAddDatabaseReferenceDialog(project);
+			addDatabaseReferenceDialog.addReference = async (proj, settings) => await this.addDatabaseReferenceCallback(proj, settings, context as dataworkspace.WorkspaceTreeItem);
 
-		// 	await addDatabaseReferenceDialog.openDialog();
-		// 	return addDatabaseReferenceDialog;
-		// } else {
-		const settings = await addDatabaseReferenceQuickpick(project);
-		if (settings) {
-			await this.addDatabaseReferenceCallback(project, settings, context as dataworkspace.WorkspaceTreeItem);
+			await addDatabaseReferenceDialog.openDialog();
+			return addDatabaseReferenceDialog;
+		} else {
+			const settings = await addDatabaseReferenceQuickpick(project);
+			if (settings) {
+				await this.addDatabaseReferenceCallback(project, settings, context as dataworkspace.WorkspaceTreeItem);
+			}
+			return undefined;
 		}
-		return undefined;
-		// }
 	}
 
 	public getAddDatabaseReferenceDialog(project: Project): AddDatabaseReferenceDialog {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1166,19 +1166,19 @@ export class ProjectsController {
 	public async addDatabaseReference(context: Project | dataworkspace.WorkspaceTreeItem): Promise<AddDatabaseReferenceDialog | undefined> {
 		const project = await this.getProjectFromContext(context);
 
-		if (utils.getAzdataApi()) {
-			const addDatabaseReferenceDialog = this.getAddDatabaseReferenceDialog(project);
-			addDatabaseReferenceDialog.addReference = async (proj, settings) => await this.addDatabaseReferenceCallback(proj, settings, context as dataworkspace.WorkspaceTreeItem);
+		// if (utils.getAzdataApi()) {
+		// 	const addDatabaseReferenceDialog = this.getAddDatabaseReferenceDialog(project);
+		// 	addDatabaseReferenceDialog.addReference = async (proj, settings) => await this.addDatabaseReferenceCallback(proj, settings, context as dataworkspace.WorkspaceTreeItem);
 
-			await addDatabaseReferenceDialog.openDialog();
-			return addDatabaseReferenceDialog;
-		} else {
-			const settings = await addDatabaseReferenceQuickpick(project);
-			if (settings) {
-				await this.addDatabaseReferenceCallback(project, settings, context as dataworkspace.WorkspaceTreeItem);
-			}
-			return undefined;
+		// 	await addDatabaseReferenceDialog.openDialog();
+		// 	return addDatabaseReferenceDialog;
+		// } else {
+		const settings = await addDatabaseReferenceQuickpick(project);
+		if (settings) {
+			await this.addDatabaseReferenceCallback(project, settings, context as dataworkspace.WorkspaceTreeItem);
 		}
+		return undefined;
+		// }
 	}
 
 	public getAddDatabaseReferenceDialog(project: Project): AddDatabaseReferenceDialog {

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -838,8 +838,9 @@ export class Project implements ISqlProject {
 			result = await sqlProjService.addSystemDatabaseReference(this.projectFilePath, systemDb, settings.suppressMissingDependenciesErrors, referenceType, settings.databaseVariableLiteralValue);
 		} else {
 			systemDb = <unknown>settings.systemDb as vscodeMssql.SystemDatabase;
+			referenceType = settings.systemDbReferenceType as vscodeMssql.SystemDbReferenceType;
 			sqlProjService = this.sqlProjService as vscodeMssql.ISqlProjectsService;
-			result = await sqlProjService.addSystemDatabaseReference(this.projectFilePath, systemDb, settings.suppressMissingDependenciesErrors, settings.databaseVariableLiteralValue);
+			result = await sqlProjService.addSystemDatabaseReference(this.projectFilePath, systemDb, settings.suppressMissingDependenciesErrors, referenceType, settings.databaseVariableLiteralValue);
 		}
 
 		if (!result.success && result.errorMessage) {

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -482,9 +482,10 @@ declare module 'vscode-mssql' {
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 * @param systemDatabase Type of system database
 		 * @param suppressMissingDependencies Whether to suppress missing dependencies
+		 * @param referenceType Type of reference - ArtifactReference or PackageReference
 		 * @param databaseLiteral Literal name used to reference another database in the same server, if not using SQLCMD variables
 		 */
-		addSystemDatabaseReference(projectUri: string, systemDatabase: SystemDatabase, suppressMissingDependencies: boolean, databaseLiteral?: string): Promise<ResultStatus>;
+		addSystemDatabaseReference(projectUri: string, systemDatabase: SystemDatabase, suppressMissingDependencies: boolean, referenceType: SystemDbReferenceType, databaseLiteral?: string): Promise<ResultStatus>;
 
 		/**
 		 * Add a nuget package database reference to a project
@@ -1112,7 +1113,7 @@ declare module 'vscode-mssql' {
 		packageFilePath: string;
 		databaseName: string;
 		upgradeExisting: boolean;
-		sqlCommandVariableValues?: Map<string, string>;
+		sqlCommandVariableValues?: Record<string, string>;
 		deploymentOptions?: DeploymentOptions;
 		ownerUri: string;
 		taskExecutionMode: TaskExecutionMode;
@@ -1121,7 +1122,7 @@ declare module 'vscode-mssql' {
 	export interface GenerateDeployScriptParams {
 		packageFilePath: string;
 		databaseName: string;
-		sqlCommandVariableValues?: Map<string, string>;
+		sqlCommandVariableValues?: Record<string, string>;
 		deploymentOptions?: DeploymentOptions;
 		ownerUri: string;
 		taskExecutionMode: TaskExecutionMode;
@@ -1153,7 +1154,7 @@ declare module 'vscode-mssql' {
 		profilePath: string;
 		databaseName: string;
 		connectionString: string;
-		sqlCommandVariableValues?: Map<string, string>;
+		sqlCommandVariableValues?: Record<string, string>;
 		deploymentOptions?: DeploymentOptions;
 	}
 
@@ -1209,6 +1210,11 @@ declare module 'vscode-mssql' {
 		 * Type of system database
 		 */
 		systemDatabase: SystemDatabase;
+
+		/**
+	 * Type of reference - ArtifactReference or PackageReference
+	 */
+		referenceType: SystemDbReferenceType;
 	}
 
 	export interface AddNugetPackageReferenceParams extends AddUserDatabaseReferenceParams {
@@ -1247,6 +1253,13 @@ declare module 'vscode-mssql' {
 		 * Path of the folder, typically relative to the .sqlproj file
 		 */
 		path: string;
+	}
+
+	export interface MoveFolderParams extends FolderParams {
+		/**
+		 * Path of the folder, typically relative to the .sqlproj file
+		 */
+		destinationPath: string;
 	}
 
 	export interface CreateSqlProjectParams extends SqlProjectParams {


### PR DESCRIPTION
This adds support for system database package references for SDK-style projects in the sql projects vscode extension, now that the system database nuget packages are [available](https://www.nuget.org/packages/Microsoft.SqlServer.Dacpacs.Master):

New quickpick step to choose between `PackageReference` and `ArtifactReference`. This only shows up for SDK-style projects, not legacy projects.
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/3be286a7-83eb-42d8-87b3-e55bfa8f10e6)

Adding a system db ref as a PackageReference, followed by adding one as an ArtifactReference:
https://github.com/microsoft/azuredatastudio/assets/31145923/194cf0db-b46d-4a43-82e5-f45d1cba0a5b


