### PR TITLE
Fix dialog buttons

### DIFF
--- a/src/sql/workbench/services/dialog/browser/dialogModal.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogModal.ts
@@ -138,6 +138,7 @@ export class DialogModal extends Modal {
 		if (this._doneButton.enabled) {
 			let buttonSpinnerHandler = setTimeout(() => {
 				this._doneButton.enabled = false;
+				// Temporarily set the label to empty since we're showing a spinner instead
 				this._doneButton.label = ''
 				this._doneButton.element.classList.add('validating');
 			}, 100);

--- a/src/sql/workbench/services/dialog/browser/dialogModal.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogModal.ts
@@ -138,9 +138,14 @@ export class DialogModal extends Modal {
 		if (this._doneButton.enabled) {
 			let buttonSpinnerHandler = setTimeout(() => {
 				this._doneButton.enabled = false;
-				this._doneButton.element.innerHTML = '&nbsp';
+				this._doneButton.label = ''
 				this._doneButton.element.classList.add('validating');
 			}, 100);
+			await new Promise<void>(resolve => {
+				setTimeout(() => {
+					resolve();
+				}, 3000);
+			})
 			if (await this._dialog.validateClose()) {
 				this._onDone.fire();
 				this.dispose();

--- a/src/sql/workbench/services/dialog/browser/dialogModal.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogModal.ts
@@ -142,11 +142,6 @@ export class DialogModal extends Modal {
 				this._doneButton.label = ''
 				this._doneButton.element.classList.add('validating');
 			}, 100);
-			await new Promise<void>(resolve => {
-				setTimeout(() => {
-					resolve();
-				}, 3000);
-			})
 			if (await this._dialog.validateClose()) {
 				this._onDone.fire();
 				this.dispose();

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -319,7 +319,7 @@ export class WizardModal extends Modal {
 		let button = newPage === undefined ? this._doneButton : this._nextButton;
 		let buttonSpinnerHandler = setTimeout(() => {
 			button.enabled = false;
-			button.element.innerHTML = '&nbsp';
+			button.label = '';
 			button.element.classList.add('validating');
 		}, 100);
 		let navigationValid = await this._wizard.validateNavigation(newPage);

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -319,6 +319,7 @@ export class WizardModal extends Modal {
 		let button = newPage === undefined ? this._doneButton : this._nextButton;
 		let buttonSpinnerHandler = setTimeout(() => {
 			button.enabled = false;
+			// Temporarily set the label to empty since we're showing a spinner instead
 			button.label = '';
 			button.element.classList.add('validating');
 		}, 100);

--- a/src/tsec.exemptions.json
+++ b/src/tsec.exemptions.json
@@ -49,8 +49,6 @@
 		"sql/base/browser/ui/panel/panel.ts",
 		"sql/base/browser/ui/selectBox/selectBox.ts",
 		"sql/base/browser/ui/panel/panel.component.ts",
-		"sql/workbench/services/dialog/browser/dialogModal.ts",
-		"sql/workbench/services/dialog/browser/wizardModal.ts",
 		"sql/base/browser/ui/taskbar/taskbar.ts",
 		"sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts",
 		"sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts",


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/23827

In the latest VS Code merge they added a check to the label setter to no-op if the label is the same. But because we were clearing the label directly here by setting the innerHTML the button still thought it had the original text so never "refreshed" with the original text. 

Before : 

![VirtualizeBroken](https://github.com/microsoft/azuredatastudio/assets/28519865/13f8bd15-c2da-4e08-9a85-f7754577eeb8)

After :

![VirtualizeFixed](https://github.com/microsoft/azuredatastudio/assets/28519865/a5dfb9b8-8874-4037-9a56-818a04b6759f)

![SavingProperties](https://github.com/microsoft/azuredatastudio/assets/28519865/bc3784c7-5c5e-4316-a939-97b4f3782a36)
