### PR TITLE
Add back "Install" text on welcome page button and remove tooltip

### DIFF
--- a/src/sql/workbench/contrib/welcome/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/browser/welcomePage.ts
@@ -577,7 +577,8 @@ class WelcomePage extends Disposable {
 		if (btnContainer) {
 			extensionPacks.forEach((extension) => {
 				const installText = localize('welcomePage.install', "Install");
-				this._register(new Button(btnContainer, { title: installText, supportIcons: true, ...defaultButtonStyles }));
+				let dropdownBtn = this._register(new Button(btnContainer, { supportIcons: true, ...defaultButtonStyles }));
+				dropdownBtn.label = installText;
 				const classes = ['btn'];
 				const getDropdownBtn = container.querySelector('.extensionPack .monaco-button:first-of-type') as HTMLAnchorElement;
 				getDropdownBtn.id = 'dropdown-btn';
@@ -601,7 +602,7 @@ class WelcomePage extends Disposable {
 				const header = container.querySelector('.extension-pack-header');
 
 				const installedText = localize('welcomePage.installed', "Installed");
-				let installedButton = new Button(btnContainer, { title: installedText, supportIcons: true, ...defaultButtonStyles });
+				let installedButton = new Button(btnContainer, { supportIcons: true, ...defaultButtonStyles });
 				this._register(installedButton);
 
 				installedButton.label = installedText;

--- a/src/sql/workbench/contrib/welcome/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/browser/welcomePage.ts
@@ -582,7 +582,6 @@ class WelcomePage extends Disposable {
 				const getDropdownBtn = container.querySelector('.extensionPack .monaco-button:first-of-type') as HTMLAnchorElement;
 				getDropdownBtn.id = 'dropdown-btn';
 				getDropdownBtn.classList.add(...classes);
-				getDropdownBtn.title = extension.title || (extension.isKeymap ? localize('welcomePage.installKeymap', "Install {0} keymap", extension.name) : localize('welcomePage.installExtensionPack', "Install additional support for {0}", extension.name));
 				getDropdownBtn.setAttribute('aria-haspopup', 'true');
 				getDropdownBtn.setAttribute('aria-controls', 'dropdown');
 				getDropdownBtn.setAttribute('role', 'navigation');
@@ -610,7 +609,6 @@ class WelcomePage extends Disposable {
 				const getInstalledButton = container.querySelector('.extensionPack .monaco-button:nth-of-type(2)') as HTMLAnchorElement;
 
 				getInstalledButton.innerText = localize('welcomePage.installed', "Installed");
-				getInstalledButton.title = extension.isKeymap ? localize('welcomePage.installedKeymap', "{0} keymap is already installed", extension.name) : localize('welcomePage.installedExtensionPack', "{0} support is already installed", extension.name);
 				getInstalledButton.classList.add('enabledExtension');
 				getInstalledButton.classList.add(...classes);
 				getInstalledButton.setAttribute('data-extension', extension.id);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #24210 where the "Install" button no longer had the text. It looks like it was mistakenly removed during the vscode merge. 

Also fixes this accessibility issue #10642 by removing the tooltips from the "Install" and "Installed" buttons. The tooltips were unnecessary because the labels are self explanatory.

before:
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/2334da77-84c9-4521-a58e-9107835015fb)

fixed:
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/a0fc8f28-5793-41f5-b044-cc4dfce55ca1)
