### PR TITLE
Adding destroy api to model view components 

### DIFF
--- a/extensions/dacpac/src/test/testContext.ts
+++ b/extensions/dacpac/src/test/testContext.ts
@@ -82,6 +82,7 @@ export function createViewContext(): ViewTestContext {
 		onValidityChanged: undefined!,
 		valid: true,
 		validate: undefined!,
+		destroy: undefined!,
 		focus: () => Promise.resolve()
 	};
 	let button: azdata.ButtonComponent = Object.assign({}, componentBase, {

--- a/extensions/datavirtualization/src/test/stubs.ts
+++ b/extensions/datavirtualization/src/test/stubs.ts
@@ -221,6 +221,15 @@ export class MockDataSourceService implements DataSourceWizardService {
 }
 
 export class MockUIComponent implements azdata.Component {
+	height?: string | number;
+	width?: string | number;
+	position?: azdata.PositionType;
+	display?: azdata.DisplayType;
+	ariaLabel?: string;
+	ariaRole?: string;
+	ariaSelected?: boolean;
+	ariaHidden?: boolean;
+	CSSStyles?: azdata.CssStyles;
 	id: string;
 	enabled: boolean;
 	onValidityChanged: vscode.Event<boolean>;
@@ -242,9 +251,20 @@ export class MockUIComponent implements azdata.Component {
 	focus(): Thenable<void> {
 		return Promise.resolve();
 	}
+	destroy(): void {
+		throw new Error('Method not implemented.');
+	}
 }
 
 export class MockInputBoxComponent extends MockUIComponent implements azdata.InputBoxComponent {
+	display?: azdata.DisplayType;
+	ariaRole?: string;
+	ariaSelected?: boolean;
+	ariaHidden?: boolean;
+	validationErrorMessage?: string;
+	readOnly?: boolean;
+	title?: string;
+	maxLength?: number;
 	onEnterKeyPressed: vscode.Event<string>;
 	value?: string;
 	ariaLabel?: string;
@@ -330,6 +350,9 @@ export class MockDeclarativeTableComponent extends MockUIComponent implements az
 	setDataValues(v: azdata.DeclarativeTableCellValue[][]): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
+	destroy(): void {
+		throw new Error('Method not implemented.');
+	}
 }
 
 export class MockTreeComponent extends MockUIComponent implements azdata.TreeComponent<any> {
@@ -406,6 +429,7 @@ export class MockToolbarContainer extends MockContainer<any, any> implements azd
 }
 
 export class MockDivContainer extends MockContainer<azdata.DivLayout, azdata.DivItemLayout> implements azdata.DivContainer {
+	ariaLive?: azdata.AriaLiveValue;
 	setItemLayout(component: azdata.Component, layout: azdata.DivItemLayout): void {
 		throw new Error('Method not implemented.');
 	}

--- a/extensions/machine-learning/src/test/views/utils.ts
+++ b/extensions/machine-learning/src/test/views/utils.ts
@@ -27,7 +27,8 @@ export function createViewContext(): ViewTestContext {
 		onValidityChanged: undefined!,
 		valid: true,
 		validate: undefined!,
-		focus: undefined!
+		focus: undefined!,
+		destroy: undefined!,
 	};
 	let button: azdata.ButtonComponent = Object.assign({}, componentBase, {
 		onDidClick: onClick.event

--- a/extensions/notebook/src/test/common.ts
+++ b/extensions/notebook/src/test/common.ts
@@ -316,6 +316,16 @@ export class TestKernel implements azdata.nb.IKernel {
 
 //#region test modelView components
 class TestComponentBase implements azdata.Component {
+	height?: string | number;
+	width?: string | number;
+	position?: azdata.PositionType;
+	enabled?: boolean;
+	display?: azdata.DisplayType;
+	ariaLabel?: string;
+	ariaRole?: string;
+	ariaSelected?: boolean;
+	ariaHidden?: boolean;
+	CSSStyles?: azdata.CssStyles;
 	id: string = '';
 	updateProperties(properties: { [key: string]: any; }): Thenable<void> {
 		Object.assign(this, properties);
@@ -334,6 +344,9 @@ class TestComponentBase implements azdata.Component {
 	}
 	focus(): Thenable<void> {
 		return Promise.resolve();
+	}
+	destroy(): void {
+		throw new Error('Method not implemented.');
 	}
 }
 

--- a/extensions/notebook/src/test/managePackages/managePackagesDialog.test.ts
+++ b/extensions/notebook/src/test/managePackages/managePackagesDialog.test.ts
@@ -127,7 +127,8 @@ describe('Manage Package Dialog', () => {
 			onValidityChanged: undefined!,
 			valid: true,
 			validate: undefined!,
-			focus: undefined!
+			focus: undefined!,
+			destroy: undefined!
 		};
 		let button: azdata.ButtonComponent = Object.assign({}, componentBase, {
 			onDidClick: onClick.event

--- a/extensions/query-store/src/test/testUtils.ts
+++ b/extensions/query-store/src/test/testUtils.ts
@@ -19,7 +19,8 @@ export function createViewContext(): TestContext {
 		onValidityChanged: undefined!,
 		valid: true,
 		validate: undefined!,
-		focus: undefined!
+		focus: undefined!,
+		destroy: undefined!,
 	};
 
 	const components: azdata.Component[] = [];

--- a/extensions/schema-compare/src/test/testContext.ts
+++ b/extensions/schema-compare/src/test/testContext.ts
@@ -81,7 +81,8 @@ export function createViewContext(): ViewTestContext {
 		onValidityChanged: undefined!,
 		valid: true,
 		validate: undefined!,
-		focus: () => Promise.resolve()
+		focus: () => Promise.resolve(),
+		destroy: undefined!
 	};
 
 	let container = {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -136,6 +136,13 @@ declare module 'azdata' {
 		loadingCompletedText?: string;
 	}
 
+	export interface Component extends ComponentProperties {
+		/**
+		 * Dispose the component and clean up its resources like listeners and do
+		 */
+		destroy(): void;
+	}
+
 	/**
 	 * The column information of a data set.
 	 */

--- a/src/sql/platform/dashboard/browser/interfaces.ts
+++ b/src/sql/platform/dashboard/browser/interfaces.ts
@@ -114,6 +114,7 @@ export interface IComponent extends IDisposable {
 	refreshDataProvider(item: any): void;
 	focus(): void;
 	doAction(action: string, ...args: any[]): void;
+	destroy(): void;
 }
 
 export enum ModelComponentTypes {

--- a/src/sql/platform/model/browser/modelViewService.ts
+++ b/src/sql/platform/model/browser/modelViewService.ts
@@ -51,4 +51,5 @@ export interface IModelView extends IView {
 	readonly onDestroy: Event<void>;
 	focus(componentId: string): void;
 	doAction(componentId: string, action: string, ...args: any[]): void;
+	destroy(componentId: string): void;
 }

--- a/src/sql/workbench/api/browser/mainThreadModelView.ts
+++ b/src/sql/workbench/api/browser/mainThreadModelView.ts
@@ -105,6 +105,10 @@ export class MainThreadModelView extends Disposable implements MainThreadModelVi
 		return new Promise(resolve => this.execModelViewAction(handle, (modelView) => resolve(modelView.doAction(componentId, action, ...args))));
 	}
 
+	$destroy(handle: number, componentId: string): Thenable<void> {
+		return new Promise(resolve => this.execModelViewAction(handle, (modelView) => resolve(modelView.disposeComponent(componentId))));
+	}
+
 	private runCustomValidations(handle: number, componentId: string): Thenable<boolean> {
 		return this._proxy.$runCustomValidations(handle, componentId);
 	}

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -20,6 +20,7 @@ import { IExtensionDescription } from 'vs/platform/extensions/common/extensions'
 import { ILogService } from 'vs/platform/log/common/log';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { SqlMainContext } from 'vs/workbench/api/common/extHost.protocol';
+import { Disposable } from 'vs/base/common/lifecycle';
 
 class ModelBuilderImpl implements azdata.ModelBuilder {
 	private nextComponentId: number;
@@ -594,7 +595,7 @@ class InternalItemConfig {
 	}
 }
 
-class ComponentWrapper implements azdata.Component {
+class ComponentWrapper extends Disposable implements azdata.Component {
 	public properties: { [key: string]: any } = {};
 	public layout: any;
 	public itemConfigs: InternalItemConfig[];
@@ -613,8 +614,14 @@ class ComponentWrapper implements azdata.Component {
 		protected _id: string,
 		protected _logService: ILogService
 	) {
+		super();
 		this.properties = {};
 		this.itemConfigs = [];
+	}
+
+	destroy(): void {
+		this._proxy.$destroy(this._handle, this._id);
+		super.dispose();
 	}
 
 	public get id(): string {

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -853,6 +853,7 @@ export interface MainThreadModelViewShape extends IDisposable {
 	$refreshDataProvider(handle: number, componentId: string, item?: any): Thenable<void>;
 	$focus(handle: number, componentId: string): Thenable<void>;
 	$doAction(handle: number, componentId: string, action: string, ...args: any[]): Thenable<void>;
+	$destroy(handle: number, componentId: string): Thenable<void>;
 }
 
 export interface ExtHostObjectExplorerShape {

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -5,7 +5,7 @@
 import 'vs/css!./media/flexContainer';
 
 import {
-	ChangeDetectorRef, ViewChildren, ElementRef, OnDestroy, QueryList, AfterViewInit
+	ChangeDetectorRef, ViewChildren, ElementRef, OnDestroy, QueryList, AfterViewInit, ViewChild, ViewContainerRef
 } from '@angular/core';
 
 import * as types from 'vs/base/common/types';
@@ -38,6 +38,8 @@ export abstract class ComponentBase<TPropertyBag extends azdata.ComponentPropert
 		protected logService: ILogService) {
 		super();
 	}
+
+	@ViewChild('ref') vcRef: ViewContainerRef;
 
 	/// IComponent implementation
 
@@ -277,6 +279,12 @@ export abstract class ComponentBase<TPropertyBag extends azdata.ComponentPropert
 
 		return x;
 	}
+
+	public destroy(): void {
+		this.baseDestroy();
+		super.dispose();
+		this.getHtml().remove();
+	}
 }
 
 export abstract class ContainerBase<T, TPropertyBag extends azdata.ContainerProperties = azdata.ContainerProperties> extends ComponentBase<TPropertyBag> {
@@ -402,5 +410,9 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ContainerProp
 
 	public set ariaLive(newValue: string | undefined) {
 		this.setPropertyFromUI<string>((props, value) => props.ariaLive = value, newValue);
+	}
+
+	public override destroy(): void {
+		this.baseDestroy();
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -271,6 +271,8 @@ export default class DeclarativeTableComponent extends ContainerBase<any, azdata
 
 	private static ACCEPTABLE_VALUES = new Set<string>(['number', 'string', 'boolean']);
 	public override setProperties(properties: { [key: string]: any; }): void {
+		this.destroy();
+		this.baseInit();
 		let castProperties = properties as azdata.DeclarativeTableProperties;
 		const basicData: any[][] = castProperties.data ?? [];
 		const complexData: azdata.DeclarativeTableCellValue[][] = castProperties.dataValues ?? [];

--- a/src/sql/workbench/browser/modelComponents/viewBase.ts
+++ b/src/sql/workbench/browser/modelComponents/viewBase.ts
@@ -226,4 +226,12 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 			component.doAction(action, ...args);
 		});
 	}
+
+	public disposeComponent(componentId: string): void {
+		this.logService.debug(`Queuing action to destroy component ${componentId}`);
+		return this.queueAction(componentId, (component) => {
+			this.logService.debug(`Destroying component ${componentId}`);
+			component.destroy();
+		});
+	}
 }


### PR DESCRIPTION
Adding a destroy api to model view components to let extensions dispose these components off. This does not fixes the memory leak problem as proper cleanup needs to be done on the component side for that happen. 
Usage:
```
component.destroy();
```