### PR TITLE
Use connection Id from result for fetching database list

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -74,6 +74,9 @@ export class CreateProjectFromDatabaseDialog {
 						this.profile.serverName = connection.options['server'];
 						this.profile.userName = connection.options['user'];
 					}
+				} else {
+					// Successfully connectted, update connection Id as received.
+					this.profile.id = result.connectionId!;
 				}
 			}
 		}


### PR DESCRIPTION
Addresses #22616 

It seems the extension was not using latest connection Id from connection result, and was sending an old id for retrieving list of databases. 
