### PR TITLE
Cleanup OE context menu order

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -61,22 +61,22 @@
         {
           "command": "adminToolExtWin.launchSsmsMinGswDialog",
           "when": "isWindows && connectionProvider == MSSQL && nodeType && nodeType == Database && mssql:engineedition != 11",
-          "group": "z-AdminToolExt@1"
+          "group": "x_admin@1"
         },
         {
           "command": "adminToolExtWin.launchSsmsMinPropertiesDialog",
           "when": "isWindows && connectionProvider == MSSQL && serverInfo && !isCloud && nodeType && nodeType == Server && mssql:engineedition != 11",
-          "group": "z-AdminToolExt@2"
+          "group": "x_admin@2"
         },
         {
           "command": "adminToolExtWin.launchSsmsMinPropertiesDialog",
           "when": "isWindows && connectionProvider == MSSQL && serverInfo && nodeType && mssql:engineedition != 11 && nodeType =~ /^(Database|Table|Column|Index|Statistic|View|ServerLevelServerRole|ServerLevelCredential|ServerLevelServerAudit|ServerLevelServerAuditSpecification|StoredProcedure|ScalarValuedFunction|TableValuedFunction|AggregateFunction|Synonym|Assembly|UserDefinedDataType|UserDefinedType|UserDefinedTableType|Sequence|ServerLevelLinkedServer)$/",
-          "group": "z-AdminToolExt@2"
+          "group": "x_admin@2"
         },
         {
           "command": "adminToolExtWin.launchSsmsMinPropertiesDialog",
           "when": "isWindows && connectionProvider == MSSQL && serverInfo && !isCloud && nodeType && mssql:engineedition != 11 && nodeType =~ /^(ServerLevelLogin|User|DatabaseRole|ApplicationRole|Schema|SecurityPolicy)$/",
-          "group": "z-AdminToolExt@2"
+          "group": "x_admin@2"
         }
       ],
       "dataExplorer/context": [

--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -381,7 +381,8 @@
       ],
       "dataGrid/item/context": [
         {
-          "command": "azure.dataGrid.openInAzurePortal"
+          "command": "azure.dataGrid.openInAzurePortal",
+          "group": "y_portal"
         }
       ]
     },

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -528,13 +528,13 @@
         {
           "command": "mssql.objectProperties",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
-          "group": "z_objectManagement",
+          "group": "z_objectexplorer@3",
           "isDefault": true
         },
         {
           "command": "mssql.objectProperties",
           "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && isDevelopment",
-          "group": "z_objectManagement"
+          "group": "z_objectexplorer@3"
         },
         {
           "command": "mssql.deleteObject",
@@ -558,7 +558,8 @@
         },
         {
           "command": "mssql.enableGroupBySchema",
-          "when": "connectionProvider == MSSQL && nodeType && nodeType =~ /^(Server|Database)$/ && !config.mssql.objectExplorer.groupBySchema"
+          "when": "connectionProvider == MSSQL && nodeType && nodeType =~ /^(Server|Database)$/ && !config.mssql.objectExplorer.groupBySchema",
+          "group": "z_objectexplorer@0"
         },
         {
           "command": "mssql.disableGroupBySchema",


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/23577 (not closing it since there's further work to be done)

Fixes https://github.com/microsoft/azuredatastudio/issues/23510
Fixes https://github.com/microsoft/azuredatastudio/issues/22346

This moves a few items around to more cleanly organize the context menu. This is the first step - further cleanup will happen once we solidify the grouping we want.

There are three new groups being added - with the goal that we will eventually land on a clearly defined set of default groups with recommendations for where new items should go. 

`x_admin` - Administration related items - e.g. profiler, scripting
`y_portal` - Items related to the Azure portal
`z_objectexplorer` - General items relating to the OE/Azure tree nodes such as refreshing and viewing properties

OE Server : 

![image](https://github.com/microsoft/azuredatastudio/assets/28519865/7dbcfd55-7b3b-491a-ad60-248c03964afb)

OE Database : 

![image](https://github.com/microsoft/azuredatastudio/assets/28519865/e936ff9c-dd99-4321-9c45-4cb0390cd894)

Azure Server :

![image](https://github.com/microsoft/azuredatastudio/assets/28519865/a9396592-fbca-4d15-a035-4d80f60cb9cf)


Azure Database : 

![image](https://github.com/microsoft/azuredatastudio/assets/28519865/72fdf07d-ea62-4ddd-bcd0-348a89394751)
