### PR TITLE
Fixing a couple codeql warnings about incomplete string replacement

### DIFF
--- a/extensions/machine-learning/src/packageManagement/sqlRPackageManageProvider.ts
+++ b/extensions/machine-learning/src/packageManagement/sqlRPackageManageProvider.ts
@@ -71,7 +71,7 @@ export class SqlRPackageManageProvider extends SqlPackageManageProviderBase impl
 
 		if (connection) {
 			connectionParts.push(utils.getKeyValueString('driver', `"${constants.supportedODBCDriver}"`));
-			let server = connection.serverName.replace('\\', '\\\\');
+			let server = connection.serverName.replace(/\\/g, '\\\\');
 			if (databaseName) {
 				connectionParts.push(utils.getKeyValueString('database', `"${databaseName}"`));
 			}

--- a/extensions/sql-bindings/src/common/utils.ts
+++ b/extensions/sql-bindings/src/common/utils.ts
@@ -114,7 +114,7 @@ export async function getUniqueFileName(fileName: string, folderPath?: string): 
 }
 
 export function escapeClosingBrackets(str: string): string {
-	return str.replace(']', ']]');
+	return str.replace(/]/g, ']]');
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
These two lines had warnings about only the first occurrence getting replaced. By adding the global flag, all occurrences in the string will get replaced.