### PR TITLE
add OE entry point for query store extension

### DIFF
--- a/extensions/query-store/package.json
+++ b/extensions/query-store/package.json
@@ -39,9 +39,20 @@
       }
     ],
     "menus": {
-      "objectExplorer/item/context": [],
+      "objectExplorer/item/context": [
+        {
+          "command": "queryStore.openQueryStoreDashboard",
+          "when": "connectionProvider == MSSQL && nodeType == Database  && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
+          "group": "queryStore"
+        }
+      ],
       "dataExplorer/context": [],
-      "commandPalette": []
+      "commandPalette": [
+        {
+          "command": "queryStore.openQueryStoreDashboard",
+          "when": "false"
+        }
+      ]
     }
   },
   "dependencies": {

--- a/extensions/query-store/src/extension.ts
+++ b/extensions/query-store/src/extension.ts
@@ -4,17 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as azdata from 'azdata';
 import { QueryStoreDashboard } from './reports/queryStoreDashboard';
 import { IconPathHelper } from './common/iconHelper';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-	// TODO: get db name
 	// TODO: add OE entry point with condition for command to only be visible for db's with Query Store enabled (or consider always showing and having a way to enable when dashboard is opened?)
-	// TODO: remove entry point from command palette - keeping for now to speed up testing so a connection doesn't need to be made to launch the dashboard
-	context.subscriptions.push(vscode.commands.registerCommand('queryStore.openQueryStoreDashboard', async (targetTab?: string) => {
+	context.subscriptions.push(vscode.commands.registerCommand('queryStore.openQueryStoreDashboard', async (connectionContext: azdata.ObjectExplorerContext, targetTab?: string) => {
 		IconPathHelper.setExtensionContext(context);
 
-		const dashboard = new QueryStoreDashboard('AdventureWorks')
+		if (!connectionContext.connectionProfile) {
+			return;
+		}
+
+		const dashboard = new QueryStoreDashboard(connectionContext.connectionProfile);
 		await dashboard.open();
 
 		if (targetTab) {

--- a/extensions/query-store/src/reports/queryStoreDashboard.ts
+++ b/extensions/query-store/src/reports/queryStoreDashboard.ts
@@ -12,8 +12,15 @@ import { Deferred } from '../common/promise';
 export class QueryStoreDashboard {
 	private dashboard?: azdata.window.ModelViewDashboard;
 	private initDashboardComplete: Deferred = new Deferred();
+	private dbName: string;
 
-	constructor(private dbName: string) { }
+	public get ConnectionProfile(): azdata.IConnectionProfile {
+		return this.connectionProfile;
+	}
+
+	constructor(private connectionProfile: azdata.IConnectionProfile) {
+		this.dbName = connectionProfile.databaseName ?? connectionProfile.serverName;
+	}
 
 	/**
 	 * Creates and opens the report


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This adds an entry point to query store dashboard to the right click context menu of databases and removes it from the context menu. Now the connection profile the command is launched from is used to populate the database name in the dashboard (no more hardcoded AdventureWorks 😄).

Still TODO: Only have this only show up for dbs with query store enabled. Or show for all and have an easy way to enable query store when this command is launched from dbs without query store enabled.

![oeEntryPoint](https://github.com/microsoft/azuredatastudio/assets/31145923/802518e5-9a06-407f-872b-57b83056bc66)
