### PR TITLE
Revert "Fix for database name in connection details after changing database"

### DIFF
--- a/src/sql/base/query/browser/untitledQueryEditorInput.ts
+++ b/src/sql/base/query/browser/untitledQueryEditorInput.ts
@@ -27,13 +27,10 @@ export class UntitledQueryEditorInput extends QueryEditorInput implements IUntit
 
 	public static readonly ID = UNTITLED_QUERY_EDITOR_TYPEID;
 
-	private originalConnectionUri: string;
-
 	constructor(
 		description: string | undefined,
 		text: UntitledTextEditorInput,
 		results: QueryResultsInput,
-		initialConnectionUri: string | undefined,
 		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
 		@IQueryModelService queryModelService: IQueryModelService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -42,7 +39,6 @@ export class UntitledQueryEditorInput extends QueryEditorInput implements IUntit
 		@IEditorResolverService private readonly editorResolverService: IEditorResolverService
 	) {
 		super(description, text, results, connectionManagementService, queryModelService, configurationService, instantiationService);
-		this.originalConnectionUri = initialConnectionUri;
 		// Set the mode explicitely to stop the auto language detection service from changing the mode unexpectedly.
 		// the auto language detection service won't do the language change only if the mode is explicitely set.
 		// if the mode (e.g. kusto, sql) do not exist for whatever reason, we will default it to sql.
@@ -124,12 +120,5 @@ export class UntitledQueryEditorInput extends QueryEditorInput implements IUntit
 	override get capabilities(): EditorInputCapabilities {
 		// Subclasses need to explicitly opt-in to being untitled.
 		return EditorInputCapabilities.Untitled;
-	}
-
-	override dispose() {
-		if (this.originalConnectionUri) {
-			this.connectionManagementService.disconnect(this.originalConnectionUri);
-		}
-		super.dispose();
 	}
 }

--- a/src/sql/platform/connection/common/connectionStatusManager.ts
+++ b/src/sql/platform/connection/common/connectionStatusManager.ts
@@ -14,8 +14,6 @@ import * as azdata from 'azdata';
 import * as nls from 'vs/nls';
 import { values } from 'vs/base/common/collections';
 import { Schemas } from 'vs/base/common/network';
