### PR TITLE
Change showOnStartUp default to 'none' when welcome page is not shown on startup

### DIFF
--- a/src/sql/workbench/contrib/welcome/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/browser/welcomePage.ts
@@ -289,7 +289,7 @@ class WelcomePage extends Disposable {
 		}
 
 		showOnStartup.addEventListener('click', e => {
-			this.configurationService.updateValue(configurationKey, showOnStartup.checked ? 'welcomePageWithTour' : 'newUntitledFile', ConfigurationTarget.USER);
+			this.configurationService.updateValue(configurationKey, showOnStartup.checked ? 'welcomePageWithTour' : 'none', ConfigurationTarget.USER);
 		});
 		const prodName = container.querySelector('.welcomePage .title .caption') as HTMLElement;
 		if (prodName) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/azuredatastudio/issues/24085. With this change, when someone unselects the `Show welcome page on startup` checkbox on the welcome page, their `workbench.startupEditor` setting will get set to `none` instead of `newUntitledFile`. Users who have already unselected `Show welcome page on startup` will have to update this setting themselves in their user settings.

The vscode welcome page also sets the configuration value to `none`, not `newUntitledFile` when the  checkbox is unchecked, so it makes sense to have the same default behavior in ADS. https://github.com/microsoft/azuredatastudio/blob/3d1e81d12e00e928554a603989202540673af785/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts#L762-L771