### PR TITLE
More server properties fixes

### DIFF
--- a/extensions/mssql/src/objectManagement/constants.ts
+++ b/extensions/mssql/src/objectManagement/constants.ts
@@ -16,6 +16,7 @@ export const enum FolderType {
 }
 
 export const PublicServerRoleName = 'public';
+export const Windows = 'Windows';
 
 export const CreateUserDocUrl = 'https://learn.microsoft.com/sql/t-sql/statements/create-user-transact-sql';
 export const AlterUserDocUrl = 'https://learn.microsoft.com/sql/t-sql/statements/alter-user-transact-sql';

--- a/extensions/mssql/src/objectManagement/interfaces.ts
+++ b/extensions/mssql/src/objectManagement/interfaces.ts
@@ -593,8 +593,8 @@ export interface Server extends ObjectManagement.SqlObject {
  * The server login types.
  */
 export const enum ServerLoginMode {
-	Integrated, //windows auth only
-	Mixed // both sql server and windows auth
+	Integrated = 1, //windows auth only
+	Mixed = 2// both sql server and windows auth
 }
 
 /**

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -350,6 +350,7 @@ export const scanStartupProcsLabel = localize('objectManagement.scanStartupProcs
 export const twoDigitYearCutoffLabel = localize('objectManagement.twoDigitYearCutoffLabel', "Two Digit Year Cutoff");
 export const costThresholdParallelismLabel = localize('objectManagement.costThresholdParallelismLabel', "Cost Threshold Parallelism");
 export const locksLabel = localize('objectManagement.locksLabel', "Locks");
+export function locksValidation(minValue: number): string { return localize('objectManagement.locksValidation', "Value should be greater than {0}. Choose 0 for default settings.", minValue); }
 export const maxDegreeParallelismLabel = localize('objectManagement.maxDegreeParallelismLabel', "Max Degree Parallelism");
 export const queryWaitLabel = localize('objectManagement.queryWaitLabel', "Query Wait");
 

--- a/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
@@ -673,6 +673,7 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 	}
 
 	private initializeAdvancedSection(): void {
+		const isEnabled = this.engineEdition !== azdata.DatabaseEngineEdition.SqlManagedInstance;
 		this.allowTriggerToFireOthersDropdown = this.createDropdown(localizedConstants.allowTriggerToFireOthersLabel, async (newValue) => {
 			this.objectInfo.allowTriggerToFireOthers = newValue === 'True';
 		}, ['True', 'False'], this.objectInfo.allowTriggerToFireOthers ? 'True' : 'False');
@@ -736,7 +737,7 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 
 		this.scanStartupProcsDropdown = this.createDropdown(localizedConstants.scanStartupProcsLabel, async (newValue) => {
 			this.objectInfo.scanStartupProcs = newValue === 'True';
-		}, ['True', 'False'], this.objectInfo.scanStartupProcs ? 'True' : 'False');
+		}, ['True', 'False'], this.objectInfo.scanStartupProcs ? 'True' : 'False', isEnabled);
 		const scanStartupProcsContainer = this.createLabelInputContainer(localizedConstants.scanStartupProcsLabel, this.scanStartupProcsDropdown);
 
 		this.twoDigitYearCutoffInput = this.createInputBox(async (newValue) => {
@@ -764,6 +765,7 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 		}, {
 			ariaLabel: localizedConstants.locksLabel,
 			inputType: 'number',
+			enabled: isEnabled,
 			max: this.objectInfo.locks.maximumValue,
 			min: 0,
 			value: this.objectInfo.locks.value.toString(),

--- a/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
@@ -757,7 +757,10 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 			inputType: 'number',
 			max: this.objectInfo.locks.maximumValue,
 			min: 0,
-			value: this.objectInfo.locks.value.toString()
+			value: this.objectInfo.locks.value.toString(),
+			validationErrorMessage: localizedConstants.locksValidation(this.objectInfo.locks.minimumValue)
+		}, async () => {
+			return !(+this.locksInput.value < this.objectInfo.locks.minimumValue && +this.locksInput.value !== 0);
 		});
 		const locksContainer = this.createLabelInputContainer(localizedConstants.locksLabel, this.locksInput);
 

--- a/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
@@ -504,8 +504,9 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 	}
 
 	private initializeSecuritySection(): void {
+		const isWindows = this.objectInfo.platform === constants.Windows;
 		// cannot change auth mode in sql managed instance or non windows instances
-		const isEnabled = this.engineEdition !== azdata.DatabaseEngineEdition.SqlManagedInstance && this.objectInfo.platform === 'Windows';
+		const isEnabled = this.engineEdition !== azdata.DatabaseEngineEdition.SqlManagedInstance && isWindows;
 		const radioServerGroupName = 'serverAuthenticationRadioGroup';
 		this.onlyWindowsAuthRadioButton = this.createRadioButton(localizedConstants.onlyWindowsAuthModeText, radioServerGroupName, this.objectInfo.authenticationMode === ServerLoginMode.Integrated, async () => { await this.handleAuthModeChange(); });
 		this.sqlServerAndWindowsAuthRadioButton = this.createRadioButton(localizedConstants.sqlServerAndWindowsAuthText, radioServerGroupName, this.objectInfo.authenticationMode === ServerLoginMode.Mixed, async () => { await this.handleAuthModeChange(); });
@@ -517,7 +518,6 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 		], true);
 
 		const radioLoginsGroupName = 'serverLoginsRadioGroup';
-		const isWindows = this.objectInfo.platform === 'Windows';
 		this.noneRadioButton = this.createRadioButton(localizedConstants.noLoginAuditingText, radioLoginsGroupName, this.objectInfo.loginAuditing === AuditLevel.None, async () => { await this.handleAuditLevelChange(); });
 		this.failedLoginsOnlyRadioButton = this.createRadioButton(localizedConstants.failedLoginsOnlyText, radioLoginsGroupName, this.objectInfo.loginAuditing === AuditLevel.Failure, async () => { await this.handleAuditLevelChange(); });
 		this.successfulLoginsOnlyRadioButton = this.createRadioButton(localizedConstants.successfulLoginsOnlyText, radioLoginsGroupName, this.objectInfo.loginAuditing === AuditLevel.Success, async () => { await this.handleAuditLevelChange(); });

--- a/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
@@ -756,6 +756,7 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 			ariaLabel: localizedConstants.locksLabel,
 			inputType: 'number',
 			max: this.objectInfo.locks.maximumValue,
+			min: 0,
 			value: this.objectInfo.locks.value.toString()
 		});
 		const locksContainer = this.createLabelInputContainer(localizedConstants.locksLabel, this.locksInput);


### PR DESCRIPTION
- Add locks validations: https://github.com/microsoft/azuredatastudio/issues/24316
- Disable scan startup procs and locks properties for Sql MI: https://github.com/microsoft/azuredatastudio/issues/24365
- Only notify user to restart server if they apply changes.