### PR TITLE
Ramudaykumar/vbump sql migration 1.4.10 insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.9",
-							"lastUpdated": "07/17/2023",
+							"version": "1.4.10",
+							"lastUpdated": "09/28/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.9.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.10.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the insiders extension gallery to the latest version 1.4.10 of the SQL Migration extension. sql-migration-1.4.10.vsix

Link to Azure Data Studio - Extensions Product pipeline run off main: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=212174&view=results

https://mssqltools.visualstudio.com/_apis/resources/Containers/6113733/drop?itemPath=drop%2Fextensions%2Fsql-migration-1.4.10.vsix