### PR TITLE
Revert "Fix flaky ADS unit tests by using DOM rendering (#23770)"

### DIFF
--- a/src/vs/platform/configuration/test/common/testConfigurationService.ts
+++ b/src/vs/platform/configuration/test/common/testConfigurationService.ts
@@ -18,23 +18,6 @@ export class TestConfigurationService implements IConfigurationService {
 	readonly onDidChangeConfiguration = this.onDidChangeConfigurationEmitter.event;
 
 	constructor(configuration?: any) {
-		// {{SQL CARBON EDIT}} - START
-		// Ensures that all configuration services use the DOM renderer. There's an issue
-		// with GPU rendering that is causing unit tests to be flaky and obscuring true failing tests.
-		// This is a temporary fix and should be removed once xterm GPU rendering is working again.
-		if (configuration) {
-			if (configuration.integrated) {
-				configuration.integrated.gpuAcceleration = 'off';
-			}
-			else {
-				configuration.integrated = { gpuAcceleration: 'off' };
-			}
-		}
-		else {
-			configuration = { integrated: { gpuAcceleration: 'off' } };
-		}
-		// {{SQL CARBON EDIT}} - END
-
 		this.configuration = configuration || Object.create(null);
 	}
 

--- a/src/vs/workbench/contrib/experiments/test/electron-sandbox/experimentService.test.ts
+++ b/src/vs/workbench/contrib/experiments/test/electron-sandbox/experimentService.test.ts
@@ -63,7 +63,7 @@ export class TestExperimentService extends ExperimentService {
 	}
 }
 
