### PR TITLE
Remove unwanted icon override

### DIFF
--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -137,11 +137,6 @@
 	background-image: url('default_server.svg');
 }
 
-.monaco-list:focus .monaco-list-rows > .monaco-list-row.selected .connection-profile-container > .icon.server-page,
-.hc-light .monaco-list:focus .monaco-list-rows > .monaco-list-row.selected .connection-profile-container > .icon.server-page {
-	background-image: url('default_server_inverse.svg');
-}
-
 .vs-dark .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content > .connection-tile > .icon.server-page,
 .hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content > .connection-tile > .icon.server-page,
 .vs-dark .monaco-list .monaco-list-rows > .monaco-list-row .connection-tile > .icon.server-page,


### PR DESCRIPTION
Fixes #23512 

Icons were being overridden by inverse icon on focus - removed custom CSS.