### PR TITLE
Adding fiilegroup name label to the input box and auto focus of newly added row

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -467,6 +467,7 @@ export const PurgeQueryDataButtonText = localize('objectManagement.databasePrope
 export const YesText = localize('objectManagement.databaseProperties.yesText', "Yes");
 export const NotAvailableText = localize('objectManagement.databaseProperties.notAvailableText', "N/A");
 export const PurgeQueryStoreDataMessage = (databaseName: string) => localize('objectManagement.databaseProperties.purgeQueryStoreDataMessage', "Are you sure you want to purge the Query Store data from '{0}'?", databaseName);
+export const fileGroupsNameInput = localize('objectManagement.filegroupsNameInput', "Filegroup Name");
 
 // Util functions
 export function getNodeTypeDisplayName(type: string, inTitle: boolean = false): string {

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -1024,6 +1024,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			// Refresh the table with new row data
 			this.updateFileGroupsOptionsAndTableRows();
 			await this.setTableData(table, newData, DefaultMaxTableRowCount);
+			table.setActiveCell(table.data?.length - 1, 0);
 		}
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -829,9 +829,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 						const fileGroup = this.rowDataFileGroupsTableRows[this.rowsFilegroupsTable.selectedRows[0]];
 						await this.rowsFilegroupNameContainer.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
 						await this.rowsFileGroupButtonContainer.updateCssStyles({ 'margin-top': fileGroup.id < 0 ? '0' : '-50px' });
-						if (fileGroup.id < 0) {
-							this.rowsFilegroupNameInput.value = fileGroup.name;
-						}
+						this.rowsFilegroupNameInput.value = fileGroup.name;
 						this.onFormFieldChange();
 					}
 				}
@@ -1068,6 +1066,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.RowsFileGroup);
 				await this.rowsFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
+				await this.rowsFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
 			}
 		}
 		else if (table === this.filestreamFilegroupsTable) {
@@ -1076,6 +1075,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.FileStreamDataFileGroup);
 				await this.filestreamFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
+				await this.filestreamFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
 			}
 		}
 		else if (table === this.memoryOptimizedFilegroupsTable) {
@@ -1084,6 +1084,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.MemoryOptimizedDataFileGroup);
 				await this.memoryOptimizedFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
+				await this.memoryOptimizedFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
 			}
 		}
 
@@ -1108,7 +1109,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			this.memoryOptimizedFilegroupNameInput = fgInput;
 		}
 
-		let fgInputGroupcontainer = this.createLabelInputContainer(localizedConstants.fileGroupsNameInput, [this.rowsFilegroupNameInput], false);
+		let fgInputGroupcontainer = this.createLabelInputContainer(localizedConstants.fileGroupsNameInput, [fgInput], false);
 		await fgInputGroupcontainer.updateCssStyles({ 'visibility': 'hidden', 'margin-left': '10px' });
 
 		return fgInputGroupcontainer;
