### PR TITLE
Address issues with revert in Edit Data and also add trim to string data from cells.

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -232,10 +232,12 @@ export class EditDataGridPanel extends GridParentComponent {
 				// If a cell is not edited and retrieved direct from the SQL server, it would be in the form of a DBCellValue.
 				// We use the DBCellValue's cleaned displayValue as the text value.
 				returnVal = this.replaceLinebreaks(value.displayValue);
+				returnVal = returnVal.trim();
 			}
 			else if (typeof value === 'string') {
 				// Once a cell has been edited, the cell value will no longer be a DBCellValue until refresh.
 				returnVal = this.replaceLinebreaks(value);
+				returnVal = returnVal.trim();
 			}
 			return returnVal;
 		};


### PR DESCRIPTION
This is to fix an issue with edit data upon revert for an invalid edit causing the current Cell to become reset when it should only be done for manual revert. (This results in additional edits after the revert on the cell not working until you move to a different row or refresh the edit session entirely).

Additionally, this PR addresses a bug where empty spaces at the end are a part of the value retrieved from the cell and that failure to delete those or overwrite them causes a "exceeded length" error, this PR adds trimming to values from the cell (and it still registers as being unchanged by the editor).