### PR TITLE
Add correct edit data background and content colors for edited cell

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/media/editData.css
+++ b/src/sql/workbench/contrib/editData/browser/media/editData.css
@@ -48,6 +48,11 @@
 	/* background-color: var(--background-color, white); */
 }
 
+.monaco-workbench.vs input, .monaco-workbench.hc-black input, .monaco-workbench.hc-light input, .monaco-workbench.vs-dark input {
+	color: var(--color-input-text, #000);
+	background-color: var(--color-input-background, #e2e2e2);
+}
+
 .editDataGrid .slick-cell.selected {
 	background-color: var(--color-cell-bg-grid-selected, rgb(173, 214, 255));
 	color: var(--color-content, #101010);
@@ -150,6 +155,8 @@ slick-grid.active .editDataGrid .slick-cell.selected {
 	--color-grid-link-hover: #ff8033;
 	--color-grid-dirty-background: #FFF;
 	--color-grid-dirty-text: #000;
+	--color-input-background: #e2e2e2;
+	--color-input-text: #000;
 }
 
 .hc-light .slickgridContainer {
@@ -166,6 +173,8 @@ slick-grid.active .editDataGrid .slick-cell.selected {
 	--color-grid-link-hover: #0b93ff;
 	--color-grid-dirty-background: #FFF;
 	--color-grid-dirty-text: #000;
+	--color-input-background: var(--background-color, #e2e2e2);
+	--color-input-text: var(--color-content, #000);
 }
 
 .vs-dark .slickgridContainer {
@@ -182,6 +191,8 @@ slick-grid.active .editDataGrid .slick-cell.selected {
 	--color-grid-link-hover: #ff8033;
 	--color-grid-dirty-background: #4d4d4d;
 	--color-grid-dirty-text: #E5E5E5;
+	--color-input-background: #e2e2e2;
+	--color-input-text: #000;
 }
 
 .vs .slickgridContainer {
@@ -198,6 +209,8 @@ slick-grid.active .editDataGrid .slick-cell.selected {
 	--color-grid-link-hover: #0b93ff;
 	--color-grid-dirty-background: #CCC;
 	--color-grid-dirty-text: #101010;
+	--color-input-background: var(--background-color, #e2e2e2);
+	--color-input-text: var(--color-content, #000);
 }
 
 

--- a/src/sql/workbench/contrib/editData/browser/media/editData.css
+++ b/src/sql/workbench/contrib/editData/browser/media/editData.css
@@ -49,8 +49,8 @@
 }
 
 .monaco-workbench.vs input, .monaco-workbench.hc-black input, .monaco-workbench.hc-light input, .monaco-workbench.vs-dark input {
-	color: var(--color-input-text, #000);
-	background-color: var(--color-input-background, #e2e2e2);
+	color: var(--color-input-text, #000000);
+	background-color: var(--color-input-background, #E5E5E5);
 }
 
 .editDataGrid .slick-cell.selected {
@@ -155,8 +155,8 @@ slick-grid.active .editDataGrid .slick-cell.selected {
 	--color-grid-link-hover: #ff8033;
 	--color-grid-dirty-background: #FFF;
 	--color-grid-dirty-text: #000;
-	--color-input-background: #e2e2e2;
-	--color-input-text: #000;
+	--color-input-background: var(--vscode-input-background);
+	--color-input-text: var(--color-content);
 }
 
 .hc-light .slickgridContainer {
@@ -173,8 +173,8 @@ slick-grid.active .editDataGrid .slick-cell.selected {
 	--color-grid-link-hover: #0b93ff;
 	--color-grid-dirty-background: #FFF;
 	--color-grid-dirty-text: #000;
-	--color-input-background: var(--background-color, #e2e2e2);
-	--color-input-text: var(--color-content, #000);
+	--color-input-background: var(--vscode-input-background);
+	--color-input-text: var(--color-content);
 }
 
 .vs-dark .slickgridContainer {
@@ -191,8 +191,8 @@ slick-grid.active .editDataGrid .slick-cell.selected {
 	--color-grid-link-hover: #ff8033;
 	--color-grid-dirty-background: #4d4d4d;
 	--color-grid-dirty-text: #E5E5E5;
-	--color-input-background: #e2e2e2;
-	--color-input-text: #000;
+	--color-input-background: var(--vscode-input-background);
+	--color-input-text: var(--color-content);
 }
 
 .vs .slickgridContainer {
@@ -209,8 +209,8 @@ slick-grid.active .editDataGrid .slick-cell.selected {
 	--color-grid-link-hover: #0b93ff;
 	--color-grid-dirty-background: #CCC;
 	--color-grid-dirty-text: #101010;
-	--color-input-background: var(--background-color, #e2e2e2);
-	--color-input-text: var(--color-content, #000);
+	--color-input-background: var(--vscode-input-background);
+	--color-input-text: var(--color-content);
 }
 
 


### PR DESCRIPTION
Fixes #23569

Screenshots showing the change made:

Default Light in High Contrast Dark:
![DefaultLightEditDataInHCDark](https://github.com/microsoft/azuredatastudio/assets/18018452/ea1d662d-cd23-4797-8f85-509d34fbcea6)

Default Dark:
![DefaultDarkEditDataBackground](https://github.com/microsoft/azuredatastudio/assets/18018452/ee519838-feb9-4c31-b0b4-c91252de1137)

Default Light:
![DefaultLightEditDataBackground](https://github.com/microsoft/azuredatastudio/assets/18018452/7d4c8079-5fbd-484d-91b7-a5e1c26d2904)

HC Dark:
![HCDarkEditDataBackground](https://github.com/microsoft/azuredatastudio/assets/18018452/f5429e0e-75f8-49c4-8a27-673c42aa0e66)

HC Light:
![HCLightEditDataBackground](https://github.com/microsoft/azuredatastudio/assets/18018452/2561c780-ba02-4a62-98ee-16f53f2b6384)

