### PR TITLE
Add log message when falling back to default kernel

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -1321,6 +1321,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		}
 		else {
 			spec = notebookConstants.sqlKernelSpec;
+			this.logService.info(`Could not find kernel spec from display name ${displayName}. Defaulting to SQL kernel.`);
 		}
 		return spec;
 	}


### PR DESCRIPTION
I somehow got in a state where non-SQL kernels weren't being registered. This manifested as the Notebook just silently switching back to the SQL kernel when I tried to switch - without any error or message of any sort. I was able to track it down to this code path being the reason why that was happening, although unfortunately the issue went away before I could root cause it.

But I figured adding this log message will at least help us know when this is happening in the future. It was very confusing to just have it switch back to the SQL kernel (seemed like nothing was happening). I considered having it be an actual toast notification, but sticking with this for now to start with since it's unclear when/how often this would happen.