### PR TITLE
Fix to Disable Apply button for Query Store tab when no changes are made

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -1764,7 +1764,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 			}, this.viewInfo.propertiesOnOffOptions, this.objectInfo.queryStoreOptions.waitStatisticsCaptureMode.toUpperCase(), this.areQueryStoreOptionsEnabled, DefaultInputWidth);
 			containers.push(this.createLabelInputContainer(localizedConstants.WaitStatisticsCaptureModeText, this.waitStatisticsCaptureMode));
 		}
-		const retentionSection = this.createGroup(localizedConstants.WaitStatisticsCaptureModeText, containers, true);
+		const retentionSection = this.createGroup(localizedConstants.QueryStoreRetentionSectionText, containers, true);
 		this.queryStoreTabSectionsContainer.push(retentionSection);
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -1759,7 +1759,8 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 		// Wait Statistics Capture Mode - supported from 2017 or higher
 		if (!isUndefinedOrNull(this.objectInfo.queryStoreOptions.waitStatisticsCaptureMode)) {
 			this.waitStatisticsCaptureMode = this.createDropdown(localizedConstants.WaitStatisticsCaptureModeText, async (newValue) => {
-				this.objectInfo.queryStoreOptions.waitStatisticsCaptureMode = newValue as string;
+				// waitStatisticsCaptureMode value comes as On/Off, but options we provide is ON/OFF, handling selected value to match with the incoming value
+				this.objectInfo.queryStoreOptions.waitStatisticsCaptureMode = newValue.charAt(0) + newValue.slice(1).toLowerCase() as string;
 			}, this.viewInfo.propertiesOnOffOptions, this.objectInfo.queryStoreOptions.waitStatisticsCaptureMode.toUpperCase(), this.areQueryStoreOptionsEnabled, DefaultInputWidth);
 			containers.push(this.createLabelInputContainer(localizedConstants.WaitStatisticsCaptureModeText, this.waitStatisticsCaptureMode));
 		}

--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -1759,7 +1759,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 		// Wait Statistics Capture Mode - supported from 2017 or higher
 		if (!isUndefinedOrNull(this.objectInfo.queryStoreOptions.waitStatisticsCaptureMode)) {
 			this.waitStatisticsCaptureMode = this.createDropdown(localizedConstants.WaitStatisticsCaptureModeText, async (newValue) => {
-				// waitStatisticsCaptureMode value comes as On/Off, but options we provide is ON/OFF, handling selected value to match with the incoming value
+				// waitStatisticsCaptureMode value comes as On/Off, but options we provide are ON/OFF, handling selected value to match with the incoming value
 				this.objectInfo.queryStoreOptions.waitStatisticsCaptureMode = newValue.charAt(0) + newValue.slice(1).toLowerCase() as string;
 			}, this.viewInfo.propertiesOnOffOptions, this.objectInfo.queryStoreOptions.waitStatisticsCaptureMode.toUpperCase(), this.areQueryStoreOptionsEnabled, DefaultInputWidth);
 			containers.push(this.createLabelInputContainer(localizedConstants.WaitStatisticsCaptureModeText, this.waitStatisticsCaptureMode));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Apply button enabling while opening query store tab even though no changes have been made. This issue is caused by waitStatisticsCaptureMode which comes as On/Off but the dropdown options we provide are ON/OFF, when the value is replaced to block letters, there causes the grid dirty and enables the button.

fixes:
1. https://github.com/microsoft/azuredatastudio/issues/24570
2. https://github.com/microsoft/azuredatastudio/issues/24605

We can either fix this by getting the new options as On/Off or by sending the expected value.
![image](https://github.com/microsoft/azuredatastudio/assets/74571829/fb0fd2d6-a5a3-4134-9e7f-9d88f6a6ce7a)
![image](https://github.com/microsoft/azuredatastudio/assets/74571829/710bda64-5852-47e6-9154-6df843b0274e)

