### PR TITLE
[Release/1.45] Clean encryption keys with cache clear command (#23875)

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -883,6 +883,9 @@ export abstract class AzureAuth implements vscode.Disposable {
 		// unlink both cache files
 		await this.msalCacheProvider.unlinkMsalCache();
 		await this.msalCacheProvider.unlinkLocalCache();
+
+		// Delete Encryption Keys
+		await this.msalCacheProvider.clearCacheEncryptionKeys();
 	}
 
 	public async deleteAllCacheAdal(): Promise<void> {

--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -20,6 +20,8 @@ import { Configuration, PublicClientApplication } from '@azure/msal-node';
 import * as Constants from '../constants';
 import { Logger } from '../utils/Logger';
 import { ILoggerCallback, LogLevel as MsalLogLevel } from "@azure/msal-common";
+import { displayReloadAds } from '../utils';
+import { reloadPromptCacheClear } from '../localizedConstants';
 
 let localize = nls.loadMessageBundle();
 
@@ -108,8 +110,7 @@ export class AzureAccountProviderService implements vscode.Disposable {
 		return Promise.all(promises)
 			.then(
 				() => {
-					let message = localize('clearTokenCacheSuccess', "Token cache successfully cleared");
-					void vscode.window.showInformationMessage(`${loc.extensionName}: ${message}`);
+					void displayReloadAds(reloadPromptCacheClear);
 				},
 				err => {
 					let message = localize('clearTokenCacheFailure', "Failed to clear token cache");

--- a/extensions/azurecore/src/account-provider/utils/fileEncryptionHelper.ts
+++ b/extensions/azurecore/src/account-provider/utils/fileEncryptionHelper.ts
@@ -100,15 +100,19 @@ export class FileEncryptionHelper {
 			if (resetOnError) {
 				// Reset IV/Keys if crypto cannot encrypt/decrypt data.
 				// This could be a possible case of corruption of expected iv/key combination
-				await this.deleteEncryptionKey(this._ivCredId);
-				await this.deleteEncryptionKey(this._keyCredId);
-				this._ivBuffer = undefined;
-				this._keyBuffer = undefined;
+				await this.clearEncryptionKeys();
 				await this.init();
 			}
 			// Throw error so cache file can be reset to empty.
 			throw new Error(`Decryption failed with error: ${ex}`);
 		}
+	}
+
+	public async clearEncryptionKeys(): Promise<void> {
+		await this.deleteEncryptionKey(this._ivCredId);
+		await this.deleteEncryptionKey(this._keyCredId);
+		this._ivBuffer = undefined;
+		this._keyBuffer = undefined;
 	}
 
 	protected async readEncryptionKey(credentialId: string): Promise<string | undefined> {

--- a/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
+++ b/extensions/azurecore/src/account-provider/utils/msalCachePlugin.ts
@@ -62,6 +62,10 @@ export class MsalCachePluginProvider {
 		return this._fileEncryptionHelper.getEncryptionKeys();
 	}
 
+	public async clearCacheEncryptionKeys(): Promise<void> {
+		await this._fileEncryptionHelper.clearEncryptionKeys();
+	}
+
 	public getCachePlugin(): ICachePlugin {
 		const beforeCacheAccess = async (cacheContext: TokenCacheContext): Promise<void> => {
 			try {

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -293,25 +293,11 @@ async function onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): Pro
 		if (vscode.workspace.getConfiguration(Constants.AzureSection).get('authenticationLibrary') === 'ADAL') {
 			void vscode.window.showInformationMessage(loc.deprecatedOption);
 		}
-		await displayReloadAds();
+		await utils.displayReloadAds(loc.reloadPrompt);
 	}
 }
 
 function updatePiiLoggingLevel(): void {
 	const piiLogging: boolean = vscode.workspace.getConfiguration(Constants.AzureSection).get('piiLogging', false);
 	Logger.piiLogging = piiLogging;
-}
-
-// Display notification with button to reload
-// return true if button clicked
-// return false if button not clicked
-async function displayReloadAds(): Promise<boolean> {
-	const result = await vscode.window.showInformationMessage(loc.reloadPrompt, loc.reloadChoice);
-	if (result === loc.reloadChoice) {
-		await vscode.commands.executeCommand('workbench.action.reloadWindow');
-		return true;
-	} else {
-		return false;
-	}
-
 }

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -64,6 +64,7 @@ export const subscription = localize('azurecore.subscription', "Subscription");
 export const typeIcon = localize('azurecore.typeIcon', "Type Icon");
 
 export const reloadPrompt = localize('azurecore.reloadPrompt', "Authentication Library has changed, please reload Azure Data Studio.");
+export const reloadPromptCacheClear = localize('azurecore.reloadPromptCacheClear', "Token cache has been cleared successfully, please reload Azure Data Studio.");
 export const reloadChoice = localize('azurecore.reloadChoice', "Reload Azure Data Studio");
 
 export const deprecatedOption = localize('azurecore.deprecated', "Warning: ADAL has been deprecated, and is scheduled to be removed in the next release. Please use MSAL instead.");

--- a/extensions/azurecore/src/utils.ts
+++ b/extensions/azurecore/src/utils.ts
@@ -200,3 +200,17 @@ export function getProxyEnabledHttpClient(): HttpClient {
 
 	return new HttpClient(proxy, agentOptions);
 }
+
+/* Display notification with button to reload
+ * return true if button clicked
+ * return false if button not clicked
+ */
+export async function displayReloadAds(message: string): Promise<boolean> {
+	const result = await vscode.window.showInformationMessage(message, loc.reloadChoice);
+	if (result === loc.reloadChoice) {
+		await vscode.commands.executeCommand('workbench.action.reloadWindow');
+		return true;
+	} else {
+		return false;
+	}
+}


### PR DESCRIPTION
Ports #23875 to release/1.45 branch for July release.
_[This change is specific to `Azure Accounts: Clear Azure Account Token Cache` command]_

Addresses #23688 