### PR TITLE
Update MacOS ARM64 download links

### DIFF
--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -234,8 +234,8 @@ export class NativeWindow extends Disposable {
 					label: localize('downloadArmBuild', "Download"),
 					run: () => {
 						const quality = this.productService.quality;
-						const stableURL = 'https://code.visualstudio.com/docs/?dv=osx';
-						const insidersURL = 'https://code.visualstudio.com/docs/?dv=osx&build=insiders';
+						const stableURL = 'https://aka.ms/download-azure-data-studio-macos-arm64'; // {{SQL CARBON EDIT}} Use our own link
+						const insidersURL = 'https://aka.ms/download-azure-data-studio-macos-arm64-insiders'; // {{SQL CARBON EDIT}} Use our own link
 						this.openerService.open(quality === 'stable' ? stableURL : insidersURL);
 					}
 				}]


### PR DESCRIPTION
Updates the download links when the emulated version of ADS is running on ARM64 MacOS

Original PR : https://github.com/microsoft/azuredatastudio/pull/24841

For https://github.com/microsoft/azuredatastudio/issues/24840