@@ -1121,7 +1122,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 	 * @returns Input component
 	 */
 	private getFilegroupNameInput(table: azdata.TableComponent, filegroupType: FileGroupType): azdata.InputBoxComponent {
-		return this.rowsFilegroupNameInput = this.createInputBox(async (value) => {
+		return this.createInputBox(async (value) => {
 			if (table.selectedRows.length === 1) {
 				let fg = null;
 				if (table === this.rowsFilegroupsTable) {

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -800,8 +800,6 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			buttonHandler: () => this.onRemoveDatabaseFileGroupsButtonClicked(this.rowsFilegroupsTable)
 		};
 		this.rowsFileGroupButtonContainer = this.addButtonsForTable(this.rowsFilegroupsTable, addButtonComponent, removeButtonComponent);
-		await this.rowsFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
-
 		this.disposables.push(
 			this.rowsFilegroupsTable.onCellAction(async (arg: azdata.ICheckboxCellActionEventArgs) => {
 				let filegroup = this.rowDataFileGroupsTableRows[arg.row];
@@ -827,8 +825,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				async () => {
 					if (this.rowsFilegroupsTable.selectedRows.length === 1) {
 						const fileGroup = this.rowDataFileGroupsTableRows[this.rowsFilegroupsTable.selectedRows[0]];
-						await this.rowsFilegroupNameContainer.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
-						await this.rowsFileGroupButtonContainer.updateCssStyles({ 'margin-top': fileGroup.id < 0 ? '0' : '-50px' });
+						this.rowsFilegroupNameContainer.display = fileGroup.id < 0 ? 'inline-flex' : 'none';
 						this.rowsFilegroupNameInput.value = fileGroup.name;
 						this.onFormFieldChange();
 					}
@@ -876,8 +873,6 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			buttonHandler: () => this.onRemoveDatabaseFileGroupsButtonClicked(this.filestreamFilegroupsTable)
 		};
 		this.filestreamFileGroupButtonContainer = this.addButtonsForTable(this.filestreamFilegroupsTable, addButtonComponent, removeButtonComponent);
-		await this.filestreamFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
-
 		this.disposables.push(
 			this.filestreamFilegroupsTable.onCellAction(async (arg: azdata.ICheckboxCellActionEventArgs) => {
 				let filegroup = this.filestreamDataFileGroupsTableRows[arg.row];
@@ -899,8 +894,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				async () => {
 					if (this.filestreamFilegroupsTable.selectedRows.length === 1) {
 						const fileGroup = this.filestreamDataFileGroupsTableRows[this.filestreamFilegroupsTable.selectedRows[0]];
-						await this.filestreamFilegroupNameContainer.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
-						await this.filestreamFileGroupButtonContainer.updateCssStyles({ 'margin-top': fileGroup.id < 0 ? '0' : '-50px' });
+						this.filestreamFilegroupNameContainer.display = fileGroup.id < 0 ? 'inline-flex' : 'none';
 						this.filestreamFilegroupNameInput.value = fileGroup.name;
 						this.onFormFieldChange();
 					}
@@ -944,15 +938,12 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			buttonHandler: () => this.onRemoveDatabaseFileGroupsButtonClicked(this.memoryOptimizedFilegroupsTable)
 		};
 		this.memoryOptimizedFileGroupButtonContainer = this.addButtonsForTable(this.memoryOptimizedFilegroupsTable, addButtonComponent, removeButtonComponent);
-		await this.memoryOptimizedFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
-
 		this.disposables.push(
 			this.memoryOptimizedFilegroupsTable.onRowSelected(
 				async () => {
 					if (this.memoryOptimizedFilegroupsTable.selectedRows.length === 1) {
 						const fileGroup = this.memoryoptimizedFileGroupsTableRows[this.memoryOptimizedFilegroupsTable.selectedRows[0]];
-						await this.memoryOptimizedFilegroupNameContainer.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
-						await this.memoryOptimizedFileGroupButtonContainer.updateCssStyles({ 'margin-top': fileGroup.id < 0 ? '0' : '-50px' });
+						this.memoryOptimizedFilegroupNameContainer.display = fileGroup.id < 0 ? 'inline-flex' : 'none';
 						this.memoryOptimizedFilegroupNameInput.value = fileGroup.name;
 						this.onFormFieldChange();
 					}
@@ -1065,8 +1056,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				const removeFilegroupIndex = this.objectInfo.filegroups.indexOf(this.rowDataFileGroupsTableRows[this.rowsFilegroupsTable.selectedRows[0]]);
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.RowsFileGroup);
-				await this.rowsFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
-				await this.rowsFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
+				this.rowsFilegroupNameContainer.display = 'none';
 			}
 		}
 		else if (table === this.filestreamFilegroupsTable) {
@@ -1074,8 +1064,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				const removeFilegroupIndex = this.objectInfo.filegroups.indexOf(this.filestreamDataFileGroupsTableRows[this.filestreamFilegroupsTable.selectedRows[0]]);
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.FileStreamDataFileGroup);
-				await this.filestreamFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
-				await this.filestreamFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
+				this.filestreamFilegroupNameContainer.display = 'none';
 			}
 		}
 		else if (table === this.memoryOptimizedFilegroupsTable) {
@@ -1083,8 +1072,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				const removeFilegroupIndex = this.objectInfo.filegroups.indexOf(this.memoryoptimizedFileGroupsTableRows[this.memoryOptimizedFilegroupsTable.selectedRows[0]]);
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.MemoryOptimizedDataFileGroup);
-				await this.memoryOptimizedFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
-				await this.memoryOptimizedFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
+				this.memoryOptimizedFilegroupNameContainer.display = 'none';
 			}
 		}
 
@@ -1110,8 +1098,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 		}
 
 		let fgInputGroupcontainer = this.createLabelInputContainer(localizedConstants.fileGroupsNameInput, [fgInput], false);
-		await fgInputGroupcontainer.updateCssStyles({ 'visibility': 'hidden', 'margin-left': '10px' });
-
+		await fgInputGroupcontainer.updateCssStyles({ 'margin': '0px 0px -10px 10px' });
+		fgInputGroupcontainer.display = 'none';
 		return fgInputGroupcontainer;
 	}
 
@@ -1144,8 +1132,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			inputType: 'text',
 			enabled: true,
 			value: '',
-			width: 200,
-			// CSSStyles: { 'margin': '5px 0px 0px 10px' }
+			width: DefaultInputWidth
 		});
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -58,8 +58,14 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 	private filestreamFilegroupsTable: azdata.TableComponent;
 	private memoryOptimizedFilegroupsTable: azdata.TableComponent;
 	private rowsFilegroupNameInput: azdata.InputBoxComponent;
+	private rowsFilegroupNameContainer: azdata.FlexContainer;
+	private rowsFileGroupButtonContainer: azdata.FlexContainer;
 	private filestreamFilegroupNameInput: azdata.InputBoxComponent;
+	private filestreamFilegroupNameContainer: azdata.FlexContainer;
+	private filestreamFileGroupButtonContainer: azdata.FlexContainer;
 	private memoryOptimizedFilegroupNameInput: azdata.InputBoxComponent;
+	private memoryOptimizedFilegroupNameContainer: azdata.FlexContainer;
+	private memoryOptimizedFileGroupButtonContainer: azdata.FlexContainer;
 	private newFileGroupTemporaryId: number = 0;
 	private rowDataFileGroupsTableRows: FileGroup[] = [];
 	private filestreamDataFileGroupsTableRows: FileGroup[] = [];
@@ -211,8 +217,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			// Initilaize FileGroups Tab
 			if (!isUndefinedOrNull(this.objectInfo.filegroups)) {
 				const rowsFileGroupSection = await this.initializeRowsFileGroupSection();
-				const fileStreamFileGroupSection = this.initializeFileStreamFileGroupSection();
-				const memoryOptimizedFileGroupSection = this.initializeMemoryOptimizedFileGroupSection();
+				const fileStreamFileGroupSection = await this.initializeFileStreamFileGroupSection();
+				const memoryOptimizedFileGroupSection = await this.initializeMemoryOptimizedFileGroupSection();
 				this.fileGroupsTab = {
 					title: localizedConstants.FileGroupsSectionHeader,
 					id: this.fileGroupsTabId,
@@ -784,7 +790,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				'margin-left': '10px'
 			}
 		}).component();
-		this.rowsFilegroupNameInput = this.getFilegroupNameInput(this.rowsFilegroupsTable, FileGroupType.RowsFileGroup);
+		this.rowsFilegroupNameContainer = await this.getFilegroupNameGroup(this.rowsFilegroupsTable, FileGroupType.RowsFileGroup);
 		const addButtonComponent: DialogButton = {
 			buttonAriaLabel: localizedConstants.AddFilegroupText,
 			buttonHandler: () => this.onAddDatabaseFileGroupsButtonClicked(this.rowsFilegroupsTable)
@@ -793,7 +799,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			buttonAriaLabel: localizedConstants.RemoveButton,
 			buttonHandler: () => this.onAddDatabaseFileGroupsButtonClicked(this.rowsFilegroupsTable)
 		};
-		const rowsFileGroupButtonContainer = this.addButtonsForTable(this.rowsFilegroupsTable, addButtonComponent, removeButtonComponent);
+		this.rowsFileGroupButtonContainer = this.addButtonsForTable(this.rowsFilegroupsTable, addButtonComponent, removeButtonComponent);
+		await this.rowsFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
 
 		this.disposables.push(
 			this.rowsFilegroupsTable.onCellAction(async (arg: azdata.ICheckboxCellActionEventArgs) => {
@@ -820,23 +827,24 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				async () => {
 					if (this.rowsFilegroupsTable.selectedRows.length === 1) {
 						const fileGroup = this.rowDataFileGroupsTableRows[this.rowsFilegroupsTable.selectedRows[0]];
-						await this.rowsFilegroupNameInput.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
-						this.rowsFilegroupNameInput.value = fileGroup.name;
+						await this.rowsFilegroupNameContainer.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
+						await this.rowsFileGroupButtonContainer.updateCssStyles({ 'margin-top': fileGroup.id < 0 ? '0' : '-50px' });
+						if (fileGroup.id < 0) {
+							this.rowsFilegroupNameInput.value = fileGroup.name;
+						}
 						this.onFormFieldChange();
 					}
 				}
 			)
 		);
-		const rowContainer = this.modelView.modelBuilder.flexContainer().withItems([this.rowsFilegroupNameInput]).component();
-		rowContainer.addItems([rowsFileGroupButtonContainer], { flex: '0 0 auto' });
-		return this.createGroup(localizedConstants.RowsFileGroupsSectionText, [this.rowsFilegroupsTable, rowContainer], true);
+		return this.createGroup(localizedConstants.RowsFileGroupsSectionText, [this.rowsFilegroupsTable, this.rowsFilegroupNameContainer, this.rowsFileGroupButtonContainer], true);
 	}
 
 	/**
 	 * Initializes the filestream filegroups section and updates the table data
 	 * @returns filestream data filegroups container
 	 */
-	private initializeFileStreamFileGroupSection(): azdata.GroupContainer {
+	private async initializeFileStreamFileGroupSection(): Promise<azdata.GroupContainer> {
 		const data = this.getTableData(FileGroupType.FileStreamDataFileGroup);
 		this.filestreamFilegroupsTable = this.modelView.modelBuilder.table().withProps({
 			columns: [{
@@ -860,7 +868,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				'margin-left': '10px'
 			}
 		}).component();
-		this.filestreamFilegroupNameInput = this.getFilegroupNameInput(this.filestreamFilegroupsTable, FileGroupType.FileStreamDataFileGroup);
+		this.filestreamFilegroupNameContainer = await this.getFilegroupNameGroup(this.filestreamFilegroupsTable, FileGroupType.FileStreamDataFileGroup);
 		const addButtonComponent: DialogButton = {
 			buttonAriaLabel: localizedConstants.AddFilegroupText,
 			buttonHandler: () => this.onAddDatabaseFileGroupsButtonClicked(this.filestreamFilegroupsTable)
@@ -869,7 +877,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			buttonAriaLabel: localizedConstants.RemoveButton,
 			buttonHandler: () => this.onRemoveDatabaseFileGroupsButtonClicked(this.filestreamFilegroupsTable)
 		};
-		const filestreamFileGroupButtonContainer = this.addButtonsForTable(this.filestreamFilegroupsTable, addButtonComponent, removeButtonComponent);
+		this.filestreamFileGroupButtonContainer = this.addButtonsForTable(this.filestreamFilegroupsTable, addButtonComponent, removeButtonComponent);
+		await this.filestreamFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
 
 		this.disposables.push(
 			this.filestreamFilegroupsTable.onCellAction(async (arg: azdata.ICheckboxCellActionEventArgs) => {
@@ -892,7 +901,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				async () => {
 					if (this.filestreamFilegroupsTable.selectedRows.length === 1) {
 						const fileGroup = this.filestreamDataFileGroupsTableRows[this.filestreamFilegroupsTable.selectedRows[0]];
-						await this.filestreamFilegroupNameInput.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
+						await this.filestreamFilegroupNameContainer.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
+						await this.filestreamFileGroupButtonContainer.updateCssStyles({ 'margin-top': fileGroup.id < 0 ? '0' : '-50px' });
 						this.filestreamFilegroupNameInput.value = fileGroup.name;
 						this.onFormFieldChange();
 					}
@@ -900,16 +910,14 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			)
 		);
 
-		const filestreamContainer = this.modelView.modelBuilder.flexContainer().withItems([this.filestreamFilegroupNameInput]).component();
-		filestreamContainer.addItems([filestreamFileGroupButtonContainer], { flex: '0 0 auto' });
-		return this.createGroup(localizedConstants.FileStreamFileGroupsSectionText, [this.filestreamFilegroupsTable, filestreamContainer], true);
+		return this.createGroup(localizedConstants.FileStreamFileGroupsSectionText, [this.filestreamFilegroupsTable, this.filestreamFilegroupNameContainer, this.filestreamFileGroupButtonContainer], true);
 	}
 
 	/**
 	 * Initializes the memory optimized filegroups section and updates the table data
 	 * @returns Memory optimized filegroups container
 	 */
-	private initializeMemoryOptimizedFileGroupSection(): azdata.GroupContainer {
+	private async initializeMemoryOptimizedFileGroupSection(): Promise<azdata.GroupContainer> {
 		const data = this.getTableData(FileGroupType.MemoryOptimizedDataFileGroup);
 		this.memoryOptimizedFilegroupsTable = this.modelView.modelBuilder.table().withProps({
 			columns: [{
@@ -927,7 +935,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				'margin-left': '10px'
 			}
 		}).component();
-		this.memoryOptimizedFilegroupNameInput = this.getFilegroupNameInput(this.memoryOptimizedFilegroupsTable, FileGroupType.MemoryOptimizedDataFileGroup);
+		this.memoryOptimizedFilegroupNameContainer = await this.getFilegroupNameGroup(this.memoryOptimizedFilegroupsTable, FileGroupType.MemoryOptimizedDataFileGroup);
 		const addButtonComponent: DialogButton = {
 			buttonAriaLabel: localizedConstants.AddFilegroupText,
 			buttonHandler: () => this.onAddDatabaseFileGroupsButtonClicked(this.memoryOptimizedFilegroupsTable),
@@ -937,14 +945,16 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			buttonAriaLabel: localizedConstants.RemoveButton,
 			buttonHandler: () => this.onRemoveDatabaseFileGroupsButtonClicked(this.memoryOptimizedFilegroupsTable)
 		};
-		const memoryOptimizedFileGroupButtonContainer = this.addButtonsForTable(this.memoryOptimizedFilegroupsTable, addButtonComponent, removeButtonComponent);
+		this.memoryOptimizedFileGroupButtonContainer = this.addButtonsForTable(this.memoryOptimizedFilegroupsTable, addButtonComponent, removeButtonComponent);
+		await this.memoryOptimizedFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });
 
 		this.disposables.push(
 			this.memoryOptimizedFilegroupsTable.onRowSelected(
 				async () => {
 					if (this.memoryOptimizedFilegroupsTable.selectedRows.length === 1) {
 						const fileGroup = this.memoryoptimizedFileGroupsTableRows[this.memoryOptimizedFilegroupsTable.selectedRows[0]];
-						await this.memoryOptimizedFilegroupNameInput.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
+						await this.memoryOptimizedFilegroupNameContainer.updateCssStyles({ 'visibility': fileGroup.id < 0 ? 'visible' : 'hidden' });
+						await this.memoryOptimizedFileGroupButtonContainer.updateCssStyles({ 'margin-top': fileGroup.id < 0 ? '0' : '-50px' });
 						this.memoryOptimizedFilegroupNameInput.value = fileGroup.name;
 						this.onFormFieldChange();
 					}
@@ -952,9 +962,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			)
 		);
 
-		const memoryOptimizedContainer = this.modelView.modelBuilder.flexContainer().withItems([this.memoryOptimizedFilegroupNameInput]).component();
-		memoryOptimizedContainer.addItems([memoryOptimizedFileGroupButtonContainer], { flex: '0 0 auto' });
-		return this.createGroup(localizedConstants.MemoryOptimizedFileGroupsSectionText, [this.memoryOptimizedFilegroupsTable, memoryOptimizedContainer], true);
+		return this.createGroup(localizedConstants.MemoryOptimizedFileGroupsSectionText, [this.memoryOptimizedFilegroupsTable, this.memoryOptimizedFilegroupNameContainer, this.memoryOptimizedFileGroupButtonContainer], true);
 	}
 
 	/**
@@ -1059,7 +1067,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				const removeFilegroupIndex = this.objectInfo.filegroups.indexOf(this.rowDataFileGroupsTableRows[this.rowsFilegroupsTable.selectedRows[0]]);
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.RowsFileGroup);
-				await this.rowsFilegroupNameInput.updateCssStyles({ 'visibility': 'hidden' });
+				await this.rowsFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
 			}
 		}
 		else if (table === this.filestreamFilegroupsTable) {
@@ -1067,7 +1075,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				const removeFilegroupIndex = this.objectInfo.filegroups.indexOf(this.filestreamDataFileGroupsTableRows[this.filestreamFilegroupsTable.selectedRows[0]]);
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.FileStreamDataFileGroup);
-				await this.filestreamFilegroupNameInput.updateCssStyles({ 'visibility': 'hidden' });
+				await this.filestreamFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
 			}
 		}
 		else if (table === this.memoryOptimizedFilegroupsTable) {
@@ -1075,7 +1083,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				const removeFilegroupIndex = this.objectInfo.filegroups.indexOf(this.memoryoptimizedFileGroupsTableRows[this.memoryOptimizedFilegroupsTable.selectedRows[0]]);
 				this.objectInfo.filegroups?.splice(removeFilegroupIndex, 1);
 				var newData = this.getTableData(FileGroupType.MemoryOptimizedDataFileGroup);
-				await this.memoryOptimizedFilegroupNameInput.updateCssStyles({ 'visibility': 'hidden' });
+				await this.memoryOptimizedFilegroupNameContainer.updateCssStyles({ 'visibility': 'hidden' });
 			}
 		}
 
@@ -1085,13 +1093,35 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 	}
 
 	/**
+	 * Creates the group container for filegroups input section
+	 * @param table table component
+	 * @param filegroupType filegroup type
+	 * @returns filegroup name group container
+	 */
+	private async getFilegroupNameGroup(table: azdata.TableComponent, filegroupType: FileGroupType): Promise<azdata.FlexContainer> {
+		const fgInput = this.getFilegroupNameInput(table, filegroupType);
+		if (table === this.rowsFilegroupsTable) {
+			this.rowsFilegroupNameInput = fgInput;
+		} else if (table === this.filestreamFilegroupsTable) {
+			this.filestreamFilegroupNameInput = fgInput;
+		} else if (table === this.memoryOptimizedFilegroupsTable) {
+			this.memoryOptimizedFilegroupNameInput = fgInput;
+		}
+
+		let fgInputGroupcontainer = this.createLabelInputContainer(localizedConstants.fileGroupsNameInput, [this.rowsFilegroupNameInput], false);
+		await fgInputGroupcontainer.updateCssStyles({ 'visibility': 'hidden', 'margin-left': '10px' });
+
+		return fgInputGroupcontainer;
+	}
+
+	/**
 	 * Creates input box for filegroup name
 	 * @param table table component
 	 * @param filegroupType filegroup type
 	 * @returns Input component
 	 */
 	private getFilegroupNameInput(table: azdata.TableComponent, filegroupType: FileGroupType): azdata.InputBoxComponent {
-		return this.createInputBox(async (value) => {
+		return this.rowsFilegroupNameInput = this.createInputBox(async (value) => {
 			if (table.selectedRows.length === 1) {
 				let fg = null;
 				if (table === this.rowsFilegroupsTable) {
@@ -1114,8 +1144,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			enabled: true,
 			value: '',
 			width: 200,
-			CSSStyles: { 'margin': '5px 0px 0px 10px', 'visibility': 'hidden' }
-		})
+			// CSSStyles: { 'margin': '5px 0px 0px 10px' }
+		});
 	}
 
 	/**

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -1079,7 +1079,10 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 
 		// Refresh the individual table rows object and table with updated data
 		this.updateFileGroupsOptionsAndTableRows();
-		await this.setTableData(table, newData)
+		await this.setTableData(table, newData);
+		if (table.selectedRows !== undefined && table.selectedRows[0] !== undefined && table.selectedRows[0] < table.data?.length) {
+			table.setActiveCell(table.selectedRows[0], 0);
+		}
 	}
 
 	/**

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -797,7 +797,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 		};
 		const removeButtonComponent: DialogButton = {
 			buttonAriaLabel: localizedConstants.RemoveButton,
-			buttonHandler: () => this.onAddDatabaseFileGroupsButtonClicked(this.rowsFilegroupsTable)
+			buttonHandler: () => this.onRemoveDatabaseFileGroupsButtonClicked(this.rowsFilegroupsTable)
 		};
 		this.rowsFileGroupButtonContainer = this.addButtonsForTable(this.rowsFilegroupsTable, addButtonComponent, removeButtonComponent);
 		await this.rowsFileGroupButtonContainer.updateCssStyles({ 'margin-top': '-50px' });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds a label to the filegroup input box and fixes the issue of row filegroup table remove button (where the button adds the rows instead of removing it). Also, Add and remove button automatically focuses on the newly added input box and next row after delete respectively.

![NewOneFileGroupUpdate](https://github.com/microsoft/azuredatastudio/assets/74571829/2e343966-0e6b-4c58-b705-5e9bbcbc4594)



