### PR TITLE
Fix markdown image 

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -265,7 +265,6 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 					if (originalImageName !== attachmentName) {
 						imageCalloutResult.insertEscapedMarkdown = `![${attachmentName}](attachment:${attachmentName.replace(/\s/g, '')})`;
 					}
-					await insertFormattedMarkdown(imageCalloutResult.insertEscapedMarkdown, this.getCellEditorControl());
 				}
 				await insertFormattedMarkdown(imageCalloutResult.insertEscapedMarkdown, this.getCellEditorControl());
 			}


### PR DESCRIPTION
For: https://github.com/microsoft/azuredatastudio/issues/24415
Remove extra call insertFormattedMarkdown, which is causing the duplicating issue. 
![attachedImage](https://github.com/microsoft/azuredatastudio/assets/34872381/7550cb42-59b3-41c9-8aeb-e0aa8a1cef46)
