### PR TITLE
Fix error when opening create project from db dialog without connection

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -52,7 +52,7 @@ export class CreateProjectFromDatabaseDialog {
 
 		let connected = false;
 
-		// make sure the profile passed in is actually a connection profile
+		// make sure the connection profile passed in has sufficient information to attempt to connect
 		if (this.profile && this.profile?.serverName) {
 			const connections = await getAzdataApi()!.connection.getConnections(true);
 			connected = !!connections.find(c => c.connectionId === this.profile!.id);

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -51,7 +51,9 @@ export class CreateProjectFromDatabaseDialog {
 		this.dialog.cancelButton.label = constants.cancelButtonText;
 
 		let connected = false;
-		if (this.profile) {
+
+		// make sure the profile passed in is actually a connection profile
+		if (this.profile && this.profile?.serverName) {
 			const connections = await getAzdataApi()!.connection.getConnections(true);
 			connected = !!connections.find(c => c.connectionId === this.profile!.id);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fix for https://github.com/microsoft/azuredatastudio/issues/23861. The update project from db dialog did not have this problem because it uses `getAzdataApi()!.connection.getCurrentConnection()` to get the current connection, rather than using the profile that may or may not be passed in. Since it would be a bigger change to update the create project from db dialog to do the same thing, this is a smaller fix to verify that the profile actually has connection information, and not only `{ preserverFocus: false}`.

I tested the other entry points (right click on server or db, command palette) to the create project from db dialog to make sure they are still working as expected.
