### PR TITLE
fix input border in some light themes

### DIFF
--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -30,7 +30,8 @@
 		"list.activeSelectionIconForeground": "#FFF",
 		"list.focusAndSelectionOutline": "#90C2F9",
 		"terminal.inactiveSelectionBackground": "#E5EBF1",
-		"widget.border": "#d4d4d4"
+		"widget.border": "#d4d4d4",
+		"input.border":"#CECECE"
 	},
 	"tokenColors": [
 		{


### PR DESCRIPTION
This pr fixes: #23541

this is not a regression.

now in Visual Light and Light+ themes:
![image](https://github.com/microsoft/azuredatastudio/assets/13777222/fed04ec1-811e-4acd-9b84-3359532a6df3)

