### PR TITLE
Expose command to show Kusto Service log

### DIFF
--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -43,6 +43,11 @@
           "dark": "resources/dark/open_notebook_inverse.svg",
           "light": "resources/light/open_notebook.svg"
         }
+      },
+      {
+        "command": "kusto.showLogFile",
+        "category": "Kusto",
+        "title": "%title.showLogFile%"
       }
     ],
     "languages": [

--- a/extensions/kusto/package.nls.json
+++ b/extensions/kusto/package.nls.json
@@ -10,6 +10,7 @@
 	"databasesListProperties.size": "Size (MB)",
 	"objectsListProperties.name": "Name",
 	"objectsListProperties.metadataTypeName": "Type",
+	"title.showLogFile": "Show Log File",
 	"kusto.configuration.title": "KUSTO configuration",
 	"kusto.query.displayBitAsNumber": "Should BIT columns be displayed as numbers (1 or 0)? If false, BIT columns will be displayed as 'true' or 'false'",
 	"kusto.format.alignColumnDefinitionsInColumns": "Should column definitions be aligned?",


### PR DESCRIPTION
Command implementation was there, but command was not exposed in package.json
PR exposes the same, so logs can be opened in ADS itself.

![kustolog](https://github.com/microsoft/azuredatastudio/assets/13396919/1e11ab5c-dad5-4de1-9920-b646f92eaeeb)
