### PR TITLE
[Port] Delete compilation.tar.gz after it's been extracted (#24539)

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -25,6 +25,8 @@ steps:
   - script: |
       set -e
       tar -xzf $(Pipeline.Workspace)/compilation.tar.gz
+      # delete tar.gz after it's been extracted to clear up the space
+      rm $(Pipeline.Workspace)/compilation.tar.gz
     displayName: Extract compilation output
 
   - script: |


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Cherry picking https://github.com/microsoft/azuredatastudio/commit/883d5714cca6c16f7d0aebf1b0b7ddf859fba42c from main to delete compilation.tar.gz after it's been extracted to deal with the "No disk space left on device" error on the linux agent in the pipeline.