### PR TITLE
Fix context menu in treeViews

### DIFF
--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -770,7 +770,7 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 				}
 			},
 
-			getActionsContext: () => (<TreeViewItemHandleArg>{ $treeViewId: this.id, $treeItemHandle: node.handle, $treeItem: node }),
+			getActionsContext: () => (<TreeViewItemHandleArg>{ $treeViewId: this.id, $treeItemHandle: node.handle }),
 
 			actionRunner
 		});


### PR DESCRIPTION
Fixes #23941 and #23942 as well.
The change fixes both issues as well as Azure tree's context menu as it uses the same tree view.

The bug got introduced post merge with VS code update, due to duplicate copy of `treeView` being maintained.
