### PR TITLE
Transfer URI Correctly

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.10.0.4",
+	"version": "4.10.0.15",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -341,6 +341,7 @@ export class QueryManagementService implements IQueryManagementService {
 			this._logService.error(`No query runner found for old URI : '${oldUri}'`);
 		} else if (this._queryRunners.get(newUri)) {
 			this._logService.error(`New URI : '${newUri}' already has a query runner.`);
+			throw new Error(nls.localize('queryManagement.uriAlreadyHasQueryRunner', 'Uri: {0} unexpectedly already has a query runner.', newUri));
 		} else {
 			this._queryRunners.set(newUri, item);
 			this._queryRunners.delete(oldUri);

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -339,16 +339,15 @@ export class QueryManagementService implements IQueryManagementService {
 		let item = this._queryRunners.get(oldUri);
 		if (!item) {
 			this._logService.error(`No query runner found for old URI : '${oldUri}'`);
-			throw new Error(nls.localize('queryManagement.noQueryRunnerForUri', 'Could not find Query Runner for uri: {0}', oldUri));
-		}
-		if (this._queryRunners.get(newUri)) {
+		} else if (this._queryRunners.get(newUri)) {
 			this._logService.error(`New URI : '${newUri}' already has a query runner.`);
-			throw new Error(nls.localize('queryManagement.uriAlreadyHasQueryRunner', 'Uri: {0} unexpectedly already has a query runner.', newUri));
+		} else {
+			this._queryRunners.set(newUri, item);
+			this._queryRunners.delete(oldUri);
 		}
-		this._queryRunners.set(newUri, item);
-		this._queryRunners.delete(oldUri);
-		return this._runAction(newUri, (runner) => {
-			return runner.connectionUriChanged(newUri, oldUri);
+
+		return this._runAction(newUri, (handler) => {
+			return handler.connectionUriChanged(newUri, oldUri);
 		});
 	}
 

--- a/src/sql/workbench/services/query/common/queryModelService.ts
+++ b/src/sql/workbench/services/query/common/queryModelService.ts
@@ -22,6 +22,7 @@ import Severity from 'vs/base/common/severity';
 import EditQueryRunner from 'sql/workbench/services/editData/common/editQueryRunner';
 import { IRange } from 'vs/editor/common/core/range';
 import { ClipboardData, IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { IQueryManagementService } from 'sql/workbench/services/query/common/queryManagement';
 
 const selectionSnippetMaxLen = 100;
 
@@ -81,6 +82,7 @@ export class QueryModelService implements IQueryModelService {
 
 	// CONSTRUCTOR /////////////////////////////////////////////////////////
 	constructor(
+		@IQueryManagementService protected queryManagementService: IQueryManagementService,
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@INotificationService private _notificationService: INotificationService,
 		@IClipboardService private _clipboardService: IClipboardService,
@@ -437,21 +439,17 @@ export class QueryModelService implements IQueryModelService {
 	}
 
 	public async changeConnectionUri(newUri: string, oldUri: string): Promise<void> {
-		// Get existing query runner
-		let queryRunner = this.internalGetQueryRunner(oldUri);
-		if (!queryRunner) {
-			// Nothing to do if we don't have a query runner currently (no connection)
-			return;
-		}
-		else if (this._queryInfoMap.has(newUri)) {
+		if (this._queryInfoMap.has(newUri)) {
 			this._logService.error(`New URI '${newUri}' already has query info associated with it.`);
 			throw new Error(nls.localize('queryModelService.uriAlreadyHasQuery', '{0} already has an existing query', newUri));
 		}
+		await this.queryManagementService.changeConnectionUri(newUri, oldUri);
 
-		await queryRunner.changeConnectionUri(newUri, oldUri);
-
-		// remove the old key and set new key with same query info as old uri. (Info existence is checked in internalGetQueryRunner)
+		// remove the old key and set new key with same query info as old uri.
 		let info = this._queryInfoMap.get(oldUri);
+		if (!info) {
+			return;
+		}
 		info.uri = newUri;
 		this._queryInfoMap.set(newUri, info);
 		this._queryInfoMap.delete(oldUri);

--- a/src/sql/workbench/services/query/common/queryRunner.ts
+++ b/src/sql/workbench/services/query/common/queryRunner.ts
@@ -468,10 +468,6 @@ export default class QueryRunner extends Disposable {
 		this._isDisposed = true;
 	}
 
-	public changeConnectionUri(oldUri: string, newUri: string): Promise<void> {
-		return this.queryManagementService.changeConnectionUri(oldUri, newUri);
-	}
-
 	get totalElapsedMilliseconds(): number {
 		return this._totalElapsedMilliseconds;
 	}


### PR DESCRIPTION
Before: Saving a query before executing would put the query editor into a disconnected state (because a query runner does not exist)

After: Connection URI is transferred correctly even without a query runner present

STS Changes: https://github.com/microsoft/sqltoolsservice/pull/2265

Fixes https://github.com/microsoft/azuredatastudio/issues/21988
