### PR TITLE
Added info box to help user navigate the wizard

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1534,7 +1534,7 @@ export function TDE_WIZARD_DATABASES_SELECTED(encryptedCount: number, totalCount
 
 export const TDE_WIZARD_MIGRATION_OPTION_MANUAL_WARNING = localize('sql.migration.tde.wizard.optionmanual.warning', "Certificates must be migrated before proceeding with the database migration otherwise a failure will occur. {0} about manually migrating TDE certificates.");
 
-export const TDE_WIZARD_ADS_CERTS_INFO = localize('sql.migration.tde.cert.network.info', "Please enter a location where the SQL Server will export the certificates. Also verify that SQL Server service has write access to this path and the current user should have administrator privileges on the computer where this network path is.");
+export const TDE_WIZARD_ADS_CERTS_INFO = localize('sql.migration.tde.cert.network.info', "Please enter a network path where SQL Server will export the certificates. Also verify that SQL Server service has write access to this path and the current user should have administrator privileges on the computer where this network path is.");
 
 export const TDE_WIZARD_CERTS_NETWORK_SHARE_LABEL = localize('sql.migration.tde.wizard.network.share.label', "Network path for certificate");
 export const TDE_WIZARD_CERTS_NETWORK_SHARE_PLACEHOLDER = localize('sql.migration.tde.wizard.network.share.placeholder', "Enter network path");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1534,13 +1534,14 @@ export function TDE_WIZARD_DATABASES_SELECTED(encryptedCount: number, totalCount
 
 export const TDE_WIZARD_MIGRATION_OPTION_MANUAL_WARNING = localize('sql.migration.tde.wizard.optionmanual.warning', "Certificates must be migrated before proceeding with the database migration otherwise a failure will occur. {0} about manually migrating TDE certificates.");
 
-export const TDE_WIZARD_ADS_CERTS_INFO = localize('sql.migration.network.share.header.text', "Please enter a location where the SQL Server will export the certificates. Also verify that SQL Server service has write access to this path and the current user should have administrator privileges on the computer where this network path is.");
+export const TDE_WIZARD_ADS_CERTS_INFO = localize('sql.migration.tde.cert.network.info', "Please enter a location where the SQL Server will export the certificates. Also verify that SQL Server service has write access to this path and the current user should have administrator privileges on the computer where this network path is.");
 
 export const TDE_WIZARD_CERTS_NETWORK_SHARE_LABEL = localize('sql.migration.tde.wizard.network.share.label', "Network path for certificate");
 export const TDE_WIZARD_CERTS_NETWORK_SHARE_PLACEHOLDER = localize('sql.migration.tde.wizard.network.share.placeholder', "Enter network path");
 export const TDE_WIZARD_CERTS_NETWORK_SHARE_INFO = localize('sql.migration.tde.wizard.network.share.info', "Network path where certificate will be placed.");
 
 export const TDE_MIGRATE_BUTTON = localize('sql.migration.tde.button.migrate', "Migrate certificates");
+export const TDE_WIZARD_CERT_MIGRATION_BUTTON_MUST_BE_CLICKED = localize('sql.migration.tde.cert.migration.info', "You must click the '{0}' button before proceeding to the next page of the wizard.", TDE_MIGRATE_BUTTON);
 
 
 export const STATE_CANCELED = localize('sql.migration.state.canceled', "Canceled");

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -47,6 +47,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 	private _migrationTargetPlatform!: utils.MigrationTargetType;
 	private _serviceContext!: MigrationServiceContext;
 	private _certMigrationEventEmitter: vscode.EventEmitter<TdeMigrationResult>;
+	private _certMigrationRequiredInfoBox!: azdata.InfoBoxComponent;
 
 	constructor(
 		wizard: azdata.window.Wizard,
@@ -55,9 +56,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			wizard,
 			azdata.window.createWizardPage(constants.AZURE_SQL_TARGET_PAGE_TITLE),
 			migrationStateModel);
-
 		this._certMigrationEventEmitter = new vscode.EventEmitter();
-
 		this._certMigrationEventEmitter.event(() => this._updateNextButton());
 	}
 
@@ -72,12 +71,26 @@ export class TargetSelectionPage extends MigrationWizardPage {
 				CSSStyles: { ...styles.BODY_CSS, 'margin': '0' }
 			}).component();
 
+		this._certMigrationRequiredInfoBox = this._view.modelBuilder.infoBox()
+			.withProps({
+				text: constants.TDE_WIZARD_CERT_MIGRATION_BUTTON_MUST_BE_CLICKED,
+				style: 'information',
+				CSSStyles: {
+					...styles.BODY_CSS,
+					'margin': '4px 14px 0px 14px',
+					'text-align': 'justify',
+					'width': WIZARD_INPUT_COMPONENT_WIDTH,
+					'display': 'none'
+				}
+			}).component();
+
 		const form = this._view.modelBuilder.formContainer()
 			.withFormItems([
 				{ component: this._pageDescription },
 				{ component: this.createAzureAccountsDropdown() },
 				{ component: this.createAzureTenantContainer() },
-				{ component: this.createTargetDropdownContainer() }
+				{ component: this.createTargetDropdownContainer() },
+				{ component: this._certMigrationRequiredInfoBox }
 			]).withProps({
 				CSSStyles: { 'padding-top': '0' }
 			}).component();
@@ -280,6 +293,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 			await utils.clearDropDown(this._azureResourceDropdown);
 		}
 
+		await utils.updateControlDisplay(this._certMigrationRequiredInfoBox, this.migrationStateModel.tdeMigrationConfig.shouldAdsMigrateCertificates());
 		await this.populateAzureAccountsDropdown();
 	}
 

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -74,7 +74,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 		this._certMigrationRequiredInfoBox = this._view.modelBuilder.infoBox()
 			.withProps({
 				text: constants.TDE_WIZARD_CERT_MIGRATION_BUTTON_MUST_BE_CLICKED,
-				style: 'information',
+				style: 'warning',
 				CSSStyles: {
 					...styles.BODY_CSS,
 					'margin': '4px 14px 0px 14px',


### PR DESCRIPTION
Added info box on target selection page of wizard to inform users of the need to click "Migrate certificates" button.

![image](https://github.com/microsoft/azuredatastudio/assets/71411280/12fe0e0c-bcee-4fba-90ce-a8744b736bfa)
