### PR TITLE
Removing unnecessary tree expansions causing errors to popup again

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -332,8 +332,6 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				const movedConnection = <ConnectionProfile>e.source;
 				const oldParent = <ConnectionProfileGroup>this._tree.getElementById(e.oldGroupId);
 				const newParent = <ConnectionProfileGroup>this._tree.getElementById(e.newGroupId);
-				// Storing the expanded state of children of the moved connection so that they can be expanded after the move.
-				const profileExpandedState = this._tree.getExpandedState(movedConnection);
 				if (oldParent) {
 					oldParent.removeConnections([movedConnection]);
 					await this._tree.updateChildren(oldParent);
@@ -348,8 +346,6 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				const newConnection = this._tree.getElementById(movedConnection.id);
 				if (newConnection) {
 					await this._tree.revealSelectFocusElement(newConnection);
-					// Expanding the previously expanded children of the moved connection after the move.
-					await this._tree.expandElements(profileExpandedState);
 				}
 			}
 		}));
@@ -401,8 +397,6 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				const movedGroup = <ConnectionProfileGroup>e.source;
 				const oldParent = <ConnectionProfileGroup>this._tree.getElementById(e.oldGroupId);
 				const newParent = <ConnectionProfileGroup>this._tree.getElementById(e.newGroupId);
-				// Storing the expanded state of children of the moved group so that they can be expanded after the move.
-				const profileExpandedState = this._tree.getExpandedState(movedGroup);
 				oldParent.children = oldParent.children.filter(c => c.id !== movedGroup.id);
 				await this._tree.updateChildren(oldParent);
 				newParent.children.push(movedGroup);
@@ -410,8 +404,6 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				(<ConnectionProfileGroup>movedGroup).parentId = newParent.id;
 				await this._tree.updateChildren(newParent);
 				await this._tree.revealSelectFocusElement(movedGroup);
-				// Expanding the previously expanded children of the moved group after the move.
-				this._tree.expandElements(profileExpandedState);
 			}
 		}));
 

--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTree.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTree.ts
@@ -120,19 +120,10 @@ export class AsyncServerTree extends WorkbenchAsyncDataTree<ConnectionProfileGro
 		return node;
 	}
 
-	public override async updateChildren(element?: ServerTreeElement, recursive?: boolean, rerender?: boolean, options?: IAsyncDataTreeUpdateChildrenOptions<ServerTreeElement>): Promise<void> {
-		const expandedChildren = this.getExpandedState(element);
+	public override async updateChildren(element?: ServerTreeElement, recursive: boolean = false, rerender: boolean = false, options: IAsyncDataTreeUpdateChildrenOptions<ServerTreeElement> = {
+		diffDepth: 0
+	}): Promise<void> {
 		await super.updateChildren(element, recursive, rerender, options);
-		await this.expandElements(expandedChildren);
-	}
-
-	public async expandElements(elements: ServerTreeElement[]): Promise<void> {
-		for (let element of elements) {
-			const node = this.getDataNode(element, false);
-			if (node) {
-				await this.expand(node.element);
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
#23830 
Storing and restoring expansion states of elements are causing the expanded nodes to refresh. This creates a problem in the case of errored nodes as the expansion of the nodes surfaces a duplicate error message. This prevents unnecessary expansion of elements in asynctree. Thereby matching the behavior of previous tree.