### PR TITLE
fix active border on input box in issue reporter not being visible

### DIFF
--- a/extensions/theme-carbon/themes/light_carbon.json
+++ b/extensions/theme-carbon/themes/light_carbon.json
@@ -46,7 +46,6 @@
 		"input.border": "#888888",
 		"input.disabled.background": "#dcdcdc",
 		"input.disabled.foreground": "#888888",
-		"inputOption.activeBorder": "#666666",
 		"input.placeholderForeground": "#767676",
 		"inputValidation.errorBackground": "#ffeaea",
 		"inputValidation.errorBorder": "#b62e00",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #23484. The active border around the input controls in the ADS issue reporter weren't very visible in the default ADS light theme because the `inputOption.activeBorder` was so similar to the `input.border` color. Other places in ADS with input boxes and dropdowns, like the connection dialog, already have a blue border when they are the active control with the default light theme, so this change makes the issue reporter do the same.

By removing `inputOption.activeBorder` from the light_carbon theme, the default `inputOption.activeBorder` that's used by other light themes now gets used: https://github.com/microsoft/azuredatastudio/blob/01e66ab3e68200cbc0b9937cae39446b777bbadb/src/vs/platform/theme/common/colorRegistry.ts#L244

before:
![beforeBorderFix](https://github.com/microsoft/azuredatastudio/assets/31145923/fba2c08f-927c-433b-9504-eacb8f01d6c7)

fixed:
![bordersFixed](https://github.com/microsoft/azuredatastudio/assets/31145923/c2177c08-1a5d-48b1-87f0-05f6a07d36d9)
