### PR TITLE
Initial changes for query store dashboard

### DIFF
--- a/extensions/query-store/package.json
+++ b/extensions/query-store/package.json
@@ -39,13 +39,7 @@
       }
     ],
     "menus": {
-      "objectExplorer/item/context": [
-        {
-          "command": "queryStore.openQueryStoreDashboard",
-          "group": "queryStore",
-          "when": "connectionProvider == MSSQL && nodeType && nodeType == Database && mssql:engineedition != 11"
-        }
-      ],
+      "objectExplorer/item/context": [],
       "dataExplorer/context": [],
       "commandPalette": []
     }

--- a/extensions/query-store/package.json
+++ b/extensions/query-store/package.json
@@ -33,18 +33,19 @@
   "contributes": {
     "commands": [
       {
-        "command": "queryStore.topResourceConsumingQueriesOpen",
-        "title": "%queryStore.topResourceConsumingQueriesOpen%",
-        "category": "%queryStore.category%"
-      },
-      {
-        "command": "queryStore.overallResourceConsumptionOpen",
-        "title": "%queryStore.overallResourceConsumptionOpen%",
+        "command": "queryStore.openQueryStoreDashboard",
+        "title": "%queryStore.openQueryStoreDashboard%",
         "category": "%queryStore.category%"
       }
     ],
     "menus": {
-      "objectExplorer/item/context": [],
+      "objectExplorer/item/context": [
+        {
+          "command": "queryStore.openQueryStoreDashboard",
+          "group": "queryStore",
+          "when": "connectionProvider == MSSQL && nodeType && nodeType == Database && mssql:engineedition != 11"
+        }
+      ],
       "dataExplorer/context": [],
       "commandPalette": []
     }

--- a/extensions/query-store/package.nls.json
+++ b/extensions/query-store/package.nls.json
@@ -2,6 +2,5 @@
 	"queryStore.displayName": "Query Store",
 	"queryStore.description": "Query Store extension for Azure Data Studio.",
 	"queryStore.category": "Query Store",
-	"queryStore.topResourceConsumingQueriesOpen": "Open Top Resource Consuming Queries",
-	"queryStore.overallResourceConsumptionOpen": "Open Overall Resource Consumption"
+	"queryStore.openQueryStoreDashboard": "Query Store"
 }

--- a/extensions/query-store/src/common/constants.ts
+++ b/extensions/query-store/src/common/constants.ts
@@ -7,6 +7,8 @@ import * as nls from 'vscode-nls';
 
 const localize = nls.loadMessageBundle();
 
+export function queryStoreDashboardTitle(databaseName: string): string { return localize('queryStoreDashboardTitle', "Query Store - {0}", databaseName); }
+
 export const overallResourceConsumption = localize('overallResourceConsumption', "Overall Resource Consumption");
 export const duration = localize('duration', "Duration");
 export const executionCount = localize('executionCount', "Execution Count");

--- a/extensions/query-store/src/extension.ts
+++ b/extensions/query-store/src/extension.ts
@@ -9,7 +9,8 @@ import { QueryStoreDashboard } from './reports/queryStoreDashboard';
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	// TODO: get db name
 	// TODO: add condition for command to only be visible for db's with Query Store enabled (or consider always showing and having a way to enable when dashboard is opened?)
-	context.subscriptions.push(vscode.commands.registerCommand('queryStore.openQueryStoreDashboard', async () => { await new QueryStoreDashboard('AdventureWorks').open() }));
+	// TODO: remove entry point from command palette - keeping for now to speed up testing so a connection doesn't need to be made to launch the dashboard
+	context.subscriptions.push(vscode.commands.registerCommand('queryStore.openQueryStoreDashboard', async () => { await new QueryStoreDashboard('AdventureWorks', context).open() }));
 }
 
 export function deactivate(): void {

--- a/extensions/query-store/src/extension.ts
+++ b/extensions/query-store/src/extension.ts
@@ -8,7 +8,7 @@ import { QueryStoreDashboard } from './reports/queryStoreDashboard';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	// TODO: get db name
-	// TODO: add condition for command to only be visible for db's with Query Store enabled (or consider always showing and having a way to enable when dashboard is opened?)
+	// TODO: add OE entry point with condition for command to only be visible for db's with Query Store enabled (or consider always showing and having a way to enable when dashboard is opened?)
 	// TODO: remove entry point from command palette - keeping for now to speed up testing so a connection doesn't need to be made to launch the dashboard
 	context.subscriptions.push(vscode.commands.registerCommand('queryStore.openQueryStoreDashboard', async () => { await new QueryStoreDashboard('AdventureWorks', context).open() }));
 }

