### PR TITLE
Update vscode version for Profiler extension

### DIFF
--- a/extensions/profiler/package.json
+++ b/extensions/profiler/package.json
@@ -8,7 +8,7 @@
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {
-    "vscode": ">=0.10.0",
+    "vscode": "*",
     "azdata": ">=1.45.0"
   },
   "activationEvents": [

--- a/extensions/profiler/package.json
+++ b/extensions/profiler/package.json
@@ -8,7 +8,7 @@
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {
-    "vscode": "0.10.0",
+    "vscode": ">=0.10.0",
     "azdata": ">=1.45.0"
   },
   "activationEvents": [


### PR DESCRIPTION
After bumping the version for Profiler extension, it still doesn't install because of vscode version.
![image](https://github.com/microsoft/azuredatastudio/assets/57200045/2a656904-f2f9-4dc9-b853-a67f6d062f96)

Updating the version in this PR.