### PR TITLE
Update vs code engine version to 1.79.2

### DIFF
--- a/product.json
+++ b/product.json
@@ -47,7 +47,7 @@
 	"gettingStartedUrl": "https://go.microsoft.com/fwlink/?linkid=862039",
 	"releaseNotesUrl": "https://go.microsoft.com/fwlink/?linkid=875578",
 	"documentationUrl": "https://go.microsoft.com/fwlink/?linkid=862277",
-	"vscodeVersion": "1.79.0",
+	"vscodeVersion": "1.79.2",
 	"commit": "9ca6200018fc206d67a47229f991901a8a453781",
 	"date": "2017-12-15T12:00:00.000Z",
 	"recommendedExtensions": [


### PR DESCRIPTION
The latest merge actually brought us up to 1.79.2, but the product.json value was never updated to match. The MongoDB extension currently requires 1.79.1 so this makes users unable to install it - even though it should be supported just fine.

So updating this value to fix that. 

For https://github.com/microsoft/azuredatastudio/issues/24021