-suite('Experiment Service', () => {
+suite.skip('Experiment Service', () => {  // {{SQL CARBON EDIT}} Tests are flaky, and have been removed in VS Code so disabling until we catch up
 	let instantiationService: TestInstantiationService;
 	let testConfigurationService: TestConfigurationService;
 	let testObject: ExperimentService;

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/test/browser/bufferContentTracker.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/test/browser/bufferContentTracker.test.ts
@@ -36,7 +36,7 @@ const defaultTerminalConfig: Partial<ITerminalConfiguration> = {
 	unicodeVersion: '6'
 };
 
-suite('Buffer Content Tracker', () => {
+suite.skip('Buffer Content Tracker', () => { // {{SQL CARBON EDIT}} skip failing suite
 	let instantiationService: TestInstantiationService;
 	let configurationService: TestConfigurationService;
 	let themeService: TestThemeService;

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkManager.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkManager.test.ts
@@ -94,7 +94,7 @@ suite('TerminalLinkManager', () => {
 		} as Partial<ITerminalCapabilityStore> as any, instantiationService.createInstance(TerminalLinkResolver));
 	});
 
-	suite('getLinks and open recent link', () => {
+	suite.skip('getLinks and open recent link', () => { // {{SQL CARBON EDIT}} skip failing suite
 		test('should return no links', async () => {
 			const links = await linkManager.getLinks();
 			equals(links.webLinks, []);

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/gettingStartedMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/gettingStartedMarkdownRenderer.test.ts
@@ -13,7 +13,7 @@ import { TestFileService } from 'vs/workbench/test/browser/workbenchTestServices
 import { TestExtensionService } from 'vs/workbench/test/common/workbenchTestServices';
 
 
-suite('Getting Started Markdown Renderer', () => {
+suite.skip('Getting Started Markdown Renderer', () => { // {{SQL CARBON EDIT}} - disable suite
 	test('renders theme picker markdown with images', async () => {
 		const fileService = new TestFileService();
 		const languageService = new LanguageService();

--- a/src/vs/workbench/services/configuration/test/browser/configuration.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configuration.test.ts
@@ -23,7 +23,7 @@ class ConfigurationCache implements IConfigurationCache {
 	async remove({ type, key }: ConfigurationKey): Promise<void> { this.cache.delete(`${type}:${key}`); }
 }
 
-suite('DefaultConfiguration', () => {
+suite.skip('DefaultConfiguration', () => { // {{SQL CARBON EDIT}} skip failing suite
 
 	const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
 	const cacheKey: ConfigurationKey = { type: 'defaults', key: 'configurationDefaultsOverrides' };

--- a/src/vs/workbench/services/configuration/test/browser/configurationEditing.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationEditing.test.ts
@@ -56,7 +56,7 @@ class ConfigurationCache implements IConfigurationCache {
 	async remove(): Promise<void> { }
 }
 
-suite('ConfigurationEditing', () => {
+suite.skip('ConfigurationEditing', () => { // {{SQL CARBON EDIT}} skip suite
 
 	let instantiationService: TestInstantiationService;
 	let userDataProfileService: IUserDataProfileService;

--- a/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
@@ -1518,7 +1518,7 @@ suite.skip('WorkspaceConfigurationService - Folder', () => { // {{SQL CARBON EDI
 	}));
 });
 
-suite('WorkspaceConfigurationService - Profiles', () => {
+suite.skip('WorkspaceConfigurationService - Profiles', () => { // {{SQL CARBON EDIT}} - skip failing suite
 
 	let testObject: WorkspaceService, workspaceService: WorkspaceService, fileService: IFileService, environmentService: IBrowserWorkbenchEnvironmentService, userDataProfileService: IUserDataProfileService, instantiationService: TestInstantiationService;
 	const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -2489,7 +2489,7 @@ suite.skip('WorkspaceConfigurationService-Multiroot', () => { // {{SQL CARBON ED
 
 });
 
-suite('WorkspaceConfigurationService - Remote Folder', () => {
+suite.skip('WorkspaceConfigurationService - Remote Folder', () => { // {{SQL CARBON EDIT}} - disable suite
 
 	let testObject: WorkspaceService, folder: URI,
 		machineSettingsResource: URI, remoteSettingsResource: URI, fileSystemProvider: InMemoryFileSystemProvider, resolveRemoteEnvironment: () => void,

--- a/src/vs/workbench/services/configurationResolver/test/electron-sandbox/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-sandbox/configurationResolverService.test.ts
@@ -58,7 +58,7 @@ const nullContext = {
 	getExecPath: () => undefined
 };
 
-suite('Configuration Resolver Service', () => {
+suite.skip('Configuration Resolver Service', () => { // {{SQL CARBON EDIT}} - skip failing suite
 	let configurationResolverService: IConfigurationResolverService | null;
 	const envVariables: { [key: string]: string } = { key1: 'Value for key1', key2: 'Value for key2' };
 	// let environmentService: MockWorkbenchEnvironmentService;

--- a/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
@@ -14,7 +14,7 @@ import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editor
 import { IEditorResolverService, ResolvedStatus, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { createEditorPart, ITestInstantiationService, TestFileEditorInput, TestServiceAccessor, workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
 
-suite('EditorResolverService', () => {
+suite.skip('EditorResolverService', () => { // {{SQL CARBON EDIT}} - disable suite
 
 	const TEST_EDITOR_INPUT_ID = 'testEditorInputForEditorResolverService';
 	const disposables = new DisposableStore();

--- a/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
@@ -111,7 +111,7 @@ export class TestExtensionEnablementService extends ExtensionEnablementService {
 	}
 }
 
-suite('ExtensionEnablementService Test', () => {
+suite.skip('ExtensionEnablementService Test', () => {
 
 	let instantiationService: TestInstantiationService;
 	let testObject: IWorkbenchExtensionEnablementService;

--- a/src/vs/workbench/services/extensions/test/browser/extensionService.test.ts
+++ b/src/vs/workbench/services/extensions/test/browser/extensionService.test.ts
@@ -128,7 +128,7 @@ suite('BrowserExtensionService', () => {
 	});
 });
 
-suite('ExtensionService', () => {
+suite.skip('ExtensionService', () => { // {{SQL CARBON EDIT}} - disable failing suite
 
 	class MyTestExtensionService extends AbstractExtensionService {
 

--- a/src/vs/workbench/services/history/test/browser/historyService.test.ts
+++ b/src/vs/workbench/services/history/test/browser/historyService.test.ts
@@ -29,7 +29,7 @@ import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
-suite('HistoryService', function () {
+suite.skip('HistoryService', function () { // {{SQL CARBON EDIT}} skip suite
 
 	const TEST_EDITOR_ID = 'MyTestEditorForEditorHistory';
 	const TEST_EDITOR_INPUT_ID = 'testEditorInputForHistoyService';


### PR DESCRIPTION
This reverts commit 952bab7542c1dd6bdea24cd3fe621aa611d6df8a.

This PR is linked to: https://github.com/microsoft/azuredatastudio/issues/23509

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
