### PR TITLE
Disable all experiements tests

### DIFF
--- a/src/vs/workbench/contrib/experiments/test/electron-sandbox/experimentService.test.ts
+++ b/src/vs/workbench/contrib/experiments/test/electron-sandbox/experimentService.test.ts
@@ -63,7 +63,7 @@ export class TestExperimentService extends ExperimentService {
 	}
 }
 
-suite.skip('Experiment Service', () => { // {{SQL CARBON EDIT}} - disable failing suite
+suite.skip('Experiment Service', () => {  // {{SQL CARBON EDIT}} Tests are flaky, and have been removed in VS Code so disabling until we catch up
 	let instantiationService: TestInstantiationService;
 	let testConfigurationService: TestConfigurationService;
 	let testObject: ExperimentService;

--- a/src/vs/workbench/contrib/experiments/test/electron-sandbox/experimentalPrompts.test.ts
+++ b/src/vs/workbench/contrib/experiments/test/electron-sandbox/experimentalPrompts.test.ts
@@ -19,7 +19,7 @@ import { TestLifecycleService } from 'vs/workbench/test/browser/workbenchTestSer
 import { TestCommandService } from 'vs/editor/test/browser/editorTestServices';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 
-suite('Experimental Prompts', () => {
+suite.skip('Experimental Prompts', () => { // {{SQL CARBON EDIT}} Tests are flaky, and have been removed in VS Code so disabling until we catch up
 	let instantiationService: TestInstantiationService;
 	let experimentService: TestExperimentService;
 	let experimentalPrompt: ExperimentalPrompts;


### PR DESCRIPTION
Was looking into test failures and noticed that the experiments service tests seem flaky - e.g. https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=204756&view=logs&j=4d2898ab-dfbe-557e-92e7-aaac158fdd2f&t=c43d40ac-bf1b-572f-0943-b12cf91eb3c7

Looking into it VS Code actually just removed this service completely from their repo - I started with trying to port that over but it ended up being a few too many changes over a couple PRs so I decided to just disable the tests for now and we'll get that in a future merge.

https://github.com/microsoft/vscode/pull/185658