### PR TITLE
Fix file browser opening race condition

### DIFF
--- a/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
+++ b/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
@@ -114,6 +114,7 @@ export class FileBrowserDialog extends Modal {
 		fileValidationServiceType: string,
 	): void {
 		this._viewModel.initialize(ownerUri, expandPath, fileFilters, fileValidationServiceType);
+		this._viewModel.openFileBrowser(0, false).catch(err => onUnexpectedError(err));
 		this._fileFilterSelectBox.setOptions(this._viewModel.formattedFileFilters);
 		this._fileFilterSelectBox.select(0);
 		this._filePathInputBox.value = expandPath;
@@ -125,7 +126,6 @@ export class FileBrowserDialog extends Modal {
 		this._fileBrowserTreeView = this._instantiationService.createInstance(FileBrowserTreeView);
 		this._fileBrowserTreeView.setOnClickedCallback((arg) => this.onClicked(arg));
 		this._fileBrowserTreeView.setOnDoubleClickedCallback((arg) => this.onDoubleClicked(arg));
-		this._viewModel.openFileBrowser(0, false).catch(err => onUnexpectedError(err));
 	}
 
 	/* enter key */


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/23832

This dialog is set up so that when the filter option is changed it fires an event to tell the provider to refresh the tree. But STS expects that this only happens AFTER the initial open event is sent so it initializes properly. And there was a race condition here where the select box event firing could happen before this initial event was actually completed.

So to fix this we send the initialize event before actually setting the filter box contents - this ensures the message is sent before we get the filter notification. 

A slightly better solution would probably be to refactor this to be completely async and keep track of whether the initialize event has been sent before sending the filter event - but that's beyond the scope of the fix for July so just going with the simpler fix for now.

Note - it's unclear why this only seems to be showing up now. I didn't see any changes that would explain this. But race conditions are weird like that - so maybe a node update or something changed things enough that this would show up more often.