### PR TITLE
Add Open file location as an option after an excel file is saved

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -77,7 +77,8 @@ suite('Data Resource Data Provider', function () {
 			contextService,
 			fileDialogService,
 			notificationService,
-			undefined // IOpenerService
+			undefined, // IOpenerService
+			undefined	// ICommandService
 		);
 		instantiationService = TypeMoq.Mock.ofType(InstantiationService, TypeMoq.MockBehavior.Strict);
 		instantiationService.setup(x => x.createInstance(TypeMoq.It.isValue(ResultSerializer)))

--- a/src/sql/workbench/services/query/common/resultSerializer.ts
+++ b/src/sql/workbench/services/query/common/resultSerializer.ts
@@ -20,6 +20,7 @@ import { IFileDialogService, FileFilter } from 'vs/platform/dialogs/common/dialo
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
 import { Schemas } from 'vs/base/common/network';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 let prevSavePath: URI;
 
@@ -58,7 +59,8 @@ export class ResultSerializer {
 		@IWorkspaceContextService private _contextService: IWorkspaceContextService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@INotificationService private _notificationService: INotificationService,
-		@IOpenerService private readonly openerService: IOpenerService
+		@IOpenerService private readonly openerService: IOpenerService,
+		@ICommandService private readonly commandService: ICommandService
 	) { }
 
 	/**
@@ -371,6 +373,12 @@ export class ResultSerializer {
 					label: nls.localize('openFile', "Open file"),
 					run: () => {
 						this.openerService.open(filePath, { openExternal: format === SaveFormat.EXCEL });
+					}
+				},
+				{
+					label: nls.localize('openFileLocation', "Open file location"),
+					run: async () => {
+						this.commandService.executeCommand('revealFileInOS', filePath);
 					}
 				}]
 			);


### PR DESCRIPTION
This PR fixes #24329 .
![openLocationQE](https://github.com/microsoft/azuredatastudio/assets/57200045/4b09782d-1de0-4cf8-8b9f-038975b20d9b)

Works as expected on Mac as well.