### PR TITLE
Fix lingering issues with backup database dialog

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -290,6 +290,7 @@ export const BackupDefaultSetting = localize('objectManagement.backupDefaultSett
 export const CompressBackup = localize('objectManagement.compressBackup', "Compress backup");
 export const DontCompressBackup = localize('objectManagement.dontCompressBackup', "Do not compress backup");
 export const RecoveryModelSimple = localize('objectManagement.recoveryModelSimple', "Simple");
+export const PathAlreadyAddedError = localize('objectManagement.pathAlreadyAddedError', "Provided path has already been added to the files list.");
 
 // Login
 export const BlankPasswordConfirmationText: string = localize('objectManagement.blankPasswordConfirmation', "Creating a login with a blank password is a security risk.  Are you sure you want to continue?");

--- a/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
@@ -296,7 +296,7 @@ export class BackupDatabaseDialog extends ObjectManagementDialogBase<Database, D
 
 	private async updateTableData(): Promise<void> {
 		await this._backupFilesTable.updateProperties({
-			data: this._backupFilePaths,
+			data: this._backupFilePaths.map(path => [path]),
 			height: getTableHeight(this._backupFilePaths.length, DefaultMinTableRowCount)
 		});
 		this.onFormFieldChange();

--- a/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
@@ -120,8 +120,6 @@ export class BackupDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		components.push(recoveryInputContainer);
 
 		this._backupTypeDropdown = this.createDropdown(loc.BackupTypeLabel, async newValue => {
-			// Update backup name with new backup type
-			this._backupSetNameInput.value = this._backupSetNameInput.ariaLabel = this.getDefaultBackupName(newValue);
 			if (newValue === loc.BackupTransactionLog) {
 				this._truncateLogButton.enabled = true;
 				this._backupLogTailButton.enabled = true;

--- a/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
@@ -272,8 +272,15 @@ export class BackupDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		try {
 			let filePath = await azdata.window.openServerFileBrowserDialog(this.options.connectionUri, this._defaultBackupFolderPath, this._fileFilters);
 			if (filePath) {
-				this._backupFilePaths.push(filePath);
-				await this.updateTableData();
+				if (this._backupFilePaths.includes(filePath)) {
+					this.dialogObject.message = {
+						text: loc.PathAlreadyAddedError,
+						level: azdata.window.MessageLevel.Error
+					}
+				} else {
+					this._backupFilePaths.push(filePath);
+					await this.updateTableData();
+				}
 			}
 		} catch (error) {
 			this.dialogObject.message = {


### PR DESCRIPTION
Fixes these issues:
1. Backup set name changing every time backup type is changed
2. File list going blank when adding other rows
3. File list allowing duplicate entries