### PR TITLE
make form container info have tooltip role

### DIFF
--- a/src/sql/workbench/browser/modelComponents/formContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/formContainer.component.ts
@@ -48,7 +48,7 @@ class FormItem {
 					<ng-container *ngIf="isHorizontal(item)">
 						<div *ngIf="hasItemTitle(item)" class="form-cell form-cell-title" [style.font-size]="getItemTitleFontSize(item)" [ngClass]="{'form-group-item': isInGroup(item)}">
 							{{getItemTitle(item)}}<span class="form-required" *ngIf="isItemRequired(item)">*</span>
-							<span class="codicon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)"></span>
+							<span class="codicon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)" role="tooltip"></span>
 						</div>
 						<div class="form-cell">
 							<div class="form-component-container">
@@ -68,7 +68,7 @@ class FormItem {
 					<div class="form-vertical-container" *ngIf="isVertical(item)" [style.height]="getRowHeight(item)" [ngClass]="{'form-group-item': isInGroup(item)}">
 						<div class="form-item-row" [style.font-size]="getItemTitleFontSize(item)">
 							{{getItemTitle(item)}}<span class="form-required" *ngIf="isItemRequired(item)">*</span>
-							<span class="codicon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)"></span>
+							<span class="codicon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)" role="tooltip"></span>
 						</div>
 						<div class="form-item-row" [style.width]="getComponentWidth(item)" [style.height]="getRowHeight(item)">
 							<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore" [style.width]="getComponentWidth(item)" [style.height]="getRowHeight(item)">


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Addresses https://github.com/microsoft/azuredatastudio/issues/24217. The info tooltip used to have a role of image, so this changes it to be tooltip for accessibility.

![image](https://github.com/microsoft/azuredatastudio/assets/31145923/c3d95fda-9ffc-4c82-92bc-2f7117a1c7c0)
