### PR TITLE
Change Cancel button label to Back for inner dialogs.

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -56,6 +56,7 @@ export const allFiles = localize('objectManagement.allFiles', "All Files");
 export const labelSelectFolder = localize('objectManagement.labelSelectFolder', "Select Folder");
 export const DataFileLabel = localize('objectManagement.dataFileLabel', "Data");
 export const LogFileLabel = localize('objectManagement.logFileLabel', "Log");
+export const BackButtonLabel = localize('objectManagement.backButtonLabel', "Back");
 
 export function ExplicitPermissionsTableLabelSelected(name: string): string { return localize('objectManagement.explicitPermissionsTableLabelSelected', "Explicit permissions for: {0}", name); }
 export function EffectivePermissionsTableLabelSelected(name: string): string { return localize('objectManagement.effectivePermissionsTableLabelSelected', "Effective permissions for: {0}", name); }

--- a/extensions/mssql/src/objectManagement/ui/findObjectDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/findObjectDialog.ts
@@ -47,6 +47,11 @@ export class FindObjectDialog extends DialogBase<FindObjectDialogResult> {
 	constructor(private readonly objectManagementService: mssql.IObjectManagementService, private readonly options: FindObjectDialogOptions) {
 		super(options.title, 'FindObjectDialog');
 		this.dialogObject.okButton.label = localizedConstants.SelectText;
+		this.dialogObject.okButton.enabled = false;
+
+		// Relabel Cancel button to Back, since clicking cancel on an inner dialog makes it seem like it would close the whole dialog overall
+		this.dialogObject.cancelButton.label = localizedConstants.BackButtonLabel;
+
 		this.result = {
 			selectedObjects: []
 		};
@@ -54,7 +59,6 @@ export class FindObjectDialog extends DialogBase<FindObjectDialogResult> {
 	}
 
 	protected override async initialize(): Promise<void> {
-		this.dialogObject.okButton.enabled = false;
 		this.objectTypesTable = this.createTableList<ObjectTypeInfo>(localizedConstants.ObjectTypesText,
 			[localizedConstants.ObjectTypeText],
 			this.options.objectTypes,

--- a/extensions/mssql/src/objectManagement/ui/objectSelectionMethodDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectSelectionMethodDialog.ts
@@ -40,6 +40,9 @@ export class ObjectSelectionMethodDialog extends DialogBase<ObjectSelectionMetho
 			schema: undefined,
 			objectTypes: []
 		};
+
+		// Relabel Cancel button to Back, since clicking cancel on an inner dialog makes it seem like it would close the whole dialog overall
+		this.dialogObject.cancelButton.label = localizedConstants.BackButtonLabel;
 	}
 
 	protected override async initialize(): Promise<void> {

--- a/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
+++ b/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
@@ -60,7 +60,7 @@ export class FileBrowserDialog extends Modal {
 		@ILogService logService: ILogService,
 		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService
 	) {
-		super(title, TelemetryKeys.ModalDialogName.FileBrowser, telemetryService, layoutService, clipboardService, themeService, logService, textResourcePropertiesService, contextKeyService, { dialogStyle: 'flyout', hasTitleIcon: false, hasBackButton: true, hasSpinner: true });
+		super(title, TelemetryKeys.ModalDialogName.FileBrowser, telemetryService, layoutService, clipboardService, themeService, logService, textResourcePropertiesService, contextKeyService, { dialogStyle: 'flyout', hasTitleIcon: false, hasBackButton: false, hasSpinner: true });
 		this._viewModel = this._instantiationService.createInstance(FileBrowserViewModel);
 		this._viewModel.onAddFileTree(args => this.handleOnAddFileTree(args.rootNode, args.selectedNode, args.expandedNodes).catch(err => onUnexpectedError(err)));
 		this._viewModel.onPathValidate(args => this.handleOnValidate(args.succeeded, args.message));
@@ -76,13 +76,6 @@ export class FileBrowserDialog extends Modal {
 	public override render() {
 		super.render();
 		attachModalDialogStyler(this, this._themeService);
-
-		if (this.backButton) {
-
-			this.backButton.onDidClick(() => {
-				this.close();
-			});
-		}
 
 		this._treeContainer = DOM.append(this._body, DOM.$('.tree-view'));
 
@@ -106,6 +99,7 @@ export class FileBrowserDialog extends Modal {
 
 		this._okButton = this.addFooterButton(localize('fileBrowser.ok', "OK"), () => this.ok());
 		this._okButton.enabled = false;
+		// Add a back button to the footer rather than use the built-in back button in the upper left of the dialog
 		this.addFooterButton(localize('fileBrowser.back', "Back"), () => this.close(), 'right', true);
 
 		this.registerListeners();

--- a/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
+++ b/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
@@ -106,7 +106,7 @@ export class FileBrowserDialog extends Modal {
 
 		this._okButton = this.addFooterButton(localize('fileBrowser.ok', "OK"), () => this.ok());
 		this._okButton.enabled = false;
-		this.addFooterButton(localize('fileBrowser.discard', "Discard"), () => this.close(), 'right', true);
+		this.addFooterButton(localize('fileBrowser.back', "Back"), () => this.close(), 'right', true);
 
 		this.registerListeners();
 		this.updateTheme();


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/23738

This PR changes the cancel button label for the file browser and find object dialogs we use in the basic admin space. Those are inner dialogs that get opened from another dialog, so having Cancel for those may cause confusion as to whether it will close the entire dialog or just the inner one. Using Back instead seems more appropriate.