### PR TITLE
Fix to Query Editor entry in recent connections

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -257,8 +257,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			return;
 		}
 		let fromEditor = params && params.connectionType === ConnectionType.editor;
-		let hasSaveProfile = connection && connection.hasOwnProperty('saveProfile');
-		let isTemporaryConnection = (params && params.connectionType === ConnectionType.temporary) || (hasSaveProfile && !connection.saveProfile);
+		let isTemporaryConnection = (params && params.connectionType === ConnectionType.temporary);
 		let uri: string = undefined;
 		if (fromEditor && params && params.input) {
 			uri = params.input.uri;


### PR DESCRIPTION
Removes unnecessary saveProfile check for isTemporaryConnection. This was probably added while figuring out how connection profiles were going to be added with the new advanced connection options feature (Probably during a meeting, we thought about making it so Query Connections won't be saved in recent, but it appears that is not expected by most users). In the final result, the query editor connection won't be added to the Connection Tree, but it will show up in recent connections as it did before.

For #24008