### PR TITLE
Commenting out listener threshold to fix extensions having mem leaks registering more listeners.

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -947,10 +947,10 @@ export class Emitter<T> {
 					this._listeners = new LinkedList();
 				}
 
-				if (this._leakageMon && this._listeners.size > this._leakageMon.threshold * 3) {
-					console.warn(`[${this._leakageMon.name}] REFUSES to accept new listeners because it exceeded its threshold by far`);
-					return Disposable.None;
-				}
+				// if (this._leakageMon && this._listeners.size > this._leakageMon.threshold * 3) {
+				// 	console.warn(`[${this._leakageMon.name}] REFUSES to accept new listeners because it exceeded its threshold by far`);
+				// 	return Disposable.None;
+				// }
 
 				const firstListener = this._listeners.isEmpty();
 

--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -947,6 +947,7 @@ export class Emitter<T> {
 					this._listeners = new LinkedList();
 				}
 
+				// {{SQL CARBON EDIT}} Disabling threshold to unblock model view components to register more listeners. Due to the threshold, the components were not able to register listeners and were not able to handle click events.
 				// if (this._leakageMon && this._listeners.size > this._leakageMon.threshold * 3) {
 				// 	console.warn(`[${this._leakageMon.name}] REFUSES to accept new listeners because it exceeded its threshold by far`);
 				// 	return Disposable.None;


### PR DESCRIPTION
For now, we are disabling this check to unblock the extension. The right fix will be to fix the memory leaks. 
Issue: https://github.com/microsoft/azuredatastudio/issues/23994
