### PR TITLE
Add latest g++ to build container

### DIFF
--- a/build/azure-pipelines/linux/Dockerfile
+++ b/build/azure-pipelines/linux/Dockerfile
@@ -18,11 +18,12 @@ RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 \
 	libkrb5-dev git apt-transport-https ca-certificates curl gnupg-agent software-properties-common \
-	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++-7 libgbm-dev wget
+	libnss3 libasound2 make gcc libx11-dev fakeroot rpm libgconf-2-4 libunwind8 g++ g++-7 libgbm-dev wget
 
 
 # make GCC 7 the default compiler
 RUN rm /usr/bin/gcc
+RUN rm /usr/bin/g++
 RUN ln -s /usr/bin/gcc-7 /usr/bin/gcc
 RUN ln -s /usr/bin/g++-7 /usr/bin/g++
 

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: linux-x64
-    image: sqltoolscontainers.azurecr.io/linux-build-agent:9
+    image: sqltoolscontainers.azurecr.io/linux-build-agent:10
     endpoint: SqlToolsContainers
 
 stages:


### PR DESCRIPTION
Add the default g++ package to the build container.  This adds in the required dependencies for the sqllite unit tests.  This is a follow-up to the changes for https://github.com/microsoft/azuredatastudio/issues/23902 to add g++ 7 to support CentOS.