### PR TITLE
Fixing dashboard tab loading for non activable extensions

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -535,8 +535,9 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 							}
 						})
 					});
-					// If the extension is already activated, we can resolve immediately
-					if (this.extensionService.getExtensionsStatus()[owningExtension.id]?.activationTimes?.activateResolvedTime !== undefined) {
+
+					// If the extension is already activated or has no activation events (i.e. it's already activated), we can resolve immediately
+					if (!owningExtension.activationEvents || owningExtension.activationEvents.length === 0 || this.extensionService.getExtensionsStatus()[owningExtension.id]?.activationTimes?.activateResolvedTime !== undefined) {
 						tab.loading = false;
 						resolveTab();
 					}


### PR DESCRIPTION
Issue: #24870 

The cause of this issue was that the sql-dw extension did not have any activation events or a way to get activated. The dashboard tab lazy loading code kept waiting for it to be activated indefinitely but unfortunately that was never going to happen. 

I did not know that some extensions could lack activation events. However, simply adding an activation event to the extension was not enough, because the extension did not have a main file that vscode could invoke for activation. Therefore, I added a special case in the code that checks for such extensions and always loads the tabs for them.