### PR TITLE
[SQL Migration] Release v1.4.9 to Insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.8",
-							"lastUpdated": "06/28/2023",
+							"version": "1.4.9",
+							"lastUpdated": "07/17/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.8.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.9.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the insiders extension gallery to the latest version 1.4.9 of the SQL Migration extension. sql-migration-1.4.9.vsix

Link to Azure Data Studio - Extensions Product pipeline run off main:
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=206710&view=artifacts&pathAsName=false&type=publishedArtifacts