### PR TITLE
ExtensionContext.LogPath: Address deprecated API usage

### DIFF
--- a/extensions/azuremonitor/src/azuremonitorServer.ts
+++ b/extensions/azuremonitor/src/azuremonitorServer.ts
@@ -35,7 +35,7 @@ export class AzureMonitorServer {
 			const installationStart = Date.now();
 			const path = await this.download(context);
 			const installationComplete = Date.now();
-			let serverOptions = generateServerOptions(context.extensionContext.logPath, path);
+			let serverOptions = generateServerOptions(context.extensionContext.logUri.fsPath, path);
 			let clientOptions = getClientOptions(context);
 			this.client = new SqlOpsDataClient(Constants.serviceName, serverOptions, clientOptions);
 			const processStart = Date.now();

--- a/extensions/azuremonitor/src/main.ts
+++ b/extensions/azuremonitor/src/main.ts
@@ -33,8 +33,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	}
 
 	// ensure our log path exists
-	if (!(await Utils.exists(context.logPath))) {
-		await fs.mkdir(context.logPath);
+	if (!(await Utils.exists(context.logUri.fsPath))) {
+		await fs.mkdir(context.logUri.fsPath);
 	}
 
 	let appContext = new AppContext(context);
@@ -64,7 +64,7 @@ function registerLogCommand(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('azuremonitor.showLogFile', async () => {
 		const choice = await vscode.window.showQuickPick(logFiles);
 		if (choice) {
-			const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(context.logPath, choice)));
+			const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(context.logUri.fsPath, choice)));
 			if (document) {
 				vscode.window.showTextDocument(document);
 			}

--- a/extensions/import/src/services/serviceClient.ts
+++ b/extensions/import/src/services/serviceClient.ts
@@ -93,7 +93,7 @@ export class ServiceClient {
 	private generateServerOptions(executablePath: string, context: vscode.ExtensionContext): ServerOptions {
 		let launchArgs = [];
 		launchArgs.push('--log-dir');
-		let logFileLocation = context.logPath;
+		let logFileLocation = context.logUri.fsPath;
 		launchArgs.push(logFileLocation);
 		let config = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
 		if (config) {

--- a/extensions/kusto/src/kustoServer.ts
+++ b/extensions/kusto/src/kustoServer.ts
@@ -33,7 +33,7 @@ export class KustoServer {
 			const installationStart = Date.now();
 			const path = await this.download(context);
 			const installationComplete = Date.now();
-			let serverOptions = generateServerOptions(context.extensionContext.logPath, path);
+			let serverOptions = generateServerOptions(context.extensionContext.logUri.fsPath, path);
 			let clientOptions = getClientOptions(context);
 			this.client = new SqlOpsDataClient(Constants.serviceName, serverOptions, clientOptions); // TodoKusto: Update constant
 			const processStart = Date.now();

--- a/extensions/kusto/src/main.ts
+++ b/extensions/kusto/src/main.ts
@@ -33,8 +33,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	}
 
 	// ensure our log path exists
-	if (!(await Utils.exists(context.logPath))) {
-		await fs.mkdir(context.logPath);
+	if (!(await Utils.exists(context.logUri.fsPath))) {
+		await fs.mkdir(context.logUri.fsPath);
 	}
 
 	let appContext = new AppContext(context);
@@ -64,7 +64,7 @@ function registerLogCommand(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('kusto.showLogFile', async () => {
 		const choice = await vscode.window.showQuickPick(logFiles);
 		if (choice) {
-			const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(context.logPath, choice)));
+			const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(context.logUri.fsPath, choice)));
 			if (document) {
 				vscode.window.showTextDocument(document);
 			}

--- a/extensions/mssql/src/credentialstore/credentialstore.ts
+++ b/extensions/mssql/src/credentialstore/credentialstore.ts
@@ -30,7 +30,7 @@ export class CredentialStore {
 			this._config.executableFiles = ['MicrosoftSqlToolsCredentials.exe', 'MicrosoftSqlToolsCredentials'];
 		}
 		this.context = context;
-		this._logPath = this.context.extensionContext.logPath;
+		this._logPath = this.context.extensionContext.logUri.fsPath;
 	}
 
 	public async start(): Promise<void> {

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -43,8 +43,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	}
 
 	// ensure our log path exists
-	if (!(await Utils.exists(context.logPath))) {
-		await fs.mkdir(context.logPath);
+	if (!(await Utils.exists(context.logUri.fsPath))) {
+		await fs.mkdir(context.logUri.fsPath);
 	}
 
 	IconPathHelper.setExtensionContext(context);
@@ -197,7 +197,7 @@ function registerLogCommand(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('mssql.showLogFile', async () => {
 		const choice = await vscode.window.showQuickPick(logFiles);
 		if (choice) {
-			const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(context.logPath, choice)));
+			const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(context.logUri.fsPath, choice)));
 			if (document) {
 				void vscode.window.showTextDocument(document);
 			}

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -61,7 +61,7 @@ export class SqlToolsServer {
 			const serverPath = await this.download(context);
 			this.installDirectory = path.dirname(serverPath);
 			const installationComplete = Date.now();
-			let serverOptions = generateServerOptions(context.extensionContext.logPath, serverPath);
+			let serverOptions = generateServerOptions(context.extensionContext.logUri.fsPath, serverPath);
 			let clientOptions = getClientOptions(context);
 			this.client = new SqlOpsDataClient('mssql', Constants.serviceName, serverOptions, clientOptions);
 			const processStart = Date.now();
@@ -143,7 +143,7 @@ export class SqlToolsServer {
 
 	private activateFeatures(context: AppContext): Promise<void> {
 		const credsStore = new CredentialStore(context, this.config);
-		const resourceProvider = new AzureResourceProvider(context.extensionContext.logPath, this.config);
+		const resourceProvider = new AzureResourceProvider(context.extensionContext.logUri.fsPath, this.config);
 		this.disposables.push(credsStore);
 		this.disposables.push(resourceProvider);
 		context.registerService(Constants.AzureBlobService, new AzureBlobService(this.client));


### PR DESCRIPTION
Replacing [logPath](https://vscode-api.js.org/interfaces/vscode.ExtensionContext.html#logPath) with [logUri.fsPath](https://vscode-api.js.org/classes/vscode.Uri.html#fsPath)