### PR TITLE
Update distro - Remove SQL Migration builtin extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.47.0",
-  "distro": "d146f84ae415cdb64ed001d44e33729a1ca79b4c",
+  "distro": "1191208e29312888ade92e7ae216abf0b02975b7",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The AGC team decided they didn't want the migration extension for now because it doesn't work in a disconnected environment since it needs to install STS separately, they want to plan on adding it back at a later time.

To be merged after ADS-release PR is merged.