### PR TITLE
fix image button style

### DIFF
--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -218,7 +218,7 @@ export class Button extends Disposable implements IButton {
 		let background, foreground, border, fontWeight, fontSize: string;
 		if (this.hasIcon) {
 			background = border = 'transparent';
-			foreground = this.options.buttonSecondaryForeground;
+			foreground = 'inherit';
 			fontWeight = fontSize = 'inherit';
 			this._element.style.backgroundRepeat = 'no-repeat';
 		} else {


### PR DESCRIPTION
This PR fixes: #23544

BTW, this is not a regression, it has been like this forever.
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/dfd08285-fb6b-4f0a-86f7-dfea8be6b519)

