### PR TITLE
Add Preview tags to object management context menu entries

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -497,6 +497,10 @@
         {
           "command": "mssql.renameObject",
           "when": "false"
+        },
+        {
+          "command": "mssql.detachDatabase",
+          "when": "false"
         }
       ],
       "objectExplorer/item/context": [

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -523,38 +523,38 @@
         {
           "command": "mssql.newObject",
           "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(ServerLevelLogins|Users|ServerLevelServerRoles|ApplicationRoles|DatabaseRoles|Databases)$/ && config.workbench.enablePreviewFeatures",
-          "group": "0_query@1"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.objectProperties",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
-          "group": "0_query@1",
+          "group": "z_objectManagement",
           "isDefault": true
         },
         {
           "command": "mssql.objectProperties",
           "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && isDevelopment",
-          "group": "0_query@1"
+          "group": "z_objectManagement"
         },
         {
           "command": "mssql.deleteObject",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole|Database)$/ && config.workbench.enablePreviewFeatures",
-          "group": "0_query@2"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.renameObject",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|Table|View|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
-          "group": "0_query@3"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.renameObject",
           "when": "connectionProvider == MSSQL && nodeType == Column && config.workbench.enablePreviewFeatures && nodePath =~ /^.*\\/Tables\\/.*\\/Columns\\/.*$/",
-          "group": "0_query@3"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.detachDatabase",
           "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && config.workbench.enablePreviewFeatures",
-          "group": "0_query@4"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.enableGroupBySchema",
@@ -604,27 +604,27 @@
         {
           "command": "mssql.newObject",
           "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(ServerLevelLogins|Users|ServerLevelServerRoles|ApplicationRoles|DatabaseRoles|Databases)$/ && config.workbench.enablePreviewFeatures",
-          "group": "connection@1"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.objectProperties",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
-          "group": "connection@1"
+          "group": "z_objectManagement"
         },
         {
           "command": "mssql.deleteObject",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole|Database)$/ && config.workbench.enablePreviewFeatures",
-          "group": "connection@2"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.renameObject",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|Table|View|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
-          "group": "connection@3"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.renameObject",
           "when": "connectionProvider == MSSQL && nodeType == Column && config.workbench.enablePreviewFeatures && nodePath =~ /^.*\\/Tables\\/.*\\/Columns\\/.*$/",
-          "group": "connection@3"
+          "group": "1_objectManagement"
         },
         {
           "command": "mssql.enableGroupBySchema",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -184,9 +184,9 @@
 	"mssql.objectExplorer.enableGroupBySchemaTitle": "SQL Server: Enable Group By Schema",
 	"mssql.objectExplorer.disableGroupBySchemaTitle": "SQL Server: Disable Group By Schema",
 	"mssql.objectExplorer.expandTimeout": "The timeout in seconds for expanding a node in Object Explorer. The default value is 45 seconds.",
-	"title.newObject": "New",
+	"title.newObject": "New (Preview)",
 	"title.objectProperties": "Properties (Preview)",
-	"title.deleteObject": "Delete",
-	"title.renameObject": "Rename",
-	"title.detachDatabase": "Detach"
+	"title.deleteObject": "Delete (Preview)",
+	"title.renameObject": "Rename (Preview)",
+	"title.detachDatabase": "Detach (Preview)"
 }

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -138,7 +138,7 @@ CommandsRegistry.registerCommand({
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: '0_query',
-	order: 3,
+	order: 1,
 	command: {
 		id: DE_NEW_NOTEBOOK_COMMAND_ID,
 		title: localize('newNotebook', "New Notebook")
@@ -160,7 +160,7 @@ CommandsRegistry.registerCommand({
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	group: '0_query',
-	order: 3,
+	order: 1,
 	command: {
 		id: OE_NEW_NOTEBOOK_COMMAND_ID,
 		title: localize('newQuery', "New Notebook")

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -74,7 +74,7 @@ new NewQueryTask().registerTask();
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	group: '0_query',
-	order: 1,
+	order: 0,
 	command: {
 		id: OE_NEW_QUERY_ACTION_ID,
 		title: localize('newQuery', "New Query")
@@ -85,7 +85,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 // New Query
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: '0_query',
-	order: 1,
+	order: 0,
 	command: {
 		id: DE_NEW_QUERY_COMMAND_ID,
 		title: localize('newQuery', "New Query")


### PR DESCRIPTION
I also fixed 2 other issues:
1. Detach Database was incorrectly showing up in the command palette
2. New Notebook context menu entry was being placed in the middle of the object management actions.

New Context Menu layout:
![ContextMenu](https://github.com/microsoft/azuredatastudio/assets/12820011/3372337d-a482-4f74-8457-318d6aec445e)

Now New Query is always in the same group order as Manage, and New Notebook is in the group order immediately below that