### PR TITLE
bump STS to remove Linked Server Logins from OE

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.8.0.23",
+	"version": "4.8.0.26",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/23365
STS changes since last version:
https://github.com/microsoft/sqltoolsservice/compare/4.8.0.23...4.8.0.26
![image](https://github.com/microsoft/azuredatastudio/assets/21186993/cd0edcc2-2d51-4dc6-9d1f-1ef71c910013)

