### PR TITLE
Update task labels for Attach, Detach, and Drop Database

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -108,6 +108,13 @@ export function OpenDetachDatabaseDialogError(error: string): string {
 	}, "An error occurred while opening the detach database dialog. {0}", error);
 }
 
+export function DetachDatabaseOperationDisplayName(objectName: string): string {
+	return localize({
+		key: 'objectManagement.detachDatabaseOperationName',
+		comment: ['{0}: object name.']
+	}, "Detach database '{0}'", objectName);
+}
+
 export function OpenDropDatabaseDialogError(error: string): string {
 	return localize({
 		key: 'objectManagement.openDropDatabaseDialogError',

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -129,12 +129,7 @@ export function OpenAttachDatabaseDialogError(error: string): string {
 	}, "An error occurred while opening the attach database dialog. {0}", error);
 }
 
-export function AttachDatabaseOperationDisplayName(objectNames: string[]): string {
-	return localize({
-		key: 'objectManagement.attachDatabaseOperationName',
-		comment: ['{0}: object names.']
-	}, "Attach database {0}", objectNames.map(name => `'${name}'`).join(', '));
-}
+export const AttachDatabaseOperationDisplayName = localize('objectManagement.attachDatabaseOperationName', "Attach database");
 
 export function OpenObjectPropertiesDialogError(objectType: string, objectName: string, error: string): string {
 	return localize({

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -129,6 +129,13 @@ export function OpenAttachDatabaseDialogError(error: string): string {
 	}, "An error occurred while opening the attach database dialog. {0}", error);
 }
 
+export function AttachDatabaseOperationDisplayName(objectNames: string[]): string {
+	return localize({
+		key: 'objectManagement.attachDatabaseOperationName',
+		comment: ['{0}: object names.']
+	}, "Attach database {0}", objectNames.map(name => `'${name}'`).join(', '));
+}
+
 export function OpenObjectPropertiesDialogError(objectType: string, objectName: string, error: string): string {
 	return localize({
 		key: 'objectManagement.openObjectPropertiesDialogError',

--- a/extensions/mssql/src/objectManagement/ui/attachDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/attachDatabaseDialog.ts
@@ -36,6 +36,10 @@ export class AttachDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		return this._databasesToAttach.length > 0;
 	}
 
+	protected override get taskLabel(): string {
+		return loc.AttachDatabaseOperationDisplayName(this._databasesToAttach.map(db => db.databaseName));
+	}
+
 	protected async initializeUI(): Promise<void> {
 		let filesSection = this.initializeAttachSection();
 		let associatedSection = this.initializeAssociatedFilesSection();

--- a/extensions/mssql/src/objectManagement/ui/attachDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/attachDatabaseDialog.ts
@@ -36,7 +36,7 @@ export class AttachDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		return this._databasesToAttach.length > 0;
 	}
 
-	protected override get taskLabel(): string {
+	protected override get saveChangesTaskLabel(): string {
 		return loc.AttachDatabaseOperationDisplayName(this._databasesToAttach.map(db => db.databaseName));
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/attachDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/attachDatabaseDialog.ts
@@ -37,7 +37,7 @@ export class AttachDatabaseDialog extends ObjectManagementDialogBase<Database, D
 	}
 
 	protected override get saveChangesTaskLabel(): string {
-		return loc.AttachDatabaseOperationDisplayName(this._databasesToAttach.map(db => db.databaseName));
+		return loc.AttachDatabaseOperationDisplayName;
 	}
 
 	protected async initializeUI(): Promise<void> {

--- a/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
@@ -23,7 +23,7 @@ export class DetachDatabaseDialog extends ObjectManagementDialogBase<Database, D
 	}
 
 	protected override get saveChangesTaskLabel(): string {
-		return loc.DetachDatabaseOperationDisplayName(this.options.objectName);
+		return loc.DetachDatabaseOperationDisplayName(this.objectInfo.name);
 	}
 
 	protected async initializeUI(): Promise<void> {

--- a/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
@@ -22,7 +22,7 @@ export class DetachDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		return true;
 	}
 
-	protected override get taskLabel(): string {
+	protected override get saveChangesTaskLabel(): string {
 		return loc.DetachDatabaseOperationDisplayName(this.options.objectName);
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/detachDatabaseDialog.ts
@@ -7,34 +7,38 @@ import { ObjectManagementDialogBase, ObjectManagementDialogOptions } from './obj
 import { IObjectManagementService, ObjectManagement } from 'mssql';
 import { Database, DatabaseViewInfo } from '../interfaces';
 import { DetachDatabaseDocUrl } from '../constants';
-import { DatabaseFileGroupLabel, DatabaseFileNameLabel, DatabaseFilePathLabel, DatabaseFileTypeLabel, DatabaseFilesLabel, DetachButtonLabel, DetachDatabaseDialogTitle, DetachDatabaseOptions, DetachDropConnections, DetachUpdateStatistics } from '../localizedConstants';
+import * as loc from '../localizedConstants';
 
 export class DetachDatabaseDialog extends ObjectManagementDialogBase<Database, DatabaseViewInfo> {
 	private _dropConnections = false;
 	private _updateStatistics = false;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		super(objectManagementService, options, DetachDatabaseDialogTitle(options.database), 'DetachDatabase');
-		this.dialogObject.okButton.label = DetachButtonLabel;
+		super(objectManagementService, options, loc.DetachDatabaseDialogTitle(options.database), 'DetachDatabase');
+		this.dialogObject.okButton.label = loc.DetachButtonLabel;
 	}
 
 	protected override get isDirty(): boolean {
 		return true;
 	}
 
+	protected override get taskLabel(): string {
+		return loc.DetachDatabaseOperationDisplayName(this.options.objectName);
+	}
+
 	protected async initializeUI(): Promise<void> {
 		let tableData = this.objectInfo.files.map(file => [file.name, file.type, file.fileGroup, file.path]);
-		let columnNames = [DatabaseFileNameLabel, DatabaseFileTypeLabel, DatabaseFileGroupLabel, DatabaseFilePathLabel];
-		let fileTable = this.createTable(DatabaseFilesLabel, columnNames, tableData);
-		let tableGroup = this.createGroup(DatabaseFilesLabel, [fileTable], false);
+		let columnNames = [loc.DatabaseFileNameLabel, loc.DatabaseFileTypeLabel, loc.DatabaseFileGroupLabel, loc.DatabaseFilePathLabel];
+		let fileTable = this.createTable(loc.DatabaseFilesLabel, columnNames, tableData);
+		let tableGroup = this.createGroup(loc.DatabaseFilesLabel, [fileTable], false);
 
-		let connCheckbox = this.createCheckbox(DetachDropConnections, async checked => {
+		let connCheckbox = this.createCheckbox(loc.DetachDropConnections, async checked => {
 			this._dropConnections = checked;
 		});
-		let updateCheckbox = this.createCheckbox(DetachUpdateStatistics, async checked => {
+		let updateCheckbox = this.createCheckbox(loc.DetachUpdateStatistics, async checked => {
 			this._updateStatistics = checked;
 		});
-		let checkboxGroup = this.createGroup(DetachDatabaseOptions, [connCheckbox, updateCheckbox], false);
+		let checkboxGroup = this.createGroup(loc.DetachDatabaseOptions, [connCheckbox, updateCheckbox], false);
 
 		let components = [tableGroup, checkboxGroup];
 		this.formContainer.addItems(components);

--- a/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
@@ -22,7 +22,7 @@ export class DropDatabaseDialog extends ObjectManagementDialogBase<Database, Dat
 		return true;
 	}
 
-	protected override get taskLabel(): string {
+	protected override get saveChangesTaskLabel(): string {
 		return loc.DropObjectOperationDisplayName(loc.DatabaseTypeDisplayName, this.options.objectName);
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
@@ -23,7 +23,7 @@ export class DropDatabaseDialog extends ObjectManagementDialogBase<Database, Dat
 	}
 
 	protected override get saveChangesTaskLabel(): string {
-		return loc.DropObjectOperationDisplayName(loc.DatabaseTypeDisplayName, this.options.objectName);
+		return loc.DropObjectOperationDisplayName(loc.DatabaseTypeDisplayName, this.objectInfo.name);
 	}
 
 	protected async initializeUI(): Promise<void> {

--- a/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/dropDatabaseDialog.ts
@@ -7,38 +7,42 @@ import { ObjectManagementDialogBase, ObjectManagementDialogOptions } from './obj
 import { IObjectManagementService, ObjectManagement } from 'mssql';
 import { Database, DatabaseViewInfo } from '../interfaces';
 import { DropDatabaseDocUrl } from '../constants';
-import { DropButtonLabel, DropDatabaseDialogTitle, DeleteBackupHistory, CloseConnections, DropDatabaseOptions, NameText, OwnerText, StatusText, DatabaseDetailsLabel } from '../localizedConstants';
+import * as loc from '../localizedConstants';
 
 export class DropDatabaseDialog extends ObjectManagementDialogBase<Database, DatabaseViewInfo> {
 	private _dropConnections = false;
 	private _deleteBackupHistory = false;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		super(objectManagementService, options, DropDatabaseDialogTitle(options.database), 'DropDatabase');
-		this.dialogObject.okButton.label = DropButtonLabel;
+		super(objectManagementService, options, loc.DropDatabaseDialogTitle(options.database), 'DropDatabase');
+		this.dialogObject.okButton.label = loc.DropButtonLabel;
 	}
 
 	protected override get isDirty(): boolean {
 		return true;
 	}
 
+	protected override get taskLabel(): string {
+		return loc.DropObjectOperationDisplayName(loc.DatabaseTypeDisplayName, this.options.objectName);
+	}
+
 	protected async initializeUI(): Promise<void> {
 		let components = [];
 
 		let tableData = [[this.objectInfo.name, this.objectInfo.owner ?? '', this.objectInfo.status ?? '']];
-		let columnNames = [NameText, OwnerText, StatusText];
-		let fileTable = this.createTable(DatabaseDetailsLabel, columnNames, tableData);
-		let tableGroup = this.createGroup(DatabaseDetailsLabel, [fileTable], false);
+		let columnNames = [loc.NameText, loc.OwnerText, loc.StatusText];
+		let fileTable = this.createTable(loc.DatabaseDetailsLabel, columnNames, tableData);
+		let tableGroup = this.createGroup(loc.DatabaseDetailsLabel, [fileTable], false);
 		components.push(tableGroup);
 
 		if (!this.viewInfo.isAzureDB && !this.viewInfo.isManagedInstance && !this.viewInfo.isSqlOnDemand) {
-			let connCheckbox = this.createCheckbox(CloseConnections, async checked => {
+			let connCheckbox = this.createCheckbox(loc.CloseConnections, async checked => {
 				this._dropConnections = checked;
 			});
-			let updateCheckbox = this.createCheckbox(DeleteBackupHistory, async checked => {
+			let updateCheckbox = this.createCheckbox(loc.DeleteBackupHistory, async checked => {
 				this._deleteBackupHistory = checked;
 			});
-			let checkboxGroup = this.createGroup(DropDatabaseOptions, [connCheckbox, updateCheckbox], false);
+			let checkboxGroup = this.createGroup(loc.DropDatabaseOptions, [connCheckbox, updateCheckbox], false);
 			components.push(checkboxGroup);
 		}
 		this.formContainer.addItems(components);

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -62,12 +62,16 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 		await this.objectManagementService.save(this._contextId, this.objectInfo);
 	}
 
+	protected get taskLabel(): string {
+		const typeDisplayName = localizedConstants.getNodeTypeDisplayName(this.options.objectType);
+		return this.options.isNewObject ? localizedConstants.CreateObjectOperationDisplayName(typeDisplayName)
+			: localizedConstants.UpdateObjectOperationDisplayName(typeDisplayName, this.options.objectName);
+	}
+
 	protected override async initialize(): Promise<void> {
 		await super.initialize();
-		const typeDisplayName = localizedConstants.getNodeTypeDisplayName(this.options.objectType);
 		this.dialogObject.registerOperation({
-			displayName: this.options.isNewObject ? localizedConstants.CreateObjectOperationDisplayName(typeDisplayName)
-				: localizedConstants.UpdateObjectOperationDisplayName(typeDisplayName, this.options.objectName),
+			displayName: this.taskLabel,
 			description: '',
 			isCancelable: false,
 			operation: async (operation: azdata.BackgroundOperation): Promise<void> => {

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -62,7 +62,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 		await this.objectManagementService.save(this._contextId, this.objectInfo);
 	}
 
-	protected get taskLabel(): string {
+	protected get saveChangesTaskLabel(): string {
 		const typeDisplayName = localizedConstants.getNodeTypeDisplayName(this.options.objectType);
 		return this.options.isNewObject ? localizedConstants.CreateObjectOperationDisplayName(typeDisplayName)
 			: localizedConstants.UpdateObjectOperationDisplayName(typeDisplayName, this.options.objectName);
@@ -71,7 +71,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 	protected override async initialize(): Promise<void> {
 		await super.initialize();
 		this.dialogObject.registerOperation({
-			displayName: this.taskLabel,
+			displayName: this.saveChangesTaskLabel,
 			description: '',
 			isCancelable: false,
 			operation: async (operation: azdata.BackgroundOperation): Promise<void> => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24188

Currently we display "Updating X" in the tasks pane for all these operations after clicking OK in the dialogs. This change updates those to "Attach database", "Detach database X", and "Drop database X".
