### PR TITLE
Limit Detach Database and Database/Server Properties to insiders and dev builds.

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -546,7 +546,7 @@
         },
         {
           "command": "mssql.detachDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && !(nodePath =~ /^.*\\/System Databases\\/.*$/)  && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
           "group": "1_objectManagement@2"
         },
         {
@@ -567,7 +567,7 @@
         },
         {
           "command": "mssql.objectProperties",
-          "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
           "group": "z_objectexplorer@3"
         },
         {


### PR DESCRIPTION
Porting change to release branch. Disables Detach Database and Database/Server Properties dialogs for stable releases since they're still incomplete experiences.

Closes https://github.com/microsoft/azuredatastudio/issues/23747
