### PR TITLE
Fix serverInfo undefined due to wrong connection URI set on connection

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -682,8 +682,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 						connection.options = connectionErrorHandleResult.options;
 					}
 					if (connectionErrorHandleResult.reconnect) {
-						// Attempt reconnect if requested by provider
-						return this.connectWithOptions(connection, uri, options, callbacks);
+						// Attempt reconnect if requested by provider and reset URI to be regenerated.
+						return this.connectWithOptions(connection, undefined, options, callbacks);
 					} else {
 						if (callbacks.onConnectCanceled) {
 							callbacks.onConnectCanceled();


### PR DESCRIPTION
Addresses #23886

This error occurred as when user selected "Enable Trust Server Certificate", the same old URI was still used to create connection, and `trustServerCertificate` was not accounted into. This conflicted with Scripting, as it ended up not finding connection for the new URI and failed with error: `Cannot read properties of undefined (reading 'serverInfo')`

Sending no URI on reconnect, allows new URI to be generated when saving new connection profile.

**Before:**

![scripting-error](https://github.com/microsoft/azuredatastudio/assets/13396919/acc9cc5f-0773-4074-a11a-8c35fb8742df)

**After:**

![scripting-fixed](https://github.com/microsoft/azuredatastudio/assets/13396919/c88e22e8-e141-404c-9e4b-f300525105b7)
