### PR TITLE
Fix About Dialog post merge for Azure Data Studio

### DIFF
--- a/src/sql/base/common/locConstants.ts
+++ b/src/sql/base/common/locConstants.ts
@@ -103,3 +103,22 @@ export function getNewThemeNotification(label: string): string {
 }
 
 //#endregion
+
+//#region VS Code About Dialog
+
+export function aboutDetail(productVersion: string, commit: string, date: string, electronVersion: string, chromeVersion: string, nodeVersion: string, v8: string, osProps: string, vscodeVersion: string): string {
+	return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
+		"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nChromium: {4}\nNode.js: {5}\nV8: {6}\nOS: {7}",
+		productVersion,
+		commit,
+		date,
+		electronVersion,
+		chromeVersion,
+		nodeVersion,
+		v8,
+		osProps,
+		vscodeVersion
+	);
+}
+
+//#endregion

--- a/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
@@ -12,6 +12,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { INativeHostService } from 'vs/platform/native/common/native';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { process } from 'vs/base/parts/sandbox/electron-sandbox/globals';
+import { aboutDetail } from 'sql/base/common/locConstants'; // {{SQL CARBON EDIT}} Imports about detail localized string for ADS about dialog
 
 export class NativeDialogHandler extends AbstractDialogHandler {
 
@@ -93,8 +94,7 @@ export class NativeDialogHandler extends AbstractDialogHandler {
 				this.productService.vscodeVersion  // {{SQL CARBON EDIT}} - add vscode version
 			);
 			*/
-			return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
-				"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nChromium: {4}\nNode.js: {5}\nV8: {6}\nOS: {7}",
+			return aboutDetail(
 				version,
 				this.productService.commit || 'Unknown',
 				this.productService.date ? `${this.productService.date}${useAgo ? ' (' + fromNow(new Date(this.productService.date), true) + ')' : ''}` : 'Unknown',

--- a/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
@@ -77,19 +77,35 @@ export class NativeDialogHandler extends AbstractDialogHandler {
 		const osProps = await this.nativeHostService.getOSProperties();
 
 		const detailString = (useAgo: boolean): string => {
+			// {{SQL CARBON EDIT}} - BEGIN - Removing Electron Build ID from detail string
+			/*
 			return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
 				"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
 				version,
 				this.productService.commit || 'Unknown',
 				this.productService.date ? `${this.productService.date}${useAgo ? ' (' + fromNow(new Date(this.productService.date), true) + ')' : ''}` : 'Unknown',
 				process.versions['electron'],
-				process.versions['microsoft-build'],
+				process.versions['microsoft-build'], // {{SQL CARBON EDIT}} Removing Electron Build ID from detail string
 				process.versions['chrome'],
 				process.versions['node'],
 				process.versions['v8'],
 				`${osProps.type} ${osProps.arch} ${osProps.release}${isLinuxSnap ? ' snap' : ''}`,
 				this.productService.vscodeVersion  // {{SQL CARBON EDIT}} - add vscode version
 			);
+			*/
+			return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
+				"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nChromium: {4}\nNode.js: {5}\nV8: {6}\nOS: {7}",
+				version,
+				this.productService.commit || 'Unknown',
+				this.productService.date ? `${this.productService.date}${useAgo ? ' (' + fromNow(new Date(this.productService.date), true) + ')' : ''}` : 'Unknown',
+				process.versions['electron'],
+				process.versions['chrome'],
+				process.versions['node'],
+				process.versions['v8'],
+				`${osProps.type} ${osProps.arch} ${osProps.release}${isLinuxSnap ? ' snap' : ''}`,
+				this.productService.vscodeVersion  // {{SQL CARBON EDIT}} - add vscode version
+			);
+			// {{SQL CARBON EDIT}} - END - New localized string doesn't include Electron Build ID since it shows up as undefined
 		};
 
 		const detail = detailString(true);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR closes #24709

This PR removes the electron build ID since it's appearing as undefined.

![image](https://github.com/microsoft/azuredatastudio/assets/87730006/58f4089a-6df5-40fe-82df-e51465a5279f)

VS Code doesn't use public Electron builds and use their own private builds, so the build ID could be coming in through a mixin that ADS doesn't have access to, which is why it's appearing as undefined.
