### PR TITLE
Use python 3.11

### DIFF
--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -9,7 +9,7 @@ steps:
 
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.x'
+      versionSpec: '3.11.x'
       addToPath: true
 
   - task: AzureKeyVault@1


### PR DESCRIPTION
Downgrade python version to fix ARM build error: `ModuleNotFoundError: No module named 'distutils'`

- VSCode also seems to be using v3.11.x in their [product pipelines](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=236040&view=logs&j=b599f925-57da-5b26-3abb-63aa7efd9fc6&t=14b645b8-df47-5692-9b0c-ccd40e27a6e6&l=9) that is fetched from cache.

Will update Wiki accordingly to address #24582 