### PR TITLE
Add loading indicator when an XEL File is opened

### DIFF
--- a/src/sql/workbench/browser/editor/profiler/profilerInput.ts
+++ b/src/sql/workbench/browser/editor/profiler/profilerInput.ts
@@ -41,6 +41,8 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 	private _onColumnsChanged = new Emitter<Slick.Column<Slick.SlickData>[]>();
 	public onColumnsChanged: Event<Slick.Column<Slick.SlickData>[]> = this._onColumnsChanged.event;
 
+	private _initializerSetup: boolean = true;
+
 	private _filter: ProfilerFilter = { clauses: [] };
 
 	constructor(
@@ -160,6 +162,14 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 
 	public get isFileSession(): boolean {
 		return !!this.fileURI;
+	}
+
+	public get isSetupPhase(): boolean {
+		return this._initializerSetup;
+	}
+
+	public setInitializerPhase(isSetupPhase: boolean) {
+		this._initializerSetup = isSetupPhase;
 	}
 
 	public setConnectionState(isConnected: boolean): void {

--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -504,7 +504,6 @@ export class ProfilerEditor extends EditorPane {
 
 			if (this.input.isFileSession && this.input.isSetupPhase) {		// Add loading indicator when opening a new file session
 				this._profilerTableEditor.loadingSpinner.loading = true;
-				this._profilerTableEditor.loadingSpinner.loadingMessage = nls.localize('Loading', "Loading...");
 				this.input.setInitializerPhase(false);
 			}
 		});

--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -501,6 +501,12 @@ export class ProfilerEditor extends EditorPane {
 			if (savedViewState) {
 				this._profilerTableEditor.restoreViewState(savedViewState);
 			}
+
+			if (this.input.isFileSession && this.input.isSetupPhase) {		// Add loading indicator when opening a new file session
+				this._profilerTableEditor.loadingSpinner.loading = true;
+				this._profilerTableEditor.loadingSpinner.loadingMessage = nls.localize('Loading', "Loading...");
+				this.input.setInitializerPhase(false);
+			}
 		});
 	}
 
@@ -546,7 +552,7 @@ export class ProfilerEditor extends EditorPane {
 			if (this.input.state.isConnected) {
 				this._updateToolbar();
 
-				// Launch the create session dialog if openning a new window.
+				// Launch the create session dialog if opening a new window.
 				let uiState = this._profilerService.getSessionViewState(this.input.id);
 				let previousSessionName = uiState && uiState.previousSessionName;
 				if (!this.input.sessionName && !previousSessionName && !this.input.isFileSession) {
@@ -583,6 +589,8 @@ export class ProfilerEditor extends EditorPane {
 				this._updateToolbar();
 				if (!this.input.isFileSession) {		// skip updating session selector for File sessions to block starting another session from a non-connected file session
 					this._updateSessionSelector();
+				} else {
+					this._profilerTableEditor.loadingSpinner.loading = false;		// Remove the loading indicator when the complete file is read
 				}
 			}
 		}

--- a/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
@@ -36,6 +36,7 @@ import { IAccessibilityService } from 'vs/platform/accessibility/common/accessib
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IComponentContextService } from 'sql/workbench/services/componentContext/browser/componentContextService';
 import { defaultTableStyles } from 'sql/platform/theme/browser/defaultStyles';
+import { LoadingSpinner } from 'sql/base/browser/ui/loadingSpinner/loadingSpinner';
 
 export interface ProfilerTableViewState {
 	scrollTop: number;
@@ -57,6 +58,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 	private _actionMap: { [x: string]: IEditorAction } = {};
 	private _statusbarItem: IDisposable;
 	private _showStatusBarItem: boolean;
+	public loadingSpinner: LoadingSpinner;
 
 	private _onDidChangeConfiguration = new Emitter<IConfigurationChangedEvent>();
 	public onDidChangeConfiguration: Event<IConfigurationChangedEvent> = this._onDidChangeConfiguration.event;
@@ -88,6 +90,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 		this._overlay.className = 'overlayWidgets';
 		this._overlay.style.width = '100%';
 		this._overlay.style.zIndex = '4';
+		this._overlay.style.paddingTop = '50px';
 		parent.appendChild(this._overlay);
 
 		this._profilerTable = new Table(parent, this._accessibilityService, this._quickInputService, defaultTableStyles, {
@@ -129,6 +132,8 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 			this._contextKeyService,
 			this._themeService
 		);
+
+		this.loadingSpinner = new LoadingSpinner(this._overlay, { showText: true, fullSize: false });
 	}
 
 	public override setInput(input: ProfilerInput): Promise<void> {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/23883.

![loadingXEL](https://github.com/microsoft/azuredatastudio/assets/57200045/545f3525-7ab4-4b48-87af-661b05afda7c)

The loading indicator is turned off when the whole file is been read. Since the data comes in large chunks and presented in the profiler table, it overlaps a little (as seen in the end of the clip).
Also, if we switch between Profiler tabs while the file is been loaded, the indicator moves around to the other tabs (and goes away when the reading is completed).