### PR TITLE
Pass through database names to enable connection cleanup

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.9.0.25",
+	"version": "4.9.0.27",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -589,6 +589,11 @@
           "group": "1_objectManagement@2"
         },
         {
+          "command": "mssql.attachDatabase",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == Databases && !isCloud && config.workbench.enablePreviewFeatures",
+          "group": "1_objectManagement@2"
+        },
+        {
           "command": "mssql.dropDatabase",
           "when": "connectionProvider == MSSQL && nodeType == Database && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@3"
@@ -597,11 +602,6 @@
           "command": "mssql.dropObject",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@3"
-        },
-        {
-          "command": "mssql.attachDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == Databases && !isCloud && config.workbench.enablePreviewFeatures",
-          "group": "1_objectManagement"
         },
         {
           "command": "mssql.enableGroupBySchema",

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1651,6 +1651,7 @@ export namespace SearchObjectRequest {
 
 export interface DetachDatabaseRequestParams {
 	connectionUri: string;
+	database: string;
 	objectUrn: string;
 	dropConnections: boolean;
 	updateStatistics: boolean;
@@ -1663,6 +1664,7 @@ export namespace DetachDatabaseRequest {
 
 export interface DropDatabaseRequestParams {
 	connectionUri: string;
+	database: string;
 	objectUrn: string;
 	dropConnections: boolean;
 	deleteBackupHistory: boolean;

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -977,23 +977,25 @@ declare module 'mssql' {
 		/**
 		 * Detach a database.
 		 * @param connectionUri The URI of the server connection.
+		 * @param database The target database.
 		 * @param objectUrn SMO Urn of the database to be detached. More information: https://learn.microsoft.com/sql/relational-databases/server-management-objects-smo/overview-smo
 		 * @param dropConnections Whether to drop active connections to this database.
 		 * @param updateStatistics Whether to update the optimization statistics related to this database.
 		 * @param generateScript Whether to generate a TSQL script for the operation instead of detaching the database.
 		 * @returns A string value representing the generated TSQL query if generateScript was set to true, and an empty string otherwise.
 		 */
-		detachDatabase(connectionUri: string, objectUrn: string, dropConnections: boolean, updateStatistics: boolean, generateScript: boolean): Thenable<string>;
+		detachDatabase(connectionUri: string, database: string, objectUrn: string, dropConnections: boolean, updateStatistics: boolean, generateScript: boolean): Thenable<string>;
 		/**
 		 * Drop a database.
 		 * @param connectionUri The URI of the server connection.
+		 * @param database The target database.
 		 * @param objectUrn SMO Urn of the database to be detached. More information: https://learn.microsoft.com/sql/relational-databases/server-management-objects-smo/overview-smo
 		 * @param dropConnections Whether to drop active connections to this database.
 		 * @param deleteBackupHistory Whether to delete backup and restore history information for this database.
 		 * @param generateScript Whether to generate a TSQL script for the operation instead of detaching the database.
 		 * @returns A string value representing the generated TSQL query if generateScript was set to true, and an empty string otherwise.
 		 */
-		dropDatabase(connectionUri: string, objectUrn: string, dropConnections: boolean, deleteBackupHistory: boolean, generateScript: boolean): Thenable<string>;
+		dropDatabase(connectionUri: string, database: string, objectUrn: string, dropConnections: boolean, deleteBackupHistory: boolean, generateScript: boolean): Thenable<string>;
 	}
 	// Object Management - End.
 }

--- a/extensions/mssql/src/objectManagement/objectManagementService.ts
+++ b/extensions/mssql/src/objectManagement/objectManagementService.ts
@@ -66,13 +66,13 @@ export class ObjectManagementService extends BaseService implements IObjectManag
 		return this.runWithErrorHandling(contracts.SearchObjectRequest.type, params);
 	}
 
-	async detachDatabase(connectionUri: string, objectUrn: string, dropConnections: boolean, updateStatistics: boolean, generateScript: boolean): Promise<string> {
-		const params: contracts.DetachDatabaseRequestParams = { connectionUri, objectUrn, dropConnections, updateStatistics, generateScript };
+	async detachDatabase(connectionUri: string, database: string, objectUrn: string, dropConnections: boolean, updateStatistics: boolean, generateScript: boolean): Promise<string> {
+		const params: contracts.DetachDatabaseRequestParams = { connectionUri, database, objectUrn, dropConnections, updateStatistics, generateScript };
 		return this.runWithErrorHandling(contracts.DetachDatabaseRequest.type, params);
 	}
 
-	async dropDatabase(connectionUri: string, objectUrn: string, dropConnections: boolean, deleteBackupHistory: boolean, generateScript: boolean): Promise<string> {
-		const params: contracts.DropDatabaseRequestParams = { connectionUri, objectUrn, dropConnections, deleteBackupHistory, generateScript };
+	async dropDatabase(connectionUri: string, database: string, objectUrn: string, dropConnections: boolean, deleteBackupHistory: boolean, generateScript: boolean): Promise<string> {
+		const params: contracts.DropDatabaseRequestParams = { connectionUri, database, objectUrn, dropConnections, deleteBackupHistory, generateScript };
 		return this.runWithErrorHandling(contracts.DropDatabaseRequest.type, params);
 	}
 }
@@ -242,11 +242,11 @@ export class TestObjectManagementService implements IObjectManagementService {
 		return this.delayAndResolve(items);
 	}
 
-	async detachDatabase(connectionUri: string, objectUrn: string, dropConnections: boolean, updateStatistics: boolean, generateScript: boolean): Promise<string> {
+	async detachDatabase(connectionUri: string, database: string, objectUrn: string, dropConnections: boolean, updateStatistics: boolean, generateScript: boolean): Promise<string> {
 		return this.delayAndResolve('');
 	}
 
-	dropDatabase(connectionUri: string, objectUrn: string, dropConnections: boolean, deleteBackupHistory: boolean, generateScript: boolean): Thenable<string> {
+	dropDatabase(connectionUri: string, database: string, objectUrn: string, dropConnections: boolean, deleteBackupHistory: boolean, generateScript: boolean): Thenable<string> {
 		return this.delayAndResolve('');
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
@@ -45,11 +45,11 @@ export class DetachDatabaseDialog extends ObjectManagementDialogBase<Database, D
 	}
 
 	protected override async saveChanges(contextId: string, object: ObjectManagement.SqlObject): Promise<void> {
-		await this.objectManagementService.detachDatabase(this.options.connectionUri, this.options.objectUrn, this._dropConnections, this._updateStatistics, false);
+		await this.objectManagementService.detachDatabase(this.options.connectionUri, this.options.database, this.options.objectUrn, this._dropConnections, this._updateStatistics, false);
 	}
 
 	protected override async generateScript(): Promise<string> {
-		return await this.objectManagementService.detachDatabase(this.options.connectionUri, this.options.objectUrn, this._dropConnections, this._updateStatistics, true);
+		return await this.objectManagementService.detachDatabase(this.options.connectionUri, this.options.database, this.options.objectUrn, this._dropConnections, this._updateStatistics, true);
 	}
 
 	protected override async validateInput(): Promise<string[]> {

--- a/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
@@ -49,11 +49,11 @@ export class DropDatabaseDialog extends ObjectManagementDialogBase<Database, Dat
 	}
 
 	protected override async saveChanges(contextId: string, object: ObjectManagement.SqlObject): Promise<void> {
-		await this.objectManagementService.dropDatabase(this.options.connectionUri, this.options.objectUrn, this._dropConnections, this._deleteBackupHistory, false);
+		await this.objectManagementService.dropDatabase(this.options.connectionUri, this.options.database, this.options.objectUrn, this._dropConnections, this._deleteBackupHistory, false);
 	}
 
 	protected override async generateScript(): Promise<string> {
-		return await this.objectManagementService.dropDatabase(this.options.connectionUri, this.options.objectUrn, this._dropConnections, this._deleteBackupHistory, true);
+		return await this.objectManagementService.dropDatabase(this.options.connectionUri, this.options.database, this.options.objectUrn, this._dropConnections, this._deleteBackupHistory, true);
 	}
 
 	protected override async validateInput(): Promise<string[]> {


### PR DESCRIPTION
The ADS counterpart to this STS change: https://github.com/microsoft/sqltoolsservice/commit/724d533090b426c5f0acf1b74f743508742fdd0d

We need to pass through the database names here so that when we call `ClearPool` during Detach and Drop operations, we'll be hitting the same connection pool as the other DB connections since pools are indexed by connection string. Without that our connection string has "master" as the database, which clears a different pool.

Fixes https://github.com/microsoft/azuredatastudio/issues/23653