### PR TITLE
Ensure Notebook v6 Pip Package Installed

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -569,7 +569,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 
 			packages.forEach(pkg => {
 				let installedPkgVersion = pipVersionMap.get(pkg.name);
-				if (!installedPkgVersion || utils.compareVersions(installedPkgVersion, pkg.version) < 0) {
+				if (!installedPkgVersion || utils.compareVersions(installedPkgVersion, pkg.version) < 0 || (pkg.installExactVersion && installedPkgVersion !== pkg.version)) {
 					packagesToInstall.push(pkg);
 				}
 			});

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -83,6 +83,12 @@ export const requiredJupyterPkg: PythonPkgDetails = {
 	version: '1.0.0'
 };
 
+export const requiredNotebookPkg: PythonPkgDetails = {
+	name: 'notebook',
+	version: '6.5.5',
+	installExactVersion: true
+};
+
 export const requiredPowershellPkg: PythonPkgDetails = {
 	name: 'powershell-kernel',
 	version: '0.1.4'
@@ -143,11 +149,11 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		this._kernelSetupCache = new Map<string, boolean>();
 		this._requiredKernelPackages = new Map<string, PythonPkgDetails[]>();
 
-		this._requiredKernelPackages.set(constants.ipykernelDisplayName, [requiredJupyterPkg]);
-		this._requiredKernelPackages.set(constants.python3DisplayName, [requiredJupyterPkg]);
-		this._requiredKernelPackages.set(constants.powershellDisplayName, [requiredJupyterPkg, requiredPowershellPkg]);
+		this._requiredKernelPackages.set(constants.ipykernelDisplayName, [requiredJupyterPkg, requiredNotebookPkg]);
+		this._requiredKernelPackages.set(constants.python3DisplayName, [requiredJupyterPkg, requiredNotebookPkg]);
+		this._requiredKernelPackages.set(constants.powershellDisplayName, [requiredJupyterPkg, requiredPowershellPkg, requiredNotebookPkg]);
 
-		let allPackages = [requiredJupyterPkg, requiredPowershellPkg];
+		let allPackages = [requiredJupyterPkg, requiredNotebookPkg, requiredPowershellPkg];
 		this._requiredKernelPackages.set(constants.allKernelsName, allPackages);
 
 		this._requiredPackagesSet = new Set<string>();
@@ -542,7 +548,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		let requiredPackages = this.getRequiredPackagesForKernel(kernelDisplayName);
 		for (let pkg of requiredPackages) {
 			let installedVersion = installedPackageMap.get(pkg.name);
-			if (!installedVersion || utils.compareVersions(installedVersion, pkg.version) < 0) {
+			if (!installedVersion || utils.compareVersions(installedVersion, pkg.version) < 0 || (pkg.installExactVersion && installedVersion !== pkg.version)) {
 				return false;
 			}
 		}

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -11,7 +11,7 @@ import * as uuid from 'uuid';
 import * as fs from 'fs-extra';
 import * as request from 'request';
 import * as utils from '../../common/utils';
-import { requiredJupyterPkg, JupyterServerInstallation, requiredPowershellPkg, PythonInstallSettings, PythonPkgDetails } from '../../jupyter/jupyterServerInstallation';
+import { requiredJupyterPkg, JupyterServerInstallation, requiredPowershellPkg, PythonInstallSettings, PythonPkgDetails, requiredNotebookPkg } from '../../jupyter/jupyterServerInstallation';
 import { powershellDisplayName, python3DisplayName, winPlatform } from '../../common/constants';
 
 describe('Jupyter Server Installation', function () {
@@ -226,12 +226,12 @@ describe('Jupyter Server Installation', function () {
 
 	it('Get required packages test - Python 3 kernel', async function () {
 		let packages = installation.getRequiredPackagesForKernel(python3DisplayName);
-		should(packages).be.deepEqual([requiredJupyterPkg]);
+		should(packages).be.deepEqual([requiredJupyterPkg, requiredNotebookPkg]);
 	});
 
 	it('Get required packages test - Powershell kernel', async function () {
 		let packages = installation.getRequiredPackagesForKernel(powershellDisplayName);
-		should(packages).be.deepEqual([requiredJupyterPkg, requiredPowershellPkg]);
+		should(packages).be.deepEqual([requiredJupyterPkg, requiredPowershellPkg, requiredNotebookPkg]);
 	});
 
 	it('Install python test - Run install while Python is already running', async function () {


### PR DESCRIPTION
A new `notebook` pip package was released and is not backwards compatible with previous versions of the package, causing issues from our users (e.g. https://github.com/microsoft/azuredatastudio/issues/23945)

Some details can be found here: 
https://github.com/jupyter/notebook/releases/tag/v7.0.0
https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html
https://jupyter-server.readthedocs.io/en/latest/operators/migrate-from-nbserver.html

I have some code that gets us 50% of the way to notebook v7 but is flaky, and don't feel comfortable pushing that at the moment. Here's the beginnings of it: https://github.com/microsoft/azuredatastudio/compare/chlafren/nb7?expand=1. This attempts to support both 6.x and 7.x.

Ideally, we can move everyone to 7.x and support that going forward -- building upon this PR, where we ensure that the version required is >= 7. This will take a fairly significant effort to ensure a quality release, which will not make September.

So, leveraging existing mechanisms to enforce 6.x versions of the package is what we should go with for now out of an abundance of caution. v6 of the package will be in support for at least 2 years as well, so this is still a supported scenario from Jupyter's perspective.

Here's what users see if they have > 6.x of the package installed:
<img width="520" alt="image" src="https://github.com/microsoft/azuredatastudio/assets/40371649/97f8c30c-2969-443c-b074-03be43b99c1f">

