### PR TITLE
Azure auth - throw original error message

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuthCodeGrant.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuthCodeGrant.ts
@@ -150,8 +150,9 @@ export class AzureAuthCodeGrant extends AzureAuth {
 
 			return authCodeRequest;
 		} catch (e) {
-			Logger.error('MSAL: Error requesting auth code', e);
-			throw new AzureAuthError('error', 'Error requesting auth code', e);
+			let errorMessage = localize('azureAuthCodeGrant.getAuthCodeUrlError', 'An error occurred in MSAL library when requesting auth code URL. For more detailed information on error, please check \'Azure Accounts\' output pane. \n\n');
+			Logger.error(errorMessage);
+			throw new AzureAuthError(errorMessage + e.message, e.message, e);
 		}
 	}
 
@@ -248,18 +249,16 @@ export class AzureAuthCodeGrant extends AzureAuth {
 			};
 			let authCodeUrl = await this.clientApplication.getAuthCodeUrl(authUrlRequest);
 
-
 			await vscode.env.openExternal(vscode.Uri.parse(`http://localhost:${serverPort}/signin?nonce=${encodeURIComponent(this.pkceCodes.nonce)}`));
 			const authCode = await this.addServerListeners(server, this.pkceCodes.nonce, authCodeUrl, authCompletePromise);
 
 			authCodeRequest.code = authCode;
-
 			return authCodeRequest;
 		}
-
 		catch (e) {
-			Logger.error('MSAL: Error requesting auth code', e);
-			throw new AzureAuthError('error', 'Error requesting auth code', e);
+			let errorMessage = localize('azureAuthCodeGrant.getAuthCodeUrlError', 'An error occurred in MSAL library when requesting auth code URL. For more detailed information on error, please check \'Azure Accounts\' output pane. \n\n');
+			Logger.error(errorMessage);
+			throw new AzureAuthError(errorMessage + e.message, e.message, e);
 		}
 	}
 


### PR DESCRIPTION
Fixes #23140 to show proper error message.

Dummy message:

<img src="https://github.com/microsoft/azuredatastudio/assets/13396919/b0a7978b-78d5-4a67-8b7e-1da5cfd3eb35" width=600 />
