### PR TITLE
Filegroup Memory optimized Add button should be disabled when have on…

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -930,7 +930,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 		this.memoryOptimizedFilegroupNameInput = this.getFilegroupNameInput(this.memoryOptimizedFilegroupsTable, FileGroupType.MemoryOptimizedDataFileGroup);
 		const addButtonComponent: DialogButton = {
 			buttonAriaLabel: localizedConstants.AddFilegroupText,
-			buttonHandler: () => this.onAddDatabaseFileGroupsButtonClicked(this.memoryOptimizedFilegroupsTable)
+			buttonHandler: () => this.onAddDatabaseFileGroupsButtonClicked(this.memoryOptimizedFilegroupsTable),
+			enabled: this.memoryoptimizedFileGroupsTableRows.length < 1
 		};
 		const removeButtonComponent: DialogButton = {
 			buttonAriaLabel: localizedConstants.RemoveButton,
@@ -954,6 +955,19 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 		const memoryOptimizedContainer = this.modelView.modelBuilder.flexContainer().withItems([this.memoryOptimizedFilegroupNameInput]).component();
 		memoryOptimizedContainer.addItems([memoryOptimizedFileGroupButtonContainer], { flex: '0 0 auto' });
 		return this.createGroup(localizedConstants.MemoryOptimizedFileGroupsSectionText, [this.memoryOptimizedFilegroupsTable, memoryOptimizedContainer], true);
+	}
+
+	/**
+	 * Overrides declarative table add button enabled/disabled state
+	 * @param table table component
+	 * @returns table add button enabled/disabled state
+	 */
+	public override addButtonEnabled(table: azdata.TableComponent | azdata.DeclarativeTableComponent): boolean {
+		let enabled = true;
+		if (table === this.memoryOptimizedFilegroupsTable) {
+			enabled = this.memoryoptimizedFileGroupsTableRows.length < 1;
+		}
+		return enabled;
 	}
 
 	/**

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -24,7 +24,8 @@ export function getTableHeight(rowCount: number, minRowCount: number = DefaultMi
 
 export interface DialogButton {
 	buttonAriaLabel: string;
-	buttonHandler: (button: azdata.ButtonComponent) => Promise<void>
+	buttonHandler: (button: azdata.ButtonComponent) => Promise<void>,
+	enabled?: boolean
 }
 
 export type TableListItemEnabledStateGetter<T> = (item: T) => boolean;
@@ -79,6 +80,8 @@ export abstract class DialogBase<DialogResult> {
 	protected onFormFieldChange(): void { }
 
 	protected removeButtonEnabled(table: azdata.TableComponent): boolean { return true; }
+
+	protected addButtonEnabled(table: azdata.TableComponent): boolean { return true; }
 
 	protected validateInput(): Promise<string[]> { return Promise.resolve([]); }
 
@@ -295,12 +298,13 @@ export abstract class DialogBase<DialogResult> {
 			if (editButton !== undefined) {
 				editButtonComponent.enabled = tableSelectedRowsLengthCheck;
 			}
+			addButtonComponent.enabled = this.addButtonEnabled(table);
 			removeButtonComponent.enabled = !!isRemoveEnabled && tableSelectedRowsLengthCheck;
 		}
 		addButtonComponent = this.createButton(uiLoc.AddText, addbutton.buttonAriaLabel, async () => {
 			await addbutton.buttonHandler(addButtonComponent);
 			updateButtons();
-		});
+		}, addbutton.enabled ?? true);
 		buttonComponents.push(addButtonComponent);
 
 		if (editButton !== undefined) {


### PR DESCRIPTION
…e filegroup #24309 (#24446)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ADS Issue: https://github.com/microsoft/azuredatastudio/issues/24309

This PR adds the ability to enable/disable add button of a table component. Memory optimized filegroups table does allow only one filegroup to add at any time, so when there is no filegroup present the add button is enabled otherwise the state is set to disable.