### PR TITLE
Bring back vscode-encrypt

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -138,6 +138,15 @@ vsda/SECURITY.md
 vsda/targets
 !vsda/build/Release/vsda.node
 
+# {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+vscode-encrypt/build/**
+vscode-encrypt/src/**
+vscode-encrypt/vendor/**
+vscode-encrypt/.gitignore
+vscode-encrypt/binding.gyp
+vscode-encrypt/README.md
+!vscode-encrypt/build/Release/vscode-encrypt-native.node
+
 @vscode/policy-watcher/build/**
 @vscode/policy-watcher/.husky/**
 @vscode/policy-watcher/src/**

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -949,7 +949,7 @@ export class CodeApplication extends Disposable {
 		services.set(IIssueMainService, new SyncDescriptor(IssueMainService, [this.userEnv]));
 
 		// Encryption
-		services.set(IEncryptionMainService, new SyncDescriptor(EncryptionMainService, [machineId])); // {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+		services.set(IEncryptionMainService, new SyncDescriptor(EncryptionMainService, [machineId])); // {{SQL CARBON EDIT}} Remove vscode-encrypt in a post-1.47 release https://github.com/microsoft/azuredatastudio/issues/24737
 
 		// Keyboard Layout
 		services.set(IKeyboardLayoutMainService, new SyncDescriptor(KeyboardLayoutMainService));

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -949,7 +949,7 @@ export class CodeApplication extends Disposable {
 		services.set(IIssueMainService, new SyncDescriptor(IssueMainService, [this.userEnv]));
 
 		// Encryption
-		services.set(IEncryptionMainService, new SyncDescriptor(EncryptionMainService));
+		services.set(IEncryptionMainService, new SyncDescriptor(EncryptionMainService, [machineId])); // {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
 
 		// Keyboard Layout
 		services.set(IKeyboardLayoutMainService, new SyncDescriptor(KeyboardLayoutMainService));

--- a/src/vs/platform/encryption/electron-main/encryptionMainService.ts
+++ b/src/vs/platform/encryption/electron-main/encryptionMainService.ts
@@ -21,7 +21,7 @@ export class EncryptionMainService implements IEncryptionMainService {
 	_serviceBrand: undefined;
 
 	constructor(
-		private readonly machineId: string, // {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+		private readonly machineId: string, // {{SQL CARBON EDIT}} Remove vscode-encrypt in a post-1.47 release https://github.com/microsoft/azuredatastudio/issues/24737
 		@ILogService private readonly logService: ILogService
 	) {
 		// if this commandLine switch is set, the user has opted in to using basic text encryption
@@ -44,7 +44,7 @@ export class EncryptionMainService implements IEncryptionMainService {
 
 	async decrypt(value: string): Promise<string> {
 		let parsedValue: { data: string };
-		// {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+		// {{SQL CARBON EDIT}} Remove vscode-encrypt in a post-1.47 release https://github.com/microsoft/azuredatastudio/issues/24737
 		try {
 			parsedValue = JSON.parse(value);
 			if (!parsedValue.data) {
@@ -106,7 +106,7 @@ export class EncryptionMainService implements IEncryptionMainService {
 		safeStorage.setUsePlainTextEncryption(true);
 	}
 
-	// {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+	// {{SQL CARBON EDIT}} Remove vscode-encrypt in a post-1.47 release https://github.com/microsoft/azuredatastudio/issues/24737
 	private async oldDecrypt(value: string): Promise<string> {
 		let encryption: { decrypt(salt: string, value: string): Promise<string> };
 		try {

--- a/src/vs/platform/encryption/node/encryptionMainService.ts
+++ b/src/vs/platform/encryption/node/encryptionMainService.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ICommonEncryptionService } from 'vs/platform/encryption/common/encryptionService';
+import { ILogService } from 'vs/platform/log/common/log';
+
+// {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+
+export interface Encryption {
+	encrypt(salt: string, value: string): Promise<string>;
+	decrypt(salt: string, value: string): Promise<string>;
+}
+export class EncryptionMainService implements ICommonEncryptionService {
+	declare readonly _serviceBrand: undefined;
+	constructor(
+		private machineId: string,
+		@ILogService private readonly logService: ILogService
+	) { }
+
+	private encryption(): Promise<Encryption> {
+		return new Promise((resolve, reject) => require(['vscode-encrypt'], resolve, reject));
+	}
+
+	async encrypt(value: string): Promise<string> {
+		let encryption: Encryption;
+		try {
+			encryption = await this.encryption();
+		} catch (e) {
+			return value;
+		}
+
+		try {
+			return encryption.encrypt(this.machineId, value);
+		} catch (e) {
+			this.logService.error(e);
+			return value;
+		}
+	}
+
+	async decrypt(value: string): Promise<string> {
+		let encryption: Encryption;
+		try {
+			encryption = await this.encryption();
+		} catch (e) {
+			return value;
+		}
+
+		try {
+			return encryption.decrypt(this.machineId, value);
+		} catch (e) {
+			this.logService.error(e);
+			return value;
+		}
+	}
+
+	async isEncryptionAvailable(): Promise<boolean> {
+		try {
+			await this.encryption();
+			return true;
+		} catch (e) {
+			return false;
+		}
+	}
+}

--- a/src/vs/platform/encryption/node/encryptionMainService.ts
+++ b/src/vs/platform/encryption/node/encryptionMainService.ts
@@ -6,7 +6,7 @@
 import { ICommonEncryptionService } from 'vs/platform/encryption/common/encryptionService';
 import { ILogService } from 'vs/platform/log/common/log';
 
-// {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+// {{SQL CARBON EDIT}} Remove vscode-encrypt in a post-1.47 release https://github.com/microsoft/azuredatastudio/issues/24737
 
 export interface Encryption {
 	encrypt(salt: string, value: string): Promise<string>;

--- a/src/vs/platform/environment/test/node/nativeModules.integrationTest.ts
+++ b/src/vs/platform/environment/test/node/nativeModules.integrationTest.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import { isLinux, isWindows } from 'vs/base/common/platform';
 import { flakySuite } from 'vs/base/test/common/testUtils';
+import { Encryption } from 'vs/platform/encryption/node/encryptionMainService'; // {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
 
 function testErrorMessage(module: string): string {
 	return `Unable to load "${module}" dependency. It was probably not compiled for the right operating system architecture or had missing build tools.`;
@@ -58,6 +59,22 @@ flakySuite('Native Modules (all platforms)', () => {
 	test('@vscode/sqlite3', async () => {
 		const sqlite3 = await import('@vscode/sqlite3');
 		assert.ok(typeof sqlite3.Database === 'function', testErrorMessage('@vscode/sqlite3'));
+	});
+
+	// {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+	test('vscode-encrypt', async () => {
+		try {
+			const vscodeEncrypt: Encryption = globalThis._VSCODE_NODE_MODULES['vscode-encrypt'];
+			const encrypted = await vscodeEncrypt.encrypt('salt', 'value');
+			const decrypted = await vscodeEncrypt.decrypt('salt', encrypted);
+
+			assert.ok(typeof encrypted === 'string', testErrorMessage('vscode-encrypt'));
+			assert.ok(typeof decrypted === 'string', testErrorMessage('vscode-encrypt'));
+		} catch (error) {
+			if (error.code !== 'MODULE_NOT_FOUND') {
+				throw error;
+			}
+		}
 	});
 
 	test('vsda', async () => {

--- a/src/vs/platform/environment/test/node/nativeModules.integrationTest.ts
+++ b/src/vs/platform/environment/test/node/nativeModules.integrationTest.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { isLinux, isWindows } from 'vs/base/common/platform';
 import { flakySuite } from 'vs/base/test/common/testUtils';
-import { Encryption } from 'vs/platform/encryption/node/encryptionMainService'; // {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+import { Encryption } from 'vs/platform/encryption/node/encryptionMainService'; // {{SQL CARBON EDIT}} Remove vscode-encrypt in a post-1.47 release https://github.com/microsoft/azuredatastudio/issues/24737
 
 function testErrorMessage(module: string): string {
 	return `Unable to load "${module}" dependency. It was probably not compiled for the right operating system architecture or had missing build tools.`;
@@ -61,7 +61,7 @@ flakySuite('Native Modules (all platforms)', () => {
 		assert.ok(typeof sqlite3.Database === 'function', testErrorMessage('@vscode/sqlite3'));
 	});
 
-	// {{SQL CARBON EDIT}} Remove vscode-encrypt after 1.47 release
+	// {{SQL CARBON EDIT}} Remove vscode-encrypt in a post-1.47 release https://github.com/microsoft/azuredatastudio/issues/24737
 	test('vscode-encrypt', async () => {
 		try {
 			const vscodeEncrypt: Encryption = globalThis._VSCODE_NODE_MODULES['vscode-encrypt'];


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24737

VS Code has gone through significant changes to move away from keytar and a customized encryption module (vscode-encrypt) in the past few releases. The changes aren't compatible, although VS Code did have a migration story where they migrated over secrets from the old store & format into the new storage & format. 

More details about this here : https://github.com/microsoft/vscode/issues/193301

The specific part that's impacting us and caused the decryption issue is that we completed skipped over the migration of the storage format (how they're encrypted) by jumping from 1.79 to 1.82. Specifically this PR where the migration code was removed : https://github.com/microsoft/vscode/pull/189252

Because of this when the secret storage tried to load the secrets it fetched them fine, but they were encrypted with the old vscode-encrypt library and so the new encryption library wasn't able to decrypt them.

The fix here is to temporarily bring this code back for this release, and then we should be fine to remove it in the next release. Assuming that everyone is fine with this plan then I'll create a tracking issue for the next milestone to ensure we get that done.