### PR TITLE
Allow empty username + fix profiles on read

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.9.0.5",
+	"version": "4.9.0.6",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -242,7 +242,7 @@ export class ConnectionConfig {
 				changed = true;
 			}
 			// SSMS 19 requires "user", fix any profiles created without user property.
-			if (profile.providerName === 'MSSQL' && !profile.options.user) {
+			if (profile.providerName === 'MSSQL' && profile.options.user === undefined) {
 				profile.options.user = '';
 				changed = true;
 			}

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -14,6 +14,7 @@ import * as nls from 'vs/nls';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { deepClone } from 'vs/base/common/objects';
 import { isDisposable } from 'vs/base/common/lifecycle';
+import { isUndefinedOrNull } from 'vs/base/common/types';
 
 export const GROUPS_CONFIG_KEY = 'datasource.connectionGroups';
 export const CONNECTIONS_CONFIG_KEY = 'datasource.connections';
@@ -242,7 +243,7 @@ export class ConnectionConfig {
 				changed = true;
 			}
 			// SSMS 19 requires "user", fix any profiles created without user property.
-			if (profile.providerName === 'MSSQL' && profile.options.user === undefined) {
+			if (profile.providerName === 'MSSQL' && isUndefinedOrNull(profile.options.user)) {
 				profile.options.user = '';
 				changed = true;
 			}

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -241,6 +241,11 @@ export class ConnectionConfig {
 				profile.id = generateUuid();
 				changed = true;
 			}
+			// SSMS 19 requires "user", fix any profiles created without user property.
+			if (profile.providerName === 'MSSQL' && !profile.options.user) {
+				profile.options.user = '';
+				changed = true;
+			}
 			idsCache[profile.id] = true;
 		}
 		return changed;

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -361,7 +361,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		Object.keys(connectionInfo.options).forEach(element => {
 			// Allow empty strings to ensure "user": "" is populated if empty << Required by SSMS 19.2
 			// Do not change this design until SSMS 19 goes out of support.
-			if (connectionInfo.options[element] === '' || !isUndefinedOrNull(connectionInfo.options[element])) {
+			if (!isUndefinedOrNull(connectionInfo.options[element])) {
 				profile.options[element] = connectionInfo.options[element];
 			}
 		});

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -359,7 +359,9 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		};
 
 		Object.keys(connectionInfo.options).forEach(element => {
-			if (connectionInfo.options[element] && connectionInfo.options[element] !== null && connectionInfo.options[element] !== '') {
+			// Allow empty strings to ensure "user": "" is populated if empty << Required by SSMS 19.2
+			// Do not change this design until SSMS 19 goes out of support.
+			if (connectionInfo.options[element] === '' || (connectionInfo.options[element] && connectionInfo.options[element] !== null)) {
 				profile.options[element] = connectionInfo.options[element];
 			}
 		});

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -9,7 +9,7 @@ import { ProviderConnectionInfo } from 'sql/platform/connection/common/providerC
 import * as interfaces from 'sql/platform/connection/common/interfaces';
 import { generateUuid } from 'vs/base/common/uuid';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
-import { isString } from 'vs/base/common/types';
+import { isString, isUndefinedOrNull } from 'vs/base/common/types';
 import { deepClone } from 'vs/base/common/objects';
 import * as Constants from 'sql/platform/connection/common/constants';
 import { URI } from 'vs/base/common/uri';
@@ -361,7 +361,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		Object.keys(connectionInfo.options).forEach(element => {
 			// Allow empty strings to ensure "user": "" is populated if empty << Required by SSMS 19.2
 			// Do not change this design until SSMS 19 goes out of support.
-			if (connectionInfo.options[element] === '' || (connectionInfo.options[element] && connectionInfo.options[element] !== null)) {
+			if (connectionInfo.options[element] === '' || !isUndefinedOrNull(connectionInfo.options[element])) {
 				profile.options[element] = connectionInfo.options[element];
 			}
 		});


### PR DESCRIPTION
Paired with https://github.com/microsoft/sqltoolsservice/pull/2151, addresses #23921

- Fixes profiles without 'user' property on read.
- Allows Empty strings to be stored in connection options.

Bump STS o 4.5.0.6: https://github.com/microsoft/sqltoolsservice/compare/4.9.0.5...4.9.0.6