### PR TITLE
Fix so screenreaders will announce section headers in sql projects dialogs

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -110,13 +110,19 @@ export class CreateProjectFromDatabaseDialog {
 
 			const connectionRow = this.createConnectionRow(view);
 			const databaseRow = this.createDatabaseRow(view);
-			const sourceDatabaseFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
-			sourceDatabaseFormSection.addItems([connectionRow, databaseRow]);
+			const sourceDatabaseFormSection = view.modelBuilder.groupContainer().withLayout({
+				header: constants.sourceDatabase,
+				collapsible: false,
+				collapsed: false
+			}).withItems([connectionRow, databaseRow]).component();
 
 			const projectNameRow = this.createProjectNameRow(view);
 			const projectLocationRow = this.createProjectLocationRow(view);
-			const targetProjectFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
-			targetProjectFormSection.addItems([projectNameRow, projectLocationRow]);
+			const targetProjectFormSection = view.modelBuilder.groupContainer().withLayout({
+				header: constants.targetProject,
+				collapsible: false,
+				collapsed: false
+			}).withItems([projectNameRow, projectLocationRow]).component();
 
 			const folderStructureRow = this.createFolderStructureRow(view);
 
@@ -140,10 +146,16 @@ export class CreateProjectFromDatabaseDialog {
 				.withItems([this.sdkStyleCheckbox, sdkLearnMore], { CSSStyles: { flex: '0 0 auto', 'margin-right': '10px' } })
 				.component();
 
+			const settingsFormSection = view.modelBuilder.groupContainer().withLayout({
+				header: constants.createProjectSettings,
+				collapsible: false,
+				collapsed: false
+			}).withItems([folderStructureRow, this.includePermissionsCheckbox, sdkFormComponentGroup]).component();
+
 			this.formBuilder = <azdataType.FormBuilder>view.modelBuilder.formContainer()
 				.withFormItems([
 					{
-						title: constants.sourceDatabase,
+						title: '',
 						components: [
 							{
 								component: sourceDatabaseFormSection,
@@ -151,7 +163,7 @@ export class CreateProjectFromDatabaseDialog {
 						]
 					},
 					{
-						title: constants.targetProject,
+						title: '',
 						components: [
 							{
 								component: targetProjectFormSection,
@@ -159,16 +171,10 @@ export class CreateProjectFromDatabaseDialog {
 						]
 					},
 					{
-						title: constants.createProjectSettings,
+						title: '',
 						components: [
 							{
-								component: folderStructureRow,
-							},
-							{
-								component: this.includePermissionsCheckbox
-							},
-							{
-								component: sdkFormComponentGroup
+								component: settingsFormSection
 							}
 						]
 					}

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseDialog.ts
@@ -92,22 +92,31 @@ export class UpdateProjectFromDatabaseDialog {
 			const databaseRow = this.createDatabaseRow(view);
 			await this.populateServerDropdown();
 
-			const sourceDatabaseFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
-			sourceDatabaseFormSection.addItems([connectionRow, databaseRow]);
+			const sourceDatabaseFormSection = view.modelBuilder.groupContainer().withLayout({
+				header: constants.sourceDatabase,
+				collapsible: false,
+				collapsed: false
+			}).withItems([connectionRow, databaseRow]).component();
 
 			const projectLocationRow = this.createProjectLocationRow(view);
 			const folderStructureRow = this.createFolderStructureRow(view);
-			const targetProjectFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
-			targetProjectFormSection.addItems([projectLocationRow, folderStructureRow]);
+			const targetProjectFormSection = view.modelBuilder.groupContainer().withLayout({
+				header: constants.TargetDatabase,
+				collapsible: false,
+				collapsed: false
+			}).withItems([projectLocationRow, folderStructureRow]).component();
 
 			const actionRow = await this.createActionRow(view);
-			const actionFormSection = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'column' }).component();
-			actionFormSection.addItems([actionRow]);
+			const actionFormSection = view.modelBuilder.groupContainer().withLayout({
+				header: constants.updateAction,
+				collapsible: false,
+				collapsed: false
+			}).withItems([actionRow]).component();
 
 			this.formBuilder = <azdata.FormBuilder>view.modelBuilder.formContainer()
 				.withFormItems([
 					{
-						title: constants.sourceDatabase,
+						title: '',
 						components: [
 							{
 								component: sourceDatabaseFormSection,
@@ -115,7 +124,7 @@ export class UpdateProjectFromDatabaseDialog {
 						]
 					},
 					{
-						title: constants.targetProject,
+						title: '',
 						components: [
 							{
 								component: targetProjectFormSection,
@@ -123,7 +132,7 @@ export class UpdateProjectFromDatabaseDialog {
 						]
 					},
 					{
-						title: constants.updateAction,
+						title: '',
 						components: [
 							{
 								component: actionFormSection,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Addresses https://github.com/microsoft/azuredatastudio/issues/24163. This switches two of the sql projects dialogs that have section headings to use the `groupContainer` component so that the section header gets announced by screenreaders. There changes in the look is that the section headers are no longer bold and the items in each group are slightly indented compared to the section title - this is how it also looks in other dialogs that use the `groupContainer` component, like the New Database dialog.

Before: 
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/cddb5938-9b8d-4f95-b484-4ea9c16b161b)


After:
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/1c81426c-8691-464c-abd1-69d392d0a2cd)

Screenreader announcing the section heading when the first item in the group is navigated to:

https://github.com/microsoft/azuredatastudio/assets/31145923/1ca2df11-09bb-4837-8eab-44e84b5fd61f

