### PR TITLE
Added fix to new row revert

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -82,8 +82,11 @@ export class EditDataGridPanel extends GridParentComponent {
 	// Prevent the cell submission function from being called multiple times.
 	private cellSubmitInProgress: boolean;
 
-	// Prevent the tab focus from doing any damage to the table while its being reverted.
+	// Prevent the tab focus from doing any damage to the table while a cell is being reverted.
 	private cellRevertInProgress: boolean;
+
+	// Prevent the tab focus from doing any damage to the table while a row is being reverted.
+	private rowRevertInProgress: boolean
 
 	// Manually submit the cell after edit end if it's the null row.
 	private isInNullRow: boolean;
@@ -343,7 +346,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		// definition for the column (ie, the selection was reset)
 		// Also skip when cell updates are happening as we don't want to affect other cells while this is going on.
 		// (focus should shift back to current cell if it is set)
-		if (row === undefined || column === undefined || this.cellSubmitInProgress || this.cellRevertInProgress) {
+		if (row === undefined || column === undefined || this.cellSubmitInProgress || this.cellRevertInProgress || this.rowRevertInProgress) {
 			return;
 		}
 
@@ -626,6 +629,7 @@ export class EditDataGridPanel extends GridParentComponent {
 	// Private Helper Functions ////////////////////////////////////////////////////////////////////////////
 
 	private async revertCurrentRow(): Promise<void> {
+		this.rowRevertInProgress = true;
 		let currentNewRowIndex = this.dataSet.totalRows - 2;
 		if (this.newRowVisible && this.currentCell.row === currentNewRowIndex) {
 			// revert our last new row
@@ -664,6 +668,7 @@ export class EditDataGridPanel extends GridParentComponent {
 				}
 			}
 		}
+		this.rowRevertInProgress = false;
 	}
 
 	private async revertCurrentCell(): Promise<void> {


### PR DESCRIPTION
Fixes a bug/oversight that was encountered during testing and mentioned in this issue:

Posted here for release DRI: https://github.com/microsoft/azuredatastudio/issues/24421 

Will be ported into September release as this is a regression.

This should prevent the cell from moving in the new row, using the existing logic.

Introduced here: https://github.com/microsoft/azuredatastudio/pull/23981

Before:
![New Row Revert Before](https://github.com/microsoft/azuredatastudio/assets/18018452/66dea4bc-e28b-4f33-adf0-4b5f5ad5c5fd)

After:
![New Row Revert After](https://github.com/microsoft/azuredatastudio/assets/18018452/1dc17083-0118-475c-90ea-a440d6d6870f)
