### PR TITLE
Partially revert URL support for backup and restore dialogs.

### DIFF
--- a/src/sql/workbench/contrib/backup/browser/backup.component.ts
+++ b/src/sql/workbench/contrib/backup/browser/backup.component.ts
@@ -528,7 +528,7 @@ export class BackupComponent extends AngularDisposable {
 			this.recoveryBox!.disable();
 			this.mediaNameBox!.disable();
 			this.mediaDescriptionBox!.disable();
-			if (this._engineEdition !== DatabaseEngineEdition.SqlDataWarehouse && this._engineEdition !== DatabaseEngineEdition.SqlOnDemand) {
+			if (this._engineEdition === DatabaseEngineEdition.SqlManagedInstance) {
 				this.toUrlCheckBox.checked = true;
 				this.copyOnlyCheckBox.checked = true;
 				this.backupTypeSelectBox!.disable();

--- a/src/sql/workbench/services/restore/browser/restoreDialog.ts
+++ b/src/sql/workbench/services/restore/browser/restoreDialog.ts
@@ -618,7 +618,7 @@ export class RestoreDialog extends Modal {
 
 	public enableRestoreButton(enabled: boolean): void {
 		this.spinner = false;
-		if (this._engineEdition !== DatabaseEngineEdition.SqlDataWarehouse && this._engineEdition !== DatabaseEngineEdition.SqlOnDemand && this.viewModel.databases.includes(this._targetDatabaseInputBox.value)) {
+		if (this._engineEdition === DatabaseEngineEdition.SqlManagedInstance && this.viewModel.databases.includes(this._targetDatabaseInputBox.value)) {
 			this._restoreButton!.enabled = false;
 			this._scriptButton!.enabled = false;
 		}
@@ -888,7 +888,7 @@ export class RestoreDialog extends Modal {
 		this._urlInputBox.value = '';
 		this._targetDatabaseInputBox.value = '';
 		let title;
-		if (this._engineEdition !== DatabaseEngineEdition.SqlDataWarehouse && this._engineEdition !== DatabaseEngineEdition.SqlOnDemand) {
+		if (this._engineEdition === DatabaseEngineEdition.SqlManagedInstance) {
 			this._restoreFromSelectBox.setOptions([this._urlTitle]);
 			title = this._urlTitle;
 			// to fetch databases


### PR DESCRIPTION
Reverts some of the changes from this commit: https://github.com/microsoft/azuredatastudio/commit/1e51c573504267b167cab05281230d4bc19bdff3

The backup & restore dialogs currently don't support switching between File and URL modes, so non-MI instances were being forced to use a URL-only mode.
