### PR TITLE
Improve null handling in ServerTreeView

### DIFF
--- a/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadConnectionManagement.ts
@@ -19,6 +19,7 @@ import { IConnectionDialogService } from 'sql/workbench/services/connection/comm
 import { deepClone } from 'vs/base/common/objects';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
 import { SqlExtHostContext, SqlMainContext } from 'vs/workbench/api/common/extHost.protocol';
+import { ILogService } from 'vs/platform/log/common/log';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadConnectionManagement)
 export class MainThreadConnectionManagement extends Disposable implements MainThreadConnectionManagementShape {
@@ -32,7 +33,8 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService,
 		@IEditorService private _workbenchEditorService: IEditorService,
 		@IConnectionDialogService private _connectionDialogService: IConnectionDialogService,
-		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService
+		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService,
+		@ILogService private _logService: ILogService
 	) {
 		super();
 		if (extHostContext) {
@@ -125,11 +127,11 @@ export class MainThreadConnectionManagement extends Disposable implements MainTh
 	}
 
 	public $getCurrentConnection(): Thenable<azdata.connection.Connection> {
-		return Promise.resolve(this.convertConnection(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, true)));
+		return Promise.resolve(this.convertConnection(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, this._logService, true)));
 	}
 
 	public $getCurrentConnectionProfile(): Thenable<azdata.connection.ConnectionProfile> {
-		return Promise.resolve(this.convertToConnectionProfile(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, true)));
+		return Promise.resolve(this.convertToConnectionProfile(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, this._logService, true)));
 	}
 
 	public $getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {

--- a/src/sql/workbench/browser/taskUtilities.ts
+++ b/src/sql/workbench/browser/taskUtilities.ts
@@ -8,6 +8,7 @@ import { IConnectionManagementService } from 'sql/platform/connection/common/con
 import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { DashboardInput } from 'sql/workbench/browser/editor/profiler/dashboardInput';
+import { ILogService } from 'vs/platform/log/common/log';
 
 /**
  * Get the current global connection, which is the connection from the active editor, unless OE
@@ -19,7 +20,11 @@ import { DashboardInput } from 'sql/workbench/browser/editor/profiler/dashboardI
  * @param workbenchEditorService
  * @param topLevelOnly If true, only return top-level (i.e. connected) Object Explorer connections instead of database connections when appropriate
 */
-export function getCurrentGlobalConnection(objectExplorerService: IObjectExplorerService, connectionManagementService: IConnectionManagementService, workbenchEditorService: IEditorService, topLevelOnly: boolean = false): IConnectionProfile | undefined {
+export function getCurrentGlobalConnection(objectExplorerService: IObjectExplorerService,
+	connectionManagementService: IConnectionManagementService,
+	workbenchEditorService: IEditorService,
+	logService: ILogService,
+	topLevelOnly: boolean = false): IConnectionProfile | undefined {
 	let connection: IConnectionProfile | undefined;
 	// object Explorer Connection
 	let objectExplorerSelection = objectExplorerService.getSelectedProfileAndDatabase();
@@ -36,6 +41,8 @@ export function getCurrentGlobalConnection(objectExplorerService: IObjectExplore
 		if (objectExplorerService.isFocused()) {
 			return connection;
 		}
+	} else {
+		logService.trace('getCurrentGlobalConnection: Object Explorer selection is undefined, finding connection from active editor.');
 	}
 
 	let activeInput = workbenchEditorService.activeEditor;
@@ -47,6 +54,8 @@ export function getCurrentGlobalConnection(objectExplorerService: IObjectExplore
 			// editor Connection
 			connection = connectionManagementService.getConnectionProfile(activeInput.resource.toString(true));
 		}
+	} else {
+		logService.warn('getCurrentGlobalConnection: No active editor found.');
 	}
 
 	return connection;

--- a/src/sql/workbench/browser/taskUtilities.ts
+++ b/src/sql/workbench/browser/taskUtilities.ts
@@ -18,6 +18,7 @@ import { ILogService } from 'vs/platform/log/common/log';
  * @param objectExplorerService
  * @param connectionManagementService
  * @param workbenchEditorService
+ * @param logService
  * @param topLevelOnly If true, only return top-level (i.e. connected) Object Explorer connections instead of database connections when appropriate
 */
 export function getCurrentGlobalConnection(objectExplorerService: IObjectExplorerService,

--- a/src/sql/workbench/contrib/backup/browser/backupActions.ts
+++ b/src/sql/workbench/contrib/backup/browser/backupActions.ts
@@ -18,6 +18,7 @@ import { Task } from 'sql/workbench/services/tasks/browser/tasksRegistry';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES } from 'sql/workbench/common/constants';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export const BackupFeatureName = 'backup';
 export const backupIsPreviewFeature = localize('backup.isPreviewFeature', "You must enable preview features in order to use backup");
@@ -54,7 +55,8 @@ export class BackupAction extends Task {
 		if (!profile) {
 			const objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
 			const workbenchEditorService = accessor.get<IEditorService>(IEditorService);
-			profile = getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService);
+			const logService = accessor.get<ILogService>(ILogService);
+			profile = getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService, logService);
 		}
 		if (profile) {
 			const serverInfo = connectionManagementService.getServerInfo(profile.id);

--- a/src/sql/workbench/contrib/connection/browser/connectionStatus.ts
+++ b/src/sql/workbench/contrib/connection/browser/connectionStatus.ts
@@ -12,24 +12,25 @@ import * as TaskUtilities from 'sql/workbench/browser/taskUtilities';
 import { IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { localize } from 'vs/nls';
+import { ILogService } from 'vs/platform/log/common/log';
 
 // Connection status bar showing the current global connection
 export class ConnectionStatusbarItem extends Disposable implements IWorkbenchContribution {
 
 	private static readonly ID = 'status.connection.status';
-
-	private statusItem: IStatusbarEntryAccessor;
 	private readonly name = localize('status.connection.status', "Connection Status");
+	private statusItem: IStatusbarEntryAccessor;
 
 	constructor(
-		@IStatusbarService private readonly statusbarService: IStatusbarService,
-		@IConnectionManagementService private readonly connectionManagementService: IConnectionManagementService,
-		@IEditorService private readonly editorService: IEditorService,
-		@IObjectExplorerService private readonly objectExplorerService: IObjectExplorerService,
+		@IStatusbarService private readonly _statusbarService: IStatusbarService,
+		@IConnectionManagementService private readonly _connectionManagementService: IConnectionManagementService,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IObjectExplorerService private readonly _objectExplorerService: IObjectExplorerService,
+		@ILogService private readonly _logService: ILogService
 	) {
 		super();
 		this.statusItem = this._register(
-			this.statusbarService.addEntry({
+			this._statusbarService.addEntry({
 				name: this.name,
 				text: '',
 				ariaLabel: ''
@@ -40,24 +41,24 @@ export class ConnectionStatusbarItem extends Disposable implements IWorkbenchCon
 
 		this.hide();
 
-		this._register(this.connectionManagementService.onConnect(() => this._updateStatus()));
-		this._register(this.connectionManagementService.onConnectionChanged(() => this._updateStatus()));
-		this._register(this.connectionManagementService.onDisconnect(() => this._updateStatus()));
-		this._register(this.editorService.onDidActiveEditorChange(() => this._updateStatus()));
-		this._register(this.objectExplorerService.onSelectionOrFocusChange(() => this._updateStatus()));
+		this._register(this._connectionManagementService.onConnect(() => this._updateStatus()));
+		this._register(this._connectionManagementService.onConnectionChanged(() => this._updateStatus()));
+		this._register(this._connectionManagementService.onDisconnect(() => this._updateStatus()));
+		this._register(this._editorService.onDidActiveEditorChange(() => this._updateStatus()));
+		this._register(this._objectExplorerService.onSelectionOrFocusChange(() => this._updateStatus()));
 	}
 
 	private hide() {
-		this.statusbarService.updateEntryVisibility(ConnectionStatusbarItem.ID, false);
+		this._statusbarService.updateEntryVisibility(ConnectionStatusbarItem.ID, false);
 	}
 
 	private show() {
-		this.statusbarService.updateEntryVisibility(ConnectionStatusbarItem.ID, true);
+		this._statusbarService.updateEntryVisibility(ConnectionStatusbarItem.ID, true);
 	}
 
 	// Update the connection status shown in the bar
 	private _updateStatus(): void {
-		let activeConnection = TaskUtilities.getCurrentGlobalConnection(this.objectExplorerService, this.connectionManagementService, this.editorService);
+		let activeConnection = TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._editorService, this._logService);
 		if (activeConnection) {
 			this._setConnectionText(activeConnection);
 			this.show();

--- a/src/sql/workbench/contrib/dashboard/browser/dashboardActions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboardActions.ts
@@ -21,6 +21,7 @@ import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/br
 import { IViewsService } from 'vs/workbench/common/views';
 import { ConnectionViewletPanel } from 'sql/workbench/contrib/dataExplorer/browser/connectionViewletPanel';
 import * as TaskUtilities from 'sql/workbench/browser/taskUtilities';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export const DE_MANAGE_COMMAND_ID = 'dataExplorer.manage';
 
@@ -75,7 +76,8 @@ export class OEManageConnectionAction extends Action {
 		@ICapabilitiesService protected readonly _capabilitiesService: ICapabilitiesService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IObjectExplorerService private readonly _objectExplorerService: IObjectExplorerService,
-		@IViewsService private readonly _viewsService: IViewsService
+		@IViewsService private readonly _viewsService: IViewsService,
+		@ILogService private readonly _logService: ILogService
 	) {
 		super(id, label);
 	}
@@ -106,12 +108,13 @@ export class OEManageConnectionAction extends Action {
 			}
 		}
 		else if (!actionContext) {
-			const globalProfile = TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._editorService);
+			const globalProfile = TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._editorService, this._logService);
 			connectionProfile = globalProfile ? ConnectionProfile.fromIConnectionProfile(this._capabilitiesService, globalProfile) : undefined;
 		}
 
 		if (!connectionProfile) {
 			// No valid connection (e.g. This was triggered without an active context to get the connection from) so just return early
+			this._logService.info('dashboardActions.doManage: No connection found to connect.');
 			return true;
 		}
 

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -63,7 +63,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 	public messages?: HTMLElement;
 	private _buttonSection?: HTMLElement;
 	private _treeSelectionHandler: TreeSelectionHandler;
-	private _tree?: ITree | AsyncServerTree;
+	private _tree: ITree | AsyncServerTree | undefined;
 	private _onSelectionOrFocusChange: Emitter<void>;
 	private _actionProvider: ServerTreeActionProvider;
 	private _viewKey: IContextKey<ServerTreeViewView>;
@@ -150,8 +150,12 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 		return this._actionProvider;
 	}
 
+	/**
+	 * Returns instance of server tree used by the server Tree View.
+	 * If server tree view has not yet rendered, tree instance can be undefined.
+	 */
 	public get tree(): ITree | AsyncServerTree | undefined {
-		return this._tree ?? undefined;
+		return this._tree;
 	}
 
 	/**

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
@@ -37,7 +37,7 @@ import { TestConfigurationService } from 'sql/platform/connection/test/common/te
 import { ServerTreeDataSource } from 'sql/workbench/services/objectExplorer/browser/serverTreeDataSource';
 import { Tree } from 'sql/base/parts/tree/browser/treeImpl';
 import { AsyncServerTree } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
-import { ConsoleLogger } from 'vs/platform/log/common/log';
+import { ConsoleLogger, NullLogService } from 'vs/platform/log/common/log';
 import { TestAccessibilityService } from 'vs/platform/accessibility/test/common/testAccessibilityService';
 import { TestEditorService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
@@ -208,7 +208,8 @@ suite('SQL Connection Tree Action tests', () => {
 			capabilitiesService,
 			instantiationService.object,
 			objectExplorerService.object,
-			viewsService);
+			viewsService,
+			new NullLogService());
 
 		let actionContext = new ObjectExplorerActionsContext();
 		actionContext.connectionProfile = connection;
@@ -254,7 +255,8 @@ suite('SQL Connection Tree Action tests', () => {
 			capabilitiesService,
 			instantiationService.object,
 			objectExplorerService.object,
-			undefined);
+			undefined,
+			new NullLogService());
 
 		let actionContext = new ObjectExplorerActionsContext();
 		actionContext.connectionProfile = connection.toIConnectionProfile();

--- a/src/sql/workbench/contrib/profiler/browser/profilerActions.contribution.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerActions.contribution.ts
@@ -20,6 +20,7 @@ import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/br
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IFileService } from 'vs/platform/files/common/files';
+import { ILogService } from 'vs/platform/log/common/log';
 
 CommandsRegistry.registerCommand({
 	id: 'profiler.newProfiler',
@@ -31,6 +32,7 @@ CommandsRegistry.registerCommand({
 		let objectExplorerService: IObjectExplorerService = accessor.get(IObjectExplorerService);
 		let connectionDialogService: IConnectionDialogService = accessor.get(IConnectionDialogService);
 		let capabilitiesService: ICapabilitiesService = accessor.get(ICapabilitiesService);
+		let logService: ILogService = accessor.get(ILogService);
 
 		// If a context is available if invoked from the context menu, we will use the connection profiler of the server node
 		if (args[0]?.connectionProfile) {
@@ -42,7 +44,7 @@ CommandsRegistry.registerCommand({
 		}
 		else {
 			// No context available, we will try to get the current global active connection
-			connectionProfile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionService, editorService) as ConnectionProfile;
+			connectionProfile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionService, editorService, logService) as ConnectionProfile;
 		}
 
 		let promise;
@@ -57,7 +59,7 @@ CommandsRegistry.registerCommand({
 
 		return promise.then(() => {
 			if (!connectionProfile) {
-				connectionProfile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionService, editorService) as ConnectionProfile;
+				connectionProfile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionService, editorService, logService) as ConnectionProfile;
 			}
 
 			if (connectionProfile && connectionProfile.providerName === mssqlProviderName) {

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -117,8 +117,10 @@ export async function openNewQuery(accessor: ServicesAccessor, profile?: IConnec
 	const queryEditorService = accessor.get(IQueryEditorService);
 	const objectExplorerService = accessor.get(IObjectExplorerService);
 	const connectionManagementService = accessor.get(IConnectionManagementService);
+	const logService = accessor.get(ILogService);
 	if (!profile) {
-		profile = getCurrentGlobalConnection(objectExplorerService, connectionManagementService, editorService);
+		logService.trace('openNewQuery: Profile not received, retrieving current global connection.');
+		profile = getCurrentGlobalConnection(objectExplorerService, connectionManagementService, editorService, logService);
 	}
 	const editorInput = await queryEditorService.newSqlEditor({ initialContent: initialContent }, profile?.providerName);
 	// Connect our editor to the input connection
@@ -131,6 +133,8 @@ export async function openNewQuery(accessor: ServicesAccessor, profile?: IConnec
 	};
 	if (profile) {
 		await connectionManagementService.connect(profile, editorInput.uri, options);
+	} else {
+		logService.trace('queryActions.openNewQuery: No connection profile found to connect.');
 	}
 }
 

--- a/src/sql/workbench/contrib/restore/browser/restoreActions.ts
+++ b/src/sql/workbench/contrib/restore/browser/restoreActions.ts
@@ -18,6 +18,7 @@ import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { CONFIG_WORKBENCH_ENABLEPREVIEWFEATURES } from 'sql/workbench/common/constants';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export function showRestore(accessor: ServicesAccessor, connection: IConnectionProfile): Promise<void> {
 	const restoreDialogService = accessor.get(IRestoreDialogController);
@@ -56,7 +57,8 @@ export class RestoreAction extends Task {
 		if (!profile) {
 			const objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
 			const workbenchEditorService = accessor.get<IEditorService>(IEditorService);
-			profile = getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService);
+			const logService = accessor.get<ILogService>(ILogService);
+			profile = getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService, logService);
 		}
 		if (profile) {
 			const serverInfo = connectionManagementService.getServerInfo(profile.id);

--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTree.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTree.ts
@@ -134,15 +134,15 @@ export class AsyncServerTree extends WorkbenchAsyncDataTree<ConnectionProfileGro
 		this.getDataNode(element).stale = true;
 	}
 
-	public async revealSelectFocusElement(element: ServerTreeElement) {
+	public revealSelectFocusElement(element: ServerTreeElement) {
 		const dataNode = this.getDataNode(element);
 		// The root of the tree is a special case as it is not rendered
 		// so we instead reveal select and focus on the first child of the root.
 		if (dataNode === this.root) {
 			element = dataNode.children[0].element;
 		}
-		await this.reveal(element);
-		await this.setSelection([element]);
+		this.reveal(element);
+		this.setSelection([element]);
 		this.setFocus([element]);
 	}
 }

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -825,7 +825,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 	 * or undefined if there are multiple selections or no such connection
 	 */
 	public getSelectedProfileAndDatabase(): { profile?: ConnectionProfile, databaseName?: string } | undefined {
-		if (!this._serverTreeView) {
+		if (!this._serverTreeView || !this._serverTreeView.tree) {
 			return undefined;
 		}
 		let selection = this._serverTreeView.getSelection();

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -829,7 +829,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 			return undefined;
 		}
 		let selection = this._serverTreeView.getSelection();
-		if (selection.length === 1) {
+		if (selection?.length === 1) {
 			let selectedNode = selection[0];
 			if (selectedNode instanceof ConnectionProfile) {
 				return { profile: selectedNode, databaseName: undefined };

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
@@ -72,7 +72,7 @@ export class ServerTreeActionProvider {
 	/**
 	 * Get the default action for the given element.
 	 */
-	public getDefaultAction(tree: AsyncServerTree | ITree, element: ServerTreeElement): IAction | undefined {
+	public getDefaultAction(tree: AsyncServerTree | ITree | undefined, element: ServerTreeElement): IAction | undefined {
 		if (tree) {
 			const actions = this.getActions(tree, element).filter(a => {
 				return a instanceof MenuItemAction && a.isDefault;

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
@@ -51,7 +51,7 @@ export class ServerTreeActionProvider {
 	 */
 	public getActions(tree: AsyncServerTree | ITree, element: ServerTreeElement, inlineOnly: boolean = false): IAction[] {
 		if (element instanceof ConnectionProfile) {
-			return this.getConnectionActions(tree, element, inlineOnly);
+			return tree ? this.getConnectionActions(tree, element, inlineOnly) : [];
 		}
 		if (element instanceof ConnectionProfileGroup) {
 			return this.getConnectionProfileGroupActions(element);
@@ -59,11 +59,11 @@ export class ServerTreeActionProvider {
 		if (element instanceof TreeNode) {
 			const profile = element.getConnectionProfile();
 			if (profile) {
-				return this.getObjectExplorerNodeActions({
+				return tree ? this.getObjectExplorerNodeActions({
 					tree: tree,
 					profile,
 					treeNode: element
-				}, inlineOnly);
+				}, inlineOnly) : [];
 			}
 		}
 		return [];
@@ -73,25 +73,26 @@ export class ServerTreeActionProvider {
 	 * Get the default action for the given element.
 	 */
 	public getDefaultAction(tree: AsyncServerTree | ITree, element: ServerTreeElement): IAction | undefined {
-		const actions = this.getActions(tree, element).filter(a => {
-			return a instanceof MenuItemAction && a.isDefault;
-		});
-		if (actions.length === 1) {
-			return actions[0];
-		} else if (actions.length > 1) {
-			let nodeName: string;
-			if (element instanceof ConnectionProfile) {
-				nodeName = element.serverName;
-			} else if (element instanceof ConnectionProfileGroup) {
-				nodeName = element.name;
-			} else {
-				nodeName = element.label;
+		if (tree) {
+			const actions = this.getActions(tree, element).filter(a => {
+				return a instanceof MenuItemAction && a.isDefault;
+			});
+			if (actions.length === 1) {
+				return actions[0];
+			} else if (actions.length > 1) {
+				let nodeName: string;
+				if (element instanceof ConnectionProfile) {
+					nodeName = element.serverName;
+				} else if (element instanceof ConnectionProfileGroup) {
+					nodeName = element.name;
+				} else {
+					nodeName = element.label;
+				}
+				this._logService.error(`Multiple default actions defined for node: ${nodeName}, actions: ${actions.map(a => a.id).join(', ')}`);
 			}
-			this._logService.error(`Multiple default actions defined for node: ${nodeName}, actions: ${actions.map(a => a.id).join(', ')}`);
 		}
 		return undefined;
 	}
-
 
 	public getRecentConnectionActions(element: ConnectionProfile): IAction[] {
 		return [

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
@@ -49,7 +49,7 @@ export class ServerTreeActionProvider {
 	/**
 	 * Return actions given an element in the tree
 	 */
-	public getActions(tree: AsyncServerTree | ITree, element: ServerTreeElement, inlineOnly: boolean = false): IAction[] {
+	public getActions(tree: AsyncServerTree | ITree | undefined, element: ServerTreeElement, inlineOnly: boolean = false): IAction[] {
 		if (element instanceof ConnectionProfile) {
 			return tree ? this.getConnectionActions(tree, element, inlineOnly) : [];
 		}
@@ -104,7 +104,7 @@ export class ServerTreeActionProvider {
 	/**
 	 * Return actions for connection elements
 	 */
-	private getConnectionActions(tree: AsyncServerTree | ITree, profile: ConnectionProfile, inlineOnly: boolean = false): IAction[] {
+	private getConnectionActions(tree: AsyncServerTree | ITree | undefined, profile: ConnectionProfile, inlineOnly: boolean = false): IAction[] {
 		let node = new TreeNode(NodeType.Server, NodeType.Server, '', false, '', '', '', '', undefined, undefined, undefined, undefined);
 		// Only update password and not access tokens to avoid login prompts when opening context menu.
 		this._connectionManagementService.addSavedPassword(profile, true);
@@ -273,7 +273,7 @@ export class ServerTreeActionProvider {
 }
 
 interface ObjectExplorerContext {
-	tree: AsyncServerTree | ITree;
+	tree: AsyncServerTree | ITree | undefined;
 	profile: ConnectionProfile;
 	treeNode?: TreeNode;
 }

--- a/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeUpdateUtils.ts
@@ -110,10 +110,10 @@ export class TreeUpdateUtils {
 			let selectedElement: any = elementToSelect;
 			let targetsToExpand: any[];
 
-			// Focus
-			tree.domFocus();
-
 			if (tree) {
+				// Focus
+				tree.domFocus();
+
 				let selection = tree.getSelection();
 				if (!selectedElement) {
 					if (selection && selection.length === 1) {
@@ -124,25 +124,25 @@ export class TreeUpdateUtils {
 				if (selectedElement && targetsToExpand.indexOf(selectedElement) === -1) {
 					targetsToExpand.push(selectedElement);
 				}
-			}
 
-			let treeInput = TreeUpdateUtils.getTreeInput(connectionManagementService);
-			if (treeInput) {
-				const originalInput = tree.getInput();
-				if (treeInput !== originalInput) {
-					return tree.setInput(treeInput).then(async () => {
-						if (originalInput && isDisposable(originalInput)) {
-							originalInput.dispose();
-						}
-						// Make sure to expand all folders that where expanded in the previous session
-						if (targetsToExpand) {
-							await tree.expandAll(targetsToExpand);
-						}
-						if (selectedElement) {
-							tree.setFocus(selectedElement);
-						}
-						tree.getFocus();
-					}, onUnexpectedError);
+				let treeInput = TreeUpdateUtils.getTreeInput(connectionManagementService);
+				if (treeInput) {
+					const originalInput = tree.getInput();
+					if (treeInput !== originalInput) {
+						return tree.setInput(treeInput).then(async () => {
+							if (originalInput && isDisposable(originalInput)) {
+								originalInput.dispose();
+							}
+							// Make sure to expand all folders that where expanded in the previous session
+							if (targetsToExpand) {
+								await tree.expandAll(targetsToExpand);
+							}
+							if (selectedElement) {
+								tree.setFocus(selectedElement);
+							}
+							tree.getFocus();
+						}, onUnexpectedError);
+					}
 				}
 			}
 		}

--- a/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/objectExplorerService.test.ts
@@ -452,7 +452,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile if it is selected', () => {
-		const serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as IServerTreeView);
+		const serverTreeView = TypeMoq.Mock.ofInstance({ tree: TypeMoq.It.isAny(), getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as IServerTreeView);
 		serverTreeView.setup(x => x.getSelection()).returns(() => [connection]);
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 
@@ -462,7 +462,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile but no database if children of a server are selected', () => {
-		const serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as IServerTreeView);
+		const serverTreeView = TypeMoq.Mock.ofInstance({ tree: TypeMoq.It.isAny(), getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as IServerTreeView);
 		const databaseNode = new TreeNode(NodeType.Folder, '', 'Folder1', false, 'testServerName/Folder1', 'testServerName', '', '', undefined, undefined, undefined, undefined);
 		databaseNode.connection = connection;
 		serverTreeView.setup(x => x.getSelection()).returns(() => [databaseNode]);
@@ -474,7 +474,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile and database if children of a database node are selected', () => {
-		const serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as IServerTreeView);
+		const serverTreeView = TypeMoq.Mock.ofInstance({ tree: TypeMoq.It.isAny(), getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as IServerTreeView);
 		const databaseMetadata = {
 			metadataType: 0,
 			metadataTypeName: 'Database',
@@ -498,7 +498,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('getSelectedProfileAndDatabase returns undefined when there is no selection', () => {
-		const serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as IServerTreeView);
+		const serverTreeView = TypeMoq.Mock.ofInstance({ tree: TypeMoq.It.isAny(), getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as IServerTreeView);
 		serverTreeView.setup(x => x.getSelection()).returns(() => []);
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 

--- a/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
@@ -24,6 +24,7 @@ import { getCurrentGlobalConnection } from 'sql/workbench/browser/taskUtilities'
 import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
+import { ILogService } from 'vs/platform/log/common/log';
 
 const defaults: INewSqlEditorOptions = {
 	open: true
@@ -42,7 +43,8 @@ export class QueryEditorService implements IQueryEditorService {
 		@IEditorService private _editorService: IEditorService,
 		@IConfigurationService private _configurationService: IConfigurationService,
 		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
-		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService
+		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService,
+		@ILogService private _logService: ILogService
 	) {
 	}
 
@@ -73,7 +75,8 @@ export class QueryEditorService implements IQueryEditorService {
 		// If we're told to connect then get the connection before opening the editor since it will try to get the connection for the current
 		// active editor and so we need to get this before opening a new one.
 		if (options.connectWithGlobal) {
-			profile = getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._editorService);
+			this._logService.trace('queryEditorService.newSqlEditor: Fetching global connection profile for connection.');
+			profile = getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._editorService, this._logService);
 		}
 		if (options.open) {
 			await this._editorService.openEditor(queryInput, { pinned: true });
@@ -87,6 +90,8 @@ export class QueryEditorService implements IQueryEditorService {
 				showFirewallRuleOnError: true
 			};
 			this._connectionManagementService.connect(profile, queryInput.uri, options).catch(err => onUnexpectedError(err));
+		} else {
+			this._logService.trace('queryEditorService.newSqlEditor: No connection profile used to connect to SQL editor');
 		}
 		return queryInput;
 	}

--- a/src/sql/workbench/test/browser/taskUtilities.test.ts
+++ b/src/sql/workbench/test/browser/taskUtilities.test.ts
@@ -12,6 +12,7 @@ import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { TestEditorInput, TestEditorService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { URI } from 'vs/base/common/uri';
+import { NullLogService } from 'vs/platform/log/common/log';
 
 suite('TaskUtilities', function () {
 	test('getCurrentGlobalConnection returns the selected OE server if a server or one of its children is selected', () => {
@@ -27,7 +28,7 @@ suite('TaskUtilities', function () {
 		mockConnectionManagementService.setup(x => x.isProfileConnected(TypeMoq.It.is(profile => profile === expectedProfile))).returns(() => true);
 
 		// If I call getCurrentGlobalConnection, it should return the expected server profile
-		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
+		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object, new NullLogService());
 		assert.strictEqual(actualProfile, expectedProfile);
 	});
 
@@ -45,7 +46,7 @@ suite('TaskUtilities', function () {
 		mockConnectionManagementService.setup(x => x.isProfileConnected(TypeMoq.It.is(profile => profile === serverProfile))).returns(() => true);
 
 		// If I call getCurrentGlobalConnection, it should return the expected database profile
-		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
+		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object, new NullLogService());
 		assert.strictEqual(actualProfile.databaseName, dbName);
 		assert.notStrictEqual(actualProfile.id, serverProfile.id);
 		// Other connection attributes still match
@@ -77,7 +78,7 @@ suite('TaskUtilities', function () {
 		mockConnectionManagementService.setup(x => x.getConnectionProfile(tabConnectionUri.toString(true))).returns(() => tabProfile);
 
 		// If I call getCurrentGlobalConnection, it should return the expected profile from the active tab
-		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
+		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object, new NullLogService());
 		assert.strictEqual(actualProfile.databaseName, connectionProfile2.databaseName);
 		assert.strictEqual(actualProfile.authenticationType, connectionProfile2.authenticationType);
 		assert.strictEqual(actualProfile.password, connectionProfile2.password);
@@ -98,7 +99,7 @@ suite('TaskUtilities', function () {
 		mockConnectionManagementService.setup(x => x.isProfileConnected(TypeMoq.It.is(profile => profile === oeProfile))).returns(() => true);
 
 		// If I call getCurrentGlobalConnection, it should return the expected profile from OE
-		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object);
+		let actualProfile = TaskUtilities.getCurrentGlobalConnection(mockObjectExplorerService.object, mockConnectionManagementService.object, mockWorkbenchEditorService.object, new NullLogService());
 		assert.strictEqual(actualProfile, oeProfile);
 	});
 });


### PR DESCRIPTION
There are multiple reports of serverTreeView initialization errors where users are not able to open SQL files in Query Editor, and it's not readily reproducible in all environments. This is likely related with calls to get global connection, where async server tree being unrendered is causing issues. 

This PR improves null reference handling to prevent NRE exceptions like below:

```
2023-10-24 19:12:16.516 [error] Cannot read properties of undefined (reading 'style'): TypeError: Cannot read properties of undefined (reading 'style')
    at Ne (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:194:43234)
    at e.ServerTreeView.refreshTree (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:2625:42509)
    at e.ServerTreeView.handleOnCapabilitiesRegistered (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:2625:32249)
```

```
2023-10-24 19:13:01.738 [error] Cannot read properties of undefined (reading 'getSelection'): TypeError: Cannot read properties of undefined (reading 'getSelection')
    at e.ServerTreeView.getSelection (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:2625:46292)
    at e.ObjectExplorerService.getSelectedProfileAndDatabase (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:919:3159)
    at y (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:1525:93983)
    at e.QueryEditorLanguageAssociation.connectInput (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:2828:10755)
    at e.QueryEditorLanguageAssociation.syncConvertInput (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:2828:10615)
```

```
2023-10-24 19:15:42.644 [error] Cannot read properties of undefined (reading 'getSelection'): TypeError: Cannot read properties of undefined (reading 'getSelection')
    at e.ServerTreeView.getSelection (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:2625:46292)
    at e.ObjectExplorerService.getSelectedProfileAndDatabase (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:919:3159)
    at Object.y [as getCurrentGlobalConnection] (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:1525:93983)
    at ps._updateStatus (vscode-file://vscode-app/c:/Users/HendrikPetzer/AppData/Local/Programs/Azure%20Data%20Studio/resources/app/out/vs/workbench/workbench.desktop.main.js:2588:22600)
```
Should help in investigating issues:
https://github.com/microsoft/azuredatastudio/issues/24762
https://github.com/microsoft/azuredatastudio/issues/24058