### PR TITLE
Removing stringify and replacing with constructed string.

### DIFF
--- a/extensions/sql-migration/src/models/loginMigrationModel.ts
+++ b/extensions/sql-migration/src/models/loginMigrationModel.ts
@@ -76,7 +76,7 @@ export class LoginMigrationModel {
 	private _currentStepIdx: number = 0;
 	private _logins: Map<string, Login>;
 	private _loginMigrationSteps: LoginMigrationStep[] = [];
-	public errorCountMapString: string[] = [];
+	public errorCountList: string[] = [];
 
 	constructor() {
 		this.resultsPerStep = new Map<contracts.LoginMigrationStep, contracts.StartLoginMigrationResult>();
@@ -181,24 +181,18 @@ export class LoginMigrationModel {
 		}
 
 		// Making a string of the map elements of errorBuckets
-		var errorBucketsString = JSON.stringify(
+		const errorBucketsString = JSON.stringify(
 			Array.from(errorBuckets.entries()).reduce((o: any, [key, value]) => {
 				o[key] = value;
 				return o;
 			}, {})
 		);
 
-		// Retaining this step in case a revert is needed, but we will be using errorCountMapString for telemetry
+		// Retaining this step in case a revert is needed, but we will be using errorCountList for telemetry
 		this.errorCountMap.set(LoginMigrationStep[step], errorBucketsString);
 
 		// Creating an array of the error codes and its counts for each step
-		this.errorCountMapString.push(
-			"[" +
-			LoginMigrationStep[step].toString() +
-			":" +
-			errorBucketsString.toString() +
-			"]"
-		);
+		this.errorCountList.push(`[${LoginMigrationStep[step]}: ${errorBucketsString}]`);
 	}
 
 	private setDurationPerStep(step: LoginMigrationStep, result: contracts.StartLoginMigrationResult) {

--- a/extensions/sql-migration/src/models/loginMigrationModel.ts
+++ b/extensions/sql-migration/src/models/loginMigrationModel.ts
@@ -76,6 +76,7 @@ export class LoginMigrationModel {
 	private _currentStepIdx: number = 0;
 	private _logins: Map<string, Login>;
 	private _loginMigrationSteps: LoginMigrationStep[] = [];
+	public errorCountMapString: string[] = [];
 
 	constructor() {
 		this.resultsPerStep = new Map<contracts.LoginMigrationStep, contracts.StartLoginMigrationResult>();
@@ -179,7 +180,25 @@ export class LoginMigrationModel {
 			}
 		}
 
-		this.errorCountMap.set(LoginMigrationStep[step], errorBuckets);
+		// Making a string of the map elements of errorBuckets
+		var errorBucketsString = JSON.stringify(
+			Array.from(errorBuckets.entries()).reduce((o: any, [key, value]) => {
+				o[key] = value;
+				return o;
+			}, {})
+		);
+
+		// Retaining this step in case a revert is needed, but we will be using errorCountMapString for telemetry
+		this.errorCountMap.set(LoginMigrationStep[step], errorBucketsString);
+
+		// Creating an array of the error codes and its counts for each step
+		this.errorCountMapString.push(
+			"[" +
+			LoginMigrationStep[step].toString() +
+			":" +
+			errorBucketsString.toString() +
+			"]"
+		);
 	}
 
 	private setDurationPerStep(step: LoginMigrationStep, result: contracts.StartLoginMigrationResult) {

--- a/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
@@ -458,7 +458,7 @@ export class LoginMigrationStatusPage extends MigrationWizardPage {
 			{
 				...getTelemetryProps(this.migrationStateModel),
 				'loginsAuthType': this.migrationStateModel._loginMigrationModel.loginsAuthType,
-				'numberLoginsFailingPerStep': this.migrationStateModel._loginMigrationModel.errorCountMapString.toString(),
+				'numberLoginsFailingPerStep': this.migrationStateModel._loginMigrationModel.errorCountList.toString(),
 				'durationPerStepTimestamp': JSON.stringify(Array.from(this.migrationStateModel._loginMigrationModel.durationPerStep)),
 				'hasSystemError': JSON.stringify(this.migrationStateModel._loginMigrationModel.hasSystemError),
 			},

--- a/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationStatusPage.ts
@@ -458,7 +458,7 @@ export class LoginMigrationStatusPage extends MigrationWizardPage {
 			{
 				...getTelemetryProps(this.migrationStateModel),
 				'loginsAuthType': this.migrationStateModel._loginMigrationModel.loginsAuthType,
-				'numberLoginsFailingPerStep': JSON.stringify(Array.from(this.migrationStateModel._loginMigrationModel.errorCountMap)),
+				'numberLoginsFailingPerStep': this.migrationStateModel._loginMigrationModel.errorCountMapString.toString(),
 				'durationPerStepTimestamp': JSON.stringify(Array.from(this.migrationStateModel._loginMigrationModel.durationPerStep)),
 				'hasSystemError': JSON.stringify(this.migrationStateModel._loginMigrationModel.hasSystemError),
 			},


### PR DESCRIPTION
Fixing bug in login migrations telemetry where the error codes weren't getting logged due to error in JSON.stringify for the numberOfLoginsPerStep column of the telemetry. Simplified it by adding the error codes in string array and doing a toString of the final map. Tested it on ADS with sideloading the custom vsix and was able to see the error codes on the telemetry:

![image](https://github.com/microsoft/azuredatastudio/assets/65304807/c80008df-2eb3-41bf-acab-8141341efc3a)

[Associated ADO work item: https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/2393077]