### PR TITLE
Create new context menu item for Database

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -84,6 +84,12 @@
         "icon": "$(add)"
       },
       {
+        "command": "mssql.newDatabase",
+        "category": "MSSQL",
+        "title": "%title.newDatabase%",
+        "icon": "$(add)"
+      },
+      {
         "command": "mssql.objectProperties",
         "category": "MSSQL",
         "title": "%title.objectProperties%",
@@ -491,6 +497,10 @@
           "when": "false"
         },
         {
+          "command": "mssql.newDatabase",
+          "when": "false"
+        },
+        {
           "command": "mssql.objectProperties",
           "when": "false"
         },
@@ -526,12 +536,22 @@
         },
         {
           "command": "mssql.newObject",
-          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(ServerLevelLogins|Users|ServerLevelServerRoles|ApplicationRoles|DatabaseRoles|Databases)$/ && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(ServerLevelLogins|Users|ServerLevelServerRoles|ApplicationRoles|DatabaseRoles)$/ && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {
           "command": "mssql.newObject",
-          "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole|Database)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
+          "group": "1_objectManagement@0"
+        },
+        {
+          "command": "mssql.newDatabase",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(Databases)$/ && config.workbench.enablePreviewFeatures",
+          "group": "1_objectManagement@0"
+        },
+        {
+          "command": "mssql.newDatabase",
+          "when": "connectionProvider == MSSQL && nodeType =~ /^(Database)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {
@@ -613,12 +633,22 @@
         },
         {
           "command": "mssql.newObject",
-          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(ServerLevelLogins|Users|ServerLevelServerRoles|ApplicationRoles|DatabaseRoles|Databases)$/ && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(ServerLevelLogins|Users|ServerLevelServerRoles|ApplicationRoles|DatabaseRoles)$/ && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {
           "command": "mssql.newObject",
-          "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole|Database)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
+          "group": "1_objectManagement@0"
+        },
+        {
+          "command": "mssql.newDatabase",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(Databases)$/ && config.workbench.enablePreviewFeatures",
+          "group": "1_objectManagement@0"
+        },
+        {
+          "command": "mssql.newDatabase",
+          "when": "connectionProvider == MSSQL && nodeType =~ /^(Database)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -546,12 +546,12 @@
         },
         {
           "command": "mssql.newDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(Databases)$/ && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == Databases && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {
           "command": "mssql.newDatabase",
-          "when": "connectionProvider == MSSQL && nodeType =~ /^(Database)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Database && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {
@@ -643,12 +643,12 @@
         },
         {
           "command": "mssql.newDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType =~ /^(Databases)$/ && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == Databases && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {
           "command": "mssql.newDatabase",
-          "when": "connectionProvider == MSSQL && nodeType =~ /^(Database)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Database  && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -186,6 +186,7 @@
 	"mssql.objectExplorer.disableGroupBySchemaTitle": "SQL Server: Disable Group By Schema",
 	"mssql.objectExplorer.expandTimeout": "The timeout in seconds for expanding a node in Object Explorer. The default value is 45 seconds.",
 	"title.newObject": "New (Preview)",
+	"title.newDatabase": "New Database (Preview)",
 	"title.objectProperties": "Properties (Preview)",
 	"title.deleteObject": "Delete (Preview)",
 	"title.renameObject": "Rename (Preview)",

--- a/extensions/mssql/src/objectManagement/commands.ts
+++ b/extensions/mssql/src/objectManagement/commands.ts
@@ -31,6 +31,9 @@ export function registerObjectManagementCommands(appContext: AppContext) {
 	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.newObject', async (context: azdata.ObjectExplorerContext) => {
 		await handleNewObjectDialogCommand(context, service);
 	}));
+	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.newDatabase', async (context: azdata.ObjectExplorerContext) => {
+		await handleNewObjectDialogCommand(context, service);
+	}));
 	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.objectProperties', async (context: azdata.ObjectExplorerContext) => {
 		await handleObjectPropertiesDialogCommand(context, service);
 	}));


### PR DESCRIPTION
We cannot modify the generic `New` command title because it's shared with other types of sql objects.  Unfortunately, it seems that the only option is creating a new one for database.

For: https://github.com/microsoft/azuredatastudio/issues/23731
<img width="223" alt="image" src="https://github.com/microsoft/azuredatastudio/assets/34872381/537dcfa6-26c1-44ca-8e11-b906559146e5">

