### PR TITLE
[SQL Migration] Release v1.4.6 to Worldwide

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.5",
-							"lastUpdated": "05/24/2023",
+							"version": "1.4.6",
+							"lastUpdated": "06/14/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.5.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.6.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4073,7 +4073,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.41.0"
+									"value": ">=1.44.1"
 								}
 							]
 						}


### PR DESCRIPTION
This PR updates the worldwide extension gallery to the latest version of the SQL Migration extension 1.4.6.
This version was already released to insiders via PR:
https://github.com/microsoft/azuredatastudio/pull/23361
