### PR TITLE
vbump sql migration 1.4.10 in extension gallery

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.9",
-							"lastUpdated": "07/20/2023",
+							"version": "1.4.10",
+							"lastUpdated": "10/04/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.9.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.10.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the extension gallery to the latest version 1.4.10 of the SQL Migration extension. sql-migration-1.4.10.vsix

Insider Gallery PR: https://github.com/microsoft/azuredatastudio/pull/24528
