### PR TITLE
Remove sql edge container option from sql projects publish

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -190,12 +190,10 @@ export const SqlServerName = 'SQL server';
 export const AzureSqlServerName = 'Azure SQL server';
 export const SqlServerDockerImageName = 'Microsoft SQL Server';
 export const SqlServerDocker2022ImageName = 'Microsoft SQL Server 2022';
-export const AzureSqlDbFullDockerImageName = 'Azure SQL Database emulator Full';
-export const AzureSqlDbLiteDockerImageName = 'Azure SQL Database emulator Lite';
+export const AzureSqlDbFullDockerImageName = 'Azure SQL Database emulator';
 export const AzureSqlLogicalServerName = 'Azure SQL logical server';
 export const selectPublishOption = localize('selectPublishOption', "Select where to publish the project to");
 export const defaultQuickPickItem = localize('defaultQuickPickItem', "Default - image defined as default in the container registry");
-export function dockerImagesPlaceHolder(name: string) { return localize('dockerImagesPlaceHolder', 'Use {0} on local arm64/Apple Silicon', name); }
 export function publishToExistingServer(name: string) { return localize('publishToExistingServer', "Publish to an existing {0}", name); }
 export function publishToDockerContainer(name: string) { return localize('publishToDockerContainer', "Publish to new {0} local development container", name); }
 export function publishToDockerContainerPreview(name: string) { return localize('publishToDockerContainerPreview', "Publish to new {0} local development container (Preview)", name); }
@@ -234,13 +232,10 @@ export const dockerImageDefaultTag = 'latest';
 export const eulaAgreementTemplate = localize({ key: 'eulaAgreementTemplate', comment: ['The placeholders are contents of the line and should not be translated.'] }, "I accept the {0}.");
 export function eulaAgreementText(name: string) { return localize({ key: 'eulaAgreementText', comment: ['The placeholders are contents of the line and should not be translated.'] }, "I accept the {0}.", name); }
 export const eulaAgreementTitle = localize('eulaAgreementTitle', "Microsoft SQL Server License Agreement");
-export const edgeEulaAgreementTitle = localize('edgeEulaAgreementTitle', "Microsoft Azure SQL Edge License Agreement");
 export const sqlServerEulaLink = 'https://aka.ms/mcr/osslegalnotice';
-export const sqlServerEdgeEulaLink = 'https://aka.ms/mcr/osslegalnotice';
 export const connectionNamePrefix = 'SQLDbProject';
 export const sqlServerDockerRegistry = 'mcr.microsoft.com';
 export const sqlServerDockerRepository = 'mssql/server';
