### PR TITLE
Remove 'Script As Alter' command and don't show for table nodes

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -32,10 +32,6 @@
     ],
     "commands": [
       {
-        "command": "objectExplorer.scriptAsAlter",
-        "title": "Script as Alter"
-      },
-      {
         "command": "mssql.exportSqlAsNotebook",
         "title": "%mssql.exportSqlAsNotebook%"
       },
@@ -541,11 +537,6 @@
         }
       ],
       "objectExplorer/item/context": [
-        {
-          "command": "objectExplorer.scriptAsAlter",
-          "when": "nodeType == Table",
-          "group": "0_query@5"
-        },
         {
           "command": "mssql.designTable",
           "when": "connectionProvider == MSSQL && nodeType == Table && nodeSubType != LedgerDropped",


### PR DESCRIPTION
These changes were recently added in PR #23407 but look irrelevant as they both don't work.

https://github.com/microsoft/azuredatastudio/pull/23407/files#diff-fdd531ac83f636b3015220925db3e0512f8304be6e1b3e6ad969e1670126d663R498-R502

Fixes #24051 and also below error when 'Script as Alter' command is run:
<img src="https://github.com/microsoft/azuredatastudio/assets/13396919/122f7d8f-3a99-442c-bad6-700d3f039a52" width=450 />

cc @Charles-Gagnon 