### PR TITLE
Add mssql.proposed.d.ts

### DIFF
--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -3,12 +3,15 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// This is the place for extensions to expose APIs.
 declare module 'mssql' {
 	import * as azdata from 'azdata';
 
 	/**
-	 * Covers defining what the mssql extension exports to other extensions
+	 * Covers defining what the mssql extension exports to other extensions.
+	 *
+	 * This file should only contain definitions which rely on STABLE azdata typings
+	 * (from azdata.d.ts). Anything which relies on PROPOSED typings (from azdata.proposed.d.ts)
+	 * should go in mssql.proposed.d.ts.
 	 *
 	 * IMPORTANT: THIS IS NOT A HARD DEFINITION unlike vscode; therefore no enums or classes should be defined here
 	 * (const enums get evaluated when typescript -> javascript so those are fine)
@@ -42,20 +45,7 @@ declare module 'mssql' {
 
 		readonly sqlProjects: ISqlProjectsService;
 
-		readonly sqlAssessment: ISqlAssessmentService;
-
 		readonly azureBlob: IAzureBlobService;
-	}
-
-	/**
-	 * A browser supporting actions over the object explorer connections provided by this extension.
-	 * Currently this is the
-	 */
-	export interface MssqlObjectExplorerBrowser {
-		/**
-		 * Gets the matching node given a context object, e.g. one from a right-click on a node in Object Explorer
-		 */
-		getNode<T extends ITreeNode>(objectExplorerContext: azdata.ObjectExplorerContext): Thenable<T>;
 	}
 
 	/**
@@ -64,14 +54,6 @@ declare module 'mssql' {
 	export interface ITreeNode {
 		getNodeInfo(): azdata.NodeInfo;
 		getChildren(refreshChildren: boolean): ITreeNode[] | Thenable<ITreeNode[]>;
-	}
-
-	/**
-	 * A HDFS file node. This is a leaf node in the object explorer tree, and its contents
-	 * can be queried
-	 */
-	export interface IFileNode extends ITreeNode {
-		getFileContentsAsString(maxBytes?: number): Thenable<string>;
 	}
 
 	//#region --- schema compare
@@ -864,18 +846,6 @@ declare module 'mssql' {
 		registeredServerGroups: Array<RegisteredServerGroup>;
 	}
 	//#endregion
-
-	/**
-	 * Sql Assessment
-	 */
-
-	// SqlAssessment interfaces  -----------------------------------------------------------------------
-
-	export interface ISqlAssessmentService {
-		assessmentInvoke(ownerUri: string, targetType: azdata.sqlAssessment.SqlAssessmentTargetType): Promise<azdata.SqlAssessmentResult>;
-		getAssessmentItems(ownerUri: string, targetType: azdata.sqlAssessment.SqlAssessmentTargetType): Promise<azdata.SqlAssessmentResult>;
-		generateAssessmentScript(items: azdata.SqlAssessmentResultItem[], targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Promise<azdata.ResultStatus>;
-	}
 
 	export interface CreateSasResponse {
 		sharedAccessSignature: string;

--- a/extensions/mssql/src/mssql.proposed.d.ts
+++ b/extensions/mssql/src/mssql.proposed.d.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'mssql' {
+	import * as azdata from 'azdata';
+
+	/**
+	 * Covers defining what the mssql extension exports to other extensions.
+	 *
+	 * This file should only contain definitions which rely on PROPOSED azdata typings
+	 * (from azdata.proposed.d.ts). Anything which relies on STABLE typings (from azdata.d.ts)
+	 * should go in mssql.d.ts.
+	 *
+	 * This is to make it easier for extensions that don't need these features to only import the ones
+	 * that depend on stable features so they don't have to copy over the proposed typings themselves.
+	 *
+	 * IMPORTANT: THIS IS NOT A HARD DEFINITION unlike vscode; therefore no enums or classes should be defined here
+	 * (const enums get evaluated when typescript -> javascript so those are fine)
+	 */
+
+	export interface IExtension {
+		readonly sqlAssessment: ISqlAssessmentService;
+	}
+
+	export interface ISqlAssessmentService {
+		assessmentInvoke(ownerUri: string, targetType: azdata.sqlAssessment.SqlAssessmentTargetType): Promise<azdata.SqlAssessmentResult>;
+		getAssessmentItems(ownerUri: string, targetType: azdata.sqlAssessment.SqlAssessmentTargetType): Promise<azdata.SqlAssessmentResult>;
+		generateAssessmentScript(items: azdata.SqlAssessmentResultItem[], targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Promise<azdata.ResultStatus>;
+	}
+
+}

--- a/extensions/sql-assessment/src/typings/ref.d.ts
+++ b/extensions/sql-assessment/src/typings/ref.d.ts
@@ -7,4 +7,5 @@
 /// <reference path='../../../../src/sql/azdata.d.ts'/>
 /// <reference path='../../../../src/sql/azdata.proposed.d.ts'/>
 /// <reference path='../../../mssql/src/mssql.d.ts'/>
+/// <reference path='../../../mssql/src/mssql.proposed.d.ts'/>
 /// <reference types='@types/node'/>


### PR DESCRIPTION
Any extensions using the mssql.d.ts typings currently need to also bring over the azdata.proposed.d.ts typings because of the SqlAssessment definitions. This is generally just an annoyance for extensions, since most of them don't need these typings at all.

So to make this better I'm splitting the MSSQL typings into "stable" and "proposed" like we do with ADS. This way anything depending on azdata.proposed.d.ts typings can go into a separate typings file without impacting other extensions. 