### PR TITLE
fix hyperlink in infoBox not visible in dark theme

### DIFF
--- a/src/sql/workbench/browser/ui/infoBox/infoBox.ts
+++ b/src/sql/workbench/browser/ui/infoBox/infoBox.ts
@@ -15,6 +15,8 @@ import { KeyCode } from 'vs/base/common/keyCodes';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ThemeIcon } from 'vs/base/common/themables';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { Link } from 'vs/platform/opener/browser/link';
 
 export interface IInfoBoxStyles {
 	informationBackground: string | undefined;
@@ -59,7 +61,8 @@ export class InfoBox extends Disposable {
 		private readonly _styles: IInfoBoxStyles,
 		options: InfoBoxOptions | undefined,
 		@IOpenerService private _openerService: IOpenerService,
-		@ILogService private _logService: ILogService
+		@ILogService private _logService: ILogService,
+		@IInstantiationService private instantiationService: IInstantiationService,
 	) {
 		super();
 		this._infoBoxElement = document.createElement('div');
@@ -155,11 +158,11 @@ export class InfoBox extends Disposable {
 			 * If the url is empty, electron displays the link as visited.
 			 * TODO: Investigate why it happens and fix the issue iin electron/vsbase.
 			 */
-			const linkElement = DOM.$('a', {
+			const linkElement = this._register(this.instantiationService.createInstance(Link,
+				this._textElement, {
+				label: link.text,
 				href: link.url === '' ? ' ' : link.url
-			});
-
-			linkElement.innerText = link.text;
+			}, undefined)).el;
 
 			if (link.accessibilityInformation) {
 				linkElement.setAttribute('aria-label', link.accessibilityInformation.label);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #24475. This updates `InfoBox` to use the vscode `Link` to create the links so that they have the correct theming. The text component also does this for creating links: https://github.com/microsoft/azuredatastudio/blob/86cd0003fe65ed660bfde4b8ec61d335461c4908/src/sql/workbench/browser/modelComponents/text.component.ts#L191-L195

Before:

<img width="610" alt="Screenshot 2023-09-20 at 3 23 42 PM" src="https://github.com/microsoft/azuredatastudio/assets/31145923/26e41494-43f3-4721-a45e-0fb189be8b7f">
<img width="621" alt="Screenshot 2023-09-20 at 3 23 31 PM" src="https://github.com/microsoft/azuredatastudio/assets/31145923/bb433c64-cbda-4a74-b9fc-77f8db22aed9">


After:
<img width="630" alt="Screenshot 2023-09-20 at 3 21 11 PM" src="https://github.com/microsoft/azuredatastudio/assets/31145923/c054d1ae-4176-40bc-a5a9-e81533e89909">
<img width="618" alt="Screenshot 2023-09-20 at 3 21 20 PM" src="https://github.com/microsoft/azuredatastudio/assets/31145923/3df11f36-6410-47d7-833f-cc54eb209644">