### PR TITLE
Require jupyter notebook >= 6.5.6

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -83,11 +83,10 @@ export const requiredJupyterPkg: PythonPkgDetails = {
 	version: '1.0.0'
 };
 
-// https://github.com/microsoft/azuredatastudio/issues/23945
+// Require notebook >= 6.5.6 for https://github.com/jupyter/notebook/issues/7048
 export const requiredNotebookPkg: PythonPkgDetails = {
 	name: 'notebook',
-	version: '6.5.5',
-	installExactVersion: true
+	version: '6.5.6'
 };
 
 // https://github.com/microsoft/azuredatastudio/issues/24405

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -83,23 +83,17 @@ export const requiredJupyterPkg: PythonPkgDetails = {
 	version: '1.0.0'
 };
 
-// Require notebook >= 6.5.6 for https://github.com/jupyter/notebook/issues/7048
+// Require notebook 6.5.6 for https://github.com/jupyter/notebook/issues/7048
 export const requiredNotebookPkg: PythonPkgDetails = {
 	name: 'notebook',
-	version: '6.5.6'
+	version: '6.5.6',
+	installExactVersion: true
 };
 
 // https://github.com/microsoft/azuredatastudio/issues/24405
 export const requiredIpykernelPkg: PythonPkgDetails = {
 	name: 'ipykernel',
 	version: '5.5.5',
-	installExactVersion: true
-};
-
-// https://github.com/microsoft/azuredatastudio/issues/24443
-export const requiredTraitletsPkg: PythonPkgDetails = {
-	name: 'traitlets',
-	version: '5.9.0',
 	installExactVersion: true
 };
 
@@ -163,11 +157,11 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		this._kernelSetupCache = new Map<string, boolean>();
 		this._requiredKernelPackages = new Map<string, PythonPkgDetails[]>();
 
-		this._requiredKernelPackages.set(constants.ipykernelDisplayName, [requiredJupyterPkg, requiredNotebookPkg, requiredIpykernelPkg, requiredTraitletsPkg]);
-		this._requiredKernelPackages.set(constants.python3DisplayName, [requiredJupyterPkg, requiredNotebookPkg, requiredIpykernelPkg, requiredTraitletsPkg]);
-		this._requiredKernelPackages.set(constants.powershellDisplayName, [requiredJupyterPkg, requiredPowershellPkg, requiredNotebookPkg, requiredIpykernelPkg, requiredTraitletsPkg]);
+		this._requiredKernelPackages.set(constants.ipykernelDisplayName, [requiredJupyterPkg, requiredNotebookPkg, requiredIpykernelPkg]);
+		this._requiredKernelPackages.set(constants.python3DisplayName, [requiredJupyterPkg, requiredNotebookPkg, requiredIpykernelPkg]);
+		this._requiredKernelPackages.set(constants.powershellDisplayName, [requiredJupyterPkg, requiredPowershellPkg, requiredNotebookPkg, requiredIpykernelPkg]);
 
-		let allPackages = [requiredJupyterPkg, requiredNotebookPkg, requiredIpykernelPkg, requiredTraitletsPkg, requiredPowershellPkg];
+		let allPackages = [requiredJupyterPkg, requiredNotebookPkg, requiredIpykernelPkg, requiredPowershellPkg];
 		this._requiredKernelPackages.set(constants.allKernelsName, allPackages);
 
 		this._requiredPackagesSet = new Set<string>();

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -11,7 +11,7 @@ import * as uuid from 'uuid';
 import * as fs from 'fs-extra';
 import * as request from 'request';
 import * as utils from '../../common/utils';
-import { requiredJupyterPkg, JupyterServerInstallation, requiredPowershellPkg, PythonInstallSettings, PythonPkgDetails, requiredNotebookPkg, requiredIpykernelPkg, requiredTraitletsPkg } from '../../jupyter/jupyterServerInstallation';
+import { requiredJupyterPkg, JupyterServerInstallation, requiredPowershellPkg, PythonInstallSettings, PythonPkgDetails, requiredNotebookPkg, requiredIpykernelPkg } from '../../jupyter/jupyterServerInstallation';
 import { powershellDisplayName, python3DisplayName, winPlatform } from '../../common/constants';
 
 describe('Jupyter Server Installation', function () {
@@ -226,12 +226,12 @@ describe('Jupyter Server Installation', function () {
 
 	it('Get required packages test - Python 3 kernel', async function () {
 		let packages = installation.getRequiredPackagesForKernel(python3DisplayName);
-		should(packages).be.deepEqual([requiredJupyterPkg, requiredNotebookPkg, requiredIpykernelPkg, requiredTraitletsPkg]);
+		should(packages).be.deepEqual([requiredJupyterPkg, requiredNotebookPkg, requiredIpykernelPkg]);
 	});
 
 	it('Get required packages test - Powershell kernel', async function () {
 		let packages = installation.getRequiredPackagesForKernel(powershellDisplayName);
-		should(packages).be.deepEqual([requiredJupyterPkg, requiredPowershellPkg, requiredNotebookPkg, requiredIpykernelPkg, requiredTraitletsPkg]);
+		should(packages).be.deepEqual([requiredJupyterPkg, requiredPowershellPkg, requiredNotebookPkg, requiredIpykernelPkg]);
 	});
 
 	it('Install python test - Run install while Python is already running', async function () {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24445
Follow-up to https://github.com/microsoft/azuredatastudio/issues/24443. A new version of the notebook package was released (6.5.6) that fixes that issue so the pinned version of traitlets is no longer needed.

https://github.com/jupyter/notebook/pull/7051

Ideally we would be able to specify notebook < 7 and >= 6.5.6 to allow future updates in the 6.x band but the package manager logic doesn't support that yet so just keeping it pinned to 6.5.6 for now.

Verified with notebook 6.5.6 and 5.10.0 traitlets

![image](https://github.com/microsoft/azuredatastudio/assets/28519865/55fbcc06-44b5-49a5-8699-c712fe48b810)
