### PR TITLE
Redirect vscode New Jupyter Notebook command

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -6,7 +6,8 @@
 	"version": "1.0.0",
 	"license": "MIT",
 	"engines": {
-		"vscode": "^1.57.0"
+		"vscode": "^1.57.0",
+		"azdata": "*"
 	},
 	"enabledApiProposals": [
 		"documentPaste",
@@ -14,7 +15,7 @@
 		"dropMetadata"
 	],
 	"activationEvents": [
-		"*"
+		"onNotebook:jupyter-notebook"
 	],
 	"extensionKind": [
 		"workspace",

--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as azdata from 'azdata';
 import { NotebookSerializer } from './notebookSerializer';
 import { ensureAllNewCellsHaveCellIds } from './cellIdService';
 import { notebookImagePasteSetup } from './notebookImagePaste';
@@ -58,21 +59,26 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	context.subscriptions.push(vscode.commands.registerCommand('ipynb.newUntitledIpynb', async () => {
-		const language = 'python';
-		const cell = new vscode.NotebookCellData(vscode.NotebookCellKind.Code, '', language);
-		const data = new vscode.NotebookData([cell]);
-		data.metadata = {
-			custom: {
-				cells: [],
-				metadata: {
-					orig_nbformat: 4
-				},
-				nbformat: 4,
-				nbformat_minor: 2
-			}
-		};
-		const doc = await vscode.workspace.openNotebookDocument('jupyter-notebook', data);
-		await vscode.window.showNotebookDocument(doc);
+		let useVSCodeNotebooks = vscode.workspace.getConfiguration('workbench')?.get<boolean>('useVSCodeNotebooks');
+		if (useVSCodeNotebooks) {
+			const language = 'python';
+			const cell = new vscode.NotebookCellData(vscode.NotebookCellKind.Code, '', language);
+			const data = new vscode.NotebookData([cell]);
+			data.metadata = {
+				custom: {
+					cells: [],
+					metadata: {
+						orig_nbformat: 4
+					},
+					nbformat: 4,
+					nbformat_minor: 2
+				}
+			};
+			const doc = await vscode.workspace.openNotebookDocument('jupyter-notebook', data);
+			await vscode.window.showNotebookDocument(doc);
+		} else {
+			await azdata.nb.showNotebookDocument(vscode.Uri.from({ scheme: 'untitled' }));
+		}
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('ipynb.openIpynbInNotebookEditor', async (uri: vscode.Uri) => {

--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as azdata from 'azdata';
+import * as azdata from 'azdata'; // {{SQL CARBON EDIT}}
 import { NotebookSerializer } from './notebookSerializer';
 import { ensureAllNewCellsHaveCellIds } from './cellIdService';
 import { notebookImagePasteSetup } from './notebookImagePaste';
@@ -59,6 +59,7 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	context.subscriptions.push(vscode.commands.registerCommand('ipynb.newUntitledIpynb', async () => {
+		// {{SQL CARBON EDIT}} Open new notebooks using the default ADS notebook viewer if VSCode notebooks aren't enabled.
 		let useVSCodeNotebooks = vscode.workspace.getConfiguration('workbench')?.get<boolean>('useVSCodeNotebooks');
 		if (useVSCodeNotebooks) {
 			const language = 'python';

--- a/extensions/ipynb/src/typings/refs.d.ts
+++ b/extensions/ipynb/src/typings/refs.d.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference path='../../../../src/sql/azdata.d.ts'/>
+/// <reference path='../../../../src/sql/azdata.proposed.d.ts'/>
+/// <reference path='../../../../src/vscode-dts/vscode.d.ts'/>
+/// <reference path='../../../resource-deployment/src/typings/resource-deployment.d.ts'/>

--- a/extensions/ipynb/src/typings/refs.d.ts
+++ b/extensions/ipynb/src/typings/refs.d.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// {{SQL CARBON EDIT}} Import ADS extension APIs
 /// <reference path='../../../../src/sql/azdata.d.ts'/>
 /// <reference path='../../../../src/sql/azdata.proposed.d.ts'/>
 /// <reference path='../../../../src/vscode-dts/vscode.d.ts'/>

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -446,7 +446,6 @@ export class NotebookService extends Disposable implements INotebookService {
 		if (!DefaultNotebookProviders.includes(p.id)) {
 			this._extensionService.whenInstalledExtensionsRegistered()
 				.then(() => this._extensionService.activateByEvent(`onNotebook:${p.id}`))
-				.then(() => this._extensionService.activateByEvent(`onNotebook:*`))
 				.catch(err => onUnexpectedError(err));
 		}
 	}

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -446,6 +446,7 @@ export class NotebookService extends Disposable implements INotebookService {
 		if (!DefaultNotebookProviders.includes(p.id)) {
 			this._extensionService.whenInstalledExtensionsRegistered()
 				.then(() => this._extensionService.activateByEvent(`onNotebook:${p.id}`))
+				.then(() => this._extensionService.activateByEvent(`onNotebook:*`))
 				.catch(err => onUnexpectedError(err));
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23859

This new notebook command is contributed from the ipynb built-in extension, which is only used for vscode notebooks. This change redirects that command to our notebook code if the useVSCodeNotebooks setting isn't enabled. This was the only palette command contributed by the ipynb extension.
