### PR TITLE
SQL-Migration:  fix get subscriptions failure, that prevents valid subscriptions from loading.

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -30,10 +30,17 @@ async function getAzureCoreAPI(): Promise<azurecore.IExtension> {
 
 export type Subscription = azurecore.azureResource.AzureResourceSubscription;
 export async function getSubscriptions(account: azdata.Account): Promise<Subscription[]> {
+	console.log('** getSubscriptions started **');
 	const api = await getAzureCoreAPI();
-	const subscriptions = await api.getSubscriptions(account, false);
+	const subscriptions = await api.getSubscriptions(account, true);
+	console.log(`** getSubscriptions retrieved subs: => '${subscriptions?.subscriptions?.length ?? ' no-subscriptions '}' **`);
+	console.log(`** getSubscriptions retrieved errs: => '${subscriptions?.errors?.length ?? ' no-errors '}' **`);
+	console.log(`** getSubscriptions retrieved errors: => '${subscriptions?.errors?.join(', ')}' **`);
+
 	let listOfSubscriptions = subscriptions.subscriptions;
+	console.log(`** getSubscriptions listOfSubscriptions: => '${listOfSubscriptions?.length ?? 0}' **`);
 	sortResourceArrayByName(listOfSubscriptions);
+	console.log(`** getSubscriptions listOfSubscriptions (sorted): => '${listOfSubscriptions?.length ?? 0}' **`);
 	return subscriptions.subscriptions;
 }
 

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -30,17 +30,11 @@ async function getAzureCoreAPI(): Promise<azurecore.IExtension> {
 
 export type Subscription = azurecore.azureResource.AzureResourceSubscription;
 export async function getSubscriptions(account: azdata.Account): Promise<Subscription[]> {
-	console.log('** getSubscriptions started **');
 	const api = await getAzureCoreAPI();
 	const subscriptions = await api.getSubscriptions(account, true);
-	console.log(`** getSubscriptions retrieved subs: => '${subscriptions?.subscriptions?.length ?? ' no-subscriptions '}' **`);
-	console.log(`** getSubscriptions retrieved errs: => '${subscriptions?.errors?.length ?? ' no-errors '}' **`);
-	console.log(`** getSubscriptions retrieved errors: => '${subscriptions?.errors?.join(', ')}' **`);
 
 	let listOfSubscriptions = subscriptions.subscriptions;
-	console.log(`** getSubscriptions listOfSubscriptions: => '${listOfSubscriptions?.length ?? 0}' **`);
 	sortResourceArrayByName(listOfSubscriptions);
-	console.log(`** getSubscriptions listOfSubscriptions (sorted): => '${listOfSubscriptions?.length ?? 0}' **`);
 	return subscriptions.subscriptions;
 }
 

--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -465,23 +465,16 @@ export function getAzureTenants(account?: Account): Tenant[] {
 }
 
 export async function getAzureSubscriptions(account?: Account, tenantId?: string): Promise<azureResource.AzureResourceSubscription[]> {
-	console.log('** getAzureSubscriptions started **');
 	let subscriptions: azureResource.AzureResourceSubscription[] = [];
 	try {
-		console.log(`** getAzureSubscriptions account name=> ${account?.displayInfo?.name ?? 'NULL'} **`);
-		console.log(`** getAzureSubscriptions tenantId=> ${tenantId ?? 'NULL'} **`);
-		console.log(`** getAzureSubscriptions isAccountTokenStale(account)=> ${isAccountTokenStale(account)} **`);
 		subscriptions = account && !isAccountTokenStale(account)
 			? await azure.getSubscriptions(account)
 			: [];
-		console.log(`** getAzureSubscriptions subscriptions=> ${subscriptions?.length ?? 'NULL'} **`);
 	} catch (e) {
 		logError(TelemetryViews.Utils, 'utils.getAzureSubscriptions', e);
 	}
 	const filtered = subscriptions.filter(subscription => subscription.tenant === tenantId);
-	console.log(`** getAzureSubscriptions subscriptions filtered by tenantId=> ${filtered?.length ?? 'NULL'} **`);
 	filtered.sort((a, b) => a.name.localeCompare(b.name));
-	console.log(`** getAzureSubscriptions subscriptions filtered by tenantId/sorted=> ${filtered?.length ?? 'NULL'} **`);
 	return filtered;
 }
 

--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -465,16 +465,23 @@ export function getAzureTenants(account?: Account): Tenant[] {
 }
 
 export async function getAzureSubscriptions(account?: Account, tenantId?: string): Promise<azureResource.AzureResourceSubscription[]> {
+	console.log('** getAzureSubscriptions started **');
 	let subscriptions: azureResource.AzureResourceSubscription[] = [];
 	try {
+		console.log(`** getAzureSubscriptions account name=> ${account?.displayInfo?.name ?? 'NULL'} **`);
+		console.log(`** getAzureSubscriptions tenantId=> ${tenantId ?? 'NULL'} **`);
+		console.log(`** getAzureSubscriptions isAccountTokenStale(account)=> ${isAccountTokenStale(account)} **`);
 		subscriptions = account && !isAccountTokenStale(account)
 			? await azure.getSubscriptions(account)
 			: [];
+		console.log(`** getAzureSubscriptions subscriptions=> ${subscriptions?.length ?? 'NULL'} **`);
 	} catch (e) {
 		logError(TelemetryViews.Utils, 'utils.getAzureSubscriptions', e);
 	}
 	const filtered = subscriptions.filter(subscription => subscription.tenant === tenantId);
+	console.log(`** getAzureSubscriptions subscriptions filtered by tenantId=> ${filtered?.length ?? 'NULL'} **`);
 	filtered.sort((a, b) => a.name.localeCompare(b.name));
+	console.log(`** getAzureSubscriptions subscriptions filtered by tenantId/sorted=> ${filtered?.length ?? 'NULL'} **`);
 	return filtered;
 }
 


### PR DESCRIPTION
This PR fixes an issue when an error occurs while loading a customer's subscriptions.  In the current behavior the api returns all subscriptions or nothing if an error occurs while loading all tenants / subscriptions.
  
This PR changes the behavior and loads available subscriptions and ignores subscription w/errors.  