### PR TITLE
Added validations to configure dialog

### DIFF
--- a/extensions/sql-migration/config.json
+++ b/extensions/sql-migration/config.json
@@ -1,7 +1,7 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.migration-{#fileName#}",
 	"useDefaultLinuxRuntime": true,
-	"version": "4.7.0.13",
+	"version": "4.10.0.3",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows": "win-x64-net7.0.zip",

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -2,7 +2,7 @@
   "name": "sql-migration",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "publisher": "Microsoft",
   "preview": false,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1517,13 +1517,13 @@ export const TDE_WIZARD_MSG_EMPTY = localize('sql.migration.tde.msg.empty', "No 
 
 export const TDE_VALIDATION_TITLE = localize('sql.migration.tde.validation.title', "Validation");
 export const TDE_VALIDATION_REQUIREMENTS_MESSAGE = localize('sql.migration.tde.validation.requirements.message', "In order for certificate migration to succeed, you must meet all of the requirements listed below.\n\nClick \"Run validation\" to check that requirements are met.");
-export const TDE_VALIDATION_STATUS_NOT_RAN = localize('sql.migration.tde.validation.status.not.ran', "Not ran");
+export const TDE_VALIDATION_STATUS_PENDING = localize('sql.migration.tde.validation.status.pending', "Pending");
 export const TDE_VALIDATION_STATUS_RUNNING = localize('sql.migration.tde.validation.running', "Running");
 export const TDE_VALIDATION_STATUS_SUCCEEDED = localize('sql.migration.tde.validation.status.succeeded', "Succeeded");
 export const TDE_VALIDATION_STATUS_RUN_VALIDATION = localize('sql.migration.tde.validation.run.validation', "Run validation");
 export const TDE_VALIDATION_DESCRIPTION = localize('sql.migration.tde.validation.description', "Description");
 export const TDE_VALIDATION_ERROR = localize('sql.migration.tde.validation.error', "Error");
-export const TDE_VALIDATION_TROUBLESHOOTING_TIPS = localize('sql.migration.tde.validation.troubleshooting.tips', "Troubleshooting Tips");
+export const TDE_VALIDATION_TROUBLESHOOTING_TIPS = localize('sql.migration.tde.validation.troubleshooting.tips', "Troubleshooting tips");
 
 export function TDE_MIGRATION_ERROR(message: string): string {
 	return localize('sql.migration.starting.migration.error', "The following error has occurred while starting the certificate migration: '{0}'", message);

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1516,14 +1516,17 @@ export const TDE_WIZARD_MSG_TDE = localize('sql.migration.tde.msg.tde', "You hav
 export const TDE_WIZARD_MSG_EMPTY = localize('sql.migration.tde.msg.empty', "No encrypted database selected.");
 
 export const TDE_VALIDATION_TITLE = localize('sql.migration.tde.validation.title', "Validation");
-export const TDE_VALIDATION_STATUS_NOT_RAN = localize('sql.migration.tde.validation.status.not.ran', "Not Ran");
+export const TDE_VALIDATION_REQUIREMENTS_MESSAGE = localize('sql.migration.tde.validation.requirements.message', "In order for certificate migration to succeed, you must meet all of the requirements listed below.\n\nClick \"Run validation\" to check that requirements are met.");
+export const TDE_VALIDATION_STATUS_NOT_RAN = localize('sql.migration.tde.validation.status.not.ran', "Not ran");
 export const TDE_VALIDATION_STATUS_RUNNING = localize('sql.migration.tde.validation.running', "Running");
 export const TDE_VALIDATION_STATUS_SUCCEEDED = localize('sql.migration.tde.validation.status.succeeded', "Succeeded");
-export const TDE_VALIDATION_REQUIREMENTS_MESSAGE = localize('sql.migration.tde.validation.requirements.message', "In order for certificate migration to succeed, you must meet all of the requirements listed below.\n\nClick \"Run Validation\" to check requirements are met.");
-export const TDE_VALIDATION_STATUS_RUN_VALIDATION = localize('sql.migration.tde.validation.run.validation', "Run Validation");
+export const TDE_VALIDATION_STATUS_RUN_VALIDATION = localize('sql.migration.tde.validation.run.validation', "Run validation");
+export const TDE_VALIDATION_DESCRIPTION = localize('sql.migration.tde.validation.description', "Description");
+export const TDE_VALIDATION_ERROR = localize('sql.migration.tde.validation.error', "Error");
+export const TDE_VALIDATION_TROUBLESHOOTING_TIPS = localize('sql.migration.tde.validation.troubleshooting.tips', "Troubleshooting Tips");
 
 export function TDE_MIGRATION_ERROR(message: string): string {
-	return localize('sql.migration.starting.migration.error', "An error occurred while starting the certificate migration: '{0}'", message);
+	return localize('sql.migration.starting.migration.error', "The following error has occurred while starting the certificate migration: '{0}'", message);
 }
 
 export function TDE_MIGRATION_ERROR_DB(name: string, message: string): string {

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1515,6 +1515,13 @@ export const TDE_WIZARD_MSG_MANUAL = localize('sql.migration.tde.msg.manual', "Y
 export const TDE_WIZARD_MSG_TDE = localize('sql.migration.tde.msg.tde', "You have given Azure Data Studio access to migrate the encryption certificates and database.");
 export const TDE_WIZARD_MSG_EMPTY = localize('sql.migration.tde.msg.empty', "No encrypted database selected.");
 
+export const TDE_VALIDATION_TITLE = localize('sql.migration.tde.validation.title', "Validation");
+export const TDE_VALIDATION_STATUS_NOT_RAN = localize('sql.migration.tde.validation.status.not.ran', "Not Ran");
+export const TDE_VALIDATION_STATUS_RUNNING = localize('sql.migration.tde.validation.running', "Running");
+export const TDE_VALIDATION_STATUS_SUCCEEDED = localize('sql.migration.tde.validation.status.succeeded', "Succeeded");
+export const TDE_VALIDATION_REQUIREMENTS_MESSAGE = localize('sql.migration.tde.validation.requirements.message', "In order for certificate migration to succeed, you must meet all of the requirements listed below.\n\nClick \"Run Validation\" to check requirements are met.");
+export const TDE_VALIDATION_STATUS_RUN_VALIDATION = localize('sql.migration.tde.validation.run.validation', "Run Validation");
+
 export function TDE_MIGRATION_ERROR(message: string): string {
 	return localize('sql.migration.starting.migration.error', "An error occurred while starting the certificate migration: '{0}'", message);
 }

--- a/extensions/sql-migration/src/dialog/tdeConfiguration/tdeConfigurationDialog.ts
+++ b/extensions/sql-migration/src/dialog/tdeConfiguration/tdeConfigurationDialog.ts
@@ -139,7 +139,7 @@ export class TdeConfigurationDialog {
 					let validationTitleData = await this.migrationStateModel.getTdeValidationTitles();
 
 					let networkPathValidated =
-						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() !== "") &&
+						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() !== '') &&
 						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() === this.migrationStateModel.tdeMigrationConfig.getLastValidatedNetworkPath())
 
 					let result = validationTitleData.result.map(validationTitle => {

--- a/extensions/sql-migration/src/dialog/tdeConfiguration/tdeConfigurationDialog.ts
+++ b/extensions/sql-migration/src/dialog/tdeConfiguration/tdeConfigurationDialog.ts
@@ -148,9 +148,9 @@ export class TdeConfigurationDialog {
 							validationTitle,
 							{
 								'icon': networkPathValidated ? IconPathHelper.completedMigration : IconPathHelper.notFound,
-								'title': networkPathValidated ? constants.TDE_VALIDATION_STATUS_SUCCEEDED : constants.TDE_VALIDATION_STATUS_NOT_RAN
+								'title': networkPathValidated ? constants.TDE_VALIDATION_STATUS_SUCCEEDED : constants.TDE_VALIDATION_STATUS_PENDING
 							},
-							networkPathValidated ? constants.TDE_VALIDATION_STATUS_SUCCEEDED : constants.TDE_VALIDATION_STATUS_NOT_RAN
+							networkPathValidated ? constants.TDE_VALIDATION_STATUS_SUCCEEDED : constants.TDE_VALIDATION_STATUS_PENDING
 						]
 					});
 

--- a/extensions/sql-migration/src/dialog/tdeConfiguration/tdeConfigurationDialog.ts
+++ b/extensions/sql-migration/src/dialog/tdeConfiguration/tdeConfigurationDialog.ts
@@ -12,6 +12,7 @@ import * as utils from '../../api/utils';
 import { EOL } from 'os';
 import { ConfigDialogSetting } from '../../models/tdeModels'
 import { IconPathHelper } from '../../constants/iconPathHelper';
+import { strings } from '../../../../../build/lib/tsb/utils';
 
 export class TdeConfigurationDialog {
 
@@ -139,7 +140,7 @@ export class TdeConfigurationDialog {
 					let validationTitleData = await this.migrationStateModel.getTdeValidationTitles();
 
 					let networkPathValidated =
-						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() !== '') &&
+						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() !== strings.empty) &&
 						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() === this.migrationStateModel.tdeMigrationConfig.getLastValidatedNetworkPath())
 
 					let result = validationTitleData.result.map(validationTitle => {
@@ -270,7 +271,7 @@ export class TdeConfigurationDialog {
 				await this.updateUI();
 			}));
 
-		const preValidationSeparator = _view.modelBuilder.separator().withProps({}).component();
+		const preValidationSeparator = _view.modelBuilder.separator().component();
 
 		const validationRequiredLabel = _view.modelBuilder.text()
 			.withProps({
@@ -355,14 +356,14 @@ export class TdeConfigurationDialog {
 						let errorMessage = this._validationSuccessDescriptionErrorAndTips[rowIndex][2];
 						let tips = this._validationSuccessDescriptionErrorAndTips[rowIndex][3];
 
-						message = `Description:${EOL}${description}`;
+						message = `${constants.TDE_VALIDATION_DESCRIPTION}:${EOL}${description}`;
 						if (!successful) {
 							message += `${EOL}${EOL}`;
 							if (errorMessage?.length > 0) {
-								message += `Error:${EOL}${errorMessage}${EOL}${EOL}`;
+								message += `${constants.TDE_VALIDATION_ERROR}:${EOL}${errorMessage}${EOL}${EOL}`;
 							}
 
-							message += `Troubleshooting Tips:${EOL}${tips}`;
+							message += `${constants.TDE_VALIDATION_TROUBLESHOOTING_TIPS}:${EOL}${tips}`;
 						}
 					});
 
@@ -378,10 +379,7 @@ export class TdeConfigurationDialog {
 			})
 			.component();
 
-		const postValidationSeparator = _view.modelBuilder.separator()
-			.withProps(
-				{
-				}).component();
+		const postValidationSeparator = _view.modelBuilder.separator().component();
 
 		container.addItems([
 			adsMethodInfoMessage,

--- a/extensions/sql-migration/src/dialog/tdeConfiguration/tdeConfigurationDialog.ts
+++ b/extensions/sql-migration/src/dialog/tdeConfiguration/tdeConfigurationDialog.ts
@@ -12,7 +12,6 @@ import * as utils from '../../api/utils';
 import { EOL } from 'os';
 import { ConfigDialogSetting } from '../../models/tdeModels'
 import { IconPathHelper } from '../../constants/iconPathHelper';
-import { strings } from '../../../../../build/lib/tsb/utils';
 
 export class TdeConfigurationDialog {
 
@@ -140,7 +139,7 @@ export class TdeConfigurationDialog {
 					let validationTitleData = await this.migrationStateModel.getTdeValidationTitles();
 
 					let networkPathValidated =
-						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() !== strings.empty) &&
+						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() !== "") &&
 						(this.migrationStateModel.tdeMigrationConfig.getPendingNetworkPath() === this.migrationStateModel.tdeMigrationConfig.getLastValidatedNetworkPath())
 
 					let result = validationTitleData.result.map(validationTitle => {

--- a/extensions/sql-migration/src/models/tdeModels.ts
+++ b/extensions/sql-migration/src/models/tdeModels.ts
@@ -41,6 +41,15 @@ export interface TdeMigrationDbResult {
 	message: string;
 }
 
+export interface TdeValidationResult {
+	validationTitle: string;
+	validationDescription: string;
+	validationTroubleshootingTips: string;
+	validationErrorMessage: string;
+	validationStatus: number;
+	validationStatusString: string;
+}
+
 export class TdeMigrationModel {
 
 	// Settings for which the user has clicked the apply button
@@ -52,6 +61,9 @@ export class TdeMigrationModel {
 	private _pendingConfigDialogSetting: ConfigDialogSetting;
 	private _pendingExportCertUserConsent: boolean;
 	private _pendingNetworkPath: string;
+
+	// Last network path for which all validations succeeded
+	private _lastValidatedNetworkPath: string;
 
 	private _configurationCompleted: boolean;
 	private _shownBefore: boolean;
@@ -75,6 +87,7 @@ export class TdeMigrationModel {
 		this._appliedExportCertUserConsent = false;
 		this._pendingExportCertUserConsent = false;
 		this._tdeMigrationCompleted = false;
+		this._lastValidatedNetworkPath = '';
 
 		this._tdeMigrationCompleted = this._tdeMigrationCompleted;
 	}
@@ -176,7 +189,12 @@ export class TdeMigrationModel {
 		}
 
 		if (this._pendingConfigDialogSetting === ConfigDialogSetting.ExportCertificates) {
-			return this._pendingExportCertUserConsent;
+			if (this._pendingNetworkPath !== this._lastValidatedNetworkPath) {
+				return false;
+			}
+
+			return this._pendingNetworkPath.length > 0 &&
+				this._pendingExportCertUserConsent;
 		}
 
 		return true;
@@ -212,5 +230,13 @@ export class TdeMigrationModel {
 
 	public setPendingExportCertUserConsent(pendingExportCertUserConsent: boolean) {
 		this._pendingExportCertUserConsent = pendingExportCertUserConsent;
+	}
+
+	public setLastValidatedNetworkPath(validatedNetworkPath: string) {
+		this._lastValidatedNetworkPath = validatedNetworkPath;
+	}
+
+	public getLastValidatedNetworkPath() {
+		return this._lastValidatedNetworkPath;
 	}
 }

--- a/extensions/sql-migration/src/service/contracts.ts
+++ b/extensions/sql-migration/src/service/contracts.ts
@@ -388,6 +388,11 @@ export const enum VirtualMachineFamily {
 	standardNVSv4Family
 }
 
+export const enum TdeValidationStatus {
+	Failed = -1,
+	Succeeded = 1
+}
+
 export namespace GetSqlMigrationSkuRecommendationsRequest {
 	export const type = new RequestType<SqlMigrationSkuRecommendationsParams, SkuRecommendationResult, void, void>('migration/getskurecommendations');
 }
@@ -548,4 +553,26 @@ export interface TdeMigrateProgressParams {
 	success: boolean;
 	message: string;
 	statusCode: string;
+}
+
+export interface TdeValidationResult {
+	validationTitle: string;
+	validationDescription: string;
+	validationTroubleshootingTips: string;
+	validationErrorMessage: string;
+	validationStatus: TdeValidationStatus;
+	validationStatusString: string;
+}
+
+export interface TdeValidationParams {
+	sourceSqlConnectionString: string;
+	networkSharePath: string;
+}
+
+export namespace TdeValidationRequest {
+	export const type = new RequestType<TdeValidationParams, TdeValidationResult[], void, void>('migration/tdevalidation');
+}
+
+export namespace TdeValidationTitlesRequest {
+	export const type = new RequestType<{}, string[], void, void>('migration/tdevalidationtitles');
 }

--- a/extensions/sql-migration/src/service/features.ts
+++ b/extensions/sql-migration/src/service/features.ts
@@ -316,5 +316,34 @@ export class SqlMigrationService extends MigrationExtensionService implements co
 
 		return undefined;
 	}
-}
 
+	async runTdeValidation(
+		sourceSqlConnectionString: string,
+		networkSharePath: string,
+	) {
+		let params: contracts.TdeValidationParams = {
+			sourceSqlConnectionString: sourceSqlConnectionString,
+			networkSharePath: networkSharePath,
+		};
+
+		try {
+			return await this._client.sendRequest(contracts.TdeValidationRequest.type, params);
+		}
+		catch (e) {
+			this._client.logFailedRequest(contracts.TdeValidationRequest.type, e);
+		}
+
+		return undefined;
+	}
+
+	async getTdeValidationTitles() {
+		try {
+			return await this._client.sendRequest(contracts.TdeValidationTitlesRequest.type, {});
+		}
+		catch (e) {
+			this._client.logFailedRequest(contracts.TdeValidationRequest.type, e);
+		}
+
+		return undefined;
+	}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This pull request makes changes to the TDE migration dialog of the Azure SQL Migration extension.
A user is now required to pass validation checks prior to completing the configuration dialog.

Failed validation:
![image](https://github.com/microsoft/azuredatastudio/assets/71411280/ffd3008a-9965-4c9a-b548-ba5f57253d06)

Successful validation:
![image](https://github.com/microsoft/azuredatastudio/assets/71411280/2cc1701f-a964-444e-ae21-6ada397666ed)

