### PR TITLE
Add ai key to fix AzureCore TelemetryReporter

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "publisher": "Microsoft",
   "preview": true,
+  "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
   "engines": {
     "vscode": "^1.30.1",
     "azdata": "*"


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24275

Adds the AI Key to fix the undefined error when starting the telemetry reporter.