### PR TITLE
[SQL Migration] Release v1.4.7 to stable gallery

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.6",
-							"lastUpdated": "06/14/2023",
+							"version": "1.4.7",
+							"lastUpdated": "06/20/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.6.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.7.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the stable extension gallery to the latest version of the SQL Migration extension 1.4.7.
This version was already released to insiders via PR:
https://github.com/microsoft/azuredatastudio/pull/23430