### PR TITLE
Add emitter for onDidChangeSelectionAndFocus event handling

### DIFF
--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -143,6 +143,9 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 	private readonly _onDidChangeCheckboxState: Emitter<readonly ITreeItem[]> = this._register(new Emitter<readonly ITreeItem[]>());
 	readonly onDidChangeCheckboxState: Event<readonly ITreeItem[]> = this._onDidChangeCheckboxState.event;
 
+	private readonly _onDidChangeSelectionAndFocus: Emitter<{ selection: readonly ITreeItem[]; focus: ITreeItem; }> = this._register(new Emitter<{ selection: readonly ITreeItem[]; focus: ITreeItem; }>);
+	readonly onDidChangeSelectionAndFocus: Event<{ selection: readonly ITreeItem[]; focus: ITreeItem; }> = this._onDidChangeSelectionAndFocus.event;
+
 	private readonly _onDidCompleteRefresh: Emitter<void> = this._register(new Emitter<void>());
 
 	private nodeContext: NodeContextKey;
@@ -169,8 +172,6 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 		// Try not to add anything that could be costly to this constructor. It gets called once per tree view
 		// during startup, and anything added here can affect performance.
 	}
-
-	onDidChangeSelectionAndFocus: Event<{ selection: readonly ITreeItem[]; focus: ITreeItem; }>;
 
 	private _isInitialized: boolean = false;
 	private initialize() {

--- a/src/sql/workbench/services/connection/test/browser/testTreeView.ts
+++ b/src/sql/workbench/services/connection/test/browser/testTreeView.ts
@@ -83,7 +83,6 @@ export class TreeView extends Disposable implements ITreeView {
 	public root: ITreeItem;
 	private elementsToRefresh: ITreeItem[] = [];
 
-
 	private readonly _onDidChangeCheckboxState: Emitter<readonly ITreeItem[]> = this._register(new Emitter<readonly ITreeItem[]>());
 	readonly onDidChangeCheckboxState: Event<readonly ITreeItem[]> = this._onDidChangeCheckboxState.event;
 
@@ -113,6 +112,9 @@ export class TreeView extends Disposable implements ITreeView {
 
 	private readonly _onDidChangeDescription: Emitter<string | undefined> = this._register(new Emitter<string | undefined>());
 	readonly onDidChangeDescription: Event<string | undefined> = this._onDidChangeDescription.event;
+
+	private readonly _onDidChangeSelectionAndFocus: Emitter<{ selection: readonly ITreeItem[]; focus: ITreeItem; }> = this._register(new Emitter<{ selection: readonly ITreeItem[]; focus: ITreeItem; }>);
+	readonly onDidChangeSelectionAndFocus: Event<{ selection: readonly ITreeItem[]; focus: ITreeItem; }> = this._onDidChangeSelectionAndFocus.event;
 
 	private readonly _onDidCompleteRefresh: Emitter<void> = this._register(new Emitter<void>());
 
@@ -155,7 +157,6 @@ export class TreeView extends Disposable implements ITreeView {
 	}
 
 	dragAndDropController?: ITreeViewDragAndDropController;
-	onDidChangeSelectionAndFocus: Event<{ selection: readonly ITreeItem[]; focus: ITreeItem; }>;
 
 	get viewContainer(): ViewContainer {
 		return this.viewDescriptorService.getViewContainerByViewId(this.id)!;


### PR DESCRIPTION
Fixes #24738

VS Code merge brought this event, but it was added without initialization, that caused the error in the issue reported. This PR initializes it and fixes registering the new event handler.