### PR TITLE
Fix column resize issue in profiler

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -503,7 +503,6 @@ export class ProfilerEditor extends EditorPane {
 			}
 
 			if (this.input.isFileSession && this.input.isSetupPhase) {		// Add loading indicator when opening a new file session
-				this._profilerTableEditor.overlay.style.paddingTop = '50px';		// Add padding on top of loading indicator to place it below the header of the table
 				this._profilerTableEditor.loadingSpinner.loading = true;
 				this.input.setInitializerPhase(false);
 			}
@@ -591,8 +590,6 @@ export class ProfilerEditor extends EditorPane {
 					this._updateSessionSelector();
 				} else {
 					this._profilerTableEditor.loadingSpinner.loading = false;		// Remove the loading indicator when the complete file is read
-					this._profilerTableEditor.overlay.style.paddingTop = '0px';	// Remove the added padding to keep the table header columns resize functional
-
 				}
 			}
 		}

--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -503,7 +503,7 @@ export class ProfilerEditor extends EditorPane {
 			}
 
 			if (this.input.isFileSession && this.input.isSetupPhase) {		// Add loading indicator when opening a new file session
-				this._profilerTableEditor._overlay.style.paddingTop = '50px';		// Add padding on top of loading indicator to place it below the header of the table
+				this._profilerTableEditor.overlay.style.paddingTop = '50px';		// Add padding on top of loading indicator to place it below the header of the table
 				this._profilerTableEditor.loadingSpinner.loading = true;
 				this.input.setInitializerPhase(false);
 			}
@@ -591,7 +591,7 @@ export class ProfilerEditor extends EditorPane {
 					this._updateSessionSelector();
 				} else {
 					this._profilerTableEditor.loadingSpinner.loading = false;		// Remove the loading indicator when the complete file is read
-					this._profilerTableEditor._overlay.style.paddingTop = '0px';	// Remove the added padding to keep the table header columns resize functional
+					this._profilerTableEditor.overlay.style.paddingTop = '0px';	// Remove the added padding to keep the table header columns resize functional
 
 				}
 			}

--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -503,6 +503,7 @@ export class ProfilerEditor extends EditorPane {
 			}
 
 			if (this.input.isFileSession && this.input.isSetupPhase) {		// Add loading indicator when opening a new file session
+				this._profilerTableEditor._overlay.style.paddingTop = '50px';		// Add padding on top of loading indicator to place it below the header of the table
 				this._profilerTableEditor.loadingSpinner.loading = true;
 				this.input.setInitializerPhase(false);
 			}
@@ -590,6 +591,8 @@ export class ProfilerEditor extends EditorPane {
 					this._updateSessionSelector();
 				} else {
 					this._profilerTableEditor.loadingSpinner.loading = false;		// Remove the loading indicator when the complete file is read
+					this._profilerTableEditor._overlay.style.paddingTop = '0px';	// Remove the added padding to keep the table header columns resize functional
+
 				}
 			}
 		}

--- a/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
@@ -53,7 +53,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 	private _findCountChangeListener: IDisposable;
 	private _findState: FindReplaceState;
 	private _finder: FindWidget;
-	public _overlay: HTMLElement;
+	public overlay: HTMLElement;
 	private _currentDimensions: Dimension;
 	private _actionMap: { [x: string]: IEditorAction } = {};
 	private _statusbarItem: IDisposable;
