### PR TITLE
Fix line height in Saved Connections tree

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -181,7 +181,7 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 			{
 				identityProvider: new IdentityProvider(),
 				horizontalScrolling: false,
-				setRowLineHeight: false,
+				setRowLineHeight: true,
 				transformOptimization: false,
 				accessibilityProvider: new ListAccessibilityProvider()
 			}) as WorkbenchAsyncDataTree<TreeModel, TreeElement>);
@@ -312,7 +312,7 @@ class ConnectionDialogTreeProviderElement {
 
 class ListDelegate implements IListVirtualDelegate<TreeElement> {
 	getHeight(): number {
-		return 22;
+		return 23;
 	}
 
 	getTemplateId(element: TreeElement): string {


### PR DESCRIPTION
Fixes #23526 

_(Line height is set to 23 to match Recent connection tree line height)_

<img src="https://github.com/microsoft/azuredatastudio/assets/13396919/7b638323-d6a8-4a63-af25-85a3b46e3d55" width=500 />
