### PR TITLE
Bump STS to v4.9.0.10

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.9.0.8",
+	"version": "4.9.0.10",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
Bump STS: https://github.com/microsoft/sqltoolsservice/compare/4.9.0.8...4.9.0.10
![image](https://github.com/microsoft/azuredatastudio/assets/13396919/601dec5e-80a8-4bad-a0b6-62669e42f215)
