### PR TITLE
Disable DataWarehouse Azure option in Create Database dialog

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.8.0.22",
+	"version": "4.8.0.23",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23381

Creating a new Data Warehouse instance in Azure is disabled in Portal, and trying to create one through TSQL throws a deprecated error message. So we decided to remove this option in the Create Database dialog.

STS changes with this version bump:
![VersionBump](https://github.com/microsoft/azuredatastudio/assets/12820011/606b2e87-cf59-4abe-ab32-80ee2490fac0)
