### PR TITLE
Support select execution on History Table

### DIFF
--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -105,6 +105,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 		ConnectionContextKey.Provider.notEqualsTo('LOGANALYTICS'),
 		ContextKeyExpr.or(
+			TreeNodeContextKey.NodeType.isEqualTo(NodeType.HistoryTable),
 			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
 			TreeNodeContextKey.NodeType.isEqualTo(NodeType.View)
 		)

--- a/src/sql/workbench/services/objectExplorer/browser/mssqlNodeContext.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/mssqlNodeContext.ts
@@ -28,7 +28,7 @@ export interface INodeContextValue {
  */
 export class MssqlNodeContext extends Disposable {
 
-	static readonly canSelect = new Set([NodeType.Table, NodeType.View]);
+	static readonly canSelect = new Set([NodeType.HistoryTable, NodeType.Table, NodeType.View]);
 	static readonly canEditData = new Set([NodeType.Table]);
 	static readonly canCreateOrDelete = new Set([NodeType.AggregateFunction, NodeType.PartitionFunction, NodeType.ScalarValuedFunction,
 	NodeType.Schema, NodeType.StoredProcedure, NodeType.Table, NodeType.TableValuedFunction,


### PR DESCRIPTION
Fixes #24458 
Enabled 'Select Top 1000' on History table.

<img src="https://github.com/microsoft/azuredatastudio/assets/13396919/1ee0d987-cbdd-4e27-9635-439fd80365e0" width=500 />
