### PR TITLE
max file size input field has wierd enable/disable behavior #24322

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/databaseFileDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseFileDialog.ts
@@ -217,9 +217,9 @@ export class DatabaseFileDialog extends DialogBase<DatabaseFile> {
 				= this.inMegabytesAutogrowth.enabled
 				= this.autoFilegrowthInput.enabled
 				= this.limitedToMbFileSize.enabled
-				= this.limitedToMbFileSizeInput.enabled
 				= this.unlimitedFileSize.enabled
 				= this.result.isAutoGrowthEnabled = checked;
+			this.limitedToMbFileSizeInput.enabled = checked && this.limitedToMbFileSize.checked;
 		}, true, true);
 
 		// Autogrowth radio button and input section


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Issue fixed for: https://github.com/microsoft/azuredatastudio/issues/24322

check/un-check 'enable Autogrowth 'checkbox is leaving the maxfilesize input box editable even unchecked.