### PR TITLE
Bump STS to v4.9.0.22

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.9.0.18",
+	"version": "4.9.0.22",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
https://github.com/microsoft/sqltoolsservice/compare/4.9.0.18...4.9.0.22

![image](https://github.com/microsoft/azuredatastudio/assets/13396919/9fd644a2-7388-48e3-a65c-eda0422d493e)
