### PR TITLE
Remove colorbox label and allow color box to be selected

### DIFF
--- a/src/sql/base/browser/ui/colorbox/colorbox.ts
+++ b/src/sql/base/browser/ui/colorbox/colorbox.ts
@@ -40,11 +40,10 @@ export class Colorbox extends Widget {
 		this.radioButton.setAttribute('aria-label', opts.color);
 		this.labelNode = DOM.$('label.colorbox-label');
 		this.labelNode.setAttribute('for', this.radioButton.id);
-		this.labelNode.innerText = opts.color;
 
+		this.labelNode.appendChild(this.colorElement);
 		radiobuttonContainer.appendChild(this.radioButton);
 		radiobuttonContainer.appendChild(this.labelNode);
-		colorboxContainer.appendChild(this.colorElement);
 		colorboxContainer.appendChild(radiobuttonContainer);
 		container.appendChild(colorboxContainer);
 


### PR DESCRIPTION
Removes the hex label, and now the color itself can be clicked to select that radio button (previously you had to select the text or the radio button itself)

Before: 
![Screenshot 2023-07-03 at 2 34 42 PM](https://github.com/microsoft/azuredatastudio/assets/18150417/c4458441-a5c4-4db9-b27f-6ee878ba9f34)

After
![Screenshot 2023-07-03 at 2 35 31 PM](https://github.com/microsoft/azuredatastudio/assets/18150417/00852ca5-60f6-4680-813f-399569fa6ce2)

Fixes #22799
