### PR TITLE
Delete compilation.tar.gz after it's been extracted

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -25,7 +25,7 @@ steps:
   - script: |
       set -e
       tar -xzf $(Pipeline.Workspace)/compilation.tar.gz
-      # delete tar.gz after it's been extracted
+      # delete tar.gz after it's been extracted to clear up the space
       rm $(Pipeline.Workspace)/compilation.tar.gz
     displayName: Extract compilation output
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -27,6 +27,12 @@ steps:
       tar -xzf $(Pipeline.Workspace)/compilation.tar.gz
     displayName: Extract compilation output
 
+#try to delete after compilation?
+  - script: |
+      set -e
+      rm $(Pipeline.Workspace)/compilation.tar.gz
+    displayName: Delete downloaded compilation output after it's been extracted
+
   - script: |
       set -e
       cat << EOF > ~/.netrc

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -25,13 +25,9 @@ steps:
   - script: |
       set -e
       tar -xzf $(Pipeline.Workspace)/compilation.tar.gz
-    displayName: Extract compilation output
-
-#try to delete after compilation?
-  - script: |
-      set -e
+      # delete tar.gz after it's been extracted
       rm $(Pipeline.Workspace)/compilation.tar.gz
-    displayName: Delete downloaded compilation output after it's been extracted
+    displayName: Extract compilation output
 
   - script: |
       set -e


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The pipeline agents started failing today due to disk space running out. This deletes the compilation.tar.gz after it's been extracted to clear up some space.