### PR TITLE
Replace usage of Delete with Drop in object management code

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -96,15 +96,15 @@
         "icon": "$(edit)"
       },
       {
-        "command": "mssql.deleteDatabase",
+        "command": "mssql.dropDatabase",
         "category": "MSSQL",
-        "title": "%title.deleteObject%",
+        "title": "%title.dropObject%",
         "icon": "$(trash)"
       },
       {
-        "command": "mssql.deleteObject",
+        "command": "mssql.dropObject",
         "category": "MSSQL",
-        "title": "%title.deleteObject%",
+        "title": "%title.dropObject%",
         "icon": "$(trash)"
       },
       {
@@ -511,11 +511,11 @@
           "when": "false"
         },
         {
-          "command": "mssql.deleteDatabase",
+          "command": "mssql.dropDatabase",
           "when": "false"
         },
         {
-          "command": "mssql.deleteObject",
+          "command": "mssql.dropObject",
           "when": "false"
         },
         {
@@ -580,12 +580,12 @@
           "group": "1_objectManagement@2"
         },
         {
-          "command": "mssql.deleteDatabase",
+          "command": "mssql.dropDatabase",
           "when": "connectionProvider == MSSQL && nodeType == Database && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@3"
         },
         {
-          "command": "mssql.deleteObject",
+          "command": "mssql.dropObject",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@3"
         },
@@ -630,12 +630,12 @@
           "group": "inline@2"
         },
         {
-          "command": "mssql.deleteDatabase",
+          "command": "mssql.dropDatabase",
           "when": "connectionProvider == MSSQL && nodeType == Database && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "inline@3"
         },
         {
-          "command": "mssql.deleteObject",
+          "command": "mssql.dropObject",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/)  && config.workbench.enablePreviewFeatures",
           "group": "inline@3"
         }
@@ -682,12 +682,12 @@
           "group": "1_objectManagement@1"
         },
         {
-          "command": "mssql.deleteDatabase",
+          "command": "mssql.dropDatabase",
           "when": "connectionProvider == MSSQL && nodeType == Database && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@3"
         },
         {
-          "command": "mssql.deleteObject",
+          "command": "mssql.dropObject",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@3"
         },

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -188,7 +188,7 @@
 	"title.newObject": "New (Preview)",
 	"title.newDatabase": "New Database (Preview)",
 	"title.objectProperties": "Properties (Preview)",
-	"title.deleteObject": "Delete (Preview)",
+	"title.dropObject": "Drop (Preview)",
 	"title.renameObject": "Rename (Preview)",
 	"title.detachDatabase": "Detach (Preview)"
 }

--- a/extensions/mssql/src/objectManagement/commands.ts
+++ b/extensions/mssql/src/objectManagement/commands.ts
@@ -24,7 +24,7 @@ import { ApplicationRoleDialog } from './ui/applicationRoleDialog';
 import { DatabaseDialog } from './ui/databaseDialog';
 import { ServerPropertiesDialog } from './ui/serverPropertiesDialog';
 import { DetachDatabaseDialog } from './ui/detachDatabaseDialog';
-import { DeleteDatabaseDialog } from './ui/deleteDatabaseDialog';
+import { DropDatabaseDialog as DropDatabaseDialog } from './ui/dropDatabaseDialog';
 
 export function registerObjectManagementCommands(appContext: AppContext) {
 	// Notes: Change the second parameter to false to use the actual object management service.
@@ -38,8 +38,8 @@ export function registerObjectManagementCommands(appContext: AppContext) {
 	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.objectProperties', async (context: azdata.ObjectExplorerContext) => {
 		await handleObjectPropertiesDialogCommand(context, service);
 	}));
-	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.deleteObject', async (context: azdata.ObjectExplorerContext) => {
-		await handleDeleteObjectCommand(context, service);
+	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.dropObject', async (context: azdata.ObjectExplorerContext) => {
+		await handleDropObjectCommand(context, service);
 	}));
 	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.renameObject', async (context: azdata.ObjectExplorerContext) => {
 		await handleRenameObjectCommand(context, service);
