### PR TITLE
Remove deprecated azure graph endpoints

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -68,8 +68,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 		this.redirectUri = this.metadata.settings.redirectUri;
 		this.clientId = this.metadata.settings.clientId;
 		this.resources = [
-			this.metadata.settings.armResource,
-			this.metadata.settings.graphResource,
+			this.metadata.settings.armResource
 		];
 		if (this.metadata.settings.sqlResource) {
 			this.resources.push(this.metadata.settings.sqlResource);

--- a/extensions/azurecore/src/account-provider/interfaces.ts
+++ b/extensions/azurecore/src/account-provider/interfaces.ts
@@ -7,7 +7,6 @@ import * as azurecore from 'azurecore';
 
 export const enum SettingIds {
 	marm = 'marm',
-	graph = 'graph',
 	msgraph = 'msgraph',
 	arm = 'arm',
 	sql = 'sql',

--- a/extensions/azurecore/src/account-provider/interfaces.ts
+++ b/extensions/azurecore/src/account-provider/interfaces.ts
@@ -48,7 +48,6 @@ export type ProviderSettingsJson = {
 				host: string,
 				clientId: string,
 				microsoftResource: string,
-				graphResource: string,
 				msGraphResource?: string,
 				armResource: string,
 				sqlResource: string,

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -23,11 +23,6 @@ const publicAzureSettings: ProviderSettings = {
 				endpoint: 'https://management.core.windows.net/',
 				azureResourceId: AzureResource.MicrosoftResourceManagement
 			},
-			graphResource: {
-				id: SettingIds.graph,
-				endpoint: 'https://graph.windows.net/',
-				azureResourceId: AzureResource.Graph
-			},
 			msGraphResource: {
 				id: SettingIds.msgraph,
 				endpoint: 'https://graph.microsoft.com/',
@@ -103,11 +98,6 @@ const usGovAzureSettings: ProviderSettings = {
 				endpoint: 'https://management.core.usgovcloudapi.net/',
 				azureResourceId: AzureResource.MicrosoftResourceManagement
 			},
-			graphResource: {
-				id: SettingIds.graph,
-				endpoint: 'https://graph.windows.net/',
-				azureResourceId: AzureResource.Graph
-			},
 			msGraphResource: {
 				id: SettingIds.msgraph,
 				endpoint: 'https://graph.microsoft.us/',
@@ -176,11 +166,6 @@ const chinaAzureSettings: ProviderSettings = {
 				id: SettingIds.marm,
 				endpoint: 'https://management.core.chinacloudapi.cn/',
 				azureResourceId: AzureResource.MicrosoftResourceManagement
-			},
-			graphResource: {
-				id: SettingIds.graph,
-				endpoint: 'https://graph.chinacloudapi.cn',
-				azureResourceId: AzureResource.Graph
 			},
 			msGraphResource: {
 				id: SettingIds.msgraph,

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -94,11 +94,6 @@ declare module 'azurecore' {
 		microsoftResource: Resource
 
 		/**
-		 * Information that describes the AAD graph resource
-		 */
-		graphResource: Resource;
-
-		/**
 		 * Information that describes the MS graph resource
 		 */
 		msGraphResource?: Resource;

--- a/extensions/azurecore/src/utils.ts
+++ b/extensions/azurecore/src/utils.ts
@@ -217,11 +217,6 @@ function buildCustomCloudProviderSettings(customProvider: ProviderSettingsJson):
 					endpoint: customProvider.settings.metadata.endpoints.armResource,
 					azureResourceId: AzureResource.ResourceManagement
 				},
-				graphResource: {
-					id: SettingIds.graph,
-					endpoint: customProvider.settings.metadata.endpoints.graphResource,
-					azureResourceId: AzureResource.Graph
-				},
 				azureStorageResource: {
 					id: SettingIds.storage,
 					endpoint: customProvider.settings.metadata.endpoints.azureStorageResource.endpoint,

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2524,38 +2524,39 @@ declare module 'azdata' {
 		 * Azure Key Vault
 		 */
 		AzureKeyVault = 3,
+		// 4 (formerly Azure Graph) is no longer used.
 		/**
 		 * Microsoft Resource Management
 		 */
-		MicrosoftResourceManagement = 4,
+		MicrosoftResourceManagement = 5,
 		/**
 		 * Azure Dev Ops
 		 */
-		AzureDevOps = 5,
+		AzureDevOps = 6,
 		/**
 		 * Microsoft Graph
 		 */
-		MsGraph = 6,
+		MsGraph = 7,
 		/**
 		 * Azure Log Analytics
 		 */
-		AzureLogAnalytics = 7,
+		AzureLogAnalytics = 8,
 		/**
 		 * Azure Storage
 		 */
-		AzureStorage = 8,
+		AzureStorage = 9,
 		/**
 		 * Kusto
 		 */
-		AzureKusto = 9,
+		AzureKusto = 10,
 		/**
 		 * Power BI
 		 */
-		PowerBi = 10,
+		PowerBi = 11,
 		/**
 		 * Represents custom resource URIs as received from server endpoint.
 		 */
-		Custom = 11
+		Custom = 12
 	}
 
 	export interface DidChangeAccountsParams {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2525,41 +2525,37 @@ declare module 'azdata' {
 		 */
 		AzureKeyVault = 3,
 		/**
-		 * Azure AD Graph
-		 */
-		Graph = 4,
-		/**
 		 * Microsoft Resource Management
 		 */
-		MicrosoftResourceManagement = 5,
+		MicrosoftResourceManagement = 4,
 		/**
 		 * Azure Dev Ops
 		 */
-		AzureDevOps = 6,
+		AzureDevOps = 5,
 		/**
 		 * Microsoft Graph
 		 */
-		MsGraph = 7,
+		MsGraph = 6,
 		/**
 		 * Azure Log Analytics
 		 */
-		AzureLogAnalytics = 8,
+		AzureLogAnalytics = 7,
 		/**
 		 * Azure Storage
 		 */
-		AzureStorage = 9,
+		AzureStorage = 8,
 		/**
 		 * Kusto
 		 */
-		AzureKusto = 10,
+		AzureKusto = 9,
 		/**
 		 * Power BI
 		 */
-		PowerBi = 11,
+		PowerBi = 10,
 		/**
 		 * Represents custom resource URIs as received from server endpoint.
 		 */
-		Custom = 12
+		Custom = 11
 	}
 
 	export interface DidChangeAccountsParams {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -476,15 +476,14 @@ export enum AzureResource {
 	Sql = 1,
 	OssRdbms = 2,
 	AzureKeyVault = 3,
-	Graph = 4,
-	MicrosoftResourceManagement = 5,
-	AzureDevOps = 6,
-	MsGraph = 7,
-	AzureLogAnalytics = 8,
-	AzureStorage = 9,
-	AzureKusto = 10,
-	PowerBi = 11,
-	Custom = 12 // Handles custom resource URIs as received from server endpoint.
+	MicrosoftResourceManagement = 4,
+	AzureDevOps = 5,
+	MsGraph = 6,
+	AzureLogAnalytics = 7,
+	AzureStorage = 8,
+	AzureKusto = 9,
+	PowerBi = 10,
+	Custom = 11 // Handles custom resource URIs as received from server endpoint.
 }
 
 export enum NodeFilterPropertyDataType {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -476,14 +476,15 @@ export enum AzureResource {
 	Sql = 1,
 	OssRdbms = 2,
 	AzureKeyVault = 3,
-	MicrosoftResourceManagement = 4,
-	AzureDevOps = 5,
-	MsGraph = 6,
-	AzureLogAnalytics = 7,
-	AzureStorage = 8,
-	AzureKusto = 9,
-	PowerBi = 10,
-	Custom = 11 // Handles custom resource URIs as received from server endpoint.
+	// 4 (formerly Azure Graph) is no longer used.
+	MicrosoftResourceManagement = 5,
+	AzureDevOps = 6,
+	MsGraph = 7,
+	AzureLogAnalytics = 8,
+	AzureStorage = 9,
+	AzureKusto = 10,
+	PowerBi = 11,
+	Custom = 12 // Handles custom resource URIs as received from server endpoint.
 }
 
 export enum NodeFilterPropertyDataType {


### PR DESCRIPTION
Azure Active Directory Graph API is getting [retired](https://learn.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview) after Sept 30th, removing the endpoints from ADS.