### PR TITLE
Add no clouds selected warning popup

### DIFF
--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -153,7 +153,7 @@ export class AzureAccountProviderService implements vscode.Disposable {
 			}
 
 			// Case 4: Provider was added from JSON - register provider
-			if (provider.configKey !== loc.enablePublicCloudCamel && provider.configKey !== loc.enableUsGovCloudCamel && provider.configKey !== loc.enableChinaCloudCamel) {
+			if (provider.configKey !== Constants.enablePublicCloud && provider.configKey !== Constants.enableUsGovCloud && provider.configKey !== Constants.enableChinaCloud) {
 				providerChanges.push(this.registerAccountProvider(provider));
 				this.activeProviderCount++;
 			}

--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -43,6 +43,7 @@ export class AzureAccountProviderService implements vscode.Disposable {
 	private readonly _uriEventHandler: UriEventHandler = new UriEventHandler();
 	public clientApplication!: PublicClientApplication;
 	private _onEncryptionKeysUpdated: vscode.EventEmitter<CacheEncryptionKeys>;
+	public activeProviderCount: number = 0;
 
 	constructor(private _context: vscode.ExtensionContext,
 		private _userStoragePath: string) {
@@ -142,17 +143,27 @@ export class AzureAccountProviderService implements vscode.Disposable {
 			// Case 2: Provider was enabled and is now disabled - unregister provider
 			if (oldConfigValue && !newConfigValue) {
 				providerChanges.push(this.unregisterAccountProvider(provider));
+				this.activeProviderCount--;
 			}
 
 			// Case 3: Provider was disabled and is now enabled - register provider
 			if (!oldConfigValue && newConfigValue) {
 				providerChanges.push(this.registerAccountProvider(provider));
+				this.activeProviderCount++;
 			}
 
 			// Case 4: Provider was added from JSON - register provider
-			if (provider.configKey !== 'enablePublicCloud' && provider.configKey !== 'enableUsGovCloud' && provider.configKey !== 'enableChinaCloud') {
+			if (provider.configKey !== loc.enablePublicCloudCamel && provider.configKey !== loc.enableUsGovCloudCamel && provider.configKey !== loc.enableChinaCloudCamel) {
 				providerChanges.push(this.registerAccountProvider(provider));
+				this.activeProviderCount++;
 			}
+		}
+		if (this.activeProviderCount === 0) {
+			void vscode.window.showWarningMessage(loc.noCloudsEnabled, loc.enablePublicCloud, loc.dismiss).then(async (result) => {
+				if (result === loc.enablePublicCloud) {
+					await vscode.workspace.getConfiguration(Constants.AccountsAzureCloudSection).update(loc.enablePublicCloudCamel, true, vscode.ConfigurationTarget.Global);
+				}
+			});
 		}
 
 		// Process all the changes before continuing

--- a/extensions/azurecore/src/constants.ts
+++ b/extensions/azurecore/src/constants.ts
@@ -25,6 +25,12 @@ export const AccountsAzureAuthSection = AccountsSection + '.' + AzureSection + '
 
 export const AccountsAzureCloudSection = AccountsSection + '.' + AzureSection + '.' + CloudSection;
 
+export const enablePublicCloud = 'enablePublicCloud';
+
+export const enableUsGovCloud = 'enableUsGovCloud';
+
+export const enableChinaCloud = 'enableChinaCloud';
+
 export const EnableArcFeaturesSection = 'enableArcFeatures';
 
 export const ServiceName = 'azuredatastudio';

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -11,6 +11,10 @@ export const extensionName = localize('azurecore.extensionName', "Azure Accounts
 export const requiresReload = localize('azurecore.requiresReload', "Modifying this setting requires reloading the window for all changes to take effect.");
 export const reload = localize('azurecore.reload', "Reload");
 export const cancel = localize('azurecore.reload', "Cancel");
+export const enablePublicCloud = localize('azurecore.enablePublicCloud', "Enable Public Cloud");
+export const enablePublicCloudCamel = localize('azurecore.enablePublicCloud', "enablePublicCloud");
+export const enableUsGovCloudCamel = localize('azurecore.enableUsGovCloud', "enableUsGovCloud");
+export const enableChinaCloudCamel = localize('azurecore.enableChinaCloud', "enableChinaCloud");
 
 export const australiaCentral = localize('azurecore.australiacentral', "Australia Central");
 export const australiaCentral2 = localize('azurecore.australiacentral2', "Australia Central 2");
@@ -97,3 +101,4 @@ export function unableToFetchTokenError(tenant: string): string {
 
 // Error Messages
 export const azureCredStoreSaveFailedError = localize('azure.credStoreSaveFailedError', `Keys for token cache could not be saved in credential store, this may cause Azure access token persistence issues and connection instabilities. It's likely that SqlTools has reached credential storage limit on Windows, please clear at least 2 credentials that start with "Microsoft.SqlTools|" in Windows Credential Manager and reload.`);
+export const noCloudsEnabled = localize('azure.noCloudsEnabled', "No clouds are enabled, please enable a cloud to continue.");

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -13,8 +13,6 @@ export const reload = localize('azurecore.reload', "Reload");
 export const cancel = localize('azurecore.reload', "Cancel");
 export const enablePublicCloud = localize('azurecore.enablePublicCloud', "Enable Public Cloud");
 export const enablePublicCloudCamel = localize('azurecore.enablePublicCloud', "enablePublicCloud");
-export const enableUsGovCloudCamel = localize('azurecore.enableUsGovCloud', "enableUsGovCloud");
-export const enableChinaCloudCamel = localize('azurecore.enableChinaCloud', "enableChinaCloud");
 
 export const australiaCentral = localize('azurecore.australiacentral', "Australia Central");
 export const australiaCentral2 = localize('azurecore.australiacentral2', "Australia Central 2");


### PR DESCRIPTION
If a user has no clouds selected, they will receive the following popup:

![Screenshot 2023-07-27 at 4 18 01 PM](https://github.com/microsoft/azuredatastudio/assets/18150417/ca21df35-a54c-43b8-ba7a-50d0d5001563)

Also localized some additional strings that were not localized.

Fixes #23216, #23208