### PR TITLE
Config helper specifies to use the 'canvas' setting

### DIFF
--- a/src/vs/platform/configuration/test/common/testConfigurationService.ts
+++ b/src/vs/platform/configuration/test/common/testConfigurationService.ts
@@ -24,14 +24,14 @@ export class TestConfigurationService implements IConfigurationService {
 		// This is a temporary fix and should be removed once xterm GPU rendering is working again.
 		if (configuration) {
 			if (configuration.integrated) {
-				configuration.integrated.gpuAcceleration = 'off';
+				configuration.integrated.gpuAcceleration = 'canvas';
 			}
 			else {
-				configuration.integrated = { gpuAcceleration: 'off' };
+				configuration.integrated = { gpuAcceleration: 'canvas' };
 			}
 		}
 		else {
-			configuration = { integrated: { gpuAcceleration: 'off' } };
+			configuration = { integrated: { gpuAcceleration: 'canvas' } };
 		}
 		// {{SQL CARBON EDIT}} - END
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Configures xterm test config helper to use 'canvas' instead of 'off'