### PR TITLE
Add syntaxes folder to markdown-math

### DIFF
--- a/extensions/markdown-math/syntaxes/md-math-block.tmLanguage.json
+++ b/extensions/markdown-math/syntaxes/md-math-block.tmLanguage.json
@@ -1,0 +1,85 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown - (comment, string, meta.paragraph.markdown, markup.math.block.markdown, markup.fenced_code.block.markdown, markup.raw.block.markdown)",
+	"patterns": [
+		{
+			"include": "#double_dollar_math_block"
+		},
+		{
+			"include": "#single_dollar_math_block"
+		}
+	],
+	"repository": {
+		"double_dollar_math_block": {
+			"name": "markup.math.block.markdown",
+			"contentName": "meta.embedded.math.markdown",
+			"begin": "(?<=^\\s*)(\\${2})(?![^$]*\\${2})",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.math.begin.markdown"
+				}
+			},
+			"end": "(.*)(\\${2})",
+			"endCaptures": {
+				"1": {
+					"name": "meta.embedded.math.markdown",
+					"patterns": [
+						{
+							"include": "text.html.markdown.math#math"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.definition.math.end.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)",
+					"while": "(^|\\G)(?!.*(\\${2}))",
+					"patterns": [
+						{
+							"include": "text.html.markdown.math#math"
+						}
+					]
+				}
+			]
+		},
+		"single_dollar_math_block": {
+			"name": "markup.math.block.markdown",
+			"contentName": "meta.embedded.math.markdown",
+			"begin": "(?<=^\\s*)(\\$)(?![^$]*\\$|\\d)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.math.begin.markdown"
+				}
+			},
+			"end": "(.*)(\\${1})",
+			"endCaptures": {
+				"1": {
+					"name": "meta.embedded.math.markdown",
+					"patterns": [
+						{
+							"include": "text.html.markdown.math#math"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.definition.math.end.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)",
+					"while": "(^|\\G)(?!.*(\\${1}))",
+					"patterns": [
+						{
+							"include": "text.html.markdown.math#math"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.math.block"
+}

--- a/extensions/markdown-math/syntaxes/md-math-inline.tmLanguage.json
+++ b/extensions/markdown-math/syntaxes/md-math-inline.tmLanguage.json
@@ -1,0 +1,79 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:meta.paragraph.markdown - (comment, string, markup.math.inline.markdown, markup.fenced_code.block.markdown)",
+	"patterns": [
+		{
+			"include": "#math_inline_double"
+		},
+		{
+			"include": "#math_inline_single"
+		},
+		{
+			"include": "#math_inline_block"
+		}
+	],
+	"repository": {
+		"math_inline_single": {
+			"name": "markup.math.inline.markdown",
+			"match": "(?<=\\s|\\W|^)(?<!\\$)(\\$)(.+?)(\\$)(?!\\$)(?=\\s|\\W|$)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.math.begin.markdown"
+				},
+				"2": {
+					"name": "meta.embedded.math.markdown",
+					"patterns": [
+						{
+							"include": "text.html.markdown.math#math"
+						}
+					]
+				},
+				"3": {
+					"name": "punctuation.definition.math.end.markdown"
+				}
+			}
+		},
+		"math_inline_double": {
+			"name": "markup.math.inline.markdown",
+			"match": "(?<=\\s|\\W|^)(?<!\\$)(\\$\\$)(.+?)(\\$\\$)(?!\\$)(?=\\s|\\W|$)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.math.begin.markdown"
+				},
+				"2": {
+					"name": "meta.embedded.math.markdown",
+					"patterns": [
+						{
+							"include": "text.html.markdown.math#math"
+						}
+					]
+				},
+				"3": {
+					"name": "punctuation.definition.math.end.markdown"
+				}
+			}
+		},
+		"math_inline_block": {
+			"name": "markup.math.inline.markdown",
+			"contentName": "meta.embedded.math.markdown",
+			"begin": "(?<=\\s|^)(\\${2})",
+			"beginCaptures": {
+				"2": {
+					"name": "punctuation.definition.math.begin.markdown"
+				}
+			},
+			"end": "(\\${2})(?=\\s|$)",
+			"endCaptures": {
+				"2": {
+					"name": "punctuation.definition.math.end.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"include": "text.html.markdown.math#math"
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.math.inline"
+}

--- a/extensions/markdown-math/syntaxes/md-math.tmLanguage.json
+++ b/extensions/markdown-math/syntaxes/md-math.tmLanguage.json
@@ -1,0 +1,107 @@
+{
+	"information_for_contributors": [
+		"This file includes some grammar rules copied from https://github.com/James-Yu/LaTeX-Workshop/blob/master/syntax/TeX.tmLanguage.json"
+	],
+	"name": "Markdown Math",
+	"scopeName": "text.html.markdown.math",
+	"patterns": [
+		{
+			"include": "#math"
+		}
+	],
+	"repository": {
+		"math": {
+			"patterns": [
+				{
+					"name": "comment.line.math.tex",
+					"match": "((?<!\\\\)%)(.+)$",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.math.tex"
+						}
+					}
+				},
+				{
+					"name": "line.separator.math.tex",
+					"match": "(\\\\\\\\)$",
+					"captures": {
+						"1": {
+							"name": "punctuation.line.separator.math.tex"
+						}
+					}
+				},
+				{
+					"name": "meta.function.math.tex",
+					"begin": "((\\\\)([a-zA-Z_]+))\\s*(\\{)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.function.math.tex"
+						},
+						"2": {
+							"name": "punctuation.definition.function.math.tex"
+						},
+						"3": {
+							"name": "entity.name.function.math.tex"
+						},
+						"4": {
+							"name": "punctuation.definition.arguments.begin.math.tex"
+						}
+					},
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.end.math.tex"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.constant.math.tex"
+						}
+					},
+					"match": "(\\\\)([a-zA-Z_]+)\\b",
+					"name": "constant.character.math.tex"
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.constant.math.tex"
+						}
+					},
+					"match": "(\\\\)(?!begin\\*\\{|verb)([A-Za-z]+)",
+					"name": "constant.other.general.math.tex"
+				},
+				{
+					"match": "(?<!\\\\)\\{",
+					"name": "punctuation.math.begin.bracket.curly"
+				},
+				{
+					"match": "(?<!\\\\)\\}",
+					"name": "punctuation.math.end.bracket.curly"
+				},
+				{
+					"match": "\\(",
+					"name": "punctuation.math.begin.bracket.round"
+				},
+				{
+					"match": "\\)",
+					"name": "punctuation.math.end.bracket.round"
+				},
+				{
+					"match": "(([0-9]*[\\.][0-9]+)|[0-9]+)",
+					"name": "constant.numeric.math.tex"
+				},
+				{
+					"match": "[\\+\\*/_\\^-]",
+					"name": "punctuation.math.operator.latex"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Fixes #23573. Copying syntaxes folder over from vscode, which doesn't look like it ever made its way over to ADS:

VS Code: [vscode/extensions/markdown-math at main · microsoft/vscode · GitHub](https://github.com/microsoft/vscode/tree/main/extensions/markdown-math)

ADS: [azuredatastudio/extensions/markdown-math at main · microsoft/azuredatastudio · GitHub](https://github.com/microsoft/azuredatastudio/tree/main/extensions/markdown-math)

I also thought about turning off markdown-math, but that would introduce yet another diff between ADS + VS Code, which could come back and bite us later.