### PR TITLE
Don't set buttonoption for link/image Actions in Markdown Toolbar

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -28,7 +28,6 @@ import { NotebookLinkHandler } from 'sql/workbench/contrib/notebook/browser/note
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { FileAccess } from 'vs/base/common/network';
-import { defaultButtonStyles } from 'vs/platform/theme/browser/defaultStyles';
 
 export const MARKDOWN_TOOLBAR_SELECTOR: string = 'markdown-toolbar-component';
 const linksRegex = /\[(?<text>.+)\]\((?<url>[^ ]+)(?: "(?<title>.+)")?\)/;
@@ -118,15 +117,9 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 	private initActionBar() {
 		let linkButtonContainer = DOM.$('li.action-item');
 		linkButtonContainer.setAttribute('role', 'presentation');
-		let linkButton = new Button(linkButtonContainer, defaultButtonStyles);
+		let linkButton = new Button(linkButtonContainer, null);
 		linkButton.title = this.insertLink;
 		linkButton.element.setAttribute('class', 'action-label codicon insert-link masked-icon');
-
-		// {{SQL CARBON TODO}} - reenable
-		// let buttonStyle: IButtonStyles = {
-		// 	buttonBackground: null
-		// };
-		// linkButton.style(buttonStyle);
 
 		this._register(DOM.addDisposableListener(linkButtonContainer, DOM.EventType.CLICK, async e => {
 			await this.onInsertButtonClick(e, MarkdownButtonType.LINK_PREVIEW);
@@ -134,12 +127,9 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 
 		let imageButtonContainer = DOM.$('li.action-item');
 		imageButtonContainer.setAttribute('role', 'presentation');
-		let imageButton = new Button(imageButtonContainer, defaultButtonStyles);
+		let imageButton = new Button(imageButtonContainer, null);
 		imageButton.title = this.insertImage;
 		imageButton.element.setAttribute('class', 'action-label codicon insert-image masked-icon');
-
-		// {{SQL CARBON TODO}} - reenable
-		//imageButton.style(buttonStyle);
 
 		this._register(DOM.addDisposableListener(imageButtonContainer, DOM.EventType.CLICK, async e => {
 			await this.onInsertButtonClick(e, MarkdownButtonType.IMAGE_PREVIEW);


### PR DESCRIPTION
Fixes #23693. Pre-merge, we weren't setting the IButtonOptions. Setting it explicitly to null ensures that the VS default styles aren't added in addition to all of the custom notebook styles.

Before:
![image](https://github.com/microsoft/azuredatastudio/assets/40371649/ad3200bd-f883-4933-b20e-c10b3c55b492)

After:
<img width="588" alt="image" src="https://github.com/microsoft/azuredatastudio/assets/40371649/851f9bf3-b1c6-4cca-bc1b-d0269e5bdd9d">
