### PR TITLE
Bump GitHub Copilot extension version to 1.128.504

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -5036,14 +5036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.95.239",
-							"lastUpdated": "07/06/2023",
+							"version": "1.128.504",
+							"lastUpdated": "10/20/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.95.239/GitHub.copilot-1.95.239.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/GitHub.copilot-1.128.504.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -5051,15 +5051,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.95.239/README.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.95.239/CHANGELOG.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.95.239/package.json"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR closes #24743

Update Copilot version in the insiders extension gallery to 1.128.504 after VS Code version 1.82 was merged into ADS.

Link to files to upload: https://microsoft-my.sharepoint.com/:f:/p/lewissanchez/EukjwrSRcRJMvQRR5FN50bMBZ6BD2rhfd0rnsp4Hv3iuGw?e=mRxXHz