### PR TITLE
SQL-Migration: fix migration summary details page view for sqldb target

### DIFF
--- a/extensions/sql-migration/src/dialog/targetDatabaseSummary/targetDatabaseSummaryDialog.ts
+++ b/extensions/sql-migration/src/dialog/targetDatabaseSummary/targetDatabaseSummaryDialog.ts
@@ -11,16 +11,15 @@ import * as styles from '../../constants/styles';
 export class TargetDatabaseSummaryDialog {
 	private _dialogObject!: azdata.window.Dialog;
 	private _view!: azdata.ModelView;
-	private _tableLength: number;
+	private _tableLength: number = 700;
 
 	constructor(private _model: MigrationStateModel) {
-		let dialogWidth: azdata.window.DialogWidth;
+		let dialogWidth: azdata.window.DialogWidth = 'medium';
+
+		// extend for blob container
 		if (this._model._databaseBackup.networkContainerType === NetworkContainerType.BLOB_CONTAINER) {
 			this._tableLength = 800;
 			dialogWidth = 900;
-		} else {
-			this._tableLength = 700;
-			dialogWidth = 'medium';
 		}
 		this._dialogObject = azdata.window.createModelViewDialog(
 			constants.DATABASE_TO_BE_MIGRATED,
@@ -77,7 +76,16 @@ export class TargetDatabaseSummaryDialog {
 					headerCssStyles: headerCssStyle
 				}];
 
-			if (this._model._databaseBackup.networkContainerType === NetworkContainerType.BLOB_CONTAINER) {
+			if (isSqlDbMigration) {
+				columns.push({
+					valueType: azdata.DeclarativeDataType.string,
+					displayName: constants.TARGET_TABLE_COUNT_NAME,
+					isReadOnly: true,
+					width: columnWidth,
+					rowCssStyles: rowCssStyle,
+					headerCssStyles: headerCssStyle
+				});
+			} else if (this._model._databaseBackup.networkContainerType === NetworkContainerType.BLOB_CONTAINER) {
 				columns.push(
 					{
 						valueType: azdata.DeclarativeDataType.string,
@@ -120,16 +128,7 @@ export class TargetDatabaseSummaryDialog {
 						headerCssStyles: headerCssStyle,
 						hidden: this._model._databaseBackup.migrationMode === MigrationMode.ONLINE
 					});
-			} else if (isSqlDbMigration) {
-				columns.push({
-					valueType: azdata.DeclarativeDataType.string,
-					displayName: constants.TARGET_TABLE_COUNT_NAME,
-					isReadOnly: true,
-					width: columnWidth,
-					rowCssStyles: rowCssStyle,
-					headerCssStyles: headerCssStyle
-				});
-			} else {
+			} else if (this._model._databaseBackup.networkContainerType === NetworkContainerType.FILE_SHARE) {
 				columns.push({
 					valueType: azdata.DeclarativeDataType.string,
 					displayName: constants.NETWORK_SHARE_PATH,
@@ -148,25 +147,24 @@ export class TargetDatabaseSummaryDialog {
 					{ value: db },
 					{ value: this._model._targetDatabaseNames[index] });
 
-				if (this._model._databaseBackup.networkContainerType === NetworkContainerType.BLOB_CONTAINER) {
-					tableRow.push(
-						{ value: this._model._databaseBackup.blobs[index].storageAccount.location },
-						{ value: this._model._databaseBackup.blobs[index].storageAccount.resourceGroup! },
-						{ value: this._model._databaseBackup.blobs[index].storageAccount.name },
-						{ value: this._model._databaseBackup.blobs[index].blobContainer.name });
-
-					if (this._model._databaseBackup.migrationMode === MigrationMode.OFFLINE) {
-						tableRow.push(
-							{ value: this._model._databaseBackup.blobs[index].lastBackupFile! });
-					}
-				} else if (isSqlDbMigration) {
+				if (isSqlDbMigration) {
 					const totalTables = this._model._sourceTargetMapping.get(db)?.sourceTables.size ?? 0;
 					let selectedTables = 0;
 					this._model._sourceTargetMapping.get(db)?.sourceTables.forEach(
 						tableInfo => selectedTables += tableInfo.selectedForMigration ? 1 : 0);
 					tableRow.push(
 						{ value: constants.TOTAL_TABLES_SELECTED(selectedTables, totalTables) });
-				} else {
+				} else if (this._model._databaseBackup.networkContainerType === NetworkContainerType.BLOB_CONTAINER) {
+					tableRow.push(
+						{ value: this._model._databaseBackup.blobs[index].storageAccount.location },
+						{ value: this._model._databaseBackup.blobs[index].storageAccount.resourceGroup! },
+						{ value: this._model._databaseBackup.blobs[index].storageAccount.name },
+						{ value: this._model._databaseBackup.blobs[index].blobContainer.name });
+					if (this._model._databaseBackup.migrationMode === MigrationMode.OFFLINE) {
+						tableRow.push(
+							{ value: this._model._databaseBackup.blobs[index].lastBackupFile! });
+					}
+				} else if (this._model._databaseBackup.networkContainerType === NetworkContainerType.FILE_SHARE) {
 					tableRow.push(
 						{ value: this._model._databaseBackup.networkShares[index].networkShareLocation });
 				}


### PR DESCRIPTION
This PR fixes a but in the SQL migration extension that shows the wrong migration details summary page for SQL DB database/table selection details.

![image](https://github.com/microsoft/azuredatastudio/assets/61598682/6e880085-e41f-41dd-b694-9c0aa197fce4)
