### PR TITLE
update Microsoft.Build.Sql SDK version to 0.1.12-preview

### DIFF
--- a/extensions/sql-database-projects/README.md
+++ b/extensions/sql-database-projects/README.md
@@ -35,7 +35,7 @@ Learn more about the SQL Database Projects extension in the documentation: https
 
 ### General Settings
 - `sqlDatabaseProjects.dotnetSDK Location`: The path to the folder containing the `dotnet` folder for the .NET SDK. If not set, the extension will attempt to find the .NET SDK on the system.
-- `sqlDatabaseProjects.microsoftBuildSqlVersion`: Version of Microsoft.Build.Sql binaries used when building SQL projects that are not SDK-style SQL projects. If not set, the extension will use Microsoft.Build.Sql 0.1.10-preview.
+- `sqlDatabaseProjects.microsoftBuildSqlVersion`: Version of Microsoft.Build.Sql binaries used when building SQL projects that are not SDK-style SQL projects. If not set, the extension will use Microsoft.Build.Sql 0.1.12-preview.
 - `sqlDatabaseProjects.netCoreDoNotAsk`: When true, no longer prompts to install .NET SDK when a supported installation is not found.
 - `sqlDatabaseProjects.collapseProjectNodes`: Option to set the default state of the project nodes in the database projects view to collapsed. If not set, the extension will default to expanded.
 

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -56,7 +56,7 @@ export class BuildHelper {
 
 	public async ensureDacFxDllsPresence(outputChannel: vscode.OutputChannel): Promise<boolean> {
 		const sdkName = 'Microsoft.Build.Sql';
-		const microsoftBuildSqlDefaultVersion = '0.1.10-preview'; // default version of Microsoft.Build.Sql nuget to use for building legacy style projects, update in README when updating this
+		const microsoftBuildSqlDefaultVersion = '0.1.12-preview'; // default version of Microsoft.Build.Sql nuget to use for building legacy style projects, update in README when updating this
 
 		const dacFxBuildFiles: string[] = [
 			'Microsoft.Data.SqlClient.dll',


### PR DESCRIPTION
Update the Microsoft.Build.Sql SDK version used to build legacy style sql projects to 0.1.12-preview. Fixes https://github.com/microsoft/azuredatastudio/issues/24170
