### PR TITLE
Update NPS survey URL to capture context parameters

### DIFF
--- a/src/vs/workbench/contrib/surveys/browser/nps.contribution.ts
+++ b/src/vs/workbench/contrib/surveys/browser/nps.contribution.ts
@@ -71,7 +71,8 @@ class NPSContribution implements IWorkbenchContribution {
 			[{
 				label: nls.localize('takeSurvey', "Take Survey"),
 				run: () => {
-					openerService.open(URI.parse(`${productService.npsSurveyUrl}?o=${encodeURIComponent(platform)}&v=${encodeURIComponent(productService.version)}&m=${encodeURIComponent(telemetryService.machineId)}`));
+					// {{SQL Carbon Edit}} Pass context parameters in correct format to NPS Survey URL to gather the same in feedback metadata.
+					openerService.open(URI.parse(`${productService.npsSurveyUrl}?ctx=${encodeURIComponent(`{"ProductVersion":"${productService.version}","Platform":"${platform}","MachineId":"${telemetryService.machineId}"`)}`));
 					storageService.store(IS_CANDIDATE_KEY, false, StorageScope.APPLICATION, StorageTarget.USER);
 					storageService.store(SKIP_VERSION_KEY, productService.version, StorageScope.APPLICATION, StorageTarget.USER);
 				}


### PR DESCRIPTION
As confirmed internally by the DTP Survey teams, the parameters with NPS URL are needed to be sent via context parameters, as explained here: https://meganvwalker.com/passing-variables-through-the-forms-pro-survey-url/

This PR updates the same to be able to capture the parameters in survey results.

cc @erinstellato-ms 

I'm also working on a similar PR for VS Code so we can get the update in future merges.