### PR TITLE
Auto-close copy notification after 3 seconds + configuration support

### DIFF
--- a/src/sql/platform/query/common/query.ts
+++ b/src/sql/platform/query/common/query.ts
@@ -32,7 +32,7 @@ export interface IQueryEditorConfiguration {
 		readonly inMemoryDataProcessingThreshold: number;
 		readonly openAfterSave: boolean;
 		readonly showActionBar: boolean;
-		readonly dataCopyNotifications: boolean;
+		readonly showCopyCompletedNotification: boolean;
 		readonly preferProvidersCopyHandler: boolean;
 		readonly promptForLargeRowSelection: boolean;
 	},

--- a/src/sql/platform/query/common/query.ts
+++ b/src/sql/platform/query/common/query.ts
@@ -32,6 +32,7 @@ export interface IQueryEditorConfiguration {
 		readonly inMemoryDataProcessingThreshold: number;
 		readonly openAfterSave: boolean;
 		readonly showActionBar: boolean;
+		readonly dataCopyNotifications: boolean;
 		readonly preferProvidersCopyHandler: boolean;
 		readonly promptForLargeRowSelection: boolean;
 	},

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -413,7 +413,7 @@ export class DataResourceDataProvider implements IGridDataProvider {
 
 	private async copyResultsAsync(selection: Slick.Range[], includeHeaders?: boolean, tableView?: IDisposableDataProvider<Slick.SlickData>): Promise<void> {
 		try {
-			await copySelectionToClipboard(this._clipboardService, this._notificationService, this, selection, includeHeaders, tableView);
+			await copySelectionToClipboard(this._clipboardService, this._notificationService, this._configurationService, this, selection, includeHeaders, tableView);
 		} catch (error) {
 			this._notificationService.error(localize('copyFailed', "Copy failed with error: {0}", getErrorMessage(error)));
 		}

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -305,7 +305,7 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.showCopyCompletedNotification': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.showCopyCompletedNotification', "Enables showing notifications for copy complete operations."),
+			'description': localize('queryEditor.results.showCopyCompletedNotification', "Whether to show notifications when a results grid copy operation is completed."),
 			'default': true
 		},
 		'queryEditor.results.skipNewLineAfterTrailingLineBreak': {

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -303,6 +303,11 @@ const queryEditorConfiguration: IConfigurationNode = {
 			'description': localize('queryEditor.results.copyRemoveNewLine', "Configuration options for copying multi-line results from the Results View"),
 			'default': true
 		},
+		'queryEditor.results.dataCopyNotifications': {
+			'type': 'boolean',
+			'description': localize('queryEditor.results.copyNotifications', "Enables notifications for data copy operations."),
+			'default': true
+		},
 		'queryEditor.results.skipNewLineAfterTrailingLineBreak': {
 			'type': 'boolean',
 			'description': localize('queryEditor.results.skipNewLineAfterTrailingLineBreak', "Whether to skip adding a line break between rows when copying results if the previous row already has a trailing line break. The default value is false."),

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -303,9 +303,9 @@ const queryEditorConfiguration: IConfigurationNode = {
 			'description': localize('queryEditor.results.copyRemoveNewLine', "Configuration options for copying multi-line results from the Results View"),
 			'default': true
 		},
-		'queryEditor.results.dataCopyNotifications': {
+		'queryEditor.results.showCopyCompletedNotification': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.copyNotifications', "Enables notifications for data copy operations."),
+			'description': localize('queryEditor.results.showCopyCompletedNotification', "Enables notifications for data copy operations."),
 			'default': true
 		},
 		'queryEditor.results.skipNewLineAfterTrailingLineBreak': {

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -305,7 +305,7 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.showCopyCompletedNotification': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.showCopyCompletedNotification', "Enables notifications for data copy operations."),
+			'description': localize('queryEditor.results.showCopyCompletedNotification', "Enables showing notifications for copy complete operations."),
 			'default': true
 		},
 		'queryEditor.results.skipNewLineAfterTrailingLineBreak': {

--- a/src/sql/workbench/services/query/common/gridDataProvider.ts
+++ b/src/sql/workbench/services/query/common/gridDataProvider.ts
@@ -60,7 +60,7 @@ export interface IGridDataProvider {
 export async function executeCopyWithNotification(notificationService: INotificationService, configurationService: IConfigurationService, selections: Slick.Range[], copyHandler: (notification: INotificationHandle, rowCount: number) => Promise<void>, cancellationTokenSource?: CancellationTokenSource): Promise<void> {
 	const rowRanges = GridRange.getUniqueRows(GridRange.fromSlickRanges(selections));
 	const rowCount = rowRanges.map(range => range.end - range.start + 1).reduce((p, c) => p + c);
-	const showCopyNotifications = configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.dataCopyNotifications;
+	const showCopyNotifications = configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.showCopyCompletedNotification;
 	const notificationHandle = notificationService.notify({
 		message: nls.localize('gridDataProvider.copying', "Copying..."),
 		severity: Severity.Info,
@@ -97,7 +97,7 @@ export async function executeCopyWithNotification(notificationService: INotifica
 							run: () => {
 								updateConfigTurnOffCopyNotifications(configurationService);
 								notificationService.info(nls.localize('gridDataProvider.turnOnCopyNotificationsMessage',
-									'Copy notifications are now disabled. To re-enable, modify the setting: queryEditor.results.dataCopyNotifications'))
+									'Copy notifications are now disabled. To re-enable, modify the setting: queryEditor.results.showCopyCompletedNotification'))
 							}
 						})]
 				});
