### PR TITLE
Temporary fix for Data Explorer context menus

### DIFF
--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -60,7 +60,6 @@ import { AriaRole } from 'vs/base/browser/ui/aria/aria';
 import { API_OPEN_EDITOR_COMMAND_ID, API_OPEN_DIFF_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { isCancellationError } from 'vs/base/common/errors';
-import { mixin } from 'vs/base/common/objects';
 
 class Root implements ITreeItem {
 	label = { label: 'root' };

--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -786,8 +786,10 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 
 				// Have to remove parent, this was added in a VS Code merge to ITreeItem instances, but isn't meant to be serializable over JSON RPC,
 				// so passing it directly will cause the command to fail as there's a loop (child -> parent -> child -> parent ...)
-				const safeNode = mixin({ parent: undefined }, node, false);
-				const treeItem = node.childProvider ? safeNode : undefined;
+				// Note: Do NOT make a new object here - the core tree logic expects the tree items to stay as the same object so returning a
+				// different object here will break functionality such as scripting.
+				delete node.parent;
+				const treeItem = node.childProvider ? node : undefined;
 				return (<TreeViewItemHandleArg>{ $treeViewId: this.id, $treeItemHandle: node.handle, $treeItem: treeItem })
 			},
 

--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -60,6 +60,7 @@ import { AriaRole } from 'vs/base/browser/ui/aria/aria';
 import { API_OPEN_EDITOR_COMMAND_ID, API_OPEN_DIFF_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { isCancellationError } from 'vs/base/common/errors';
+import { mixin } from 'vs/base/common/objects';
 
 class Root implements ITreeItem {
 	label = { label: 'root' };
@@ -770,7 +771,25 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 				}
 			},
 
-			getActionsContext: () => (<TreeViewItemHandleArg>{ $treeViewId: this.id, $treeItemHandle: node.handle }),
+			getActionsContext: () => {
+				// This context is used in two ways - one is for the original Data Explorer tree view that extensions can register. Items
+				// for the tree view itself don't have a childProvider so are routed directly to the extension. In this case we want to have
+				// the actions behave like VS Code expects them to behave - so we don't pass in a $treeItem at all so it gets handled by the
+				// VS Code logic here :
+				// https://github.com/microsoft/azuredatastudio/blob/f5bed289affca2fce04fee6dd2db3ce02a8f5c83/src/vs/workbench/api/common/extHostTreeViews.ts#L65
+
+				// The other is for the "childProvider" nodes - which come from a registered provider directly. These currently expect that
+				// the node (with its payload) is passed, which gets handled by processors such as https://github.com/microsoft/azuredatastudio/blob/f5bed289affca2fce04fee6dd2db3ce02a8f5c83/src/sql/workbench/api/common/extHostObjectExplorer.ts#L27
+
+				// This should be a temporary fix until further investigation can be done and a fix to the core data explorer logic can be made
+				// (which will likely involve that logic using the treeItemHandle to look up the treeItem itself like VS Code seems to be doing)
+
+				// Have to remove parent, this was added in a VS Code merge to ITreeItem instances, but isn't meant to be serializable over JSON RPC,
+				// so passing it directly will cause the command to fail as there's a loop (child -> parent -> child -> parent ...)
+				const safeNode = mixin({ parent: undefined }, node, false);
+				const treeItem = node.childProvider ? safeNode : undefined;
+				return (<TreeViewItemHandleArg>{ $treeViewId: this.id, $treeItemHandle: node.handle, $treeItem: treeItem })
+			},
 
 			actionRunner
 		});

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
@@ -37,7 +37,7 @@ export class OEShimService extends Disposable implements IOEShimService {
 	_serviceBrand: undefined;
 
 	private nodeHandleMap = new Map<number, string>();
-	private nodeInfoMap = new Map<string, azdata.NodeInfo>();
+	private nodeInfoMap = new Map<ITreeItem, azdata.NodeInfo>();
 
 	constructor(
 		@IObjectExplorerService private oe: IObjectExplorerService,
@@ -197,7 +197,7 @@ export class OEShimService extends Disposable implements IOEShimService {
 			sessionId: parentNode.sessionId
 		};
 		this.nodeHandleMap.set(generateNodeMapKey(viewId, newTreeItem), nodePath);
-		this.nodeInfoMap.set(newTreeItem.handle, nodeInfo);
+		this.nodeInfoMap.set(newTreeItem, nodeInfo);
 		return newTreeItem;
 	}
 
@@ -210,9 +210,8 @@ export class OEShimService extends Disposable implements IOEShimService {
 	}
 
 	public getNodeInfoForTreeItem(treeItem: ITreeItem): azdata.NodeInfo | undefined {
-		const handle = treeItem.handle;
-		if (this.nodeInfoMap.has(handle)) {
-			return this.nodeInfoMap.get(handle);
+		if (this.nodeInfoMap.has(treeItem)) {
+			return this.nodeInfoMap.get(treeItem);
 		}
 		return undefined;
 	}

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
@@ -37,7 +37,7 @@ export class OEShimService extends Disposable implements IOEShimService {
 	_serviceBrand: undefined;
 
 	private nodeHandleMap = new Map<number, string>();
-	private nodeInfoMap = new Map<ITreeItem, azdata.NodeInfo>();
+	private nodeInfoMap = new Map<string, azdata.NodeInfo>();
 
 	constructor(
 		@IObjectExplorerService private oe: IObjectExplorerService,
@@ -197,7 +197,7 @@ export class OEShimService extends Disposable implements IOEShimService {
 			sessionId: parentNode.sessionId
 		};
 		this.nodeHandleMap.set(generateNodeMapKey(viewId, newTreeItem), nodePath);
-		this.nodeInfoMap.set(newTreeItem, nodeInfo);
+		this.nodeInfoMap.set(newTreeItem.handle, nodeInfo);
 		return newTreeItem;
 	}
 
@@ -210,8 +210,9 @@ export class OEShimService extends Disposable implements IOEShimService {
 	}
 
 	public getNodeInfoForTreeItem(treeItem: ITreeItem): azdata.NodeInfo | undefined {
-		if (this.nodeInfoMap.has(treeItem)) {
-			return this.nodeInfoMap.get(treeItem);
+		const handle = treeItem.handle;
+		if (this.nodeInfoMap.has(handle)) {
+			return this.nodeInfoMap.get(handle);
 		}
 		return undefined;
 	}


### PR DESCRIPTION
Follow up for https://github.com/microsoft/azuredatastudio/issues/23941

See the comment in the code for the description of the issue and the fix. This is definitely something I feel should be temporary - if we don't fix it in a safer way then we're very likely to run into issues down the line as tree items continued to be modified by VS (or us).

Couple notes : 
- This is similar to the fix Cheena had out earlier, but covers all providers. Removing the parent property ensures that those childProvider commands are always handled like they were previously (going through the Data Explorer argument processor to put the information in the format the DE commands expect)
- Just removing "parent" from the node wasn't enough - as that meant that ALL items were being treated as DE items, and so handled by the [Data Explorer processor](https://github.com/microsoft/azuredatastudio/blob/34fbd2d140cebb5ae61aa1726e93537ea2a4404c/src/sql/workbench/api/common/extHostObjectExplorer.ts#L37) (logic for that is  [here](https://github.com/microsoft/azuredatastudio/blob/f5bed289affca2fce04fee6dd2db3ce02a8f5c83/src/vs/workbench/api/common/extHostTreeViews.ts#L65) - which would result in those commands not getting the context they were expecting.

Menu item from root DE tree : 

![NewServerGroup](https://github.com/microsoft/azuredatastudio/assets/28519865/0de3bf36-53fc-4e7d-bb8e-3852d6f7a430)

Menu item from core DE action : 

![NewQuery](https://github.com/microsoft/azuredatastudio/assets/28519865/37dc5d57-ac37-48ca-84b3-992ebf0a9eb4)

Menu item from separate extension : 

![SchemaCompare](https://github.com/microsoft/azuredatastudio/assets/28519865/fb0c80f6-7208-4551-9c11-c8c4a447a4aa)

~~Edit1: Fixed issue with scripting. The OE shim logic was relying on the same object being re-used, but with the change here I create a new object without the parent property so that logic stopped working. I'm concerned about just removing the parent property from the original object (since there might be core VS code that depends on it) - so just changing OE shim service to use the node handle instead (which is a better solution regardless - relying on objects being the exact same is risky if you don't have full control over the lifecycle of the objects and how they're passed around)~~

Edit2: Turns out that breaks other stuff, since the core VS tree logic expects the tree item objects to stay the same object. So changed it to just delete the parent property instead.