### PR TITLE
Add basic validation to database names

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -137,7 +137,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 	//#region Create Database
 	private initializeGeneralSection(): azdata.GroupContainer {
 		let containers: azdata.Component[] = [];
-		// The max length for database names is 128 characters: https://learn.microsoft.com/en-us/sql/t-sql/functions/db-name-transact-sql?view=sql-server-ver16
+		// The max length for database names is 128 characters: https://learn.microsoft.com/sql/t-sql/functions/db-name-transact-sql
 		const maxLengthDatabaseName: number = 128;
 		const props: azdata.InputBoxProperties = {
 			ariaLabel: localizedConstants.NameText,

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -145,9 +145,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			maxLength: 128
 		};
 
-		this.nameInput = this.createInputBoxWithProperties(localizedConstants.NameText, async () => {
+		this.nameInput = this.createInputBoxWithProperties(async () => {
 			this.objectInfo.name = this.nameInput.value;
-			await this.runValidation(false);
 		}, props);
 		containers.push(this.createLabelInputContainer(localizedConstants.NameText, this.nameInput));
 

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -137,10 +137,17 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 	//#region Create Database
 	private initializeGeneralSection(): azdata.GroupContainer {
 		let containers: azdata.Component[] = [];
-		this.nameInput = this.createInputBox(localizedConstants.NameText, async () => {
+		const props: azdata.InputBoxProperties = {
+			ariaLabel: localizedConstants.NameText,
+			width: DefaultInputWidth,
+			required: true,
+			maxLength: 20
+		};
+
+		this.nameInput = this.createTextInputBox(localizedConstants.NameText, async () => {
 			this.objectInfo.name = this.nameInput.value;
 			await this.runValidation(false);
-		});
+		}, '', props);
 		containers.push(this.createLabelInputContainer(localizedConstants.NameText, this.nameInput));
 
 		if (this.viewInfo.loginNames?.length > 0) {

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -137,10 +137,12 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 	//#region Create Database
 	private initializeGeneralSection(): azdata.GroupContainer {
 		let containers: azdata.Component[] = [];
+		// The max length for database names is 128 characters: https://learn.microsoft.com/en-us/sql/t-sql/functions/db-name-transact-sql?view=sql-server-ver16
+		const maxLengthDatabaseName: number = 128;
 		const props: azdata.InputBoxProperties = {
 			ariaLabel: localizedConstants.NameText,
 			required: true,
-			maxLength: 128
+			maxLength: maxLengthDatabaseName
 		};
 
 		this.nameInput = this.createInputBoxWithProperties(async () => {

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -141,13 +141,14 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			ariaLabel: localizedConstants.NameText,
 			width: DefaultInputWidth,
 			required: true,
-			maxLength: 20
+			value: '',
+			maxLength: 128
 		};
 
-		this.nameInput = this.createTextInputBox(localizedConstants.NameText, async () => {
+		this.nameInput = this.createInputBoxWithProperties(localizedConstants.NameText, async () => {
 			this.objectInfo.name = this.nameInput.value;
 			await this.runValidation(false);
-		}, '', props);
+		}, props);
 		containers.push(this.createLabelInputContainer(localizedConstants.NameText, this.nameInput));
 
 		if (this.viewInfo.loginNames?.length > 0) {

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -139,9 +139,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 		let containers: azdata.Component[] = [];
 		const props: azdata.InputBoxProperties = {
 			ariaLabel: localizedConstants.NameText,
-			width: DefaultInputWidth,
 			required: true,
-			value: '',
 			maxLength: 128
 		};
 

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -161,6 +161,7 @@ export abstract class DialogBase<DialogResult> {
 		this.disposables.push(inputbox.onTextChanged(async () => {
 			await textChangeHandler(inputbox.value!);
 			this.onFormFieldChange();
+			await this.runValidation(false);
 		}));
 		return inputbox;
 	}

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -152,7 +152,12 @@ export abstract class DialogBase<DialogResult> {
 		properties.inputType = properties.inputType ?? 'text';
 		properties.value = properties.value ?? '';
 		properties.enabled = properties.enabled ?? true;
-		const inputbox: azdata.InputBoxComponent = customValidation ? this.modelView.modelBuilder.inputBox().withProps(properties).withValidation(customValidation).component() : this.modelView.modelBuilder.inputBox().withProps(properties).component();
+		let inputbox: azdata.InputBoxComponent;
+		if (customValidation) {
+			inputbox = this.modelView.modelBuilder.inputBox().withProps(properties).withValidation(customValidation).component();
+		} else {
+			inputbox = this.modelView.modelBuilder.inputBox().withProps(properties).component();
+		}
 		this.disposables.push(inputbox.onTextChanged(async () => {
 			await textChangeHandler(inputbox.value!);
 			this.onFormFieldChange();

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -147,8 +147,7 @@ export abstract class DialogBase<DialogResult> {
 		return this.createInputBox(ariaLabel, textChangeHandler, value, enabled, 'password', width);
 	}
 
-	protected createInputBoxWithProperties(ariaLabel: string, textChangeHandler: (newValue: string) => Promise<void>, properties: azdata.InputBoxProperties, customValidation?: () => Promise<boolean>): azdata.InputBoxComponent {
-		properties.ariaLabel = ariaLabel;
+	protected createInputBoxWithProperties(textChangeHandler: (newValue: string) => Promise<void>, properties: azdata.InputBoxProperties, customValidation?: () => Promise<boolean>): azdata.InputBoxComponent {
 		const inputbox: azdata.InputBoxComponent = this.modelView.modelBuilder.inputBox().withProps(properties).withValidation(customValidation).component();
 		this.disposables.push(inputbox.onTextChanged(async () => {
 			await textChangeHandler(inputbox.value!);

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -152,18 +152,17 @@ export abstract class DialogBase<DialogResult> {
 		properties.inputType = properties.inputType ?? 'text';
 		properties.value = properties.value ?? '';
 		properties.enabled = properties.enabled ?? true;
-		let inputbox: azdata.InputBoxComponent;
+		const inputbox = this.modelView.modelBuilder.inputBox().withProps(properties);
 		if (customValidation) {
-			inputbox = this.modelView.modelBuilder.inputBox().withProps(properties).withValidation(customValidation).component();
-		} else {
-			inputbox = this.modelView.modelBuilder.inputBox().withProps(properties).component();
+			inputbox.withValidation(customValidation);
 		}
-		this.disposables.push(inputbox.onTextChanged(async () => {
-			await textChangeHandler(inputbox.value!);
+		const inputBoxComponent = inputbox.component();
+		this.disposables.push(inputBoxComponent.onTextChanged(async () => {
+			await textChangeHandler(inputBoxComponent.value!);
 			this.onFormFieldChange();
 			await this.runValidation(false);
 		}));
-		return inputbox;
+		return inputBoxComponent;
 	}
 
 	protected createInputBox(ariaLabel: string, textChangeHandler: (newValue: string) => Promise<void>, value: string = '', enabled: boolean = true, type: azdata.InputBoxInputType = 'text', width: number = DefaultInputWidth, required?: boolean, min?: number, max?: number): azdata.InputBoxComponent {

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -148,7 +148,11 @@ export abstract class DialogBase<DialogResult> {
 	}
 
 	protected createInputBoxWithProperties(textChangeHandler: (newValue: string) => Promise<void>, properties: azdata.InputBoxProperties, customValidation?: () => Promise<boolean>): azdata.InputBoxComponent {
-		const inputbox: azdata.InputBoxComponent = this.modelView.modelBuilder.inputBox().withProps(properties).withValidation(customValidation).component();
+		properties.width = properties.width ?? DefaultInputWidth;
+		properties.inputType = properties.inputType ?? 'text';
+		properties.value = properties.value ?? '';
+		properties.enabled = properties.enabled ?? true;
+		const inputbox: azdata.InputBoxComponent = customValidation ? this.modelView.modelBuilder.inputBox().withProps(properties).withValidation(customValidation).component() : this.modelView.modelBuilder.inputBox().withProps(properties).component();
 		this.disposables.push(inputbox.onTextChanged(async () => {
 			await textChangeHandler(inputbox.value!);
 			this.onFormFieldChange();

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -147,13 +147,9 @@ export abstract class DialogBase<DialogResult> {
 		return this.createInputBox(ariaLabel, textChangeHandler, value, enabled, 'password', width);
 	}
 
-	protected createTextInputBox(ariaLabel: string, textChangeHandler: (newValue: string) => Promise<void>, value: string = '', properties: azdata.InputBoxProperties, customValidation?: () => Promise<boolean>): azdata.InputBoxComponent {
-		const textValidation = new RegExp('^[a-zA-Z0-9_]*$');
+	protected createInputBoxWithProperties(ariaLabel: string, textChangeHandler: (newValue: string) => Promise<void>, properties: azdata.InputBoxProperties, customValidation?: () => Promise<boolean>): azdata.InputBoxComponent {
 		properties.ariaLabel = ariaLabel;
-		properties.validationErrorMessage = customValidation ? properties.validationErrorMessage : uiLoc.OnlyAlphanumericValuesAllowed;
-		const inputbox: azdata.InputBoxComponent = this.modelView.modelBuilder.inputBox().withProps(properties).withValidation(customValidation ? customValidation : () => {
-			return textValidation.test(inputbox.value)
-		}).component();
+		const inputbox: azdata.InputBoxComponent = this.modelView.modelBuilder.inputBox().withProps(properties).withValidation(customValidation).component();
 		this.disposables.push(inputbox.onTextChanged(async () => {
 			await textChangeHandler(inputbox.value!);
 			this.onFormFieldChange();

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -161,7 +161,6 @@ export abstract class DialogBase<DialogResult> {
 		this.disposables.push(inputbox.onTextChanged(async () => {
 			await textChangeHandler(inputbox.value!);
 			this.onFormFieldChange();
-			await this.runValidation(false);
 		}));
 		return inputbox;
 	}

--- a/extensions/mssql/src/ui/localizedConstants.ts
+++ b/extensions/mssql/src/ui/localizedConstants.ts
@@ -19,7 +19,7 @@ export const NoActionScriptedMessage: string = localize('mssql.ui.noActionScript
 export const ScriptGeneratedText: string = localize('mssql.ui.scriptGenerated', "Script has been generated successfully. You can close the dialog to view it in the newly opened editor.")
 export const GeneratingScriptText: string = localize('mssql.ui.generatingScript', "Generating script...");
 export const GeneratingScriptCompletedText: string = localize('mssql.ui.generatingScriptCompleted', "Script generated");
-export const OnlyAlphanumericValuesAllowed = localize('objectManagement.OnlyAlphanumericValuesAllowed', " 'Only alphanumeric characters allowed'");
+export const OnlyAlphanumericValuesAllowed = localize('objectManagement.OnlyAlphanumericValuesAllowed', "Only alphanumeric characters allowed");
 
 export function scriptError(error: string): string {
 	return localize('mssql.ui.scriptError', "An error occurred while generating the script. {0}", error);

--- a/extensions/mssql/src/ui/localizedConstants.ts
+++ b/extensions/mssql/src/ui/localizedConstants.ts
@@ -19,7 +19,6 @@ export const NoActionScriptedMessage: string = localize('mssql.ui.noActionScript
 export const ScriptGeneratedText: string = localize('mssql.ui.scriptGenerated', "Script has been generated successfully. You can close the dialog to view it in the newly opened editor.")
 export const GeneratingScriptText: string = localize('mssql.ui.generatingScript', "Generating script...");
 export const GeneratingScriptCompletedText: string = localize('mssql.ui.generatingScriptCompleted', "Script generated");
-export const OnlyAlphanumericValuesAllowed = localize('objectManagement.OnlyAlphanumericValuesAllowed', "Only alphanumeric characters allowed");
 
 export function scriptError(error: string): string {
 	return localize('mssql.ui.scriptError', "An error occurred while generating the script. {0}", error);

--- a/extensions/mssql/src/ui/localizedConstants.ts
+++ b/extensions/mssql/src/ui/localizedConstants.ts
@@ -19,6 +19,7 @@ export const NoActionScriptedMessage: string = localize('mssql.ui.noActionScript
 export const ScriptGeneratedText: string = localize('mssql.ui.scriptGenerated', "Script has been generated successfully. You can close the dialog to view it in the newly opened editor.")
 export const GeneratingScriptText: string = localize('mssql.ui.generatingScript', "Generating script...");
 export const GeneratingScriptCompletedText: string = localize('mssql.ui.generatingScriptCompleted', "Script generated");
+export const OnlyAlphanumericValuesAllowed = localize('objectManagement.OnlyAlphanumericValuesAllowed', " 'Only alphanumeric characters allowed'");
 
 export function scriptError(error: string): string {
 	return localize('mssql.ui.scriptError', "An error occurred while generating the script. {0}", error);


### PR DESCRIPTION
Add basic dynamic validation for database names:
  - No empty values
  - No more than 128 characters
  
For https://github.com/microsoft/azuredatastudio/issues/23823
For https://github.com/microsoft/azuredatastudio/issues/23822

<img width="249" alt="image" src="https://github.com/microsoft/azuredatastudio/assets/34872381/99190551-2020-4e03-9087-7247b0e0c2e2">

