### PR TITLE
Setting right options of command based new connections

### DIFF
--- a/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
@@ -21,6 +21,7 @@ import { ContextKeyEqualsExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ActiveConnectionsFilterAction, AddServerAction, AddServerGroupAction } from 'sql/workbench/services/objectExplorer/browser/connectionTreeAction';
 import { CONTEXT_SERVER_TREE_VIEW, CONTEXT_SERVER_TREE_HAS_CONNECTIONS } from 'sql/workbench/contrib/objectExplorer/browser/serverTreeView';
 import { SqlIconId } from 'sql/base/common/codicons';
+import * as Utils from 'sql/platform/connection/common/utils';
 
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 
@@ -132,11 +133,13 @@ CommandsRegistry.registerCommand('azdata.connect',
 				groupFullName: undefined,
 				saveProfile: true,
 				id: undefined,
-				groupId: undefined,
+				groupId: Utils.defaultGroupId,
 				options: args.options
 			};
 			const connectionProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesServices, profile);
-
+			const root = connectionManagementService.getConnectionGroups().filter(g => g.id === Utils.defaultGroupId)[0];
+			connectionProfile.parent = root;
+			connectionProfile.groupFullName = root.fullName;
 			connectionManagementService.connect(connectionProfile, undefined, {
 				saveTheConnection: true,
 				showDashboard: true,

--- a/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
@@ -11,7 +11,7 @@ import { Action2, MenuId, MenuRegistry, registerAction2 } from 'vs/platform/acti
 import { localize } from 'vs/nls';
 import { ConnectionStatusbarItem } from 'sql/workbench/contrib/connection/browser/connectionStatus';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
-import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
+import { ConnectionType, IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
@@ -141,14 +141,20 @@ CommandsRegistry.registerCommand('azdata.connect',
 				saveTheConnection: true,
 				showDashboard: true,
 				showConnectionDialogOnError: true,
-				showFirewallRuleOnError: true
+				showFirewallRuleOnError: true,
+				params: {
+					connectionType: ConnectionType.default,
+				}
 			});
 		} else {
 			connectionManagementService.showConnectionDialog(undefined, {
 				saveTheConnection: true,
 				showDashboard: true,
 				showConnectionDialogOnError: true,
-				showFirewallRuleOnError: true
+				showFirewallRuleOnError: true,
+				params: {
+					connectionType: ConnectionType.default,
+				}
 			});
 		}
 	});


### PR DESCRIPTION
Previously, right options for command-based connections were not set. Now, I am making the connection type as default so that the connection can be saved in OE. 
Issue: #23833 