@@ -47,8 +47,8 @@ export function registerObjectManagementCommands(appContext: AppContext) {
 	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.detachDatabase', async (context: azdata.ObjectExplorerContext) => {
 		await handleDetachDatabase(context, service);
 	}));
-	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.deleteDatabase', async (context: azdata.ObjectExplorerContext) => {
-		await handleDeleteDatabase(context, service);
+	appContext.extensionContext.subscriptions.push(vscode.commands.registerCommand('mssql.dropDatabase', async (context: azdata.ObjectExplorerContext) => {
+		await handleDropDatabase(context, service);
 	}));
 }
 
@@ -158,7 +158,7 @@ async function handleObjectPropertiesDialogCommand(context: azdata.ObjectExplore
 	}
 }
 
-async function handleDeleteObjectCommand(context: azdata.ObjectExplorerContext, service: IObjectManagementService): Promise<void> {
+async function handleDropObjectCommand(context: azdata.ObjectExplorerContext, service: IObjectManagementService): Promise<void> {
 	const connectionUri = await getConnectionUri(context);
 	if (!connectionUri) {
 		return;
@@ -166,13 +166,13 @@ async function handleDeleteObjectCommand(context: azdata.ObjectExplorerContext, 
 	let additionalConfirmationMessage: string | undefined = undefined;
 	switch (context.nodeInfo!.nodeType) {
 		case ObjectManagement.NodeType.ServerLevelLogin:
-			additionalConfirmationMessage = objectManagementLoc.DeleteLoginConfirmationText;
+			additionalConfirmationMessage = objectManagementLoc.DropLoginConfirmationText;
 			break;
 		default:
 			break;
 	}
 	const nodeTypeDisplayName = objectManagementLoc.getNodeTypeDisplayName(context.nodeInfo!.nodeType);
-	let confirmMessage = objectManagementLoc.DeleteObjectConfirmationText(nodeTypeDisplayName, context.nodeInfo!.label);
+	let confirmMessage = objectManagementLoc.DropObjectConfirmationText(nodeTypeDisplayName, context.nodeInfo!.label);
 	if (additionalConfirmationMessage) {
 		confirmMessage = `${additionalConfirmationMessage} ${confirmMessage}`;
 	}
@@ -181,22 +181,22 @@ async function handleDeleteObjectCommand(context: azdata.ObjectExplorerContext, 
 		return;
 	}
 	azdata.tasks.startBackgroundOperation({
-		displayName: objectManagementLoc.DeleteObjectOperationDisplayName(nodeTypeDisplayName, context.nodeInfo!.label),
+		displayName: objectManagementLoc.DropObjectOperationDisplayName(nodeTypeDisplayName, context.nodeInfo!.label),
 		description: '',
 		isCancelable: false,
 		operation: async (operation) => {
 			try {
 				const startTime = Date.now();
 				await service.drop(connectionUri, context.nodeInfo.nodeType as ObjectManagement.NodeType, context.nodeInfo!.metadata!.urn);
-				TelemetryReporter.sendTelemetryEvent(TelemetryActions.DeleteObject, {
+				TelemetryReporter.sendTelemetryEvent(TelemetryActions.DropObject, {
 					objectType: context.nodeInfo!.nodeType
 				}, {
 					elapsedTimeMs: Date.now() - startTime
 				});
 			}
 			catch (err) {
-				operation.updateStatus(azdata.TaskStatus.Failed, objectManagementLoc.DeleteObjectError(nodeTypeDisplayName, context.nodeInfo!.label, getErrorMessage(err)));
-				TelemetryReporter.createErrorEvent2(ObjectManagementViewName, TelemetryActions.DeleteObject, err).withAdditionalProperties({
+				operation.updateStatus(azdata.TaskStatus.Failed, objectManagementLoc.DropObjectError(nodeTypeDisplayName, context.nodeInfo!.label, getErrorMessage(err)));
+				TelemetryReporter.createErrorEvent2(ObjectManagementViewName, TelemetryActions.DropObject, err).withAdditionalProperties({
 					objectType: context.nodeInfo!.nodeType
 				}).send();
 				console.error(err);
@@ -290,7 +290,7 @@ async function handleDetachDatabase(context: azdata.ObjectExplorerContext, servi
 	}
 }
 
-async function handleDeleteDatabase(context: azdata.ObjectExplorerContext, service: IObjectManagementService): Promise<void> {
+async function handleDropDatabase(context: azdata.ObjectExplorerContext, service: IObjectManagementService): Promise<void> {
 	const connectionUri = await getConnectionUri(context);
 	if (!connectionUri) {
 		return;
@@ -307,15 +307,15 @@ async function handleDeleteDatabase(context: azdata.ObjectExplorerContext, servi
 			objectUrn: context.nodeInfo!.metadata!.urn,
 			objectExplorerContext: context
 		};
-		const dialog = new DeleteDatabaseDialog(service, options);
+		const dialog = new DropDatabaseDialog(service, options);
 		await dialog.open();
 	}
 	catch (err) {
-		TelemetryReporter.createErrorEvent2(ObjectManagementViewName, TelemetryActions.OpenDeleteDatabaseDialog, err).withAdditionalProperties({
+		TelemetryReporter.createErrorEvent2(ObjectManagementViewName, TelemetryActions.OpenDropDatabaseDialog, err).withAdditionalProperties({
 			objectType: context.nodeInfo!.nodeType
 		}).send();
 		console.error(err);
-		await vscode.window.showErrorMessage(objectManagementLoc.OpenDeleteDatabaseDialogError(getErrorMessage(err)));
+		await vscode.window.showErrorMessage(objectManagementLoc.OpenDropDatabaseDialogError(getErrorMessage(err)));
 	}
 }
 

--- a/extensions/mssql/src/objectManagement/constants.ts
+++ b/extensions/mssql/src/objectManagement/constants.ts
@@ -37,13 +37,13 @@ export const DropDatabaseDocUrl = 'https://learn.microsoft.com/sql/t-sql/stateme
 
 export const enum TelemetryActions {
 	CreateObject = 'CreateObject',
-	DeleteObject = 'DeleteObject',
+	DropObject = 'DropObject',
 	OpenNewObjectDialog = 'OpenNewObjectDialog',
 	OpenPropertiesDialog = 'OpenPropertiesDialog',
 	RenameObject = 'RenameObject',
 	UpdateObject = 'UpdateObject',
 	OpenDetachDatabaseDialog = 'OpenDetachDatabaseDialog',
-	OpenDeleteDatabaseDialog = 'OpenDeleteDatabaseDialog'
+	OpenDropDatabaseDialog = 'OpenDropDatabaseDialog'
 }
 
 export const ObjectManagementViewName = 'ObjectManagement';

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -60,11 +60,11 @@ export function RefreshObjectExplorerError(error: string): string {
 	}, "An error occurred while refreshing the object explorer. {0}", error);
 }
 
-export function DeleteObjectConfirmationText(objectType: string, objectName: string): string {
+export function DropObjectConfirmationText(objectType: string, objectName: string): string {
 	return localize({
-		key: 'objectManagement.deleteObjectConfirmation',
+		key: 'objectManagement.dropObjectConfirmation',
 		comment: ['{0} object type, {1}: object name.']
-	}, "Are you sure you want to delete the {0}: {1}?", objectType, objectName);
+	}, "Are you sure you want to drop the {0}: {1}?", objectType, objectName);
 }
 
 export function CreateObjectOperationDisplayName(objectType: string): string {
@@ -81,18 +81,18 @@ export function UpdateObjectOperationDisplayName(objectType: string, objectName:
 	}, "Update {0} '{1}'", objectType, objectName);
 }
 
-export function DeleteObjectOperationDisplayName(objectType: string, objectName: string): string {
+export function DropObjectOperationDisplayName(objectType: string, objectName: string): string {
 	return localize({
-		key: 'objectManagement.deleteObjectOperationName',
+		key: 'objectManagement.dropObjectOperationName',
 		comment: ['{0} object type, {1}: object name.']
-	}, "Delete {0} '{1}'", objectType, objectName);
+	}, "Drop {0} '{1}'", objectType, objectName);
 }
 
-export function DeleteObjectError(objectType: string, objectName: string, error: string): string {
+export function DropObjectError(objectType: string, objectName: string, error: string): string {
 	return localize({
-		key: 'objectManagement.deleteObjectError',
+		key: 'objectManagement.dropObjectError',
 		comment: ['{0} object type, {1}: object name, {2}: error message.']
-	}, "An error occurred while deleting the {0}: {1}. {2}", objectType, objectName, error);
+	}, "An error occurred while dropping the {0}: {1}. {2}", objectType, objectName, error);
 }
 
 export function OpenDetachDatabaseDialogError(error: string): string {
@@ -102,11 +102,11 @@ export function OpenDetachDatabaseDialogError(error: string): string {
 	}, "An error occurred while opening the detach database dialog. {0}", error);
 }
 
-export function OpenDeleteDatabaseDialogError(error: string): string {
+export function OpenDropDatabaseDialogError(error: string): string {
 	return localize({
-		key: 'objectManagement.openDeleteDatabaseDialogError',
+		key: 'objectManagement.openDropDatabaseDialogError',
 		comment: ['{0}: error message.']
-	}, "An error occurred while opening the delete database dialog. {0}", error);
+	}, "An error occurred while opening the drop database dialog. {0}", error);
 }
 
 export function OpenObjectPropertiesDialogError(objectType: string, objectName: string, error: string): string {
@@ -189,16 +189,16 @@ export const DatabaseFilePathLabel = localize('objectManagement.databaseFilePath
 export const DatabaseFileGroupLabel = localize('objectManagement.databaseFileGroup', "File Group");
 export const DetachDatabaseOptions = localize('objectManagement.detachDatabaseOptions', "Detach Database Options");
 export const DetachButtonLabel = localize('objectManagement.detachButtonLabel', "Detach");
-export const DeleteDatabaseDialogTitle = (dbName: string) => localize('objectManagement.deleteDatabaseDialogTitle', "Delete Database - {0} (Preview)", dbName);
-export const DeleteButtonLabel = localize('objectManagement.deleteButtonLabel', "Delete");
-export const DeleteDatabaseOptions = localize('objectManagement.deleteDatabaseOptions', "Delete Database Options");
-export const DeleteDropConnections = localize('objectManagement.deleteDropConnections', "Close existing connections");
-export const DeleteDropBackupHistory = localize('objectManagement.deleteDropBackupHistory', "Delete backup and restore history information for database");
+export const DropDatabaseDialogTitle = (dbName: string) => localize('objectManagement.dropDatabaseDialogTitle', "Drop Database - {0} (Preview)", dbName);
+export const DropButtonLabel = localize('objectManagement.dropButtonLabel', "Drop");
+export const DropDatabaseOptions = localize('objectManagement.dropDatabaseOptions', "Drop Database Options");
+export const CloseConnections = localize('objectManagement.dropDropConnections', "Close existing connections");
+export const DeleteBackupHistory = localize('objectManagement.deleteDropBackupHistory', "Delete backup and restore history information for database");
 export const DatabaseDetailsLabel = localize('objectManagement.databaseDetails', "Database Details");
 
 // Login
 export const BlankPasswordConfirmationText: string = localize('objectManagement.blankPasswordConfirmation', "Creating a login with a blank password is a security risk.  Are you sure you want to continue?");
-export const DeleteLoginConfirmationText: string = localize('objectManagement.deleteLoginConfirmation', "Deleting server logins does not delete the database users associated with the logins. To complete the process, delete the users in each database. It may be necessary to first transfer the ownership of schemas to new users.");
+export const DropLoginConfirmationText: string = localize('objectManagement.dropLoginConfirmation', "Dropping server logins does not drop the database users associated with the logins. To complete the process, drop the users in each database. It may be necessary to first transfer the ownership of schemas to new users.");
 export const SQLAuthenticationSectionHeader = localize('objectManagement.login.sqlAuthSectionHeader', "SQL Authentication");
 export const ServerRoleSectionHeader = localize('objectManagement.login.serverRoleSectionHeader', "Server Roles");
 export const AuthTypeText = localize('objectManagement.login.authenticateType', "Authentication");

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -193,7 +193,7 @@ export const DropDatabaseDialogTitle = (dbName: string) => localize('objectManag
 export const DropButtonLabel = localize('objectManagement.dropButtonLabel', "Drop");
 export const DropDatabaseOptions = localize('objectManagement.dropDatabaseOptions', "Drop Database Options");
 export const CloseConnections = localize('objectManagement.closeConnections', "Close existing connections");
-export const DeleteBackupHistory = localize('objectManagement.deleteDropBackupHistory', "Delete backup and restore history information for database");
+export const DeleteBackupHistory = localize('objectManagement.deleteBackupHistory', "Delete backup and restore history information for database");
 export const DatabaseDetailsLabel = localize('objectManagement.databaseDetails', "Database Details");
 
 // Login

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -192,7 +192,7 @@ export const DetachButtonLabel = localize('objectManagement.detachButtonLabel', 
 export const DropDatabaseDialogTitle = (dbName: string) => localize('objectManagement.dropDatabaseDialogTitle', "Drop Database - {0} (Preview)", dbName);
 export const DropButtonLabel = localize('objectManagement.dropButtonLabel', "Drop");
 export const DropDatabaseOptions = localize('objectManagement.dropDatabaseOptions', "Drop Database Options");
-export const CloseConnections = localize('objectManagement.dropDropConnections', "Close existing connections");
+export const CloseConnections = localize('objectManagement.closeConnections', "Close existing connections");
 export const DeleteBackupHistory = localize('objectManagement.deleteDropBackupHistory', "Delete backup and restore history information for database");
 export const DatabaseDetailsLabel = localize('objectManagement.databaseDetails', "Database Details");
 

--- a/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
@@ -7,15 +7,15 @@ import { ObjectManagementDialogBase, ObjectManagementDialogOptions } from './obj
 import { IObjectManagementService, ObjectManagement } from 'mssql';
 import { Database, DatabaseViewInfo } from '../interfaces';
 import { DropDatabaseDocUrl } from '../constants';
-import { DeleteButtonLabel, DeleteDatabaseDialogTitle, DeleteDropBackupHistory, DeleteDropConnections, DeleteDatabaseOptions, NameText, OwnerText, StatusText, DatabaseDetailsLabel } from '../localizedConstants';
+import { DropButtonLabel, DropDatabaseDialogTitle, DeleteBackupHistory, CloseConnections, DropDatabaseOptions, NameText, OwnerText, StatusText, DatabaseDetailsLabel } from '../localizedConstants';
 
-export class DeleteDatabaseDialog extends ObjectManagementDialogBase<Database, DatabaseViewInfo> {
+export class DropDatabaseDialog extends ObjectManagementDialogBase<Database, DatabaseViewInfo> {
 	private _dropConnections = false;
 	private _deleteBackupHistory = false;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		super(objectManagementService, options, DeleteDatabaseDialogTitle(options.database), 'DeleteDatabase');
-		this.dialogObject.okButton.label = DeleteButtonLabel;
+		super(objectManagementService, options, DropDatabaseDialogTitle(options.database), 'DropDatabase');
+		this.dialogObject.okButton.label = DropButtonLabel;
 	}
 
 	protected override get isDirty(): boolean {
@@ -32,13 +32,13 @@ export class DeleteDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		components.push(tableGroup);
 
 		if (!this.viewInfo.isAzureDB && !this.viewInfo.isManagedInstance && !this.viewInfo.isSqlOnDemand) {
-			let connCheckbox = this.createCheckbox(DeleteDropConnections, async checked => {
+			let connCheckbox = this.createCheckbox(CloseConnections, async checked => {
 				this._dropConnections = checked;
 			});
-			let updateCheckbox = this.createCheckbox(DeleteDropBackupHistory, async checked => {
+			let updateCheckbox = this.createCheckbox(DeleteBackupHistory, async checked => {
 				this._deleteBackupHistory = checked;
 			});
-			let checkboxGroup = this.createGroup(DeleteDatabaseOptions, [connCheckbox, updateCheckbox], false);
+			let checkboxGroup = this.createGroup(DropDatabaseOptions, [connCheckbox, updateCheckbox], false);
 			components.push(checkboxGroup);
 		}
 		this.formContainer.addItems(components);


### PR DESCRIPTION
I noticed we use Delete and Drop interchangeably in some places, so we had an offline discussion and settled on using drop for all "delete" object operations to align with TSQL terminology.
