### PR TITLE
Fix enable/disable script button behavior

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -107,9 +107,6 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 				}
 			}
 		});
-		this.modelView.onValidityChanged((isValid: boolean) => {
-			this.dialogObject.customButtons[1].enabled = isValid;
-		});
 	}
 
 	protected get viewInfo(): ViewInfoType {

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -107,6 +107,9 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 				}
 			}
 		});
+		this.modelView.onValidityChanged((isValid: boolean) => {
+			this.dialogObject.customButtons[1].enabled = isValid;
+		});
 	}
 
 	protected get viewInfo(): ViewInfoType {

--- a/extensions/mssql/src/ui/scriptableDialogBase.ts
+++ b/extensions/mssql/src/ui/scriptableDialogBase.ts
@@ -63,7 +63,7 @@ export abstract class ScriptableDialogBase<OptionsType extends ScriptableDialogO
 	protected abstract get isDirty(): boolean;
 
 	protected override onFormFieldChange(): void {
-		this._scriptButton.enabled = this.isDirty;
+		this._scriptButton.enabled = this.isDirty && this.modelView.valid;
 		this.dialogObject.okButton.enabled = this.isDirty;
 	}
 

--- a/extensions/mssql/src/ui/scriptableDialogBase.ts
+++ b/extensions/mssql/src/ui/scriptableDialogBase.ts
@@ -63,15 +63,15 @@ export abstract class ScriptableDialogBase<OptionsType extends ScriptableDialogO
 	protected abstract get isDirty(): boolean;
 
 	protected override onFormFieldChange(): void {
-		this._scriptButton.enabled = this.isDirty && this.modelView.valid;
+		this.updateScriptButtonState();
 		this.dialogObject.okButton.enabled = this.isDirty;
 	}
 
 	protected override async initialize(): Promise<void> {
 		await this.initializeData();
 		await this.initializeUI();
-		this.disposables.push(this.modelView.onValidityChanged((isValid: boolean) => {
-			this._scriptButton.enabled = isValid;
+		this.disposables.push(this.modelView.onValidityChanged(() => {
+			this.updateScriptButtonState();
 		}));
 	}
 
@@ -133,5 +133,9 @@ export abstract class ScriptableDialogBase<OptionsType extends ScriptableDialogO
 		} finally {
 			this.updateLoadingStatus(false, localizedConstants.GeneratingScriptText, localizedConstants.GeneratingScriptCompletedText);
 		}
+	}
+
+	private updateScriptButtonState(): void {
+		this._scriptButton.enabled = this.isDirty && this.modelView.valid;
 	}
 }

--- a/extensions/mssql/src/ui/scriptableDialogBase.ts
+++ b/extensions/mssql/src/ui/scriptableDialogBase.ts
@@ -70,6 +70,9 @@ export abstract class ScriptableDialogBase<OptionsType extends ScriptableDialogO
 	protected override async initialize(): Promise<void> {
 		await this.initializeData();
 		await this.initializeUI();
+		this.disposables.push(this.modelView.onValidityChanged((isValid: boolean) => {
+			this._scriptButton.enabled = isValid;
+		}));
 	}
 
 	protected override updateLoadingStatus(isLoading: boolean, loadingText?: string, loadingCompletedText?: string): void {


### PR DESCRIPTION
Currently, the script and ok buttons are enabled when the dialog is dirty. However, the ok button is later enabled or disabled depending on the validity of the ModelView object in the [dialogModal](https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/services/dialog/browser/dialogModal.ts#L78) object. We need to add this functionality to the script button to disable the button for invalid values.

For: https://github.com/microsoft/azuredatastudio/issues/24311