### PR TITLE
Adding libssl to build-image to sign extension. 

### DIFF
--- a/build/azure-pipelines/linux/Dockerfile
+++ b/build/azure-pipelines/linux/Dockerfile
@@ -14,7 +14,13 @@ RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 \
 	libkrb5-dev git apt-transport-https ca-certificates curl gnupg-agent software-properties-common \
-	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++ libgbm-dev
+	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++ libgbm-dev wget
+
+# Adding Libssl for dotnet 5.0 and ESRP signing to work
+RUN wget -c http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN apt install ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN wget -c http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.16_amd64.deb
+RUN apt install ./openssl_1.1.1f-1ubuntu2.16_amd64.deb
 
 #docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -

--- a/build/azure-pipelines/linux/Dockerfile
+++ b/build/azure-pipelines/linux/Dockerfile
@@ -17,10 +17,8 @@ RUN apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xv
 	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++ libgbm-dev wget
 
 # Adding Libssl for dotnet 5.0 and ESRP signing to work
-RUN wget -c http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
-RUN apt install ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
-RUN wget -c http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.16_amd64.deb
-RUN apt install ./openssl_1.1.1f-1ubuntu2.16_amd64.deb
+RUN wget -c http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5_amd64.deb
+RUN dpkg -i libssl1.0.0_1.0.2n-1ubuntu5_amd64.deb
 
 #docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -200,38 +200,37 @@ steps:
       version: 5.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
-  # {{SQL CARBON TODO}} - disable extension signing while investigating build break
-  # - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  #   inputs:
-  #     ConnectedServiceName: 'Code Signing'
-  #     FolderPath: '$(Build.SourcesDirectory)/.build'
-  #     Pattern: 'extensions/*.vsix,langpacks/*.vsix'
-  #     signConfigType: inlineSignParams
-  #     inlineOperation: |
-  #       [
-  #         {
-  #           "keyCode": "CP-233016",
-  #           "operationSetCode": "OpcSign",
-  #           "parameters": [
-  #             {
-  #               "parameterName": "FileDigest",
-  #               "parameterValue": "/fd \"SHA256\""
-  #             }
-  #           ],
-  #           "toolName": "sign",
-  #           "toolVersion": "1.0"
-  #         },
-  #         {
-  #           "keyCode": "CP-233016",
-  #           "operationSetCode": "OpcVerify",
-  #           "parameters": [],
-  #           "toolName": "sign",
-  #           "toolVersion": "1.0"
-  #         }
-  #       ]
-  #     SessionTimeout: 120
-  #   displayName: 'Signing Extensions and Langpacks'
-  #   condition: and(succeeded(), eq(variables['signed'], true))
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    inputs:
+      ConnectedServiceName: 'Code Signing'
+      FolderPath: '$(Build.SourcesDirectory)/.build'
+      Pattern: 'extensions/*.vsix,langpacks/*.vsix'
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [
+          {
+            "keyCode": "CP-233016",
+            "operationSetCode": "OpcSign",
+            "parameters": [
+              {
+                "parameterName": "FileDigest",
+                "parameterValue": "/fd \"SHA256\""
+              }
+            ],
+            "toolName": "sign",
+            "toolVersion": "1.0"
+          },
+          {
+            "keyCode": "CP-233016",
+            "operationSetCode": "OpcVerify",
+            "parameters": [],
+            "toolName": "sign",
+            "toolVersion": "1.0"
+          }
+        ]
+      SessionTimeout: 120
+    displayName: 'Signing Extensions and Langpacks'
+    condition: and(succeeded(), eq(variables['signed'], true))
 
   - script: |
       set -e

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: linux-x64
-    image: sqltoolscontainers.azurecr.io/linux-build-agent:7
+    image: sqltoolscontainers.azurecr.io/linux-build-agent:8
     endpoint: SqlToolsContainers
 
 stages:


### PR DESCRIPTION
This PR fixes the esrp task, which requires dotnet 5.0. However, dotnet 5.0 does not use libssl 3.0 in ubuntu22 but instead relies on libssl1.0. This PR manually installs libssl in the ubuntu22 container image so that we can use esrp to sign extensions.

Example build:

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=204703&view=artifacts&pathAsName=false&type=publishedArtifacts
