### PR TITLE
update sql projects azdata dependency to 1.46.0

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -7,7 +7,7 @@
   "preview": false,
   "engines": {
     "vscode": "^1.30.1",
-    "azdata": ">=1.44.0"
+    "azdata": ">=1.46.0"
   },
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/sqlDatabaseProjects.png",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Update azdata dependency of sql projects since recent Fabric and microsoft.build.sql version updates depend on recent STS changes, so wouldn't work with older versions of ADS.