### PR TITLE
Fixing setting layout in OE

### DIFF
--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -46,6 +46,7 @@ configurationRegistry.registerConfiguration({
 	'id': 'startupConfig',
 	'title': localize('startupConfig', "Startup Configuration"),
 	'type': 'object',
+	'order': 0,
 	'properties': {
 		'startup.alwaysShowServersView': {
 			'type': 'boolean',

--- a/src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution.ts
+++ b/src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution.ts
@@ -15,12 +15,21 @@ const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Con
 export const SERVER_GROUP_AUTOEXPAND_CONFIG = 'autoExpand';
 
 const serverGroupConfig: IConfigurationNode = {
-	id: 'Server Groups',
+	id: 'serverGroup',
 	type: 'object',
+	title: localize('objectExplorerConfigurationTitle', "Object Explorer"),
+	order: 2,
 	properties: {
-		[SERVER_GROUP_CONFIG + '.' + SERVER_GROUP_COLORS_CONFIG]: <IJSONSchema>{
+		[`${SERVER_GROUP_CONFIG}.${SERVER_GROUP_AUTOEXPAND_CONFIG}`]: {
+			'order': 2,
+			'type': 'boolean',
+			'description': localize('serverGroup.autoExpand', "Auto-expand Server Groups in the Object Explorer viewlet."),
+			'default': 'true'
+		},
+		[`${SERVER_GROUP_CONFIG}.${SERVER_GROUP_COLORS_CONFIG}`]: <IJSONSchema>{
 			type: 'array',
 			items: 'string',
+			order: 3,
 			'description': localize('serverGroup.colors', "Server Group color palette used in the Object Explorer viewlet."),
 			default: [
 				'#A1634D',
@@ -33,11 +42,6 @@ const serverGroupConfig: IConfigurationNode = {
 				DefaultServerGroupColor
 			]
 		},
-		[SERVER_GROUP_CONFIG + '.' + SERVER_GROUP_AUTOEXPAND_CONFIG]: {
-			'type': 'boolean',
-			'description': localize('serverGroup.autoExpand', "Auto-expand Server Groups in the Object Explorer viewlet."),
-			'default': 'true'
-		},
 	}
 };
 
@@ -46,8 +50,9 @@ const serverTreeConfig: IConfigurationNode = {
 	'id': 'serverTree',
 	'title': localize('serverTree.configuration.title', "Server Tree"),
 	'type': 'object',
+	'order': 1,
 	'properties': {
-		'serverTree.useAsyncServerTree': {
+		[`serverTree.useAsyncServerTree`]: {
 			'type': 'boolean',
 			'default': true,
 			'description': localize('serverTree.useAsyncServerTree', "Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering. Requires a restart to take effect.")
@@ -55,5 +60,5 @@ const serverTreeConfig: IConfigurationNode = {
 	}
 };
 
-configurationRegistry.registerConfiguration(serverGroupConfig);
 configurationRegistry.registerConfiguration(serverTreeConfig);
+configurationRegistry.registerConfiguration(serverGroupConfig);

--- a/src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout.ts
+++ b/src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout.ts
@@ -6,6 +6,8 @@
 import { localize } from 'vs/nls';
 import { tocData as vstocData, ITOCEntry } from 'vs/workbench/contrib/preferences/browser/settingsLayout';
 
+export const OBJECT_EXPLORER_CONFIG_PREFIX = 'objectExplorer';
+
 // Copy existing table of contents and append
 export const tocData: ITOCEntry<string> = Object.assign({}, vstocData);
 let sqlTocItems: ITOCEntry<string>[] = [{
@@ -15,7 +17,12 @@ let sqlTocItems: ITOCEntry<string>[] = [{
 		{
 			id: 'data/connection',
 			label: localize('connection', "Connection"),
-			settings: ['startup.alwaysShowServersView', 'connection.*', 'serverGroup.*', 'datasource.*']
+			settings: ['connection.*', 'datasource.*']
+		},
+		{
+			id: 'data/objectExplorer',
+			label: localize('objectExplorer', "Object Explorer"),
+			settings: ['startup.alwaysShowServersView', 'serverTree.*', 'serverGroup.*']
 		},
 		{
 			id: 'data/queryEditor',


### PR DESCRIPTION
Fixes #22756

Adding a new category in Data for Object Explorer
OE will contain all server tree and server group related settings. 
![image](https://github.com/microsoft/azuredatastudio/assets/6816294/3daa3764-c883-483b-8418-9181fb004407)
