### PR TITLE
Remove New Database command for Database nodes

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -618,11 +618,6 @@
           "group": "1_objectManagement@0"
         },
         {
-          "command": "mssql.newDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Database && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
-          "group": "1_objectManagement@0"
-        },
-        {
           "command": "mssql.newDatabaseRole",
           "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == DatabaseRoles && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
@@ -767,11 +762,6 @@
         {
           "command": "mssql.newDatabase",
           "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == Databases && config.workbench.enablePreviewFeatures",
-          "group": "1_objectManagement@0"
-        },
-        {
-          "command": "mssql.newDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Database  && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@0"
         },
         {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24391

We had some design feedback that New Database should only be present at the folder level i.e. when right-clicking on the "Databases" folder. This change removes the New Database command for database nodes, which we originally added for a consistent experience with SSMS.