### PR TITLE
Azure SQL MI supports maximum 100 DB per instance.

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -117,7 +117,7 @@ export const SKU_RECOMMENDATION_ASSESSMENT_ERROR_DETAIL = localize('sql.migratio
 export const AZURE_SQL_MI_DB_COUNT_THRESHOLD_EXCEEDS_ERROR = (selectedDbCount: number): string => {
 	return localize('sql.migration.select.azure.mi.db.count.threshold.exceeds.error', 'Error: Azure SQL Managed Instance supports maximum {0} user databases per instance. Select {0} or less database(s) to proceed further.', selectedDbCount);
 };
-export const AZURE_SQL_MI_DB_COUNT_UNDER_THRESHOLD = localize('sql.migration.select.azure.mi.db.count.under.threshold', 'To proceed, press "Select" button.');
+export const AZURE_SQL_MI_DB_COUNT_UNDER_THRESHOLD = localize('sql.migration.select.azure.mi.db.count.under.threshold', 'To proceed, press Select button');
 export const REFRESH_ASSESSMENT_BUTTON_LABEL = localize('sql.migration.refresh.assessment.button.label', "Refresh assessment");
 export const SKU_RECOMMENDATION_CHOOSE_A_TARGET = localize('sql.migration.wizard.sku.choose_a_target', "Choose your Azure SQL target");
 export const SKU_RECOMMENDATION_CHOOSE_A_TARGET_HELP = localize('sql.migration.wizard.sku.choose_a_target.help', "Not sure which Azure SQL target is right for you? Learn more");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -117,7 +117,7 @@ export const SKU_RECOMMENDATION_ASSESSMENT_ERROR_DETAIL = localize('sql.migratio
 export const AZURE_SQL_MI_DB_COUNT_THRESHOLD_EXCEEDS_ERROR = (selectedDbCount: number): string => {
 	return localize('sql.migration.select.azure.mi.db.count.threshold.exceeds.error', 'Error: Azure SQL Managed Instance supports maximum {0} user databases per instance. Select {0} or less database(s) to proceed further.', selectedDbCount);
 };
-export const AZURE_SQL_MI_DB_COUNT_UNDER_THRESHOLD = localize('sql.migration.select.azure.mi.db.count.under.threshold', 'To proceed press select button.');
+export const AZURE_SQL_MI_DB_COUNT_UNDER_THRESHOLD = localize('sql.migration.select.azure.mi.db.count.under.threshold', 'To proceed, press "Select" button.');
 export const REFRESH_ASSESSMENT_BUTTON_LABEL = localize('sql.migration.refresh.assessment.button.label', "Refresh assessment");
 export const SKU_RECOMMENDATION_CHOOSE_A_TARGET = localize('sql.migration.wizard.sku.choose_a_target', "Choose your Azure SQL target");
 export const SKU_RECOMMENDATION_CHOOSE_A_TARGET_HELP = localize('sql.migration.wizard.sku.choose_a_target.help', "Not sure which Azure SQL target is right for you? Learn more");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -114,6 +114,10 @@ export const PERF_DATA_COLLECTION_ERROR = (serverName: string, errors: string[])
 };
 export const SKU_RECOMMENDATION_ASSESSMENT_ERROR_BYPASS = localize('sql.migration.wizard.sku.assessment.error.bypass', 'Check this option to skip assessment and continue the migration.');
 export const SKU_RECOMMENDATION_ASSESSMENT_ERROR_DETAIL = localize('sql.migration.wizard.sku.assessment.error.detail', '[There are no assessment results to validate readiness of your database migration. By checking this box, you acknowledge you want to proceed migrating your database to the desired Azure SQL target.]',);
+export const AZURE_SQL_MI_DB_COUNT_THRESHOLD_EXCEEDS_ERROR = (selectedDbCount: number): string => {
+	return localize('sql.migration.select.azure.mi.db.count.threshold.exceeds.error', 'Error: Azure SQL Managed Instance supports maximum {0} user databases per instance. Select {0} or less database(s) to proceed further.', selectedDbCount);
+};
+export const AZURE_SQL_MI_DB_COUNT_UNDER_THRESHOLD = localize('sql.migration.select.azure.mi.db.count.under.threshold', 'To proceed press select button.');
 export const REFRESH_ASSESSMENT_BUTTON_LABEL = localize('sql.migration.refresh.assessment.button.label', "Refresh assessment");
 export const SKU_RECOMMENDATION_CHOOSE_A_TARGET = localize('sql.migration.wizard.sku.choose_a_target', "Choose your Azure SQL target");
 export const SKU_RECOMMENDATION_CHOOSE_A_TARGET_HELP = localize('sql.migration.wizard.sku.choose_a_target.help', "Not sure which Azure SQL target is right for you? Learn more");

--- a/extensions/sql-migration/src/dialog/assessment/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessment/sqlDatabasesTree.ts
@@ -892,7 +892,10 @@ export class SqlDatabaseTree {
 		} else {
 			if (this._targetType === MigrationTargetType.SQLMI && selectedDbs?.length > AZURE_SQL_MI_DB_COUNT_THRESHOLD) {
 				this._dialog.okButton.enabled = false;
-				void vscode.window.showErrorMessage(constants.AZURE_SQL_MI_DB_COUNT_THRESHOLD_EXCEEDS_ERROR(AZURE_SQL_MI_DB_COUNT_THRESHOLD));
+				this._dialog.message = {
+					level: azdata.window.MessageLevel.Error,
+					text: constants.AZURE_SQL_MI_DB_COUNT_THRESHOLD_EXCEEDS_ERROR(AZURE_SQL_MI_DB_COUNT_THRESHOLD),
+				};
 			}
 
 			instanceTableValues = [[
@@ -943,11 +946,17 @@ export class SqlDatabaseTree {
 		const selectedDbsCount = this.selectedDbs()?.length;
 		if (this._targetType === MigrationTargetType.SQLMI && selectedDbsCount > AZURE_SQL_MI_DB_COUNT_THRESHOLD) {
 			this._dialog.okButton.enabled = false;
-			void vscode.window.showErrorMessage(constants.AZURE_SQL_MI_DB_COUNT_THRESHOLD_EXCEEDS_ERROR(AZURE_SQL_MI_DB_COUNT_THRESHOLD));
+			this._dialog.message = {
+				level: azdata.window.MessageLevel.Error,
+				text: constants.AZURE_SQL_MI_DB_COUNT_THRESHOLD_EXCEEDS_ERROR(AZURE_SQL_MI_DB_COUNT_THRESHOLD)
+			};
 		}
 		else if (!this._dialog.okButton.enabled) {
 			this._dialog.okButton.enabled = true;
-			void vscode.window.showInformationMessage(constants.AZURE_SQL_MI_DB_COUNT_UNDER_THRESHOLD);
+			this._dialog.message = {
+				level: azdata.window.MessageLevel.Information,
+				text: constants.AZURE_SQL_MI_DB_COUNT_UNDER_THRESHOLD
+			};
 		}
 
 		await this._databaseCount.updateProperties({


### PR DESCRIPTION
Azure SQL Managed Instance supports maximum 100 user databases per instance. Enforce the threshold limit at the time of DB selection for migration.

[Work item](https://github.com/microsoft/azuredatastudio/issues/23352)

Experience details:
1. Customers selects than Azure MI supported limit (100 DBs), dialog will show an error message and select button will be disabled.
![DB Selection threshold Error (See 4 as 100, locally changed 100 to 4 to produce the error) ](https://github.com/microsoft/azuredatastudio/assets/95093687/8293a3f1-496f-4f2c-a20d-4784eac9db94)



2. As soon as user selected DB count goes under limit, it will show an info message and select button will be enabled.
![DB Selection proceed message](https://github.com/microsoft/azuredatastudio/assets/95093687/b5634c78-6ddc-4376-afa4-a5a2a357402c)

