### PR TITLE
Update session dropdown and fix running state info

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -553,7 +553,7 @@ export class ProfilerEditor extends EditorPane {
 					this._profilerService.launchCreateSessionDialog(this.input);
 				}
 
-				if (previousSessionName) {		// skip updating session selector if there is no previous session name
+				if (!this.input.isFileSession) {		// skip updating session selector for File session
 					this._updateSessionSelector(previousSessionName);
 				}
 			} else {

--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -553,7 +553,7 @@ export class ProfilerEditor extends EditorPane {
 					this._profilerService.launchCreateSessionDialog(this.input);
 				}
 
-				if (!this.input.isFileSession) {		// skip updating session selector for File session
+				if (!this.input.isFileSession) {		// skip updating session selector for File session to block starting another session from a non-connected file session
 					this._updateSessionSelector(previousSessionName);
 				}
 			} else {
@@ -581,7 +581,7 @@ export class ProfilerEditor extends EditorPane {
 			}
 			if (this.input.state.isStopped) {
 				this._updateToolbar();
-				if (!this.input.isFileSession) {		// skip updating session selector for File sessions
+				if (!this.input.isFileSession) {		// skip updating session selector for File sessions to block starting another session from a non-connected file session
 					this._updateSessionSelector();
 				}
 			}

--- a/src/sql/workbench/services/profiler/browser/profilerService.ts
+++ b/src/sql/workbench/services/profiler/browser/profilerService.ts
@@ -161,7 +161,7 @@ export class ProfilerService implements IProfilerService {
 			this.updateMemento(id, { previousSessionName: sessionName });
 			try {
 				await this._runAction(id, provider => provider.startSession(this._idMap.get(id)!, sessionName, sessionType));
-				let isRunning = sessionType === ProfilingSessionType.RemoteSession ? true : false;		// Reading session stops when the file reading completes
+				let isRunning = sessionType === ProfilingSessionType.LocalFile ? false : true;		// Reading session stops when the file reading completes
 				this._sessionMap.get(this._idMap.reverseGet(id)!)!.onSessionStateChanged({ isRunning: isRunning, isStopped: false, isPaused: false });
 
 				return true;


### PR DESCRIPTION
Addresses https://github.com/microsoft/azuredatastudio/issues/23998 .

When an XEL file is opened, it doesn't populate the dropdown. Accidentally in the original change, the condition was wrongly set- updated it in this change.
Before:
![image](https://github.com/microsoft/azuredatastudio/assets/57200045/0638772a-fc7b-474d-8816-b9c4bb19476f)

After:
![image](https://github.com/microsoft/azuredatastudio/assets/57200045/62984bca-5ef8-4f22-b296-41283fc74080)


Also, after a session is stopped and then started again, the running state was incorrectly set, which was not enabling Stop and Pause button (and start was enabled), after a session started. SessionType is not always set, it can be undefined in one case. Hence updated the check to verify against LocalFile enum instead of RemoteSession enum.

Before (when the session is running):
![image](https://github.com/microsoft/azuredatastudio/assets/57200045/eec539c2-43f5-4cef-8b25-349dcb2bb1c0)

After:
![image](https://github.com/microsoft/azuredatastudio/assets/57200045/e9693ee3-a8fc-48d0-a8af-620df2cb3261)
