### PR TITLE
Fix server and database dialog width

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -580,7 +580,7 @@
         },
         {
           "command": "mssql.detachDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
+          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@2"
         },
         {
@@ -611,7 +611,7 @@
         },
         {
           "command": "mssql.objectProperties",
-          "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
+          "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures",
           "group": "z_objectexplorer@3"
         },
         {

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -580,7 +580,7 @@
         },
         {
           "command": "mssql.detachDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
           "group": "1_objectManagement@2"
         },
         {
@@ -611,7 +611,7 @@
         },
         {
           "command": "mssql.objectProperties",
-          "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
           "group": "z_objectexplorer@3"
         },
         {
@@ -626,6 +626,11 @@
         {
           "command": "mssql.newTable",
           "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == Tables",
+          "group": "inline@0"
+        },
+        {
+          "command": "mssql.newDatabase",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == Databases && config.workbench.enablePreviewFeatures",
           "group": "inline@0"
         },
         {
@@ -1567,7 +1572,7 @@
   "dependencies": {
     "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.7",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#1.3.8",
     "find-remove": "1.2.1",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^4.0.0"

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -118,6 +118,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
+		options.width = '645px';
 		super(objectManagementService, options);
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 const MAXDOP_Max_Limit = 32767;
 const PAUSED_RESUMABLE_INDEX_Max_Limit = 71582;
 const DscTableRowLength = 15;
+const Dialog_Width = '650px';
 
 export class DatabaseDialog extends ObjectManagementDialogBase<Database, DatabaseViewInfo> {
 	// Database Properties tabs
@@ -118,7 +119,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		options.width = '645px';
+		options.width = Dialog_Width;
 		super(objectManagementService, options);
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
@@ -90,6 +90,7 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 	private shouldRestartServer: boolean = false;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
+		options.width = '560px'
 		super(objectManagementService, options);
 		this.disposables.push(this.dialogObject.onClosed(async (reason: azdata.window.CloseReason) => {
 			if (reason === 'ok') {

--- a/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
@@ -11,6 +11,8 @@ import * as localizedConstants from '../localizedConstants';
 import * as constants from '../constants';
 import { Server, ServerViewInfo, NumaNode, AffinityType, ServerLoginMode, AuditLevel } from '../interfaces';
 
+const Dialog_Width = '560px';
+
 export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, ServerViewInfo> {
 	private generalTab: azdata.Tab;
 	private readonly generalTabId: string = 'generalId';
@@ -90,7 +92,7 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 	private shouldRestartServer: boolean = false;
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
-		options.width = '560px'
+		options.width = Dialog_Width;
 		super(objectManagementService, options);
 		this.disposables.push(this.dialogObject.onClosed(async (reason: azdata.window.CloseReason) => {
 			if (reason === 'ok') {


### PR DESCRIPTION
1. Fix dialog width to fit the horizontal tabs: 

<img width="485" alt="databasePropertiesWidth" src="https://github.com/microsoft/azuredatastudio/assets/34872381/bf75e244-c966-4f65-beb1-2ee5a9e9f788">
<img width="420" alt="serverPropertiesWidth" src="https://github.com/microsoft/azuredatastudio/assets/34872381/26696d1f-4b44-4b1d-87ec-47b86e97f5f7">


For: https://github.com/microsoft/azuredatastudio/issues/24403
