### PR TITLE
Added working cell revert for invalid submissions in edit data.

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -193,7 +193,6 @@ export class EditDataGridPanel extends GridParentComponent {
 		this.onActiveCellChanged = this.onCellSelect;
 
 		this.onCellEditEnd = (event: Slick.OnCellChangeEventArgs<any>): void => {
-
 			if (self.currentEditCellValue !== event.item[event.cell]) {
 				self.currentCell.isDirty = true;
 			}
@@ -352,7 +351,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		// get the cell we have just immediately clicked (to set as the new active cell in handleChanges).
 		this.lastClickedCell = { row, column };
 
-		// Skip processing if the cell hasn't moved or is marked not dirty.
+		// Skip processing if the cell hasn't moved and is marked not dirty. (Need to handle last cell on the last row)
 		if (this.currentCell.row === row && this.currentCell.column === column && this.currentCell.isDirty === false) {
 			return;
 		}


### PR DESCRIPTION
This is to fix the cell edit trigger for submitting cells that only worked if it detected changes in the cell from slickgrid. Previously the cell was left alone during an invalid edit (and recognized by slickgrid as having no changes), which meant that when submitting again the trigger would not be fired, causing the invalid data in the cell to be falsely added to the grid. Now a cell revert is done and the invalid cell data is restored so that the cell is recognized as dirty again by slickgrid.

This is similar to the existing logic for invalid edits in the new row. 

Fixes https://github.com/microsoft/azuredatastudio/issues/21182

GIFS of the change in action:

Existing row:
![Revert cell on existing row](https://github.com/microsoft/azuredatastudio/assets/18018452/793143ac-e58f-4b16-939b-4fc1083a2ea5)

New row:
![Revert cell on new row](https://github.com/microsoft/azuredatastudio/assets/18018452/b3bdd35a-08fa-47d8-aeec-efdf8b56c0d0)