--- a/extensions/query-store/src/extension.ts
+++ b/extensions/query-store/src/extension.ts
@@ -4,13 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { TopResourceConsumingQueries } from './reports/topResourceConsumingQueries';
-import { OverallResourceConsumption } from './reports/overallResourceConsumption';
+import { QueryStoreDashboard } from './reports/queryStoreDashboard';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	// TODO: get db name
-	context.subscriptions.push(vscode.commands.registerCommand('queryStore.topResourceConsumingQueriesOpen', async () => { await new TopResourceConsumingQueries(context, 'WideWorldImporters').open() }));
-	context.subscriptions.push(vscode.commands.registerCommand('queryStore.overallResourceConsumptionOpen', async () => { await new OverallResourceConsumption(context, 'WideWorldImporters').open() }));
+	// TODO: add condition for command to only be visible for db's with Query Store enabled (or consider always showing and having a way to enable when dashboard is opened?)
+	context.subscriptions.push(vscode.commands.registerCommand('queryStore.openQueryStoreDashboard', async () => { await new QueryStoreDashboard('AdventureWorks').open() }));
 }
 
 export function deactivate(): void {

--- a/extensions/query-store/src/reports/baseQueryStoreReport.ts
+++ b/extensions/query-store/src/reports/baseQueryStoreReport.ts
@@ -11,11 +11,14 @@ import * as constants from '../common/constants';
 import { ConfigureDialog } from '../settings/configureDialog';
 
 export abstract class BaseQueryStoreReport {
-	public flexModel?: azdata.FlexContainer;
+	protected flexModel?: azdata.FlexContainer;
 	protected configureDialog?: ConfigureDialog;
 	protected configureButton?: azdata.ButtonComponent;
 
-	constructor(private reportTitle: string, protected resizeable: boolean, private extensionContext: vscode.ExtensionContext) {
+	constructor(private reportTitle: string, protected resizeable: boolean, private extensionContext: vscode.ExtensionContext) { }
+
+	public get ReportContent(): azdata.FlexContainer | undefined {
+		return this.flexModel;
 	}
 
 	/**

--- a/extensions/query-store/src/reports/baseQueryStoreReport.ts
+++ b/extensions/query-store/src/reports/baseQueryStoreReport.ts
@@ -11,40 +11,32 @@ import * as constants from '../common/constants';
 import { ConfigureDialog } from '../settings/configureDialog';
 
 export abstract class BaseQueryStoreReport {
-	protected editor: azdata.workspace.ModelViewEditor;
-	protected flexModel?: azdata.FlexContainer;
+	public flexModel?: azdata.FlexContainer;
 	protected configureDialog?: ConfigureDialog;
 	protected configureButton?: azdata.ButtonComponent;
 
-	constructor(reportName: string, private reportTitle: string, protected resizeable: boolean, private extensionContext: vscode.ExtensionContext) {
-		this.editor = azdata.workspace.createModelViewEditor(reportName, { retainContextWhenHidden: true, supportsSave: false }, reportName);
+	constructor(private reportTitle: string, protected resizeable: boolean, private extensionContext: vscode.ExtensionContext) {
 	}
 
 	/**
 	 * Creates and opens the report
 	 */
-	public async open(): Promise<void> {
-		this.editor.registerContent(async (view) => {
-			this.flexModel = <azdata.FlexContainer>view.modelBuilder.flexContainer().component();
+	public async createReport(view: azdata.ModelView): Promise<void> {
+		this.flexModel = <azdata.FlexContainer>view.modelBuilder.flexContainer().component();
 
-			const toolbar = await this.createToolbar(view);
-			this.flexModel.addItem(toolbar, { flex: 'none' });
+		const toolbar = await this.createToolbar(view);
+		this.flexModel.addItem(toolbar, { flex: 'none' });
 
-			const views = await this.createViews(view);
+		const views = await this.createViews(view);
 
-			const mainContainer = await this.createMainContainer(view, views);
+		const mainContainer = await this.createMainContainer(view, views);
 
-			this.flexModel.addItem(mainContainer, { CSSStyles: { 'width': '100%', 'height': '100%' } });
+		this.flexModel.addItem(mainContainer, { CSSStyles: { 'width': '100%', 'height': '100%' } });
 
-			this.flexModel.setLayout({
-				flexFlow: 'column',
-				height: '100%'
-			});
-
-			await view.initializeModel(this.flexModel);
+		this.flexModel.setLayout({
+			flexFlow: 'column',
+			height: '100%'
 		});
-
-		await this.editor.openEditor();
 	}
 
 	/**

--- a/extensions/query-store/src/reports/overallResourceConsumption.ts
+++ b/extensions/query-store/src/reports/overallResourceConsumption.ts
@@ -19,7 +19,7 @@ export class OverallResourceConsumption extends BaseQueryStoreReport {
 	private logicalReads: QueryStoreView;
 
 	constructor(extensionContext: vscode.ExtensionContext, databaseName: string) {
-		super(constants.overallResourceConsumption, constants.overallResourceConsumptionToolbarLabel(databaseName), /*resizeable*/ false, extensionContext);
+		super(constants.overallResourceConsumptionToolbarLabel(databaseName), /*resizeable*/ false, extensionContext);
 		this.duration = new QueryStoreView(constants.duration, 'chartreuse');
 		this.executionCount = new QueryStoreView(constants.executionCount, 'coral');
 		this.cpuTime = new QueryStoreView(constants.cpuTime, 'darkturquoise');

--- a/extensions/query-store/src/reports/queryStoreDashboard.ts
+++ b/extensions/query-store/src/reports/queryStoreDashboard.ts
@@ -10,13 +10,10 @@ import { TopResourceConsumingQueries } from './topResourceConsumingQueries';
 import { OverallResourceConsumption } from './overallResourceConsumption';
 
 export class QueryStoreDashboard {
-	protected editor: azdata.workspace.ModelViewEditor;
 	protected flexModel?: azdata.FlexContainer;
 	protected configureButton?: azdata.ButtonComponent;
 
-	constructor(private dbName: string, private extensionContext: vscode.ExtensionContext) {
-		this.editor = azdata.workspace.createModelViewEditor(dbName, { retainContextWhenHidden: true, supportsSave: false }, dbName);
-	}
+	constructor(private dbName: string, private extensionContext: vscode.ExtensionContext) { }
 
 	/**
 	 * Creates and opens the report
@@ -30,21 +27,21 @@ export class QueryStoreDashboard {
 
 			await Promise.all([topResourceConsumingQueriesReport.createReport(view), overallResourceConsumptionReport.createReport(view)]);
 
-			const topResourceConsumingTab: azdata.DashboardTab = {
-				id: 'TopResourceConsumingTab',
-				content: topResourceConsumingQueriesReport.flexModel!,
+			const topResourceConsumingQueriesTab: azdata.DashboardTab = {
+				id: 'TopResourceConsumingQueriesTab',
+				content: topResourceConsumingQueriesReport.ReportContent!,
 				title: constants.topResourceConsumingQueries
 			};
 
 			const overallResourceConsumptionTab: azdata.DashboardTab = {
 				id: 'OverallResourceConsumptionTab',
-				content: overallResourceConsumptionReport.flexModel!,
+				content: overallResourceConsumptionReport.ReportContent!,
 				title: constants.overallResourceConsumption
 			};
 
 			return [
 				overallResourceConsumptionTab,
-				topResourceConsumingTab
+				topResourceConsumingQueriesTab
 			];
 		});
 

--- a/extensions/query-store/src/reports/queryStoreDashboard.ts
+++ b/extensions/query-store/src/reports/queryStoreDashboard.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+// import * as path from 'path';
+// import * as utils from '../common/utils';
+// import * as constants from '../common/constants';
+
+export class QueryStoreDashboard {
+	protected editor: azdata.workspace.ModelViewEditor;
+	protected flexModel?: azdata.FlexContainer;
+	protected configureButton?: azdata.ButtonComponent;
+
+	constructor(reportName: string) {
+		this.editor = azdata.workspace.createModelViewEditor(reportName, { retainContextWhenHidden: true, supportsSave: false }, reportName);
+	}
+
+	/**
+	 * Creates and opens the report
+	 */
+	public async open(): Promise<void> {
+		const dashboard = azdata.window.createModelViewDashboard('Overall Resource Consumption - AdventureWorks');
+		dashboard.registerTabs(async (view: azdata.ModelView) => {
+
+			this.flexModel = <azdata.FlexContainer>view.modelBuilder.flexContainer().component();
+
+			// this.flexModel.addItem(mainContainer, { CSSStyles: { 'width': '100%', 'height': '100%' } });
+
+			this.flexModel.setLayout({
+				flexFlow: 'column',
+				height: '100%'
+			});
+
+			// const input1 = view.modelBuilder.inputBox().withProps({ value: 'input 1' }).component();
+			// const homeTab: azdata.DashboardTab = {
+			// 	id: 'home',
+			// 	toolbar: toolbar,
+			// 	content: input1,
+			// 	title: 'Home',
+			// };
+
+			const topResourceConsumingTabText = view.modelBuilder.inputBox().withProps({ value: 'Top Resource Consuming Queries placeholder', width: '400px' }).component();
+
+			const topResourceConsumingTab: azdata.DashboardTab = {
+				id: 'TopResourceConsumingTab',
+				content: topResourceConsumingTabText,
+				title: 'Top Resource Consuming Queries'
+			};
+
+			const overallResourceConsumptionTabText = view.modelBuilder.inputBox().withProps({ value: 'Overall Resource Consumption', width: '400px' }).component();
+
+			const overallResourceConsumptionTab: azdata.DashboardTab = {
+				id: 'OverallResourceConsumptionTab',
+				content: overallResourceConsumptionTabText,
+				title: 'Overall Resource Consumption'
+			};
+
+			const oqueriesWithForcedPlansTabText = view.modelBuilder.inputBox().withProps({ value: 'Queries With Forced Plans Placeholder', width: '400px' }).component();
+
+			const queriesWithForcedPlansTab: azdata.DashboardTab = {
+				id: 'QueriesWithForcedPlansTab',
+				content: oqueriesWithForcedPlansTabText,
+				title: 'Queries With Forced Plans'
+			};
+
+			const trackedQueriesTabText = view.modelBuilder.inputBox().withProps({ value: 'Tracked Queries', width: '400px' }).component();
+
+			const trackedQueriesTab: azdata.DashboardTab = {
+				id: 'TrackedQueriesTab',
+				content: trackedQueriesTabText,
+				title: 'Tracked Queries'
+			};
+
+			return [
+				overallResourceConsumptionTab,
+				topResourceConsumingTab,
+				queriesWithForcedPlansTab,
+				trackedQueriesTab];
+		});
+		await dashboard.open();
+	}
+}
+

--- a/extensions/query-store/src/reports/queryStoreDashboard.ts
+++ b/extensions/query-store/src/reports/queryStoreDashboard.ts
@@ -10,9 +10,6 @@ import { TopResourceConsumingQueries } from './topResourceConsumingQueries';
 import { OverallResourceConsumption } from './overallResourceConsumption';
 
 export class QueryStoreDashboard {
-	protected flexModel?: azdata.FlexContainer;
-	protected configureButton?: azdata.ButtonComponent;
-
 	constructor(private dbName: string, private extensionContext: vscode.ExtensionContext) { }
 
 	/**

--- a/extensions/query-store/src/reports/topResourceConsumingQueries.ts
+++ b/extensions/query-store/src/reports/topResourceConsumingQueries.ts
@@ -17,7 +17,7 @@ export class TopResourceConsumingQueries extends BaseQueryStoreReport {
 	private plan: QueryStoreView;
 
 	constructor(extensionContext: vscode.ExtensionContext, databaseName: string) {
-		super(constants.topResourceConsumingQueries, constants.topResourceConsumingQueriesToolbarLabel(databaseName), /*resizeable*/ true, extensionContext);
+		super(constants.topResourceConsumingQueriesToolbarLabel(databaseName), /*resizeable*/ true, extensionContext);
 		this.queries = new QueryStoreView(constants.queries, 'chartreuse');
 		this.planSummary = new QueryStoreView(constants.planSummary('x'), 'coral'); // TODO: replace 'x' with actual query id
 		this.plan = new QueryStoreView(constants.plan('x'), 'darkturquoise');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Initial changes to make the query store reports all be available in a query store dashboard. This removes the previous commands to open the two placeholder reports and adds a single "Query Store" command to open this dashboard (having this in the command palette is to speed up testing and will be removed later). 

Still several things to come in the next PRs after this is checked in:
- Add launch point from Object Explorer in the context menu of db's with query store enabled and pass actual db's name to report
- add launch point to Manage dashboard
- add button to toolbar to open the current report in another editor tab
- update editor title to have current report in name (if possible)
![querystoredashboardinitial](https://github.com/microsoft/azuredatastudio/assets/31145923/f7575ddc-7564-40c6-97f4-dbcba816b1df)
