### PR TITLE
Fix schema compare 'Yes' button not showing for recomparing after changing options

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -68,8 +68,7 @@ export class SchemaCompareOptionsDialog {
 		this.schemaComparison.setDeploymentOptions(this.optionsModel.deploymentOptions);
 
 		const yesItem: vscode.MessageItem = {
-			title: loc.YesButtonText,
-			isCloseAffordance: true
+			title: loc.YesButtonText
 		};
 
 		const noItem: vscode.MessageItem = {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24120. The latest vscode merge changed how modal messages are shown, making it so that the close button gets set to the option with `isCloseAffordance` set to true. The `isCloseAffordance` option is meant to be specified for the button/option that will get triggered when the `ESC` key is used, and the schema compare options dialog was incorrectly setting it to true for both the Yes and No option. The fix is to have it only set to true for the No option. 

change from vscode merge that caused the change in behavior: 
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/bbad2e0d-71b2-4934-8d5d-565f555e49a0)


Before:
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/437ac899-bd96-4a03-a9fe-70f8eda38d9b)

Fixed: 
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/a3d233c2-dba6-4b61-b3ff-107497023afc)
