### PR TITLE
Announce when extension install is finished

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -432,8 +432,12 @@ export abstract class AbstractInstallAction extends ExtensionAction {
 
 		const extension = await this.install(this.extension);
 
-		if (extension && extension?.local) {
+		// {{SQL CARBON EDIT}} Announce extension is finished being installed even if extension.local is undefined
+		if (extension) {
 			alert(localize('installExtensionComplete', "Installing extension {0} is completed.", this.extension.displayName));
+		}
+
+		if (extension && (extension?.local)) {
 			const runningExtension = await this.getRunningExtension(extension.local);
 			if (runningExtension && !(runningExtension.activationEvents && runningExtension.activationEvents.some(activationEent => activationEent.startsWith('onLanguage')))) {
 				const action = await this.getThemeAction(extension);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Addresses this accessibility issue https://github.com/microsoft/azuredatastudio/issues/24161. Vscode announces the extension installation, but ADS wasn't going into the `if` block with the alert because `extension?.local` was undefined. I found that the extension getting returned from `this.install()` was an [ILocalExtension](https://github.com/microsoft/azuredatastudio/blob/01e66ab3e68200cbc0b9937cae39446b777bbadb/src/vs/platform/extensionManagement/common/extensionManagement.ts#L261), but it extends an [IExtension](https://github.com/microsoft/azuredatastudio/blob/01e66ab3e68200cbc0b9937cae39446b777bbadb/src/vs/platform/extensions/common/extensions.ts#L321) interface that does not have the local property. There is a different[ IExtension interface](https://github.com/microsoft/azuredatastudio/blob/01e66ab3e68200cbc0b9937cae39446b777bbadb/src/vs/workbench/contrib/extensions/common/extensions.ts#L43) that does have a local property (which has the type `ILocalExtension`) that this if is looking for. Not sure if this mismatch is due to some ADS edits to work with the ADS marketplace or if it broke during a previous ADS merge.

I went back several releases (tried back to 1.40.2) and it was the same bug of the installation completion not getting announced, so it's been a problem for a while. This is a quick fix to get the installation completion announced because this is a sev2 accessibility issue, since the underlying problem will require more investigation.

![announceExtensionInstall](https://github.com/microsoft/azuredatastudio/assets/31145923/6c3a34a0-8589-499c-9f3e-e4b8cfae366b)