### PR TITLE
Removing preview flag from OE filtering

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -595,7 +595,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 	public async filterElementChildren(node: TreeNode): Promise<void> {
 		await FilterDialog.getFiltersForProperties(
 			node.filterProperties,
-			localize('objectExplorer.filterDialogTitle', "(Preview) Filter Settings: {0}", node.getConnectionProfile().title),
+			localize('objectExplorer.filterDialogTitle', "Filter Settings: {0}", node.getConnectionProfile().title),
 			localize('objectExplorer.nodePath', "Node Path: {0}", node.nodePath),
 			node.filters,
 			async (filters) => {

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -595,7 +595,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 	public async filterElementChildren(node: TreeNode): Promise<void> {
 		await FilterDialog.getFiltersForProperties(
 			node.filterProperties,
-			localize('objectExplorer.filterDialogTitle', "Filter Settings: {0}", node.getConnectionProfile().title),
+			localize('objectExplorer.filterDialogTitle', "Filter Settings"),
 			node.nodePath,
 			node.filters,
 			async (filters) => {

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -596,7 +596,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 		await FilterDialog.getFiltersForProperties(
 			node.filterProperties,
 			localize('objectExplorer.filterDialogTitle', "Filter Settings: {0}", node.getConnectionProfile().title),
-			localize('objectExplorer.nodePath', "Node Path: {0}", node.nodePath),
+			node.nodePath,
 			node.filters,
 			async (filters) => {
 				let errorListener;

--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -316,7 +316,7 @@ export class DeleteConnectionAction extends Action {
 
 export class FilterChildrenAction extends Action {
 	public static ID = 'objectExplorer.filterChildren';
-	public static LABEL = localize('objectExplorer.filterChildren', "Filter (Preview)");
+	public static LABEL = localize('objectExplorer.filterChildren', "Filter");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/services/objectExplorer/browser/filterDialog/filterDialog.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/filterDialog/filterDialog.ts
@@ -73,7 +73,7 @@ const CLEAR_COLUMN_HEADER = localize('objectExplorer.clearColumnHeader', "Clear"
 const TRUE_SELECT_BOX = localize('objectExplorer.trueSelectBox', "True");
 const FALSE_SELECT_BOX = localize('objectExplorer.falseSelectBox', "False");
 
-function nodePathDisplayString(nodepath: string): string { return localize('objectExplorer.nodePath', "Node Path: {0}", nodepath) }
+function nodePathDisplayString(nodepath: string): string { return localize('objectExplorer.nodePath', "Path: {0}", nodepath) }
 
 const PROPERTY_COLUMN_ID = 'property';
 const OPERATOR_COLUMN_ID = 'operator';

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
@@ -27,8 +27,6 @@ import { fillInActions } from 'vs/platform/actions/browser/menuEntryActionViewIt
 import { AsyncServerTree, ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ILogService } from 'vs/platform/log/common/log';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES } from 'sql/workbench/common/constants';
 
 /**
  *  Provides actions for the server tree elements
@@ -45,7 +43,6 @@ export class ServerTreeActionProvider {
 		@IContextKeyService private _contextKeyService: IContextKeyService,
 		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService,
 		@ILogService private _logService: ILogService,
-		@IConfigurationService private _configurationService: IConfigurationService
 	) {
 	}
 
@@ -252,7 +249,7 @@ export class ServerTreeActionProvider {
 		// Contribute refresh action for scriptable objects via contribution
 		if (!this.isScriptableObject(context)) {
 			// Adding filter action if the node has filter properties
-			if (treeNode?.filterProperties?.length > 0 && this._configurationService.getValue<boolean>(CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES)) {
+			if (treeNode?.filterProperties?.length > 0) {
 				actions.push(this._instantiationService.createInstance(FilterChildrenAction, FilterChildrenAction.ID, FilterChildrenAction.LABEL, context.treeNode));
 			}
 			// Adding remove filter action if the node has filters applied to it and the action is not inline only.


### PR DESCRIPTION
Removing Filter Dialog:
![image](https://github.com/microsoft/azuredatastudio/assets/6816294/01332f8d-e7b5-4b4e-a162-1cfe9ac3a8a1)

Removing double node path and fixing filter:
Before:
![image](https://github.com/microsoft/azuredatastudio/assets/6816294/7a433a8a-77f6-4a5e-9491-de1e53ded297)
Now:
![image](https://github.com/microsoft/azuredatastudio/assets/6816294/7deef406-72e8-4ca0-8785-752e37915b99)
