### PR TITLE
handle error scenarios for validity check

### DIFF
--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -298,9 +298,16 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ContainerProp
 		this._validations.push(() => {
 			this.logService.debug(`Running container validation on component ${this.descriptor.id} to check validity of all child items`);
 			return this.items.every(item => {
-				const valid = this.modelStore.getComponent(item.descriptor.id)?.valid;
+				const component = this.modelStore.getComponent(item.descriptor.id);
+				if (component === undefined) {
+					this.logService.warn(`Child item ${item.descriptor.id} of type ${item.descriptor.type} is undefined`);
+				} else if (component.valid === undefined) {
+					this.logService.warn(`The validity of child item ${item.descriptor.id} of type ${item.descriptor.type} undefined`);
+				}
+				// if the component is not found or the `valid` property is not set, we should treat it as valid.
+				const valid = component?.valid ?? true;
 				this.logService.debug(`Child item ${item.descriptor.id} validity is ${valid}`);
-				return valid || false;
+				return valid;
 			});
 		});
 	}


### PR DESCRIPTION
@barbaravaldez  reached out to me for help on this issue: https://github.com/microsoft/azuredatastudio/issues/24200
I noticed the following problems while changing the value (valid to invalid or invalid to valid), apparently, some components are not registered or disposed properly. 

![image](https://github.com/microsoft/azuredatastudio/assets/13777222/37cc4dd2-735d-4e78-b022-0b2645056d3d)

I think we should add warning for these scenarios as a safe guard. and in the meanwhile, @barbaravaldez, please investigate what caused the component to be undefined and fix it.
