### PR TITLE
Fix F11 key binding

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -28,7 +28,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IViewsService, ViewContainerLocation } from 'vs/workbench/common/views';
 import { deepClone } from 'vs/base/common/objects';
-import { isWeb, isWindows } from 'vs/base/common/platform';
+import { isWeb } from 'vs/base/common/platform';
 import { saveAllBeforeDebugStart } from 'vs/workbench/contrib/debug/common/debugUtils';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 import { showLoadedScriptMenu } from 'vs/workbench/contrib/debug/common/loadedScriptsPicker';

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -496,12 +496,13 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	// Use a more flexible when clause to not allow full screen command to take over when F11 pressed a lot of times
 	when: CONTEXT_DEBUG_STATE.notEqualsTo('inactive'),
 	handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
-		const contextKeyService = accessor.get(IContextKeyService);
+		// {{SQL CARBON EDIT}} - Disable F11 binding to use it as shortcut for full screen in ADS
+		/*const contextKeyService = accessor.get(IContextKeyService);
 		if (CONTEXT_DISASSEMBLY_VIEW_FOCUS.getValue(contextKeyService)) {
 			await getThreadAndRun(accessor, context, (thread: IThread) => thread.stepIn('instruction'));
 		} else {
 			await getThreadAndRun(accessor, context, (thread: IThread) => thread.stepIn());
-		}
+		}*/
 	}
 });
 

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -487,7 +487,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 // Windows browsers use F11 for full screen, thus use alt+F11 as the default shortcut
-const STEP_INTO_KEYBINDING = (isWeb && isWindows) ? (KeyMod.Alt | KeyCode.F11) : KeyCode.F11;
+// {{SQL CARBON EDIT}} - Disable F11 binding to use it as shortcut for full screen in ADS
+/*const STEP_INTO_KEYBINDING = (isWeb && isWindows) ? (KeyMod.Alt | KeyCode.F11) : KeyCode.F11;
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: STEP_INTO_ID,
@@ -496,15 +497,14 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	// Use a more flexible when clause to not allow full screen command to take over when F11 pressed a lot of times
 	when: CONTEXT_DEBUG_STATE.notEqualsTo('inactive'),
 	handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
-		// {{SQL CARBON EDIT}} - Disable F11 binding to use it as shortcut for full screen in ADS
-		/*const contextKeyService = accessor.get(IContextKeyService);
+		const contextKeyService = accessor.get(IContextKeyService);
 		if (CONTEXT_DISASSEMBLY_VIEW_FOCUS.getValue(contextKeyService)) {
 			await getThreadAndRun(accessor, context, (thread: IThread) => thread.stepIn('instruction'));
 		} else {
 			await getThreadAndRun(accessor, context, (thread: IThread) => thread.stepIn());
-		}*/
+		}
 	}
-});
+});*/
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: STEP_OUT_ID,
@@ -534,7 +534,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: STEP_INTO_TARGET_ID,
-	primary: STEP_INTO_KEYBINDING | KeyMod.CtrlCmd,
+	primary: KeyMod.CtrlCmd,		// {{SQL CARBON EDIT}} - Remove STEP_INTO_KEYBINDING
 	when: ContextKeyExpr.and(CONTEXT_STEP_INTO_TARGETS_SUPPORTED, CONTEXT_IN_DEBUG_MODE, CONTEXT_DEBUG_STATE.isEqualTo('stopped')),
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {


### PR DESCRIPTION
This PR fixes #24233. 
This change disables custom F11 keybinding added to step into the code while debugging in VSCode. This adds back the functionality of F11 to toggle between full screen.

Before:
![image](https://github.com/microsoft/azuredatastudio/assets/57200045/9f31f041-1817-4f39-ae7e-b6a054d7feef)

After (on pressing F11 it toggles between full screen and current size):
![fixF11](https://github.com/microsoft/azuredatastudio/assets/57200045/0f5d3aa7-34f6-423c-8275-6a62778befd0)