### PR TITLE
Add null checks for server tree view

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
@@ -70,12 +70,15 @@ class ConnectionProfileGroupTemplate extends Disposable {
 			matches: createMatches(filterData)
 		});
 
-		const actionProvider = this._objectExplorerService.getServerTreeView().treeActionProvider;
-		const tree = this._objectExplorerService.getServerTreeView().tree;
-		const actions = actionProvider.getActions(tree, element, true);
-		this._actionBar.context = this._objectExplorerService.getServerTreeView().getActionContext(element);
-		this._actionBar.clear();
-		this._actionBar.pushAction(actions, { icon: true, label: false });
+		let serverTreeView = this._objectExplorerService.getServerTreeView();
+		if (serverTreeView) {
+			const actionProvider = serverTreeView.treeActionProvider;
+			const tree = serverTreeView.tree;
+			const actions = actionProvider.getActions(tree, element, true);
+			this._actionBar.context = serverTreeView.getActionContext(element);
+			this._actionBar.clear();
+			this._actionBar.pushAction(actions, { icon: true, label: false });
+		}
 	}
 }
 
@@ -150,18 +153,21 @@ class ConnectionProfileTemplate extends Disposable {
 			matches: createMatches(filterData)
 		});
 		this._root.title = treeNode?.filters?.length > 0 ? getLabelWithFilteredSuffix(element.serverInfo) : element.serverInfo;
-		const actionProvider = this._objectExplorerService.getServerTreeView().treeActionProvider;
-		if (!this._isCompact) {
-			const tree = this._objectExplorerService.getServerTreeView().tree;
-			const actions = actionProvider.getActions(tree, element, true);
-			this._actionBar.context = this._objectExplorerService.getServerTreeView().getActionContext(element);
-			this._actionBar.clear();
-			this._actionBar.pushAction(actions, { icon: true, label: false });
-		} else {
-			const actions = actionProvider.getRecentConnectionActions(element);
-			this._actionBar.context = undefined;
-			this._actionBar.clear();
-			this._actionBar.pushAction(actions, { icon: true, label: false });
+		let serverTreeView = this._objectExplorerService.getServerTreeView();
+		if (serverTreeView) {
+			const actionProvider = serverTreeView.treeActionProvider;
+			if (!this._isCompact) {
+				const tree = serverTreeView.tree;
+				const actions = actionProvider.getActions(tree, element, true);
+				this._actionBar.context = serverTreeView.getActionContext(element);
+				this._actionBar.clear();
+				this._actionBar.pushAction(actions, { icon: true, label: false });
+			} else {
+				const actions = actionProvider.getRecentConnectionActions(element);
+				this._actionBar.context = undefined;
+				this._actionBar.clear();
+				this._actionBar.pushAction(actions, { icon: true, label: false });
+			}
 		}
 	}
 }
@@ -247,12 +253,15 @@ class TreeNodeTemplate extends Disposable {
 			matches: createMatches(filterData)
 		});
 		this._root.title = labelText;
-		const tree = this._objectExplorerService.getServerTreeView().tree;
-		const actionProvider = this._objectExplorerService.getServerTreeView().treeActionProvider;
-		const actions = actionProvider.getActions(tree, element, true);
-		this._actionBar.context = this._objectExplorerService.getServerTreeView().getActionContext(element);
-		this._actionBar.clear();
-		this._actionBar.pushAction(actions, { icon: true, label: false });
+		let serverTreeView = this._objectExplorerService.getServerTreeView();
+		if (serverTreeView) {
+			const tree = serverTreeView.tree;
+			const actionProvider = serverTreeView.treeActionProvider;
+			const actions = actionProvider.getActions(tree, element, true);
+			this._actionBar.context = serverTreeView.getActionContext(element);
+			this._actionBar.clear();
+			this._actionBar.pushAction(actions, { icon: true, label: false });
+		}
 	}
 }
 

--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
@@ -78,6 +78,8 @@ class ConnectionProfileGroupTemplate extends Disposable {
 			this._actionBar.context = serverTreeView.getActionContext(element);
 			this._actionBar.clear();
 			this._actionBar.pushAction(actions, { icon: true, label: false });
+		} else {
+			console.log('Server Tree view not loaded, action bar will not be populated.');
 		}
 	}
 }
@@ -168,6 +170,8 @@ class ConnectionProfileTemplate extends Disposable {
 				this._actionBar.clear();
 				this._actionBar.pushAction(actions, { icon: true, label: false });
 			}
+		} else {
+			console.log('Server Tree view not loaded, action bar will not be populated.');
 		}
 	}
 }
@@ -261,6 +265,8 @@ class TreeNodeTemplate extends Disposable {
 			this._actionBar.context = serverTreeView.getActionContext(element);
 			this._actionBar.clear();
 			this._actionBar.pushAction(actions, { icon: true, label: false });
+		} else {
+			console.log('Server Tree view not loaded, action bar will not be populated.');
 		}
 	}
 }


### PR DESCRIPTION
Addresses issue https://github.com/microsoft/azuredatastudio/issues/24027 which seems like has a significant impact on the stability of connection browser.
Async Server tree renderer assumes that server tree view is available, which may be collapsed on startup.

The PR fixes the renderer to load action bar only when server tree view is available.