### PR TITLE
Fix issue updating installed extension list

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -284,7 +284,13 @@ export class ExtensionsListView extends ViewPane {
 	}
 
 	count(): number {
-		return this.queryResult?.model.length ?? 0;
+		// {{SQL CARBON EDIT}} - try to use the list model before the queryResult model
+		// {{SQL CARBON EDIT}} - since there are code paths that call updateModel without updating queryResults
+		if (this.list?.model) {
+			return this.list.model.length;
+		} else {
+			return this.queryResult?.model.length ?? 0;
+		}
 	}
 
 	protected showEmptyModel(): Promise<IPagedModel<IExtension>> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23552, where installing initial extensions don't refresh the Extension Manager install view without a manual refresh or ADS restart.  The page model is updating from a different path than the initial code that populates the query model, so we can use the list model directly to get the correct Pager object.  I left the fallback to query model "just in case" but it shouldn't be needed as the code that updates query model also updates the list model.