### PR TITLE
Fix dashboard opening server vs database view

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -480,6 +480,10 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				profile.userName = accounts?.find(a => a.key.accountId === profile.azureAccount)?.displayInfo.displayName
 					?? profile.userName;
 			}
+			// This is used to specify whether a connection is server level or database level
+			if (profile.databaseName !== 'master' || !profile.databaseName) {
+				profile.options.originalDatabase = profile.databaseName
+			}
 		}
 		return profile;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #22621

Before: Selecting "Manage" on a database node would still open the server dashboard.

https://github.com/microsoft/azuredatastudio/assets/18150417/ab6093a3-094a-4bea-ad7e-d24714e43757


After: Selecting "Manage" on a database node opens the correct database dashboard.

https://github.com/microsoft/azuredatastudio/assets/18150417/9642c1c1-329e-453f-8fb8-a702ab84456c

