### PR TITLE
Add limit on the file size that can be opened with Open XEL feature

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profilerActions.contribution.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerActions.contribution.ts
@@ -19,6 +19,7 @@ import { IConnectionDialogService } from 'sql/workbench/services/connection/comm
 import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IFileService } from 'vs/platform/files/common/files';
 
 CommandsRegistry.registerCommand({
 	id: 'profiler.newProfiler',
@@ -107,9 +108,10 @@ CommandsRegistry.registerCommand({
 		const editorService: IEditorService = accessor.get(IEditorService);
 		const fileDialogService: IFileDialogService = accessor.get(IFileDialogService);
 		const profilerService: IProfilerService = accessor.get(IProfilerService);
-		const instantiationService: IInstantiationService = accessor.get(IInstantiationService)
+		const instantiationService: IInstantiationService = accessor.get(IInstantiationService);
+		const fileService: IFileService = accessor.get(IFileService);
 
-		const result = await profilerService.openFile(fileDialogService, editorService, instantiationService);
+		const result = await profilerService.openFile(fileDialogService, editorService, instantiationService, fileService);
 
 		return result;
 	}

--- a/src/sql/workbench/services/profiler/browser/interfaces.ts
+++ b/src/sql/workbench/services/profiler/browser/interfaces.ts
@@ -11,6 +11,7 @@ import * as azdata from 'azdata';
 import { INewProfilerState } from 'sql/workbench/common/editor/profiler/profilerState';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IFileService } from 'vs/platform/files/common/files';
 
 const PROFILER_SERVICE_ID = 'profilerService';
 export const IProfilerService = createDecorator<IProfilerService>(PROFILER_SERVICE_ID);
@@ -148,7 +149,7 @@ export interface IProfilerService {
 	 * @param editorService service to open profiler editor
 	 * @param instantiationService service to create profiler instance
 	 */
-	openFile(fileDialogService: IFileDialogService, editorService: IEditorService, instantiationService: IInstantiationService): Promise<boolean>;
+	openFile(fileDialogService: IFileDialogService, editorService: IEditorService, instantiationService: IInstantiationService, fileService: IFileService): Promise<boolean>;
 }
 
 export enum ProfilingSessionType {

--- a/src/sql/workbench/services/profiler/browser/profilerService.ts
+++ b/src/sql/workbench/services/profiler/browser/profilerService.ts
@@ -22,8 +22,7 @@ import { ProfilerFilterDialog } from 'sql/workbench/services/profiler/browser/pr
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ACTIVE_GROUP, IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { promises as fs } from 'fs';
-import { ByteSize } from 'vs/platform/files/common/files';
+import { ByteSize, IFileService } from 'vs/platform/files/common/files';
 
 class TwoWayMap<T, K> {
 	private forwardMap: Map<T, K>;
@@ -305,7 +304,7 @@ export class ProfilerService implements IProfilerService {
 		await this._configurationService.updateValue(PROFILER_FILTER_SETTINGS, config, ConfigurationTarget.USER);
 	}
 
-	public async openFile(fileDialogService: IFileDialogService, editorService: IEditorService, instantiationService: IInstantiationService): Promise<boolean> {
+	public async openFile(fileDialogService: IFileDialogService, editorService: IEditorService, instantiationService: IInstantiationService, fileService: IFileService): Promise<boolean> {
 		const fileURIs = await fileDialogService.showOpenDialog({
 			filters: [
 				{
@@ -320,7 +319,7 @@ export class ProfilerService implements IProfilerService {
 			const fileURI = fileURIs[0];
 
 			try {
-				const fileSize = (await fs.stat(fileURI.fsPath)).size;
+				const fileSize = (await fileService.stat(fileURI)).size;
 				const fileLimitSize = 1 * ByteSize.GB;
 				const fileOpenWarningSize = 100 * ByteSize.MB;
 

--- a/src/sql/workbench/services/profiler/browser/profilerService.ts
+++ b/src/sql/workbench/services/profiler/browser/profilerService.ts
@@ -328,7 +328,7 @@ export class ProfilerService implements IProfilerService {
 					this._notificationService.error(nls.localize('FileTooLarge', "The file is too large to open in profiler. The profiler can open files that are less than 1GB."));
 					return false;
 				} else if (fileSize > fileOpenWarningSize) {
-					this._notificationService.info(nls.localize('LargeFileWait', "Loading the file might take a moment, because the file is large."));
+					this._notificationService.info(nls.localize('LargeFileWait', "Loading the file might take a moment due to the file size."));
 				}
 			} catch (err) {
 				this._notificationService.error(err.message);


### PR DESCRIPTION
This PR works on fixing https://github.com/microsoft/azuredatastudio/issues/23806.

For files within 100MB, no notification is posted.

For files from 100MB-1GB, a notification is posted:
![image](https://github.com/microsoft/azuredatastudio/assets/57200045/5ccf9bde-caa2-4ea5-8e9d-cd1b1fdd815f)

For files more than 1GB, an error is thrown and file is not loaded:
![image](https://github.com/microsoft/azuredatastudio/assets/57200045/16e9f6da-930d-43eb-961a-15be695e7738)
