### PR TITLE
Resize splitview when window is resized

### DIFF
--- a/src/sql/workbench/browser/modelComponents/splitviewContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/splitviewContainer.component.ts
@@ -99,7 +99,7 @@ export default class SplitViewContainerImpl extends ContainerBase<FlexItemLayout
 		return basicView;
 	}
 
-	@debounce(300)
+	@debounce(20)
 	private resizeSplitview() {
 		if (this._resizeable) {
 			this._splitViewSize = this.calculateSplitViewSize(this.orientation);
@@ -113,7 +113,7 @@ export default class SplitViewContainerImpl extends ContainerBase<FlexItemLayout
 	 * @returns
 	 */
 	private calculateSplitViewSize(orientation: string): number {
-		const modelViewContainer = document.getElementsByClassName('model-view-container')[0] as HTMLDivElement;
+		const modelViewContainer = DOM.findParentWithClass(this._el.nativeElement, 'model-view-container');
 		const modelViewContainerRect = modelViewContainer.getBoundingClientRect();
 		return orientation.toLowerCase() === 'vertical' ? modelViewContainerRect.height : modelViewContainerRect.width;
 	}

--- a/src/sql/workbench/browser/modelComponents/splitviewContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/splitviewContainer.component.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import 'vs/css!./media/flexContainer';
+import * as DOM from 'vs/base/browser/dom';
 import { Component, Input, Inject, ChangeDetectorRef, forwardRef, ElementRef, OnDestroy } from '@angular/core';
 
 import { FlexItemLayout, SplitViewLayout, SplitViewContainer, CssStyles } from 'azdata';
@@ -13,6 +14,7 @@ import { SplitView, Orientation, Sizing, IView } from 'vs/base/browser/ui/splitv
 import { IComponent, IComponentDescriptor, IModelStore } from 'sql/platform/dashboard/browser/interfaces';
 import { ILogService } from 'vs/platform/log/common/log';
 import { convertSize, convertSizeToNumber } from 'sql/base/browser/dom';
+import { debounce } from 'vs/base/common/decorators';
 
 class SplitPane implements IView {
 	orientation: Orientation;
@@ -60,6 +62,7 @@ export default class SplitViewContainerImpl extends ContainerBase<FlexItemLayout
 	private _splitView: SplitView;
 	private _orientation: Orientation;
 	private _splitViewSize: number;
+	private _resizeable: boolean;
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
@@ -70,6 +73,10 @@ export default class SplitViewContainerImpl extends ContainerBase<FlexItemLayout
 		this._flexFlow = '';	// default
 		this._justifyContent = '';	// default
 		this._orientation = Orientation.VERTICAL; // default
+
+		this._register(DOM.addDisposableListener(window, DOM.EventType.RESIZE, e => {
+			this.resizeSplitview();
+		}));
 	}
 
 	override ngOnDestroy(): void {
@@ -92,6 +99,25 @@ export default class SplitViewContainerImpl extends ContainerBase<FlexItemLayout
 		return basicView;
 	}
 
+	@debounce(300)
+	private resizeSplitview() {
+		if (this._resizeable) {
+			this._splitViewSize = this.calculateSplitViewSize(this.orientation);
+			this._splitView.layout(this._splitViewSize);
+		}
+	}
+
+	/**
+	 * Calculates the size of the split view based on the dimensions of the model view container and orientation of the splitview
+	 * @param orientation
+	 * @returns
+	 */
+	private calculateSplitViewSize(orientation: string): number {
+		const modelViewContainer = document.getElementsByClassName('model-view-container')[0] as HTMLDivElement;
+		const modelViewContainerRect = modelViewContainer.getBoundingClientRect();
+		return orientation.toLowerCase() === 'vertical' ? modelViewContainerRect.height : modelViewContainerRect.width;
+	}
+
 	/// IComponent implementation
 
 	public setLayout(layout: SplitViewLayout): void {
@@ -106,10 +132,10 @@ export default class SplitViewContainerImpl extends ContainerBase<FlexItemLayout
 
 		if (!layout.splitViewSize) {
 			// if no size was passed in for the split view, use the dimensions of the model view container
-			const modelViewContainer = document.getElementsByClassName('model-view-container')[0] as HTMLDivElement;
-			const modelViewContainerRect = modelViewContainer.getBoundingClientRect();
-			this._splitViewSize = layout.orientation.toLowerCase() === 'vertical' ? modelViewContainerRect.height : modelViewContainerRect.width;
+			this._resizeable = true;
+			this._splitViewSize = this.calculateSplitViewSize(layout.orientation);
 		} else {
+			this._resizeable = false;
 			this._splitViewSize = convertSizeToNumber(layout.splitViewSize);
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/azuredatastudio/issues/23888. This adds supports for splitviews resizing when the window is resized, if the splitview wasn't created with a set height.

before:
QDS - has a horizontal and vertical splitview
![qdsResizeBefore](https://github.com/microsoft/azuredatastudio/assets/31145923/dd1c1328-3f22-41ca-aa69-e96d822e222d)

schema compare - notice that the bottom section doesn't keep expanding and there is blank space
![schemaCompareBefore](https://github.com/microsoft/azuredatastudio/assets/31145923/f0e7dc11-9780-460e-b2a6-4674f3c6efdd)

after:
![qdsResize](https://github.com/microsoft/azuredatastudio/assets/31145923/071a0bae-8f35-418e-8c96-4359a21ddb26)
![splitviewResize](https://github.com/microsoft/azuredatastudio/assets/31145923/3c7a9212-1c9f-4789-9fbe-ad40a064ec59)
