### PR TITLE
Bump SQL Tools version to 4.9.0.3 (#23813)

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.8.1.1",
+	"version": "4.9.0.3",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23729

A recent change for the database properties dialog was causing the RestrictAccess setting to be set to null, which resets the value to SINGLE_USER. We should be doing MULTI_USER by default, so the fix in STS was a simple null check.