### PR TITLE
Ignore Code type cells in horizontalScrollbar

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -339,8 +339,8 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			// Have to offset the height based on the contents viewport and the additional scrollbars that are present in markdown editor and notebook
 			let horizontalTop = Math.floor(Math.abs(viewportTop + viewportHeight) - Math.abs(2 * horizontalScrollbar.scrollHeight));
 
-			// Set opacity for both fixed and absolute
-			horizontalScrollbar.style.opacity = '1';
+			// Set display for both fixed and absolute
+			horizontalScrollbar.style.display = 'block';
 
 			// If the bottom of the editor is in the viewport, then set the horizontal scrollbar to the bottom of the editor space
 			if (markdownEditorBottom < viewportBottom) {
@@ -357,7 +357,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 			}
 		} else if (this.cellModel.cellType !== CellTypes.Code) {
 			// If horizontal scrollbar is not needed then set do not show it
-			horizontalScrollbar.style.opacity = '0';
+			horizontalScrollbar.style.display = 'none';
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -355,7 +355,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 				horizontalScrollbar.style.top = horizontalTop + 'px';
 				horizontalScrollbar.style.bottom = '';
 			}
-		} else {
+		} else if (this.cellModel.cellType !== CellTypes.Code) {
 			// If horizontal scrollbar is not needed then set do not show it
 			horizontalScrollbar.style.opacity = '0';
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

#21145

Ignore Code Cells being applied with Markdown Cell specific behavior around the horizontal scrollbar.

The scrollbar is already there, just opacity was set to 0.

Before:
![image](https://github.com/microsoft/azuredatastudio/assets/6894612/e86389b9-c758-48d3-a9c4-b371d71355b4)

After:
![image](https://github.com/microsoft/azuredatastudio/assets/6894612/eaa090e5-5a0f-4274-84af-cce278e8b41a)
