### PR TITLE
Add link to Azure pricing calculator in New Database dialog

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -160,6 +160,7 @@ export const BackupRedundancyText = localize('objectManagement.backupRedundancyL
 export const CurrentSLOText = localize('objectManagement.currentSLOLabel', "Current Service Level Objective");
 export const EditionText = localize('objectManagement.editionLabel', "Edition");
 export const MaxSizeText = localize('objectManagement.maxSizeLabel', "Max Size");
+export const AzurePricingLinkText = localize('objectManagement.azurePricingLink', "More info about Azure SQL Database pricing.");
 
 // Login
 export const BlankPasswordConfirmationText: string = localize('objectManagement.blankPasswordConfirmation', "Creating a login with a blank password is a security risk.  Are you sure you want to continue?");

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -160,7 +160,7 @@ export const BackupRedundancyText = localize('objectManagement.backupRedundancyL
 export const CurrentSLOText = localize('objectManagement.currentSLOLabel', "Current Service Level Objective");
 export const EditionText = localize('objectManagement.editionLabel', "Edition");
 export const MaxSizeText = localize('objectManagement.maxSizeLabel', "Max Size");
-export const AzurePricingLinkText = localize('objectManagement.azurePricingLink', "More info about Azure SQL Database pricing.");
+export const AzurePricingLinkText = localize('objectManagement.azurePricingLink', "Azure SQL Database pricing calculator");
 
 // Login
 export const BlankPasswordConfirmationText: string = localize('objectManagement.blankPasswordConfirmation', "Creating a login with a blank password is a security risk.  Are you sure you want to continue?");

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -140,7 +140,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			containers.push(this.createLabelInputContainer(localizedConstants.BackupRedundancyText, backupDropbox));
 		}
 
-		containers.push(this.createHyperlink(localizedConstants.AzurePricingLinkText, 'https://azure.microsoft.com/en-us/pricing/details/azure-sql-database/single'));
+		containers.push(this.createHyperlink(localizedConstants.AzurePricingLinkText, 'https://go.microsoft.com/fwlink/?linkid=2239183'));
 
 		return this.createGroup(localizedConstants.ConfigureSLOSectionHeader, containers, true, true);
 	}

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -140,6 +140,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			containers.push(this.createLabelInputContainer(localizedConstants.BackupRedundancyText, backupDropbox));
 		}
 
+		containers.push(this.createHyperlink(localizedConstants.AzurePricingLinkText, 'https://azure.microsoft.com/en-us/pricing/details/azure-sql-database/single'));
+
 		return this.createGroup(localizedConstants.ConfigureSLOSectionHeader, containers, true, true);
 	}
 }

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -356,4 +356,8 @@ export abstract class DialogBase<DialogResult> {
 	protected getSectionItemLayout(): azdata.FlexItemLayout {
 		return { CSSStyles: { 'margin-block-end': '5px' } };
 	}
+
+	protected createHyperlink(label: string, url: string): azdata.HyperlinkComponent {
+		return this.modelView.modelBuilder.hyperlink().withProps({ label: label, ariaLabel: label, url: url, showLinkIcon: true }).component();
+	}
 }

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -123,7 +123,7 @@ export abstract class DialogBase<DialogResult> {
 	}
 
 	protected createLabelInputContainer(label: string, component: azdata.Component, required: boolean = false): azdata.FlexContainer {
-		const labelComponent = this.modelView.modelBuilder.text().withProps({ width: DefaultLabelWidth, value: label, requiredIndicator: required }).component();
+		const labelComponent = this.modelView.modelBuilder.text().withProps({ width: DefaultLabelWidth, value: label, requiredIndicator: required, CSSStyles: { 'padding-right': '10px' } }).component();
 		const container = this.modelView.modelBuilder.flexContainer().withLayout({ flexFlow: 'horizontal', flexWrap: 'nowrap', alignItems: 'center' }).withItems([labelComponent], { flex: '0 0 auto' }).component();
 		container.addItem(component, { flex: '1 1 auto' });
 		return container;


### PR DESCRIPTION
We had a discussion offline that the options for an Azure database in the New Database dialog are a bit ambiguous, and you could easily create an expensive instance without knowing it. This change adds a hyperlink in the Azure Configure SLO section to the azure pricing calculator so that users can see the costs for each option.

![AzureLinkDialog](https://github.com/microsoft/azuredatastudio/assets/12820011/1931e1a3-da5c-4f6a-a5e9-1ff01f1f8814)
