### PR TITLE
Add YAML schema setting for pipeline yamls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -136,5 +136,8 @@
 	],
 	"application.experimental.rendererProfiling": true,
 	"editor.experimental.asyncTokenization": true,
-	"editor.experimental.asyncTokenizationVerification": true
+	"editor.experimental.asyncTokenizationVerification": true,
+	"yaml.schemas": {
+		"https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json": "build/azure-pipelines/**/*.yml"
+	}
 }


### PR DESCRIPTION
Set default schema for our azure pipeline yaml files for validation/autocomplete. Note that there are a number of "errors" that show up due to various issues with the validation - but overall this is still useful (if anything for the hover and autocomplete support)