### PR TITLE
Change default value of diffEditor.experimental.useVersion2 back to false

### DIFF
--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -244,7 +244,7 @@ const editorConfiguration: IConfigurationNode = {
 		},
 		'diffEditor.experimental.useVersion2': {
 			type: 'boolean',
-			default: true,
+			default: false, // {{SQL CARBON EDIT}} default experimental setting to false. Schema compare is broken when set to true
 			description: nls.localize('useVersion2', "Controls whether the diff editor uses the new or the old implementation."),
 			tags: ['experimental'],
 		},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/azuredatastudio/issues/24712. This setting defaulted to false in the previous ADS release and the default was changed to true in the latest vscode merge. Besides the colors not being swapped when using the diff editor version2, there's other weird behavior that the schema compare diff editor component stays when the tab is changed.

The diff editor version2 is still experimental, so it makes more sense to default to not using it right now rather than trying to get schema compare to work with it when it isn't stable yet. Users can change the setting to true if they want to use the experimental version2 of the diff editor.

https://github.com/microsoft/azuredatastudio/assets/31145923/82c22c50-359e-4653-9c35-94806389a210

