### PR TITLE
Include VS Code version missing in About dialog

### DIFF
--- a/src/sql/base/common/locConstants.ts
+++ b/src/sql/base/common/locConstants.ts
@@ -108,16 +108,16 @@ export function getNewThemeNotification(label: string): string {
 
 export function aboutDetail(productVersion: string, commit: string, date: string, electronVersion: string, chromeVersion: string, nodeVersion: string, v8: string, osProps: string, vscodeVersion: string): string {
 	return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
-		"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nChromium: {4}\nNode.js: {5}\nV8: {6}\nOS: {7}",
+		"Version: {0}\nCommit: {1}\nDate: {2}\nVS Code: {3}\nElectron: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
 		productVersion,
 		commit,
 		date,
+		vscodeVersion,
 		electronVersion,
 		chromeVersion,
 		nodeVersion,
 		v8,
-		osProps,
-		vscodeVersion
+		osProps
 	);
 }
 


### PR DESCRIPTION
Before:
<img src="https://github.com/microsoft/azuredatastudio/assets/13396919/25884d70-97b5-48cb-9a98-bd0b633a713b" width=500 />

After:
<img src="https://github.com/microsoft/azuredatastudio/assets/13396919/be0f3aec-051d-4c95-9ac5-561ae8bfed14" width=500 />