### PR TITLE
Change OK button label based on whether the dialog is creating a new object or updating an existing one.

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -181,6 +181,7 @@ export const DatabaseFileTypeLabel = localize('objectManagement.databaseFileType
 export const DatabaseFilePathLabel = localize('objectManagement.databaseFilePath', "Path");
 export const DatabaseFileGroupLabel = localize('objectManagement.databaseFileGroup', "File Group");
 export const DetachDatabaseOptions = localize('objectManagement.detachDatabaseOptions', "Detach Database Options");
+export const DetachButtonLabel = localize('objectManagement.detachButtonLabel', "Detach");
 
 // Login
 export const BlankPasswordConfirmationText: string = localize('objectManagement.blankPasswordConfirmation', "Creating a login with a blank password is a security risk.  Are you sure you want to continue?");

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -47,6 +47,8 @@ export const GrantColumnHeader = localize('objectManagement.grantColumnHeader', 
 export const WithGrantColumnHeader = localize('objectManagement.withGrantColumnHeader', "With Grant");
 export const DenyColumnHeader = localize('objectManagement.denyColumnHeader', "Deny");
 export const SelectSecurablesDialogTitle = localize('objectManagement.selectSecurablesDialogTitle', "Select Securables");
+export const CreateObjectLabel = localize('objectManagement.createObjectLabel', "Create");
+export const ApplyUpdatesLabel = localize('objectManagement.applyUpdatesLabel', "Apply");
 
 export function ExplicitPermissionsTableLabelSelected(name: string): string { return localize('objectManagement.explicitPermissionsTableLabelSelected', "Explicit permissions for: {0}", name); }
 export function EffectivePermissionsTableLabelSelected(name: string): string { return localize('objectManagement.effectivePermissionsTableLabelSelected', "Effective permissions for: {0}", name); }

--- a/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
@@ -7,7 +7,7 @@ import { ObjectManagementDialogBase, ObjectManagementDialogOptions } from './obj
 import { IObjectManagementService, ObjectManagement } from 'mssql';
 import { Database, DatabaseViewInfo } from '../interfaces';
 import { DetachDatabaseDocUrl } from '../constants';
-import { DatabaseFileGroupLabel, DatabaseFileNameLabel, DatabaseFilePathLabel, DatabaseFileTypeLabel, DatabaseFilesLabel, DetachDatabaseDialogTitle, DetachDatabaseOptions, DetachDropConnections, DetachUpdateStatistics } from '../localizedConstants';
+import { DatabaseFileGroupLabel, DatabaseFileNameLabel, DatabaseFilePathLabel, DatabaseFileTypeLabel, DatabaseFilesLabel, DetachButtonLabel, DetachDatabaseDialogTitle, DetachDatabaseOptions, DetachDropConnections, DetachUpdateStatistics } from '../localizedConstants';
 
 export class DetachDatabaseDialog extends ObjectManagementDialogBase<Database, DatabaseViewInfo> {
 	private _dropConnections = false;
@@ -15,6 +15,7 @@ export class DetachDatabaseDialog extends ObjectManagementDialogBase<Database, D
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
 		super(objectManagementService, options, DetachDatabaseDialogTitle(options.database), 'DetachDatabase');
+		this.dialogObject.okButton.label = DetachButtonLabel;
 	}
 
 	protected override get isDirty(): boolean {

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -31,7 +31,7 @@ export interface ObjectManagementDialogOptions extends ScriptableDialogOptions {
 }
 
 export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectManagement.SqlObject, ViewInfoType extends ObjectManagement.ObjectViewInfo<ObjectInfoType>> extends ScriptableDialogBase<ObjectManagementDialogOptions> {
-	private _contextId: string;
+	private readonly _contextId: string;
 	private _viewInfo: ViewInfoType;
 	private _originalObjectInfo: ObjectInfoType;
 
@@ -46,6 +46,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 		}
 		super(dialogTitle, dialogName, options);
 		this._contextId = generateUuid();
+		this.dialogObject.okButton.label = options.isNewObject ? localizedConstants.CreateObjectLabel : localizedConstants.ApplyUpdatesLabel;
 	}
 
 	protected postInitializeData(): void { }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23730
Fixes https://github.com/microsoft/azuredatastudio/issues/23647

If the dialog is creating a new object, then the button will say "Create", otherwise it will say "Apply" for existing objects.
