### PR TITLE
Consolidate 2 context endpoints to just one

### DIFF
--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -1567,10 +1567,6 @@ export interface ServerContextualizationParams {
 	ownerUri: string;
 }
 
-export namespace GenerateServerContextualizationRequest {
-	export const type = new RequestType<ServerContextualizationParams, azdata.contextualization.GenerateServerContextualizationResult, void, void>('metadata/generateServerContext');
-}
-
 export namespace GetServerContextualizationRequest {
 	export const type = new RequestType<ServerContextualizationParams, azdata.contextualization.GetServerContextualizationResult, void, void>('metadata/getServerContext');
 }

--- a/extensions/mssql/src/features.ts
+++ b/extensions/mssql/src/features.ts
@@ -1310,7 +1310,7 @@ export class ExecutionPlanServiceFeature extends SqlOpsFeature<undefined> {
  */
 export class ServerContextualizationServiceFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
-		contracts.GenerateServerContextualizationRequest.type
+		contracts.GetServerContextualizationRequest.type
 	];
 
 	constructor(client: SqlOpsDataClient) {
@@ -1330,20 +1330,6 @@ export class ServerContextualizationServiceFeature extends SqlOpsFeature<undefin
 	protected registerProvider(options: undefined): Disposable {
 		const client = this._client;
 
-		const generateServerContextualization = (ownerUri: string): Thenable<azdata.contextualization.GenerateServerContextualizationResult> => {
-			const params: contracts.ServerContextualizationParams = {
-				ownerUri: ownerUri
-			};
-
-			return client.sendRequest(contracts.GenerateServerContextualizationRequest.type, params).then(
-				r => r,
-				e => {
-					client.logFailedRequest(contracts.GenerateServerContextualizationRequest.type, e);
-					return Promise.reject(e);
-				}
-			);
-		};
-
 		const getServerContextualization = (ownerUri: string): Thenable<azdata.contextualization.GetServerContextualizationResult> => {
 			const params: contracts.ServerContextualizationParams = {
 				ownerUri: ownerUri
@@ -1360,7 +1346,6 @@ export class ServerContextualizationServiceFeature extends SqlOpsFeature<undefin
 
 		return azdata.dataprotocol.registerServerContextualizationProvider({
 			providerId: client.providerId,
-			generateServerContextualization: generateServerContextualization,
 			getServerContextualization: getServerContextualization
 		});
 	}

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1783,13 +1783,6 @@ declare module 'azdata' {
 	}
 
 	export namespace contextualization {
-		export interface GenerateServerContextualizationResult {
-			/**
-			 * The generated server context.
-			 */
-			context: string | undefined;
-		}
-
 		export interface GetServerContextualizationResult {
 			/**
 			 * The retrieved server context.
@@ -1798,12 +1791,6 @@ declare module 'azdata' {
 		}
 
 		export interface ServerContextualizationProvider extends DataProvider {
-			/**
-			 * Generates server context.
-			 * @param ownerUri The URI of the connection to generate context for.
-			 */
-			generateServerContextualization(ownerUri: string): Thenable<GenerateServerContextualizationResult>;
-
 			/**
 			 * Gets server context, which can be in the form of create scripts but is left up each provider.
 			 * @param ownerUri The URI of the connection to get context for.

--- a/src/sql/workbench/api/browser/mainThreadDataProtocol.ts
+++ b/src/sql/workbench/api/browser/mainThreadDataProtocol.ts
@@ -573,10 +573,9 @@ export class MainThreadDataProtocol extends Disposable implements MainThreadData
 		});
 	}
 
-	// Database server contextualization handler
+	// Server contextualization handler
 	public $registerServerContextualizationProvider(providerId: string, handle: number): void {
 		this._serverContextualizationService.registerProvider(providerId, <azdata.contextualization.ServerContextualizationProvider>{
-			generateServerContextualization: (ownerUri: string) => this._proxy.$generateServerContextualization(handle, ownerUri),
 			getServerContextualization: (ownerUri: string) => this._proxy.$getServerContextualization(handle, ownerUri)
 		});
 	}

--- a/src/sql/workbench/api/common/extHostDataProtocol.ts
+++ b/src/sql/workbench/api/common/extHostDataProtocol.ts
@@ -970,11 +970,7 @@ export class ExtHostDataProtocol extends ExtHostDataProtocolShape {
 		return this._resolveProvider<azdata.executionPlan.ExecutionPlanProvider>(handle).isExecutionPlan(value);
 	}
 
-	// Database Server Contextualization API
-
-	public override $generateServerContextualization(handle: number, ownerUri: string): Thenable<azdata.contextualization.GenerateServerContextualizationResult> {
-		return this._resolveProvider<azdata.contextualization.ServerContextualizationProvider>(handle).generateServerContextualization(ownerUri);
-	}
+	// Server Contextualization API
 
 	public override $getServerContextualization(handle: number, ownerUri: string): Thenable<azdata.contextualization.GetServerContextualizationResult> {
 		return this._resolveProvider<azdata.contextualization.ServerContextualizationProvider>(handle).getServerContextualization(ownerUri);

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -596,10 +596,6 @@ export abstract class ExtHostDataProtocolShape {
 	 */
 	$isExecutionPlan(handle: number, value: string): Thenable<azdata.executionPlan.IsExecutionPlanResult> { throw ni(); }
 	/**
-	 * Generates server context.
-	 */
-	$generateServerContextualization(handle: number, ownerUri: string): Thenable<azdata.contextualization.GenerateServerContextualizationResult> { throw ni(); }
-	/**
 	 * Gets server context.
 	 */
 	$getServerContextualization(handle: number, ownerUri: string): Thenable<azdata.contextualization.GetServerContextualizationResult> { throw ni(); }

--- a/src/sql/workbench/services/contextualization/common/serverContextualizationService.ts
+++ b/src/sql/workbench/services/contextualization/common/serverContextualizationService.ts
@@ -75,43 +75,12 @@ export class ServerContextualizationService extends Disposable implements IServe
 
 		const getServerContextualizationResult = await this.getServerContextualization(uri);
 		if (getServerContextualizationResult.context) {
-			this._logService.info(`Server contextualization was previously generated for the URI (${uri}) connection, so sending that to Copilot for context.`);
+			this._logService.info(`Server contextualization was retrieved for the URI (${uri}) connection, so sending that to Copilot for context.`);
 
 			await this.sendServerContextualizationToCopilot(getServerContextualizationResult.context);
 		}
 		else {
-			this._logService.info(`Server contextualization was not previously generated for the URI (${uri}) connection. Generating now...`);
-
-			const generateServerContextualizationResult = await this.generateServerContextualization(uri);
-			if (generateServerContextualizationResult.context) {
-				this._logService.info(`Server contextualization was generated for the URI (${uri}) connection, so sending that to Copilot.`);
-
-				await this.sendServerContextualizationToCopilot(generateServerContextualizationResult.context);
-			}
-			else {
-				this._logService.warn(`Server contextualization was not generated for the URI (${uri}) connection, so no context will be sent to Copilot.`);
-			}
-		}
-	}
-
-	/**
-	 * Generates server context
-	 * @param ownerUri The URI of the connection to generate context for.
-	 */
-	private async generateServerContextualization(ownerUri: string): Promise<azdata.contextualization.GenerateServerContextualizationResult> {
-		const providerName = this._connectionManagementService.getProviderIdFromUri(ownerUri);
-		const handler = this.getProvider(providerName);
-		if (handler) {
-			this._logService.info(`Generating server contextualization for ${ownerUri}`);
-
-			return await handler.generateServerContextualization(ownerUri);
-		}
-		else {
-			this._logService.info(`No server contextualization provider found for ${ownerUri}`);
-
-			return Promise.resolve({
-				context: undefined
-			});
+			this._logService.warn(`Server contextualization was not generated for the URI (${uri}) connection, so no context will be sent to Copilot.`);
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR closes #24263

The PR consolidates the generate and get context request endpoints to just get context which generates context or returns previously generated context.