### PR TITLE
change the text to more generic

### DIFF
--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -211,7 +211,7 @@ async function runScriptingAction(accessor: ServicesAccessor, args: ObjectExplor
 	const logService = accessor.get(ILogService);
 	const selectionHandler = instantiationService.createInstance(TreeSelectionHandler);
 	const notificationHandle = notificationService.notify({
-		message: localize('scriptingAction.inProgress', "Generating script..."),
+		message: localize('scriptingAction.inProgress', "Executing action..."),
 		severity: Severity.Info,
 		progress: {
 			infinite: true


### PR DESCRIPTION
this is something I added a while back for the scripting actions, but it is not accurate, the actions are more than just generating script, it actually wait for the editor to be opened and executed, also edit data action is covered by this, so change the text to a more generic one.

![image](https://github.com/microsoft/azuredatastudio/assets/13777222/c966fafe-b8cd-4102-8eff-caba05432a2c)