-import { generateUuid } from 'vs/base/common/uuid';
-import * as ConnectionUtils from 'sql/platform/connection/common/utils';
 
 export class ConnectionStatusManager {
 
@@ -85,23 +83,8 @@ export class ConnectionStatusManager {
 		return connectionInfoForId ? connectionInfoForId.connectionProfile : undefined;
 	}
 
-	private isNonEditorUri(uri: string): boolean {
-		return uri.startsWith(ConnectionUtils.uriPrefixes.connection)
-			|| uri.startsWith(ConnectionUtils.uriPrefixes.dashboard)
-			|| uri.startsWith(ConnectionUtils.uriPrefixes.insights)
-			|| uri.startsWith(ConnectionUtils.uriPrefixes.notebook);
-	}
-
 	public addConnection(connection: IConnectionProfile, id: string): ConnectionManagementInfo {
 		this._logService.info(`Adding connection ${id}`);
-
-		// Newly generated URIs are used in areas where the same connection profile id is expected for callbacks,
-		// This is used for Editor URIs such as Query Editor, which do not have uriPrefixes recognized above.
-		// (This is done to not retrieve the base connection profile, which may be different if a user changes the database).
-		if (!this.isNonEditorUri(id) && this.findConnectionByProfileId(connection.id) !== undefined) {
-			connection.id = generateUuid();
-		}
-
 		// Always create a copy and save that in the list
 		let connectionProfile = new ConnectionProfile(this._capabilitiesService, connection);
 		let connectionInfo: ConnectionManagementInfo = {

--- a/src/sql/platform/connection/test/node/connectionStatusManager.test.ts
+++ b/src/sql/platform/connection/test/node/connectionStatusManager.test.ts
@@ -250,16 +250,13 @@ suite('SQL ConnectionStatusManager tests', () => {
 		newConnection.id = 'test_id';
 		newConnection.serverName = 'new_server_name';
 		newConnection.options['databaseDisplayName'] = newConnection.databaseName;
-		//Duplicate should not be registered if uri is of connection/dashboard type (required for functionality)
-		connections.addConnection(newConnection, 'connection:test_uri_1');
-		connections.addConnection(newConnection, 'dashboard:test_uri_1');
-		//Editor type URIs should generate a new profile id (needed to properly update the connection string)
-		connections.addConnection(newConnection, 'untitled:TestQuery1')
+		connections.addConnection(newConnection, 'test_uri_1');
+		connections.addConnection(newConnection, 'test_uri_2');
 		newConnection = new ConnectionProfile(capabilitiesService, newConnection);
 
-		// Get the connections and verify that the non editor duplicate is only returned once
+		// Get the connections and verify that the duplicate is only returned once
 		let activeConnections = connections.getActiveConnectionProfiles();
-		assert.strictEqual(activeConnections.length, 5);
-		assert.strictEqual(activeConnections.filter(connection => connection.matches(newConnection)).length, 2, 'Did not find newConnection in active connections');
+		assert.strictEqual(activeConnections.length, 4);
+		assert.strictEqual(activeConnections.filter(connection => connection.matches(newConnection)).length, 1, 'Did not find newConnection in active connections');
 	});
 });

--- a/src/sql/workbench/browser/editData/editDataInput.ts
+++ b/src/sql/workbench/browser/editData/editDataInput.ts
@@ -44,7 +44,6 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 		private _sql: UntitledTextEditorInput,
 		private _queryString: string,
 		private _results: EditDataResultsInput,
-		private _initialConnectionUri: string,
 		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
 		@IQueryModelService private _queryModelService: IQueryModelService,
 		@INotificationService private notificationService: INotificationService
@@ -206,9 +205,6 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 	public override dispose(): void {
 		// Dispose our edit session then disconnect our input
 		this._queryModelService.disposeEdit(this.uri).then(() => {
-			if (this._initialConnectionUri) {
-				this._connectionManagementService.disconnect(this._initialConnectionUri);
-			}
 			return this._connectionManagementService.disconnectEditor(this, true);
 		});
 		this._queryModelService.disposeQuery(this.uri);

--- a/src/sql/workbench/browser/scriptingUtils.ts
+++ b/src/sql/workbench/browser/scriptingUtils.ts
@@ -48,7 +48,7 @@ export async function scriptSelect(connectionProfile: IConnectionProfile, metada
 		let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
 		const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails);
 		if (result && result.script) {
-			const owner = await queryEditorService.newSqlEditor({ initialContent: result.script }, connectionProfile?.providerName, connectionResult);
+			const owner = await queryEditorService.newSqlEditor({ initialContent: result.script }, connectionProfile?.providerName);
 			// Connect our editor to the input connection
 			let options: IConnectionCompletionOptions = {
 				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery, input: owner },
@@ -75,7 +75,7 @@ export async function scriptEditSelect(connectionProfile: IConnectionProfile, me
 		let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata);
 		const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails!);
 		if (result && result.script) {
-			const owner = await queryEditorService.newEditDataEditor(metadata.schema, metadata.name, result.script, connectionResult);
+			const owner = await queryEditorService.newEditDataEditor(metadata.schema, metadata.name, result.script);
 			// Connect our editor
 			let options: IConnectionCompletionOptions = {
 				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
@@ -133,7 +133,7 @@ export async function script(connectionProfile: IConnectionProfile, metadata: az
 
 			if (script) {
 				let description = (metadata.schema && metadata.schema !== '') ? `${metadata.schema}.${metadata.name}` : metadata.name;
-				const owner = await queryEditorService.newSqlEditor({ initialContent: script, description }, connectionProfile.providerName, connectionResult);
+				const owner = await queryEditorService.newSqlEditor({ initialContent: script, description }, connectionProfile.providerName);
 				// Connect our editor to the input connection
 				let options: IConnectionCompletionOptions = {
 					params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },

--- a/src/sql/workbench/common/editor/query/queryEditorInput.ts
+++ b/src/sql/workbench/common/editor/query/queryEditorInput.ts
@@ -146,7 +146,7 @@ export abstract class QueryEditorInput extends EditorInput implements IConnectab
 		private _description: string | undefined,
 		protected _text: AbstractTextResourceEditorInput,
 		protected _results: QueryResultsInput,
-		@IConnectionManagementService protected readonly connectionManagementService: IConnectionManagementService,
+		@IConnectionManagementService private readonly connectionManagementService: IConnectionManagementService,
 		@IQueryModelService private readonly queryModelService: IQueryModelService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IInstantiationService protected readonly instantiationService: IInstantiationService

--- a/src/sql/workbench/contrib/query/browser/queryEditorFactory.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditorFactory.ts
@@ -67,7 +67,7 @@ export class QueryEditorLanguageAssociation implements ILanguageAssociation {
 		if (activeEditor instanceof FileEditorInput) {
 			queryEditorInput = this.instantiationService.createInstance(FileQueryEditorInput, '', activeEditor, queryResultsInput);
 		} else if (activeEditor instanceof UntitledTextEditorInput) {
-			queryEditorInput = this.instantiationService.createInstance(UntitledQueryEditorInput, '', activeEditor, queryResultsInput, undefined);
+			queryEditorInput = this.instantiationService.createInstance(UntitledQueryEditorInput, '', activeEditor, queryResultsInput);
 		} else {
 			return undefined;
 		}
@@ -146,7 +146,7 @@ export class UntitledQueryEditorSerializer implements IEditorSerializer {
 		const factory = editorFactoryRegistry.getEditorSerializer(UntitledTextEditorInput.ID);
 		const untitledEditorInput = factory.deserialize(instantiationService, serializedEditorInput) as UntitledTextEditorInput;
 		const queryResultsInput = instantiationService.createInstance(QueryResultsInput, untitledEditorInput.resource.toString());
-		return instantiationService.createInstance(UntitledQueryEditorInput, '', untitledEditorInput, queryResultsInput, undefined);
+		return instantiationService.createInstance(UntitledQueryEditorInput, '', untitledEditorInput, queryResultsInput);
 	}
 
 	canSerialize(): boolean { // we can always serialize query inputs

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -84,7 +84,7 @@ suite('SQL QueryAction Tests', () => {
 		testQueryInputState = TypeMoq.Mock.ofType(QueryEditorState, TypeMoq.MockBehavior.Strict);
 		testQueryInputState.setup(x => x.isActualExecutionPlanMode).returns(() => false);
 
-		testQueryInput = TypeMoq.Mock.ofType(UntitledQueryEditorInput, TypeMoq.MockBehavior.Strict, undefined, fileInput, undefined, undefined, connectionManagementService.object, queryModelService.object, configurationService.object);
+		testQueryInput = TypeMoq.Mock.ofType(UntitledQueryEditorInput, TypeMoq.MockBehavior.Strict, undefined, fileInput, undefined, connectionManagementService.object, queryModelService.object, configurationService.object);
 		testQueryInput.setup(x => x.uri).returns(() => testUri);
 		testQueryInput.setup(x => x.runQuery(undefined)).callback(() => { calledRunQueryOnInput = true; });
 		testQueryInput.setup(x => x.state).returns(() => testQueryInputState.object);
@@ -150,7 +150,7 @@ suite('SQL QueryAction Tests', () => {
 		let queryInputState = TypeMoq.Mock.ofType(QueryEditorState, TypeMoq.MockBehavior.Loose);
 		queryInputState.setup(x => x.isActualExecutionPlanMode).returns(() => false);
 
-		let queryInput = TypeMoq.Mock.ofType(UntitledQueryEditorInput, TypeMoq.MockBehavior.Strict, undefined, fileInput, undefined, undefined, connectionManagementService.object, queryModelService.object, configurationService.object);
+		let queryInput = TypeMoq.Mock.ofType(UntitledQueryEditorInput, TypeMoq.MockBehavior.Strict, undefined, fileInput, undefined, connectionManagementService.object, queryModelService.object, configurationService.object);
 		queryInput.setup(x => x.uri).returns(() => testUri);
 		queryInput.setup(x => x.runQuery(undefined)).callback(() => {
 			countCalledRunQuery++;
@@ -205,7 +205,7 @@ suite('SQL QueryAction Tests', () => {
 		let queryInputState = TypeMoq.Mock.ofType(QueryEditorState, TypeMoq.MockBehavior.Loose);
 		queryInputState.setup(x => x.isActualExecutionPlanMode).returns(() => false);
 
-		let queryInput = TypeMoq.Mock.ofType(UntitledQueryEditorInput, TypeMoq.MockBehavior.Loose, undefined, fileInput, undefined, undefined, connectionManagementService.object, queryModelService.object, configurationService.object);
+		let queryInput = TypeMoq.Mock.ofType(UntitledQueryEditorInput, TypeMoq.MockBehavior.Loose, undefined, fileInput, undefined, connectionManagementService.object, queryModelService.object, configurationService.object);
 		queryInput.setup(x => x.uri).returns(() => testUri);
 		queryInput.setup(x => x.runQuery(TypeMoq.It.isAny())).callback((selection: IRange) => {
 			runQuerySelection = selection;

--- a/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
@@ -311,7 +311,6 @@ suite('SQL QueryEditor Tests', () => {
 				'',
 				fileInput,
 				undefined,
-				undefined,
 				connectionManagementService.object,
 				queryModelService.object,
 				configurationService.object,

--- a/src/sql/workbench/contrib/query/test/browser/queryInputFactory.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryInputFactory.test.ts
@@ -187,7 +187,7 @@ suite('Query Input Factory', () => {
 		const newsqlEditorStub = sinon.stub(queryeditorservice, 'newSqlEditor').callsFake(() => {
 			const untitledInput = instantiationService.createInstance(UntitledTextEditorInput, untitledService.create());
 			const queryResultsInput: QueryResultsInput = instantiationService.createInstance(QueryResultsInput, untitledInput.resource.toString());
-			let queryInput = instantiationService.createInstance(UntitledQueryEditorInput, '', untitledInput, queryResultsInput, undefined);
+			let queryInput = instantiationService.createInstance(UntitledQueryEditorInput, '', untitledInput, queryResultsInput);
 			return Promise.resolve(queryInput);
 		});
 		const input = instantiationService.createInstance(UntitledTextEditorInput, untitledService.create());
@@ -319,7 +319,7 @@ suite('Query Input Factory', () => {
 		const newsqlEditorStub = sinon.stub(queryeditorservice, 'newSqlEditor').callsFake(() => {
 			const untitledInput = instantiationService.createInstance(UntitledTextEditorInput, untitledService.create());
 			const queryResultsInput: QueryResultsInput = instantiationService.createInstance(QueryResultsInput, untitledInput.resource.toString());
-			let queryInput = instantiationService.createInstance(UntitledQueryEditorInput, '', untitledInput, queryResultsInput, undefined);
+			let queryInput = instantiationService.createInstance(UntitledQueryEditorInput, '', untitledInput, queryResultsInput);
 			return Promise.resolve(queryInput);
 		});
 		const response = queryEditorLanguageAssociation.convertInput(input);
@@ -349,7 +349,7 @@ class MockEditorService extends TestEditorService {
 			const accessor = workbenchinstantiationService.createInstance(ServiceAccessor);
 			const service = accessor.untitledTextEditorService;
 			const untitledInput = instantiationService.createInstance(UntitledTextEditorInput, service.create({ associatedResource: URI.file('/test/file') }));
-			this.__activeEditor = instantiationService.createInstance(UntitledQueryEditorInput, '', untitledInput, undefined, undefined);
+			this.__activeEditor = instantiationService.createInstance(UntitledQueryEditorInput, '', untitledInput, undefined);
 		}
 	}
 }

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -992,7 +992,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 	test('Edit Connection - Changing connection profile name for same URI should persist after edit', async () => {
 		let profile = Object.assign({}, connectionProfile);
-		let uri1 = 'connection:test_uri1';
+		let uri1 = 'test_uri1';
 		let newname = 'connection renamed';
 		let options: IConnectionCompletionOptions = {
 			params: {
@@ -1021,21 +1021,20 @@ suite('SQL ConnectionManagementService tests', () => {
 			let result = newProfile.getOptionsKey() === originalProfileKey;
 			return Promise.resolve(result);
 		});
-		profile.getOptionsKey = () => { return 'test_uri1'; };
+
 		await connect(uri1, options, true, profile);
 		let originalProfile = ConnectionProfile.fromIConnectionProfile(new TestCapabilitiesService(), connectionProfile);
 		originalProfileKey = originalProfile.getOptionsKey();
 		let newProfile = Object.assign({}, connectionProfile);
 		newProfile.connectionName = newname;
-		newProfile.getOptionsKey = () => { return 'test_uri1'; };
 		options.params.isEditConnection = true;
 		await connect(uri1, options, true, newProfile);
 		assert.strictEqual(connectionManagementService.getConnectionProfile(uri1).connectionName, newname);
 	});
 
-	test('Edit Connection - Connecting a different non editor URI with same profile via edit should not change profile ID.', async () => {
-		let currentUri = 'test_uri1';
-		let uri = 'connection:' + currentUri;
+	test('Edit Connection - Connecting a different URI with same profile via edit should not change profile ID.', async () => {
+		let uri1 = 'test_uri1';
+		let uri2 = 'test_uri2';
 		let profile = Object.assign({}, connectionProfile);
 		profile.id = '0451';
 		let options: IConnectionCompletionOptions = {
@@ -1047,7 +1046,7 @@ suite('SQL ConnectionManagementService tests', () => {
 					onConnectStart: undefined,
 					onDisconnect: undefined,
 					onConnectCanceled: undefined,
-					uri: uri
+					uri: uri1
 				},
 				queryRange: undefined,
 				runQueryOnCompletion: RunQueryOnConnectionMode.none,
@@ -1059,17 +1058,14 @@ suite('SQL ConnectionManagementService tests', () => {
 			showFirewallRuleOnError: true
 		};
 
-		// In an actual edit situation, the profile options would be different for different URIs, as a placeholder, we return false.
-		connectionStore.setup(x => x.isDuplicateEdit(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(false));
-		profile.getOptionsKey = () => { return currentUri; };
+		// In an actual edit situation, the profile options would be different for different URIs, as a placeholder, we check the test uris instead here.
+		connectionStore.setup(x => x.isDuplicateEdit(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(uri1 === uri2));
 
-		await connect(uri, options, true, profile);
-		let uri1info = connectionManagementService.getConnectionInfo(uri);
+		await connect(uri1, options, true, profile);
 		options.params.isEditConnection = true;
-		currentUri = 'test_uri2';
-		uri = 'connection:' + currentUri;
-		await connect(uri, options, true, profile);
-		let uri2info = connectionManagementService.getConnectionInfo(uri);
+		await connect(uri2, options, true, profile);
+		let uri1info = connectionManagementService.getConnectionInfo(uri1);
+		let uri2info = connectionManagementService.getConnectionInfo(uri2);
 		assert.strictEqual(uri1info.connectionProfile.id, uri2info.connectionProfile.id);
 	});
 

--- a/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
@@ -51,7 +51,7 @@ export class QueryEditorService implements IQueryEditorService {
 	/**
 	 * Creates new untitled document for SQL/Kusto query and opens in new editor tab
 	 */
-	public async newSqlEditor(options: INewSqlEditorOptions = {}, connectionProviderName?: string, initialConnectionUri?: string): Promise<UntitledQueryEditorInput> {
+	public async newSqlEditor(options: INewSqlEditorOptions = {}, connectionProviderName?: string): Promise<UntitledQueryEditorInput> {
 		options = mixin(options, defaults, false);
 		// Create file path and file URI
 		let docUri: URI = options.resource ?? URI.from({ scheme: Schemas.untitled, path: await this.createUntitledSqlFilePath(connectionProviderName) });
@@ -68,7 +68,7 @@ export class QueryEditorService implements IQueryEditorService {
 		}
 
 		const queryResultsInput: QueryResultsInput = this._instantiationService.createInstance(QueryResultsInput, docUri.toString());
-		let queryInput = this._instantiationService.createInstance(UntitledQueryEditorInput, options.description, fileInput, queryResultsInput, initialConnectionUri);
+		let queryInput = this._instantiationService.createInstance(UntitledQueryEditorInput, options.description, fileInput, queryResultsInput);
 		let profile: IConnectionProfile | undefined = undefined;
 		// If we're told to connect then get the connection before opening the editor since it will try to get the connection for the current
 		// active editor and so we need to get this before opening a new one.
@@ -94,7 +94,7 @@ export class QueryEditorService implements IQueryEditorService {
 	/**
 	 * Creates new edit data session
 	 */
-	public async newEditDataEditor(schemaName: string, tableName: string, sqlContent: string, initialConnectionUri?: string): Promise<IConnectableInput> {
+	public async newEditDataEditor(schemaName: string, tableName: string, sqlContent: string): Promise<IConnectableInput> {
 
 		// Create file path and file URI
 		let objectName = schemaName ? schemaName + '.' + tableName : tableName;
@@ -108,7 +108,7 @@ export class QueryEditorService implements IQueryEditorService {
 		(m as UntitledTextEditorModel).setDirty(false);
 		// Create an EditDataInput for editing
 		const resultsInput: EditDataResultsInput = this._instantiationService.createInstance(EditDataResultsInput, docUri.toString());
-		let editDataInput: EditDataInput = this._instantiationService.createInstance(EditDataInput, docUri, schemaName, tableName, fileInput, sqlContent, resultsInput, initialConnectionUri);
+		let editDataInput: EditDataInput = this._instantiationService.createInstance(EditDataInput, docUri, schemaName, tableName, fileInput, sqlContent, resultsInput);
 		// Determine whether to show edit data upon opening.
 		editDataInput.queryPaneEnabled = this._configurationService.getValue('editor.showEditDataSqlPaneOnStartup');
 		if (sqlContent) {

--- a/src/sql/workbench/services/queryEditor/common/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/common/queryEditorService.ts
@@ -45,8 +45,8 @@ export interface IQueryEditorService {
 	_serviceBrand: undefined;
 
 	// Creates new untitled document for SQL/KUSTO queries and opens it in a new editor tab
-	newSqlEditor(options?: INewSqlEditorOptions, connectionProviderName?: string, initialConnectionUri?: string): Promise<IUntitledQueryEditorInput>;
+	newSqlEditor(options?: INewSqlEditorOptions, connectionProviderName?: string): Promise<IUntitledQueryEditorInput>;
 
 	// Creates new edit data session
-	newEditDataEditor(schemaName: string, tableName: string, queryString: string, initialConnectionUri?: string): Promise<IConnectableInput>;
+	newEditDataEditor(schemaName: string, tableName: string, queryString: string): Promise<IConnectableInput>;
 }

--- a/src/sql/workbench/services/queryEditor/test/browser/testQueryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/test/browser/testQueryEditorService.ts
@@ -22,7 +22,7 @@ export class TestQueryEditorService implements IQueryEditorService {
 
 	async newSqlEditor(options?: INewSqlEditorOptions): Promise<IUntitledQueryEditorInput> {
 		const base = await this.editorService.createEditorInput({ resource: undefined, forceUntitled: true }) as UntitledTextEditorInput;
-		return Promise.resolve(this.instantiationService.createInstance(UntitledQueryEditorInput, '', base, new QueryResultsInput(base.resource.toString(true)), undefined));
+		return Promise.resolve(this.instantiationService.createInstance(UntitledQueryEditorInput, '', base, new QueryResultsInput(base.resource.toString(true))));
 	}
 
 	newEditDataEditor(schemaName: string, tableName: string, queryString: string): Promise<IConnectableInput> {


### PR DESCRIPTION
Reverting #22376 as there have been numerous complaints on the after affects across providers.
Will look into it again - the change is critical to address #6406 but the URI changes need to be handled across all areas.

This reverts commit 89386c9c11c704243b908c34d05201966a426d0d.

Fixes #23597 
Fixes #23562 
Fixes #23501 
Fixes #23414 