@@ -238,5 +238,5 @@ function removeNewLines(inputString: string): string {
  * Disables data copy configuration setting.
  */
 function updateConfigTurnOffCopyNotifications(configurationService: IConfigurationService) {
-	configurationService.updateValue('queryEditor.results.dataCopyNotifications', false);
+	configurationService.updateValue('queryEditor.results.showCopyCompletedNotification', false);
 }

--- a/src/sql/workbench/services/query/common/gridDataProvider.ts
+++ b/src/sql/workbench/services/query/common/gridDataProvider.ts
@@ -90,6 +90,8 @@ export async function executeCopyWithNotification(notificationService: INotifica
 			});
 			notificationHandle.updateMessage(nls.localize('gridDataProvider.copyResultsCompleted', "Selected data has been copied to the clipboard. Row count: {0}.", rowCount));
 		}
+		// Auto-close notification after 3 seconds.
+		setTimeout(() => notificationHandle.close(), 3000);
 	}
 	catch (err) {
 		notificationHandle.close();

--- a/src/sql/workbench/services/query/common/gridDataProvider.ts
+++ b/src/sql/workbench/services/query/common/gridDataProvider.ts
@@ -60,7 +60,7 @@ export interface IGridDataProvider {
 export async function executeCopyWithNotification(notificationService: INotificationService, configurationService: IConfigurationService, selections: Slick.Range[], copyHandler: (notification: INotificationHandle, rowCount: number) => Promise<void>, cancellationTokenSource?: CancellationTokenSource): Promise<void> {
 	const rowRanges = GridRange.getUniqueRows(GridRange.fromSlickRanges(selections));
 	const rowCount = rowRanges.map(range => range.end - range.start + 1).reduce((p, c) => p + c);
-	const showCopyNotifications = configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.showCopyCompletedNotification;
+	const showCopyCompleteNotifications = configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.showCopyCompletedNotification;
 	const notificationHandle = notificationService.notify({
 		message: nls.localize('gridDataProvider.copying', "Copying..."),
 		severity: Severity.Info,
@@ -83,7 +83,7 @@ export async function executeCopyWithNotification(notificationService: INotifica
 		await copyHandler(notificationHandle, rowCount);
 		if (cancellationTokenSource === undefined || !cancellationTokenSource.token.isCancellationRequested) {
 			notificationHandle.progress.done();
-			if (showCopyNotifications) {
+			if (showCopyCompleteNotifications) {
 				notificationHandle.updateActions({
 					primary: [
 						toAction({
@@ -93,11 +93,11 @@ export async function executeCopyWithNotification(notificationService: INotifica
 						}),
 						toAction({
 							id: 'disableCopyNotification',
-							label: nls.localize('gridDataProvider.disableCopyNotification', 'Turn off notifications'),
+							label: nls.localize('gridDataProvider.disableCopyNotification', `Don't show again`),
 							run: () => {
 								updateConfigTurnOffCopyNotifications(configurationService);
 								notificationService.info(nls.localize('gridDataProvider.turnOnCopyNotificationsMessage',
-									'Copy notifications are now disabled. To re-enable, modify the setting: queryEditor.results.showCopyCompletedNotification'))
+									'Copy completed notifications are now disabled. To re-enable, modify the setting: queryEditor.results.showCopyCompletedNotification'))
 							}
 						})]
 				});

--- a/src/sql/workbench/services/query/common/gridDataProvider.ts
+++ b/src/sql/workbench/services/query/common/gridDataProvider.ts
@@ -13,6 +13,8 @@ import { toAction } from 'vs/base/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { GridRange } from 'sql/base/common/gridRange';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
 
 export interface IGridDataProvider {
 
@@ -55,9 +57,10 @@ export interface IGridDataProvider {
 	serializeResults(format: SaveFormat, selection: Slick.Range[]): Thenable<void>;
 }
 
-export async function executeCopyWithNotification(notificationService: INotificationService, selections: Slick.Range[], copyHandler: (notification: INotificationHandle, rowCount: number) => Promise<void>, cancellationTokenSource?: CancellationTokenSource): Promise<void> {
+export async function executeCopyWithNotification(notificationService: INotificationService, configurationService: IConfigurationService, selections: Slick.Range[], copyHandler: (notification: INotificationHandle, rowCount: number) => Promise<void>, cancellationTokenSource?: CancellationTokenSource): Promise<void> {
 	const rowRanges = GridRange.getUniqueRows(GridRange.fromSlickRanges(selections));
 	const rowCount = rowRanges.map(range => range.end - range.start + 1).reduce((p, c) => p + c);
+	const showCopyNotifications = configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.dataCopyNotifications;
 	const notificationHandle = notificationService.notify({
 		message: nls.localize('gridDataProvider.copying', "Copying..."),
 		severity: Severity.Info,
@@ -80,18 +83,31 @@ export async function executeCopyWithNotification(notificationService: INotifica
 		await copyHandler(notificationHandle, rowCount);
 		if (cancellationTokenSource === undefined || !cancellationTokenSource.token.isCancellationRequested) {
 			notificationHandle.progress.done();
-			notificationHandle.updateActions({
-				primary: [
-					toAction({
-						id: 'closeCopyResultsNotification',
-						label: nls.localize('gridDataProvider.closeNotification', "Close"),
-						run: () => { notificationHandle.close(); }
-					})]
-			});
-			notificationHandle.updateMessage(nls.localize('gridDataProvider.copyResultsCompleted', "Selected data has been copied to the clipboard. Row count: {0}.", rowCount));
+			if (showCopyNotifications) {
+				notificationHandle.updateActions({
+					primary: [
+						toAction({
+							id: 'closeCopyResultsNotification',
+							label: nls.localize('gridDataProvider.closeNotification', 'Close'),
+							run: () => { notificationHandle.close(); }
+						}),
+						toAction({
+							id: 'disableCopyNotification',
+							label: nls.localize('gridDataProvider.disableCopyNotification', 'Turn off notifications'),
+							run: () => {
+								updateConfigTurnOffCopyNotifications(configurationService);
+								notificationService.info(nls.localize('gridDataProvider.turnOnCopyNotificationsMessage',
+									'Copy notifications are now disabled. To re-enable, modify the setting: queryEditor.results.dataCopyNotifications'))
+							}
+						})]
+				});
+				notificationHandle.updateMessage(nls.localize('gridDataProvider.copyResultsCompleted', "Selected data has been copied to the clipboard. Row count: {0}.", rowCount));
+				// Auto-close notification after 3 seconds.
+				setTimeout(() => notificationHandle.close(), 3000);
+			} else {
+				notificationHandle.close();
+			}
 		}
-		// Auto-close notification after 3 seconds.
-		setTimeout(() => notificationHandle.close(), 3000);
 	}
 	catch (err) {
 		notificationHandle.close();
@@ -99,9 +115,10 @@ export async function executeCopyWithNotification(notificationService: INotifica
 	}
 }
 
-export async function copySelectionToClipboard(clipboardService: IClipboardService, notificationService: INotificationService, provider: IGridDataProvider, selections: Slick.Range[], includeHeaders?: boolean, tableView?: IDisposableDataProvider<Slick.SlickData>): Promise<void> {
+export async function copySelectionToClipboard(clipboardService: IClipboardService, notificationService: INotificationService, configurationService: IConfigurationService,
+	provider: IGridDataProvider, selections: Slick.Range[], includeHeaders?: boolean, tableView?: IDisposableDataProvider<Slick.SlickData>): Promise<void> {
 	const cancellationTokenSource = new CancellationTokenSource()
-	await executeCopyWithNotification(notificationService, selections, async (notificationHandle, rowCount) => {
+	await executeCopyWithNotification(notificationService, configurationService, selections, async (notificationHandle, rowCount) => {
 		const eol = provider.getEolString();
 		const valueSeparator = '\t';
 		const shouldRemoveNewLines = provider.shouldRemoveNewLines();
@@ -215,4 +232,11 @@ function removeNewLines(inputString: string): string {
 
 	let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, ' ');
 	return outputString;
+}
+
+/**
+ * Disables data copy configuration setting.
+ */
+function updateConfigTurnOffCopyNotifications(configurationService: IConfigurationService) {
+	configurationService.updateValue('queryEditor.results.dataCopyNotifications', false);
 }

--- a/src/sql/workbench/services/query/common/queryRunner.ts
+++ b/src/sql/workbench/services/query/common/queryRunner.ts
@@ -581,7 +581,7 @@ export class QueryGridDataProvider implements IGridDataProvider {
 			if (preferProvidersCopyHandler && providerSupportCopyResults && (tableView === undefined || !tableView.isDataInMemory)) {
 				await this.handleCopyRequestByProvider(selections, includeHeaders);
 			} else {
-				await copySelectionToClipboard(this._clipboardService, this._notificationService, this, selections, includeHeaders, tableView);
+				await copySelectionToClipboard(this._clipboardService, this._notificationService, this._configurationService, this, selections, includeHeaders, tableView);
 			}
 		} catch (error) {
 			this._notificationService.error(nls.localize('copyFailed', "Copy failed with error: {0}", getErrorMessage(error)));
@@ -589,7 +589,7 @@ export class QueryGridDataProvider implements IGridDataProvider {
 	}
 
 	private async handleCopyRequestByProvider(selections: Slick.Range[], includeHeaders?: boolean): Promise<void> {
-		executeCopyWithNotification(this._notificationService, selections, async () => {
+		executeCopyWithNotification(this._notificationService, this._configurationService, selections, async () => {
 			await this.queryRunner.copyResults(selections, this.batchId, this.resultSetId, this.shouldIncludeHeaders(includeHeaders));
 		});
 	}


### PR DESCRIPTION
Addresses #24009 by auto-closing Copy notification in 3 seconds.

![auto close](https://github.com/microsoft/azuredatastudio/assets/13396919/cbfbe9a7-7150-487b-b2de-4cfd529cb819)

Additionally added support to disable notifications:
![image](https://github.com/microsoft/azuredatastudio/assets/13396919/46a7b522-711c-458d-88f9-995494e7f0dc)

New behavior:
![disable notifications](https://github.com/microsoft/azuredatastudio/assets/13396919/b534a86a-62e8-4dca-a810-e3431e8cb27f)
