### PR TITLE
Fix and enable GitHub CI workflow

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
-        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
+        run: echo "{value}=$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
       - name: Cache node modules
         id: cacheNodeModules
         uses: actions/cache@v3
@@ -46,7 +46,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarnCacheDirPath
         if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{dir}=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Cache yarn directory
         if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         uses: actions/cache@v3
@@ -89,7 +89,7 @@ jobs:
       # {{SQL CARBON TODO}} Update node modules caching to work with our cache keys
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
-        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
+        run: echo "{value}=$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
       - name: Cache node modules
         id: cacheNodeModules
         uses: actions/cache@v3
@@ -100,7 +100,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarnCacheDirPath
         if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{dir}=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Cache yarn directory
         if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,16 @@
 name: CI
 
-on: workflow_dispatch
-
-# on:
-#   push:
-#     branches:
-#       - main
-#       - release/*
-#   pull_request:
-#     branches:
-#       - main
-#       - release/*
+# {{SQL CARBON EDIT}} Enable CI on push/pull_requests
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - release/*
+  pull_request:
+    branches:
+      - main
+      - release/*
 
 jobs:
   windows:
@@ -22,53 +22,50 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15
-
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11.x"
 
-      # {{SQL CARBON EDIT}} Skip caching for now
-      # - name: Compute node modules cache key
-      #   id: nodeModulesCacheKey
-      #   run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
-      # - name: Cache node_modules archive
-      #   id: cacheNodeModules
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ".build/node_modules_cache"
-      #     key: "${{ runner.os }}-cacheNodeModulesArchive-${{ steps.nodeModulesCacheKey.outputs.value }}"
-      # - name: Extract node_modules archive
-      #   if: ${{ steps.cacheNodeModules.outputs.cache-hit == 'true' }}
-      #   run: 7z.exe x .build/node_modules_cache/cache.7z -aos
-      # - name: Get yarn cache directory path
-      #   id: yarnCacheDirPath
-      #   if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-      #   run: echo "::set-output name=dir::$(yarn cache dir)"
-      # - name: Cache yarn directory
-      #   if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ${{ steps.yarnCacheDirPath.outputs.dir }}
-      #     key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
-      #     restore-keys: ${{ runner.os }}-yarnCacheDir-
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "{value}=$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+      - name: Cache node_modules archive
+        id: cacheNodeModules
+        uses: actions/cache@v3
+        with:
+          path: ".build/node_modules_cache"
+          key: "${{ runner.os }}-cacheNodeModulesArchive-${{ steps.nodeModulesCacheKey.outputs.value }}"
+      - name: Extract node_modules archive
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit == 'true' }}
+        run: 7z.exe x .build/node_modules_cache/cache.7z -aos
+      - name: Get yarn cache directory path
+        id: yarnCacheDirPath
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: echo "{dir}=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache yarn directory
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
+          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-yarnCacheDir-
 
       - name: Execute yarn
-        # if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }} {{SQL CARBON EDIT}} Skipping caching for now
+        # if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
         run: yarn --frozen-lockfile --network-timeout 180000
-      # - name: Create node_modules archive {{SQL CARBON EDIT}} Skip caching for now
-      #   if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-      #   run: |
-      #     mkdir -Force .build
-      #     node build/azure-pipelines/common/listNodeModules.js .build/node_modules_list.txt
-      #     mkdir -Force .build/node_modules_cache
-      #     7z.exe a .build/node_modules_cache/cache.7z -mx3 `@.build/node_modules_list.txt
+      - name: Create node_modules archive
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -Force .build
+          node build/azure-pipelines/common/listNodeModules.js .build/node_modules_list.txt
+          mkdir -Force .build/node_modules_cache
+          7z.exe a .build/node_modules_cache/cache.7z -mx3 `@.build/node_modules_list.txt
 
       - name: Compile and Download
         run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" # {{SQL CARBON EDIT}} Remove unused options playwright-install download-builtin-extensions
@@ -105,30 +102,29 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15
-      # {{SQL CARBON EDIT}} Skip caching for now
-      # - name: Compute node modules cache key
-      #   id: nodeModulesCacheKey
-      #   run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
-      # - name: Cache node modules
-      #   id: cacheNodeModules
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: "**/node_modules"
-      #     key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
-      #     restore-keys: ${{ runner.os }}-cacheNodeModules14-
-      # - name: Get yarn cache directory path
-      #   id: yarnCacheDirPath
-      #   if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-      #   run: echo "::set-output name=dir::$(yarn cache dir)"
-      # - name: Cache yarn directory
-      #   if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ${{ steps.yarnCacheDirPath.outputs.dir }}
-      #     key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
-      #     restore-keys: ${{ runner.os }}-yarnCacheDir-
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "{value}=$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+      - name: Cache node modules
+        id: cacheNodeModules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-cacheNodeModules14-
+      - name: Get yarn cache directory path
+        id: yarnCacheDirPath
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: echo "{dir}=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache yarn directory
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
+          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-yarnCacheDir-
       - name: Execute yarn
-        # if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }} {{SQL CARBON EDIT}} Skip caching for now
+        # if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
@@ -174,35 +170,32 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15
-
-      # {{SQL CARBON EDIT}} Skip caching for now
-      # - name: Compute node modules cache key
-      #   id: nodeModulesCacheKey
-      #   run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
-      # - name: Cache node modules
-      #   id: cacheNodeModules
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: "**/node_modules"
-      #     key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
-      #     restore-keys: ${{ runner.os }}-cacheNodeModules14-
-      # - name: Get yarn cache directory path
-      #   id: yarnCacheDirPath
-      #   if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-      #   run: echo "::set-output name=dir::$(yarn cache dir)"
-      # - name: Cache yarn directory
-      #   if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ${{ steps.yarnCacheDirPath.outputs.dir }}
-      #     key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
-      #     restore-keys: ${{ runner.os }}-yarnCacheDir-
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "{value}=$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+      - name: Cache node modules
+        id: cacheNodeModules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-cacheNodeModules14-
+      - name: Get yarn cache directory path
+        id: yarnCacheDirPath
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: echo "{dir}=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache yarn directory
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
+          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-yarnCacheDir-
       - name: Execute yarn
-        # if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }} {{SQL CARBON EDIT}} Skip caching for now
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
@@ -237,14 +230,13 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15
 
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
-        run: echo "::set-output name=value::$(node build/azure-pipelines/common/sql-computeNodeModulesCacheKey.js)"
+        run: echo "{value}=$(node build/azure-pipelines/common/sql-computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
       - name: Cache node modules
         id: cacheNodeModules
         uses: actions/cache@v3
@@ -255,7 +247,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarnCacheDirPath
         if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{dir}=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Cache yarn directory
         if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "2.x"
+          python-version: "3.11.x"
 
       # {{SQL CARBON EDIT}} Skip caching for now
       # - name: Compute node modules cache key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
           restore-keys: ${{ runner.os }}-yarnCacheDir-
       - name: Execute yarn
-        # if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1


### PR DESCRIPTION
+Updates set-output to GitHub Output
(ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

The CI build is disabled in VSCode repo as well so I'm open to keeping it disabled if needed, as we're not really running integration tests.