### PR TITLE
Remove fixed size of schema compare split view

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -451,7 +451,7 @@ export class SchemaCompareMainWindow {
 			this.splitView.addItem(this.diffEditor);
 			this.splitView.setLayout({
 				orientation: 'vertical',
-				splitViewSize: 800
+				splitViewSize: undefined // setting this to undefined will default the splitview size to use the model view container's size
 			});
 
 			// create a map of the differences to row numbers


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #8276. #23889 added support for split view model view components to be the size of the model view container, rather than requiring the size to be specified. Schema compare had previously hard coded the height of the split view to be 800px, which didn't use up all the space on larger screens.

**Bigger window**
before - empty space below Compare Details:
![Screenshot 2023-07-17 at 3 57 23 PM](https://github.com/microsoft/azuredatastudio/assets/31145923/ffdca0c1-57c5-4559-a05e-23d84da21325)

after:
![Screenshot 2023-07-17 at 3 58 10 PM](https://github.com/microsoft/azuredatastudio/assets/31145923/8104f615-58e8-48bc-8f2a-501264a74e2c)

**Smaller window**
before - didn't show Compare Details and had to scroll down to see them:
![Screenshot 2023-07-17 at 5 04 29 PM](https://github.com/microsoft/azuredatastudio/assets/31145923/c9a25578-5d6e-46c2-bd74-295d8dd20ca1)

after - split view shows both the top and bottom components from the start:
![Screenshot 2023-07-17 at 5 04 20 PM](https://github.com/microsoft/azuredatastudio/assets/31145923/363aaf03-88ad-4f87-a71a-ed82475e1fdd)
