### PR TITLE
Downgrade MSAL to 1.16.0 to resolve potential proxy auth issues

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -506,8 +506,8 @@
   "dependencies": {
     "@azure/arm-resourcegraph": "^4.2.1",
     "@azure/arm-subscriptions": "^3.0.0",
-    "@azure/msal-common": "14.1.0",
-    "@azure/msal-node": "2.2.0",
+    "@azure/msal-common": "11.0.0",
+    "@azure/msal-node": "1.16.0",
     "@azure/ms-rest-js": "^2.2.0",
     "@azure/storage-blob": "^12.13.0",
     "axios": "^1.5.0",

--- a/extensions/azurecore/yarn.lock
+++ b/extensions/azurecore/yarn.lock
@@ -128,17 +128,17 @@
     uuid "^8.3.2"
     xml2js "^0.5.0"
 
-"@azure/msal-common@14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-14.1.0.tgz#b3a1de13dddd0eb86b1c6a7ef052a87d3ce941b7"
-  integrity sha512-xphmhcfl5VL+uq5//VKMwQn+wfEZLMKNpFCcMi8Ur8ej5UT166g6chBsxgMzc9xo9Y24R9FB3m/tjDiV03xMIA==
+"@azure/msal-common@11.0.0", "@azure/msal-common@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-11.0.0.tgz#d35bfa6cdd2a5b8c036ce427aa3fd36f8f985239"
+  integrity sha512-SZH8ObQ3Hq5v3ogVGBYJp1nNW7p+MtM4PH4wfNadBP9wf7K0beQHF9iOtRcjPOkwZf+ZD49oXqw91LndIkdk8g==
 
-"@azure/msal-node@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-2.2.0.tgz#5d0164d31797a55087793385271189a82c72d751"
-  integrity sha512-aZZ1m7OATOR9kz7+/Kl+/LZrNEj+HYaEH84XZfnBtN/9JPRazngk1XTjvAkh7W1u/O/yQrlYiiSwSAKHnNBc8A==
+"@azure/msal-node@1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.16.0.tgz#0bd469916f5a9da22d844edc879ac7e8225c0ccb"
+  integrity sha512-eGXPp65i++mAIvziafbCH970TCeECB6iaQP7aRzZEjtU238cW4zKm40U8YxkiCn9rR1G2VeMHENB5h6WRk7ZCQ==
   dependencies:
-    "@azure/msal-common" "14.1.0"
+    "@azure/msal-common" "^11.0.0"
     jsonwebtoken "^9.0.0"
     uuid "^8.3.0"
 


### PR DESCRIPTION
Internally found: The latest update of MSAL 2.2.0 led to non-returning login redirect. The redirection to `login.microsoftonline.com` after proxy authentication would not complete, which had worked in the past in the same proxy-enabled environment.