### PR TITLE
Cleanup uneccessary awaits in query store extension

### DIFF
--- a/extensions/query-store/src/common/utils.ts
+++ b/extensions/query-store/src/common/utils.ts
@@ -36,7 +36,7 @@ export async function createOneComponentFlexContainer(view: azdata.ModelView, co
  * @param flexFlow row or column
  * @returns Flex container containing the two components
  */
-export async function createTwoComponentFlexContainer(view: azdata.ModelView, firstComponent: azdata.Component, secondComponent: azdata.Component, flexFlow: string): Promise<azdata.FlexContainer> {
+export function createTwoComponentFlexContainer(view: azdata.ModelView, firstComponent: azdata.Component, secondComponent: azdata.Component, flexFlow: string): azdata.FlexContainer {
 	const flexContainer = view.modelBuilder.flexContainer().component();
 
 	if (flexFlow === 'row') {

--- a/extensions/query-store/src/reports/baseQueryStoreReport.ts
+++ b/extensions/query-store/src/reports/baseQueryStoreReport.ts
@@ -61,18 +61,18 @@ export abstract class BaseQueryStoreReport {
 			case 2: {
 				// TODO: replace 800 to have the number be based on how big the window is
 				// one container on top, one on the bottom
-				mainContainer = this.resizeable ? utils.createVerticalSplitView(view, containers[0], containers[1], 800) : await utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'column');
+				mainContainer = this.resizeable ? utils.createVerticalSplitView(view, containers[0], containers[1], 800) : utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'column');
 				break;
 			} case 3: {
 				// 2 containers on top, one on the bottom
 				// TODO: support portrait and landscape view. Right now it's landscape view only
-				mainContainer = this.resizeable ? utils.createVerticalSplitView(view, await utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'row'), containers[2], 800)
-					: await utils.createTwoComponentFlexContainer(view, await utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'row'), containers[2], 'column');
+				mainContainer = this.resizeable ? utils.createVerticalSplitView(view, utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'row'), containers[2], 800)
+					: utils.createTwoComponentFlexContainer(view, utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'row'), containers[2], 'column');
 				break;
 			} case 4: {
 				// 2 containers on top, 2 on the bottom
-				mainContainer = this.resizeable ? utils.createVerticalSplitView(view, await utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'row'), await utils.createTwoComponentFlexContainer(view, containers[2], containers[3], 'row'), 800)
-					: await utils.createTwoComponentFlexContainer(view, await utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'row'), await utils.createTwoComponentFlexContainer(view, containers[2], containers[3], 'row'), 'column');
+				mainContainer = this.resizeable ? utils.createVerticalSplitView(view, utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'row'), utils.createTwoComponentFlexContainer(view, containers[2], containers[3], 'row'), 800)
+					: utils.createTwoComponentFlexContainer(view, utils.createTwoComponentFlexContainer(view, containers[0], containers[1], 'row'), utils.createTwoComponentFlexContainer(view, containers[2], containers[3], 'row'), 'column');
 				break;
 			} default: {
 				throw new Error(`{views.length} number of views in a QDS report is not supported`);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
I noticed the utils function `createTwoComponentFlexContainer()` doesn't actually need to be async while looking into the horizontal split view bug, so removing these all these unnecessary awaits.