-export const azureSqlEdgeDockerRepository = 'azure-sql-edge';
 export const commandsFolderName = 'commands';
 export const mssqlFolderName = '.mssql';
 export const dockerFileName = 'Dockerfile';

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -440,21 +440,21 @@ export class ProjectsController {
 	public async publishProject(project: Project): Promise<void>;
 	public async publishProject(context: Project | dataworkspace.WorkspaceTreeItem): Promise<void> {
 		const project: Project = await this.getProjectFromContext(context);
-		// if (utils.getAzdataApi()) {
-		// 	let publishDatabaseDialog = this.getPublishDialog(project);
+		if (utils.getAzdataApi()) {
+			let publishDatabaseDialog = this.getPublishDialog(project);
 
-		// 	publishDatabaseDialog.publish = async (proj, prof) => this.publishOrScriptProject(proj, prof, true);
-		// 	publishDatabaseDialog.publishToContainer = async (proj, prof) => this.publishToDockerContainer(proj, prof);
-		// 	publishDatabaseDialog.generateScript = async (proj, prof) => this.publishOrScriptProject(proj, prof, false);
-		// 	publishDatabaseDialog.readPublishProfile = async (profileUri) => readPublishProfile(profileUri);
-		// 	publishDatabaseDialog.savePublishProfile = async (profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions) => savePublishProfile(profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions);
+			publishDatabaseDialog.publish = async (proj, prof) => this.publishOrScriptProject(proj, prof, true);
+			publishDatabaseDialog.publishToContainer = async (proj, prof) => this.publishToDockerContainer(proj, prof);
+			publishDatabaseDialog.generateScript = async (proj, prof) => this.publishOrScriptProject(proj, prof, false);
+			publishDatabaseDialog.readPublishProfile = async (profileUri) => readPublishProfile(profileUri);
+			publishDatabaseDialog.savePublishProfile = async (profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions) => savePublishProfile(profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions);
 
-		// 	publishDatabaseDialog.openDialog();
+			publishDatabaseDialog.openDialog();
 
-		// 	return publishDatabaseDialog.waitForClose();
-		// } else {
-		return this.publishDatabase(project);
-		// }
+			return publishDatabaseDialog.waitForClose();
+		} else {
+			return this.publishDatabase(project);
+		}
 	}
 
 	public getPublishDialog(project: Project): PublishDatabaseDialog {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -440,21 +440,21 @@ export class ProjectsController {
 	public async publishProject(project: Project): Promise<void>;
 	public async publishProject(context: Project | dataworkspace.WorkspaceTreeItem): Promise<void> {
 		const project: Project = await this.getProjectFromContext(context);
-		if (utils.getAzdataApi()) {
-			let publishDatabaseDialog = this.getPublishDialog(project);
+		// if (utils.getAzdataApi()) {
+		// 	let publishDatabaseDialog = this.getPublishDialog(project);
 
-			publishDatabaseDialog.publish = async (proj, prof) => this.publishOrScriptProject(proj, prof, true);
-			publishDatabaseDialog.publishToContainer = async (proj, prof) => this.publishToDockerContainer(proj, prof);
-			publishDatabaseDialog.generateScript = async (proj, prof) => this.publishOrScriptProject(proj, prof, false);
-			publishDatabaseDialog.readPublishProfile = async (profileUri) => readPublishProfile(profileUri);
-			publishDatabaseDialog.savePublishProfile = async (profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions) => savePublishProfile(profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions);
+		// 	publishDatabaseDialog.publish = async (proj, prof) => this.publishOrScriptProject(proj, prof, true);
+		// 	publishDatabaseDialog.publishToContainer = async (proj, prof) => this.publishToDockerContainer(proj, prof);
+		// 	publishDatabaseDialog.generateScript = async (proj, prof) => this.publishOrScriptProject(proj, prof, false);
+		// 	publishDatabaseDialog.readPublishProfile = async (profileUri) => readPublishProfile(profileUri);
+		// 	publishDatabaseDialog.savePublishProfile = async (profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions) => savePublishProfile(profilePath, databaseName, connectionString, sqlCommandVariableValues, deploymentOptions);
 
-			publishDatabaseDialog.openDialog();
+		// 	publishDatabaseDialog.openDialog();
 
-			return publishDatabaseDialog.waitForClose();
-		} else {
-			return this.publishDatabase(project);
-		}
+		// 	return publishDatabaseDialog.waitForClose();
+		// } else {
+		return this.publishDatabase(project);
+		// }
 	}
 
 	public getPublishDialog(project: Project): PublishDatabaseDialog {

--- a/extensions/sql-database-projects/src/dialogs/publishToDockerQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishToDockerQuickpick.ts
@@ -62,16 +62,7 @@ export async function getPublishToDockerSettings(project: ISqlProject): Promise<
 	}
 
 	const baseImages = uiUtils.getDockerBaseImages(target);
-	const baseImage = await vscode.window.showQuickPick(
-		baseImages.map(x => x.displayName),
-		{ title: constants.selectBaseImage(name), ignoreFocusOut: true, placeHolder: uiUtils.getDockerImagePlaceHolder(target) });
-
-	// Return when user hits escape
-	if (!baseImage) {
-		return undefined;
-	}
-
-	const imageInfo = baseImages.find(x => x.displayName === baseImage);
+	const imageInfo = baseImages[0];
 
 	if (!imageInfo) {
 		return undefined;

--- a/extensions/sql-database-projects/src/dialogs/utils.ts
+++ b/extensions/sql-database-projects/src/dialogs/utils.ts
@@ -44,15 +44,6 @@ export function getPublishServerName(target: string): string {
 }
 
 /**
- * Returns the docker image place holder based on the target version
- */
-export function getDockerImagePlaceHolder(target: string): string {
-	return target === constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlAzure) ?
-		constants.dockerImagesPlaceHolder(constants.AzureSqlDbLiteDockerImageName) :
-		constants.dockerImagesPlaceHolder(SqlTargetPlatform.sqlEdge);
-}
-
-/**
  * Returns the list of image tags for given target
  * @param imageInfo docker image info
  * @param target project target version
@@ -126,17 +117,6 @@ export function getDockerBaseImages(target: string): DockerImageInfo[] {
 			},
 			tagsUrl: `https://${constants.sqlServerDockerRegistry}/v2/${constants.sqlServerDockerRepository}/tags/list`,
 			defaultTag: constants.dockerImageDefaultTag
-		}, {
-			name: `${constants.sqlServerDockerRegistry}/${constants.azureSqlEdgeDockerRepository}`,
-			displayName: constants.AzureSqlDbLiteDockerImageName,
-			agreementInfo: {
-				link: {
-					text: constants.edgeEulaAgreementTitle,
-					url: constants.sqlServerEdgeEulaLink,
-				}
-			},
-			tagsUrl: `https://${constants.sqlServerDockerRegistry}/v2/${constants.azureSqlEdgeDockerRepository}/tags/list`,
-			defaultTag: constants.dockerImageDefaultTag
 		}];
 	} else {
 		return [
@@ -151,19 +131,7 @@ export function getDockerBaseImages(target: string): DockerImageInfo[] {
 				},
 				tagsUrl: `https://${constants.sqlServerDockerRegistry}/v2/${constants.sqlServerDockerRepository}/tags/list`,
 				defaultTag: constants.dockerImageDefaultTag
-			},
-			{
-				name: `${constants.sqlServerDockerRegistry}/${constants.azureSqlEdgeDockerRepository}`,
-				displayName: SqlTargetPlatform.sqlEdge,
-				agreementInfo: {
-					link: {
-						text: constants.edgeEulaAgreementTitle,
-						url: constants.sqlServerEdgeEulaLink,
-					}
-				},
-				tagsUrl: `https://${constants.sqlServerDockerRegistry}/v2/${constants.azureSqlEdgeDockerRepository}/tags/list`,
-				defaultTag: constants.dockerImageDefaultTag
-			},
+			}
 		];
 	}
 }

--- a/extensions/sql-database-projects/src/test/dialogs/utils.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/utils.test.ts
@@ -12,20 +12,16 @@ describe('Tests to verify dialog utils functions', function (): void {
 	it('getDefaultDockerImageWithTag should return correct image', () => {
 		const baseImages = getDockerBaseImages(constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlServer2022)!);
 		const sqlServerImageInfo = baseImages.find(image => image.displayName === constants.SqlServerDockerImageName);
-		const edgeImageInfo = baseImages.find(image => image.displayName === SqlTargetPlatform.sqlEdge);
 
 		should(getDefaultDockerImageWithTag('160', 'mcr.microsoft.com/mssql/server', sqlServerImageInfo)).equals(`${sqlServerImageInfo?.name}:2022-latest`, 'Unexpected docker image returned for target platform SQL Server 2022 and SQL Server base image');
 		should(getDefaultDockerImageWithTag('150', 'mcr.microsoft.com/mssql/server', sqlServerImageInfo)).equals(`${sqlServerImageInfo?.name}:2019-latest`, 'Unexpected docker image returned for target platform SQL Server 2019 and SQL Server base image');
 		should(getDefaultDockerImageWithTag('140', 'mcr.microsoft.com/mssql/server', sqlServerImageInfo)).equals(`${sqlServerImageInfo?.name}:2017-latest`, 'Unexpected docker image returned for target platform SQL Server 2017 and SQL Server base image');
 		should(getDefaultDockerImageWithTag('130', 'mcr.microsoft.com/mssql/server', sqlServerImageInfo)).equals(`${sqlServerImageInfo?.name}`, 'Unexpected docker image returned for target platform SQL Server 2016 and SQL Server base image');
-		should(getDefaultDockerImageWithTag('150', 'mcr.microsoft.com/azure-sql-edge', edgeImageInfo)).equals(`${edgeImageInfo?.name}`, 'Unexpected docker image returned for target platform SQL Server 2019 and Edge base image');
 
 		// different display names are returned when a project's target platform is Azure, but currently the Azure full image points to mcr.microsoft.com/mssql/server
 		const azureBaseImages = getDockerBaseImages(constants.targetPlatformToVersion.get(SqlTargetPlatform.sqlAzure)!);
 		const azureFullImageInfo = azureBaseImages.find(image => image.displayName === constants.AzureSqlDbFullDockerImageName);
-		const azureLiteImageInfo = azureBaseImages.find(image => image.displayName === constants.AzureSqlDbLiteDockerImageName);
 
 		should(getDefaultDockerImageWithTag('AzureV12', 'mcr.microsoft.com/mssql/server', azureFullImageInfo)).equals(`${azureFullImageInfo?.name}`, 'Unexpected docker image returned for target platform Azure and Azure full base image');
-		should(getDefaultDockerImageWithTag('AzureV12', 'mcr.microsoft.com/azure-sql-edge', azureLiteImageInfo)).equals(`${azureLiteImageInfo?.name}`, 'Unexpected docker image returned for target platform Azure Azure lite base image');
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This removes the SQL Edge container as an option from sql project publish since it is being retired: https://techcommunity.microsoft.com/t5/sql-server-blog/azure-sql-edge-update-september-2023/ba-p/3930827

**Before:**
ADS:
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/13d3b911-0ca6-4a0a-b2d1-47888bdf9fe0)

vscode - this step is removed in this PR: 
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/853199ec-c539-458c-a223-45e56a657501)


**After:**
ADS publish dialog - removed edge option and changed `Azure SQL Database emulator Full` to `Azure SQL Database emulator`:
![removeEdge](https://github.com/microsoft/azuredatastudio/assets/31145923/7f6e6d5e-e2cb-495f-8a1d-c74b45403863)

Quickpick used in vscode extension - removed step where the base image is chosen since there's only one option now:
![removeEdgeQuickpick](https://github.com/microsoft/azuredatastudio/assets/31145923/45859f58-d8d9-412f-b974-cb472f009092)
