### PR TITLE
Remove dashboard color overrides

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
@@ -26,7 +26,6 @@ import { CommonServiceInterface } from 'sql/workbench/services/bootstrap/browser
 
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import * as colors from 'vs/platform/theme/common/colorRegistry';
-import * as themeColors from 'vs/workbench/common/theme';
 import { Action, IAction } from 'vs/base/common/actions';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
@@ -259,24 +258,10 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 			const el = <HTMLElement>this._ref.nativeElement;
 			const headerEl: HTMLElement = this.header.nativeElement;
 			let borderColor = theme.getColor(DASHBOARD_BORDER);
-			let backgroundColor = theme.getColor(colors.editorBackground, true);
-			const foregroundColor = theme.getColor(themeColors.SIDE_BAR_FOREGROUND, true);
 			const border = theme.getColor(colors.contrastBorder, true);
-
-			if (this._config.background_color) {
-				backgroundColor = theme.getColor(this._config.background_color);
-			}
 
 			if (this._config.border === 'none') {
 				borderColor = undefined;
-			}
-
-			if (backgroundColor) {
-				el.style.backgroundColor = backgroundColor.toString();
-			}
-
-			if (foregroundColor) {
-				el.style.color = foregroundColor.toString();
 			}
 
 			let borderString = undefined;


### PR DESCRIPTION
Fixes #23521 

Dashboard widget's `updateTheme` was going against theme color scheme by setting 'NULL' color (SIDE_BAR_FOREGROUND), which now has a default dull color, that causes accessibility issues. PR fixes issue by removing color overrides to keep text/background color in sync with theme.

![DashboardOverride](https://github.com/microsoft/azuredatastudio/assets/13396919/fc528fcc-8fa1-4764-ab19-161230166175)
