### PR TITLE
Adding a null check for serverInfo

### DIFF
--- a/src/sql/workbench/browser/scriptingUtils.ts
+++ b/src/sql/workbench/browser/scriptingUtils.ts
@@ -180,5 +180,5 @@ function getScriptingParamDetails(connectionService: IConnectionManagementServic
 
 function getServerInfo(connectionService: IConnectionManagementService, ownerUri: string): azdata.ServerInfo | undefined {
 	let connection: ConnectionManagementInfo = connectionService.getConnectionInfo(ownerUri);
-	return connection.serverInfo;
+	return connection?.serverInfo;
 }


### PR DESCRIPTION
May address https://github.com/microsoft/azuredatastudio/issues/21737

The root cause of why connection is not available when selecting scripting option in context menu needs to be investigated, but adding null check in the meantime to unblock code paths to proceed further.