@@ -86,11 +86,11 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 
 	protected createEditor(parent: HTMLElement): void {
 
-		this._overlay = document.createElement('div');
-		this._overlay.className = 'overlayWidgets';
-		this._overlay.style.width = '100%';
-		this._overlay.style.zIndex = '4';
-		parent.appendChild(this._overlay);
+		this.overlay = document.createElement('div');
+		this.overlay.className = 'overlayWidgets';
+		this.overlay.style.width = '100%';
+		this.overlay.style.zIndex = '4';
+		parent.appendChild(this.overlay);
 
 		this._profilerTable = new Table(parent, this._accessibilityService, this._quickInputService, defaultTableStyles, {
 			sorter: (args) => {
@@ -132,7 +132,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 			this._themeService
 		);
 
-		this.loadingSpinner = new LoadingSpinner(this._overlay, { showText: true, fullSize: false });
+		this.loadingSpinner = new LoadingSpinner(this.overlay, { showText: true, fullSize: false });
 	}
 
 	public override setInput(input: ProfilerInput): Promise<void> {
@@ -225,7 +225,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 	public addOverlayWidget(widget: IOverlayWidget): void {
 		let domNode = widget.getDomNode();
 		domNode.style.right = '28px';
-		this._overlay.appendChild(widget.getDomNode());
+		this.overlay.appendChild(widget.getDomNode());
 		this._findState.change({ isRevealed: false }, false);
 	}
 

--- a/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
@@ -53,7 +53,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 	private _findCountChangeListener: IDisposable;
 	private _findState: FindReplaceState;
 	private _finder: FindWidget;
-	public overlay: HTMLElement;
+	private _overlay: HTMLElement;
 	private _currentDimensions: Dimension;
 	private _actionMap: { [x: string]: IEditorAction } = {};
 	private _statusbarItem: IDisposable;
@@ -86,11 +86,12 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 
 	protected createEditor(parent: HTMLElement): void {
 
-		this.overlay = document.createElement('div');
-		this.overlay.className = 'overlayWidgets';
-		this.overlay.style.width = '100%';
-		this.overlay.style.zIndex = '4';
-		parent.appendChild(this.overlay);
+		this._overlay = document.createElement('div');
+		this._overlay.className = 'overlayWidgets';
+		this._overlay.style.width = '100%';
+		this._overlay.style.zIndex = '4';
+		this._overlay.style.top = '50px';
+		parent.appendChild(this._overlay);
 
 		this._profilerTable = new Table(parent, this._accessibilityService, this._quickInputService, defaultTableStyles, {
 			sorter: (args) => {
@@ -132,7 +133,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 			this._themeService
 		);
 
-		this.loadingSpinner = new LoadingSpinner(this.overlay, { showText: true, fullSize: false });
+		this.loadingSpinner = new LoadingSpinner(this._overlay, { showText: true, fullSize: false });
 	}
 
 	public override setInput(input: ProfilerInput): Promise<void> {

--- a/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
@@ -226,7 +226,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 	public addOverlayWidget(widget: IOverlayWidget): void {
 		let domNode = widget.getDomNode();
 		domNode.style.right = '28px';
-		this.overlay.appendChild(widget.getDomNode());
+		this._overlay.appendChild(widget.getDomNode());
 		this._findState.change({ isRevealed: false }, false);
 	}
 

--- a/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerTableEditor.ts
@@ -53,7 +53,7 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 	private _findCountChangeListener: IDisposable;
 	private _findState: FindReplaceState;
 	private _finder: FindWidget;
-	private _overlay: HTMLElement;
+	public _overlay: HTMLElement;
 	private _currentDimensions: Dimension;
 	private _actionMap: { [x: string]: IEditorAction } = {};
 	private _statusbarItem: IDisposable;
@@ -90,7 +90,6 @@ export class ProfilerTableEditor extends EditorPane implements IProfilerControll
 		this._overlay.className = 'overlayWidgets';
 		this._overlay.style.width = '100%';
 		this._overlay.style.zIndex = '4';
-		this._overlay.style.paddingTop = '50px';
 		parent.appendChild(this._overlay);
 
 		this._profilerTable = new Table(parent, this._accessibilityService, this._quickInputService, defaultTableStyles, {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/24540.
Somehow setting the padding to move the loading indicator down messed up the columns' resize functionality. Localizing the issue to when the loading indicator is actually added and removing the padding when it is removed.

Before:
Profiling server:
![Problem1](https://github.com/microsoft/azuredatastudio/assets/57200045/01ebd745-8638-499e-a535-68aac58fa17b)

Opening XEL File:
![Problem2](https://github.com/microsoft/azuredatastudio/assets/57200045/121f0330-32ae-488e-a25f-baa6e620f25e)

After:
Profiling server:
![profilerFix1](https://github.com/microsoft/azuredatastudio/assets/57200045/cadc6a54-3395-4ee6-bec3-d492072447ac)

Opening XEL File:
![profilerFix12](https://github.com/microsoft/azuredatastudio/assets/57200045/5ff16879-9888-4947-9f93-26763ad8f1ab)
