### PR TITLE
Change instantiation of ShellIntegrationAddon

### DIFF
--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -207,8 +207,8 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 
 	constructor(
 		private _nonce: string,
-		private readonly _disableTelemetry: boolean | undefined,
-		private readonly _telemetryService: ITelemetryService | undefined,
+		private readonly _disableTelemetry: boolean,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService, // {{SQL CARBON EDIT}} - inject service to avoid type issue with instantiation service service
 		@ILogService private readonly _logService: ILogService
 	) {
 		super();

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -33,7 +33,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { DecorationAddon } from 'vs/workbench/contrib/terminal/browser/xterm/decorationAddon';
 import { ITerminalCapabilityStore, ITerminalCommand, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { Emitter } from 'vs/base/common/event';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+// import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry'; {{SQL CARBON EDIT}} - remove unused
 import { SuggestAddon } from 'vs/workbench/contrib/terminal/browser/xterm/suggestAddon';
 import { IContextKey } from 'vs/platform/contextkey/common/contextkey';
 
@@ -189,7 +189,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@IThemeService private readonly _themeService: IThemeService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService
+		// @ITelemetryService private readonly _telemetryService: ITelemetryService // {{SQL CARBON EDIT}} - remove unused injection
 	) {
 		super();
 		const font = this._configHelper.getFont(undefined, true);
@@ -252,7 +252,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 		this._decorationAddon = this._instantiationService.createInstance(DecorationAddon, this._capabilities);
 		this._decorationAddon.onDidRequestRunCommand(e => this._onDidRequestRunCommand.fire(e));
 		this.raw.loadAddon(this._decorationAddon);
-		this._shellIntegrationAddon = new ShellIntegrationAddon(shellIntegrationNonce, disableShellIntegrationReporting, this._telemetryService, this._logService); // {{SQL CARBON EDIT}} - create directly due to issues with instantiation service type checking
+		this._shellIntegrationAddon = this._instantiationService.createInstance(ShellIntegrationAddon, shellIntegrationNonce, disableShellIntegrationReporting);
 		this.raw.loadAddon(this._shellIntegrationAddon);
 
 		// Load the suggest addon, this should be loaded regardless of the setting as the sequences

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
@@ -11,6 +11,8 @@ import { ITerminalCapabilityStore, TerminalCapability } from 'vs/platform/termin
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
 import { writeP } from 'vs/workbench/contrib/terminal/browser/terminalTestHelpers';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';  // {{SQL CARBON EDIT}} - inject telemetry service
+import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils'; // {{SQL CARBON EDIT}} - inject telemetry service
 
 class TestShellIntegrationAddon extends ShellIntegrationAddon {
 	getCommandDetectionMock(terminal: Terminal): sinon.SinonMock {
@@ -34,6 +36,7 @@ suite('ShellIntegrationAddon', () => {
 		xterm = new Terminal({ allowProposedApi: true, cols: 80, rows: 30 });
 		const instantiationService = new TestInstantiationService();
 		instantiationService.stub(ILogService, NullLogService);
+		instantiationService.stub(ITelemetryService, NullTelemetryService); // {{SQL CARBON EDIT}} - inject telemetry service
 		shellIntegrationAddon = instantiationService.createInstance(TestShellIntegrationAddon, '', true);
 		xterm.loadAddon(shellIntegrationAddon);
 		capabilities = shellIntegrationAddon.capabilities;


### PR DESCRIPTION
This gets the code closer to what VS Code has upstream.  Unfortunately our compile flags are different so the upstream code can't build in this repo as-is.  This is possibly related to some of the unit test intermittent failures we're seeing with ` Cannot read properties of undefined (reading 'getRasterizedGlyph') (/__w/1/s/node_modules/xterm-addon-canvas/lib/xterm-addon-canvas.js:1)`.  Though I haven't been able to confirm this as a fix yet.