### PR TITLE
Added Arialabel for SqlMigration Service Name InputBox

### DIFF
--- a/extensions/sql-migration/src/dialog/createSqlMigrationService/createSqlMigrationServiceDialog.ts
+++ b/extensions/sql-migration/src/dialog/createSqlMigrationService/createSqlMigrationServiceDialog.ts
@@ -311,6 +311,7 @@ export class CreateSqlMigrationServiceDialog {
 		}));
 
 		this.migrationServiceNameText = this._view.modelBuilder.inputBox().withProps({
+			ariaLabel: constants.NAME,
 			CSSStyles: {
 				'margin-top': '-1em'
 			}


### PR DESCRIPTION
I added missing aria-label for Input Box in create Migration Service Dialog

Resolving one of the issue in the bug - https://github.com/microsoft/azuredatastudio/issues/23897
"ORCA screen reader is not announcing "Name" edit field label name along with edit box."
