### PR TITLE
Remove extra filter icon from Top Operations tab

### DIFF
--- a/src/sql/workbench/contrib/executionPlan/browser/topOperationsTab.ts
+++ b/src/sql/workbench/contrib/executionPlan/browser/topOperationsTab.ts
@@ -178,7 +178,6 @@ export class TopOperationsTabView extends Disposable implements IPanelView {
 
 		const headerSearchBarContainer = DOM.$('.top-operations-header-search-bar');
 		headerContainer.appendChild(headerSearchBarContainer);
-		headerContainer.classList.add('codicon', filterIconClassNames);
 
 		const topOperationsSearchInput = this._register(new InputBox(headerSearchBarContainer, this._contextViewService, {
 			ariaDescription: topOperationsSearchDescription,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR fixes #23611

This PR removes an additional filter icon that didn't do anything and would appear over a query:
Now:
![image](https://github.com/microsoft/azuredatastudio/assets/87730006/8d9d9f53-1a32-4062-bb34-2ceafc8c6960)


Before:
![image](https://github.com/microsoft/azuredatastudio/assets/87730006/77834cff-6e21-49c4-baef-50f2b00d7521)


