### PR TITLE
Enable no-unsafe-assignments for MSSQL

### DIFF
--- a/extensions/.eslintrc.json
+++ b/extensions/.eslintrc.json
@@ -3,6 +3,7 @@
 		"no-cond-assign": 2,
 		"jsdoc/check-param-names": "error",
 		"@typescript-eslint/explicit-function-return-type": ["error"],
-		"@typescript-eslint/await-thenable": ["error"]
+		"@typescript-eslint/await-thenable": ["error"],
+		"@typescript-eslint/no-unsafe-assignment": "error"
 	}
 }

--- a/extensions/admin-tool-ext-win/.eslintrc.json
+++ b/extensions/admin-tool-ext-win/.eslintrc.json
@@ -8,6 +8,7 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/agent/.eslintrc.json
+++ b/extensions/agent/.eslintrc.json
@@ -5,6 +5,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/arc/.eslintrc.json
+++ b/extensions/arc/.eslintrc.json
@@ -5,6 +5,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/azuremonitor/.eslintrc.json
+++ b/extensions/azuremonitor/.eslintrc.json
@@ -5,6 +5,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/cms/.eslintrc.json
+++ b/extensions/cms/.eslintrc.json
@@ -4,6 +4,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/configuration-editing/.eslintrc.json
+++ b/extensions/configuration-editing/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/css-language-features/.eslintrc.json
+++ b/extensions/css-language-features/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/dacpac/.eslintrc.json
+++ b/extensions/dacpac/.eslintrc.json
@@ -5,6 +5,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/data-workspace/.eslintrc.json
+++ b/extensions/data-workspace/.eslintrc.json
@@ -11,6 +11,7 @@
 			}
 		],
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/datavirtualization/.eslintrc.json
+++ b/extensions/datavirtualization/.eslintrc.json
@@ -4,6 +4,7 @@
 		"createDefaultProgram": true
 	},
 	"rules": {
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/git-base/.eslintrc.json
+++ b/extensions/git-base/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/git/.eslintrc.json
+++ b/extensions/git/.eslintrc.json
@@ -2,6 +2,7 @@
 	"rules": {
 		"no-cond-assign": 0,
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/github-authentication/.eslintrc.json
+++ b/extensions/github-authentication/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/github/.eslintrc.json
+++ b/extensions/github/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/html-language-features/.eslintrc.json
+++ b/extensions/html-language-features/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/image-preview/.eslintrc.json
+++ b/extensions/image-preview/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/import/.eslintrc.json
+++ b/extensions/import/.eslintrc.json
@@ -4,6 +4,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/integration-tests/.eslintrc.json
+++ b/extensions/integration-tests/.eslintrc.json
@@ -5,6 +5,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/ipynb/.eslintrc.json
+++ b/extensions/ipynb/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/json-language-features/.eslintrc.json
+++ b/extensions/json-language-features/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/kusto/.eslintrc.json
+++ b/extensions/kusto/.eslintrc.json
@@ -5,6 +5,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/machine-learning/.eslintrc.json
+++ b/extensions/machine-learning/.eslintrc.json
@@ -1,10 +1,8 @@
 {
 	"parserOptions": {
-		"project": "./extensions/resource-deployment/tsconfig.json",
-		"createDefaultProgram": true
+		"project": "./extensions/machine-learning/tsconfig.json"
 	},
 	"rules": {
-		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"],
 		"@typescript-eslint/no-unsafe-assignment": "off"
 	}

--- a/extensions/machine-learning/src/.eslintrc.json
+++ b/extensions/machine-learning/src/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-	"parserOptions": {
-		"project": "./extensions/machine-learning/tsconfig.json"
-	},
-	"rules": {
-		"@typescript-eslint/explicit-function-return-type": ["off"]
-	}
-}

--- a/extensions/markdown-language-features/.eslintrc.json
+++ b/extensions/markdown-language-features/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/markdown-math/.eslintrc.json
+++ b/extensions/markdown-math/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/merge-conflict/.eslintrc.json
+++ b/extensions/merge-conflict/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/microsoft-authentication/.eslintrc.json
+++ b/extensions/microsoft-authentication/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -33,6 +33,10 @@
     ],
     "commands": [
       {
+        "command": "objectExplorer.scriptAsAlter",
+        "title": "Script as Alter"
+      },
+      {
         "command": "mssql.exportSqlAsNotebook",
         "title": "%mssql.exportSqlAsNotebook%"
       },
@@ -491,6 +495,11 @@
         }
       ],
       "objectExplorer/item/context": [
+        {
+          "command": "objectExplorer.scriptAsAlter",
+          "when": "nodeType == Table",
+          "group": "0_query@5"
+        },
         {
           "command": "mssql.designTable",
           "when": "connectionProvider == MSSQL && nodeType == Table && nodeSubType != LedgerDropped",

--- a/extensions/mssql/src/contextProvider.ts
+++ b/extensions/mssql/src/contextProvider.ts
@@ -60,6 +60,7 @@ export default class ContextProvider {
 	}
 
 	dispose(): void {
-		this._disposables = this._disposables.map(i => i.dispose());
+		this._disposables.forEach(i => i.dispose());
+		this._disposables = [];
 	}
 }

--- a/extensions/mssql/src/credentialstore/credentialstore.ts
+++ b/extensions/mssql/src/credentialstore/credentialstore.ts
@@ -26,7 +26,7 @@ export class CredentialStore {
 		baseConfig: IConfig
 	) {
 		if (baseConfig) {
-			this._config = JSON.parse(JSON.stringify(baseConfig));
+			this._config = JSON.parse(JSON.stringify(baseConfig)) as IConfig;
 			this._config.executableFiles = ['MicrosoftSqlToolsCredentials.exe', 'MicrosoftSqlToolsCredentials'];
 		}
 		this.context = context;

--- a/extensions/mssql/src/dashboard/bookExtensions.ts
+++ b/extensions/mssql/src/dashboard/bookExtensions.ts
@@ -56,7 +56,7 @@ namespace BookContributions {
 	export function fromExtension(
 		extension: vscode.Extension<any>
 	): BookContribution[] {
-		const contributions = extension.packageJSON && extension.packageJSON.contributes;
+		const contributions = extension.packageJSON?.contributes as unknown[];
 		if (!contributions) {
 			return [];
 		}

--- a/extensions/mssql/src/features.ts
+++ b/extensions/mssql/src/features.ts
@@ -107,14 +107,14 @@ export class AccountFeature implements StaticFeature {
 
 		// find account
 		const accountList = await azdata.accounts.getAllAccounts();
-		const account = accountList.find(a => a.key.accountId === request.accountId);
+		const account: azurecore.AzureAccount | undefined = accountList.find(a => a.key.accountId === request.accountId);
 		if (!account) {
 			console.log(`Failed to find azure account ${request.accountId} when executing token refresh`);
 			throw Error(localizedConstants.failedToFindAccount(request.accountId));
 		}
 
 		// find tenant
-		const tenant = account.properties.tenants.find((tenant: any) => tenant.id === request.tenantId);
+		const tenant = account.properties.tenants.find(tenant => tenant.id === request.tenantId);
 		if (!tenant) {
 			console.log(`Failed to find tenant ${request.tenantId} in account ${account.displayInfo.displayName} when refreshing security token`);
 			throw Error(localizedConstants.failedToFindTenants(request.tenantId, account.displayInfo.displayName));

--- a/extensions/mssql/src/objectManagement/ui/principalDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/principalDialogBase.ts
@@ -81,7 +81,7 @@ export abstract class PrincipalDialogBase<ObjectInfoType extends SecurityPrincip
 			width: DefaultTableWidth
 		}).component();
 		this.disposables.push(this.permissionTable.onCellAction(async (arg: azdata.ICheckboxCellActionEventArgs) => {
-			const permissionName = this.permissionTable.data[arg.row][0];
+			const permissionName = this.permissionTable.data[arg.row][0] as string;
 			const securable = this.securablePermissions[this.securableTable.selectedRows[0]];
 			let permission: SecurablePermissionItem = securable.permissions.find(securablePermission => securablePermission.permission === permissionName);
 			if (!permission) {

--- a/extensions/mssql/src/resourceProvider/resourceProvider.ts
+++ b/extensions/mssql/src/resourceProvider/resourceProvider.ts
@@ -77,7 +77,7 @@ export class AzureResourceProvider {
 
 	constructor(private logPath: string, baseConfig: IConfig) {
 		if (baseConfig) {
-			this._config = JSON.parse(JSON.stringify(baseConfig));
+			this._config = JSON.parse(JSON.stringify(baseConfig)) as IConfig;
 			this._config.executableFiles = ['SqlToolsResourceProviderService.exe', 'SqlToolsResourceProviderService'];
 		}
 	}

--- a/extensions/mssql/src/sqlNotebook/sqlNotebookController.ts
+++ b/extensions/mssql/src/sqlNotebook/sqlNotebookController.ts
@@ -41,7 +41,7 @@ export class SqlNotebookController implements vscode.Disposable {
 
 		this._controller.supportedLanguages = ['sql'];
 		this._controller.supportsExecutionOrder = true;
-		this._controller.executeHandler = this.execute.bind(this);
+		this._controller.executeHandler = this.execute.bind(this) as (cells: vscode.NotebookCell[], notebook: vscode.NotebookDocument, controller: vscode.NotebookController) => void | Thenable<void>;
 
 		const sqlProvider = 'MSSQL';
 		this._queryProvider = azdata.dataprotocol.getProvider<azdata.QueryProvider>(sqlProvider, azdata.DataProviderType.QueryProvider);
@@ -105,13 +105,13 @@ export class SqlNotebookController implements vscode.Disposable {
 
 	public getConnectionProfile(connection: azdata.connection.Connection): azdata.IConnectionProfile {
 		let connectionProfile: azdata.IConnectionProfile = {
-			connectionName: connection.options.connectionName,
-			serverName: connection.options.server,
-			databaseName: connection.options.database,
-			userName: connection.options.user,
-			password: connection.options.password,
-			authenticationType: connection.options.authenticationType,
-			savePassword: connection.options.savePassword,
+			connectionName: connection.options.connectionName as string,
+			serverName: connection.options.server as string,
+			databaseName: connection.options.database as string,
+			userName: connection.options.user as string,
+			password: connection.options.password as string,
+			authenticationType: connection.options.authenticationType as string,
+			savePassword: connection.options.savePassword as boolean,
 			groupFullName: undefined,
 			groupId: undefined,
 			providerName: connection.providerName,

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -132,7 +132,7 @@ export class SqlToolsServer {
 	private async download(context: AppContext): Promise<string> {
 		const configDir = context.extensionContext.extensionPath;
 		const rawConfig = await fs.readFile(path.join(configDir, 'config.json'));
-		this.config = JSON.parse(rawConfig.toString());
+		this.config = JSON.parse(rawConfig.toString()) as IConfig;
 		this.config.installDirectory = path.join(configDir, this.config.installDirectory);
 		this.config.proxy = vscode.workspace.getConfiguration('http').get<string>('proxy', '');
 		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL', true);

--- a/extensions/mssql/src/tableDesigner/tableDesigner.ts
+++ b/extensions/mssql/src/tableDesigner/tableDesigner.ts
@@ -36,7 +36,7 @@ export function registerTableDesignerCommands(appContext: AppContext) {
 				isNewTable: true,
 				id: generateUuid(),
 				connectionString: connectionString,
-				accessToken: context.connectionProfile!.options.azureAccountToken,
+				accessToken: context.connectionProfile!.options.azureAccountToken as string,
 				tableIcon: tableIcon
 			}, telemetryInfo, context);
 		} catch (error) {
@@ -68,7 +68,7 @@ export function registerTableDesignerCommands(appContext: AppContext) {
 				schema: schema,
 				id: `${sqlProviderName}|${server}|${database}|${schema}|${name}`,
 				connectionString: connectionString,
-				accessToken: context.connectionProfile!.options.azureAccountToken,
+				accessToken: context.connectionProfile!.options.azureAccountToken as string,
 				tableIcon: tableIcon
 			}, telemetryInfo, context);
 		} catch (error) {

--- a/extensions/mssql/src/telemetry.ts
+++ b/extensions/mssql/src/telemetry.ts
@@ -11,11 +11,16 @@ import * as Constants from './constants';
 import * as nls from 'vscode-nls';
 import { ServerInfo } from 'azdata';
 
+interface IPackageInfo {
+	name: string;
+	version: string;
+	aiKey: string;
+}
 
 const localize = nls.loadMessageBundle();
 const viewKnownIssuesAction = localize('viewKnownIssuesText', "View Known Issues");
 
-const packageInfo = vscode.extensions.getExtension(Constants.packageName)?.packageJSON;
+const packageInfo = vscode.extensions.getExtension(Constants.packageName)?.packageJSON as IPackageInfo | undefined;
 export const TelemetryReporter = new AdsTelemetryReporter<string, string>(packageInfo?.name, packageInfo?.version, packageInfo?.aiKey);
 
 /**

--- a/extensions/mssql/src/util/objects.ts
+++ b/extensions/mssql/src/util/objects.ts
@@ -80,9 +80,9 @@ export function deepClone<T>(obj: T): T {
 	const result: any = Array.isArray(obj) ? [] : {};
 	Object.keys(<any>obj).forEach((key: string) => {
 		if ((<any>obj)[key] && typeof (<any>obj)[key] === 'object') {
-			result[key] = deepClone((<any>obj)[key]);
+			result[key] = deepClone((<any>obj)[key]) as unknown;
 		} else {
-			result[key] = (<any>obj)[key];
+			result[key] = (<any>obj)[key] as unknown;
 		}
 	});
 	return result;

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -223,7 +223,7 @@ export function getErrorMessage(error: Error | any, removeHeader: boolean = fals
 	if (error instanceof Error) {
 		errorMessage = error.message;
 	} else if (error.responseText) {
-		errorMessage = error.responseText.toString() as string;
+		errorMessage = error.responseText as string;
 		if (error.status) {
 			errorMessage += ` (${error.status})`;
 		}

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -205,7 +205,7 @@ export function getCommonLaunchArgsAndCleanupOldLogFiles(logPath: string, fileNa
 
 export function ensure(target: { [key: string]: any }, key: string): any {
 	if (target[key] === void 0) {
-		target[key] = {} as any;
+		target[key] = {};
 	}
 	return target[key];
 }
@@ -223,7 +223,7 @@ export function getErrorMessage(error: Error | any, removeHeader: boolean = fals
 	if (error instanceof Error) {
 		errorMessage = error.message;
 	} else if (error.responseText) {
-		errorMessage = error.responseText;
+		errorMessage = error.responseText.toString() as string;
 		if (error.status) {
 			errorMessage += ` (${error.status})`;
 		}
@@ -265,9 +265,9 @@ export function isValidNumber(maybeNumber: any) {
  * Helper to log messages to the developer console if enabled
  * @param msg Message to log to the console
  */
-export function logDebug(msg: any): void {
+export function logDebug(msg: unknown): void {
 	let config = vscode.workspace.getConfiguration(extensionConfigSectionName);
-	let logDebugInfo = config[configLogDebugInfo];
+	let logDebugInfo = !!config[configLogDebugInfo];
 	if (logDebugInfo === true) {
 		let currentTime = new Date().toLocaleTimeString();
 		let outputMsg = '[' + currentTime + ']: ' + msg ? msg.toString() : '';

--- a/extensions/notebook-renderers/.eslintrc.json
+++ b/extensions/notebook-renderers/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/notebook/.eslintrc.json
+++ b/extensions/notebook/.eslintrc.json
@@ -11,6 +11,7 @@
 			}
 		],
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/profiler/.eslintrc.json
+++ b/extensions/profiler/.eslintrc.json
@@ -4,6 +4,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/query-history/.eslintrc.json
+++ b/extensions/query-history/.eslintrc.json
@@ -8,6 +8,7 @@
 			{
 				"ignoreVoid": true
 			}
-		]
+		],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/schema-compare/.eslintrc.json
+++ b/extensions/schema-compare/.eslintrc.json
@@ -4,6 +4,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/search-result/.eslintrc.json
+++ b/extensions/search-result/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/server-report/.eslintrc.json
+++ b/extensions/server-report/.eslintrc.json
@@ -1,5 +1,8 @@
 {
 	"parserOptions": {
 		"project": "./extensions/server-report/tsconfig.json"
+	},
+	"rules": {
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/simple-browser/.eslintrc.json
+++ b/extensions/simple-browser/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/sql-assessment/.eslintrc.json
+++ b/extensions/sql-assessment/.eslintrc.json
@@ -4,6 +4,7 @@
 	},
 	"rules": {
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/sql-bindings/.eslintrc.json
+++ b/extensions/sql-bindings/.eslintrc.json
@@ -9,6 +9,7 @@
 				"ignoreVoid": true
 			}
 		],
-		"jsdoc/require-param": "error"
+		"jsdoc/require-param": "error",
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/sql-database-projects/.eslintrc.json
+++ b/extensions/sql-database-projects/.eslintrc.json
@@ -10,6 +10,7 @@
 			}
 		],
 		// Disabled until the issues can be fixed
-		"@typescript-eslint/explicit-function-return-type": ["off"]
+		"@typescript-eslint/explicit-function-return-type": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/sql-migration/.eslintrc.json
+++ b/extensions/sql-migration/.eslintrc.json
@@ -5,6 +5,7 @@
 	"rules": {
 		// Disabled until the issues can be fixed
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/no-async-promise-executor": ["off"]
+		"@typescript-eslint/no-async-promise-executor": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/typescript-language-features/.eslintrc.json
+++ b/extensions/typescript-language-features/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/vscode-api-tests/.eslintrc.json
+++ b/extensions/vscode-api-tests/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/vscode-test-resolver/.eslintrc.json
+++ b/extensions/vscode-test-resolver/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }

--- a/extensions/xml-language-features/.eslintrc.json
+++ b/extensions/xml-language-features/.eslintrc.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"@typescript-eslint/explicit-function-return-type": ["off"],
-		"@typescript-eslint/await-thenable": ["off"]
+		"@typescript-eslint/await-thenable": ["off"],
+		"@typescript-eslint/no-unsafe-assignment": "off"
 	}
 }


### PR DESCRIPTION
https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md

`any` is dangerous to use in a lot of situations, so wherever we can be explicit about not using it the better. I'm enabling this for the MSSQL extension, and then moving it to the extension-level eslintrc so that other extensions can easily enable it later if needed (and new extensions get it automatically).

Smallish number of fixes, none of them a concern that I saw. 