### PR TITLE
fix windows signing

### DIFF
--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -178,27 +178,7 @@ steps:
     inputs:
       ConnectedServiceName: 'Code Signing'
       FolderPath: '$(agent.builddirectory)/azuredatastudio-win32-$(VSCODE_ARCH)'
-      Pattern: |
-        *.exe
-        *.node
-        !**/node_modules/**/*
-        resources/app/node_modules.asar.unpacked/*.dll
-        d3dcompiler_47.dll
-        vulkan-1.dll
-        libGLESv2.dll
-        ffmpeg.dll
-        libEGL.dll
-        Microsoft.SqlTools.Hosting.dll
-        Microsoft.SqlTools.ResourceProvider.Core.dll
-        Microsoft.SqlTools.ResourceProvider.DefaultImpl.dll
-        MicrosoftSqlToolsCredentials.dll
-        MicrosoftSqlToolsServiceLayer.dll
-        MicrosoftSqlToolsSqlCore.dll
-        Newtonsoft.Json.dll,SqlSerializationService.dll
-        SqlToolsResourceProviderService.dll
-        Microsoft.SqlServer.*.dll
-        Microsoft.Data.Tools.Sql.BatchParser.dll
-      useMinimatch: true
+      Pattern: '*.exe,*.node,resources/app/node_modules.asar.unpacked/*.dll,d3dcompiler_47.dll,vulkan-1.dll,libGLESv2.dll,ffmpeg.dll,libEGL.dll,Microsoft.SqlTools.Hosting.dll,Microsoft.SqlTools.ResourceProvider.Core.dll,Microsoft.SqlTools.ResourceProvider.DefaultImpl.dll,MicrosoftSqlToolsCredentials.dll,MicrosoftSqlToolsServiceLayer.dll,Newtonsoft.Json.dll,SqlSerializationService.dll,SqlToolsResourceProviderService.dll,Microsoft.SqlServer.*.dll,Microsoft.Data.Tools.Sql.BatchParser.dll'
       signConfigType: inlineSignParams
       inlineOperation: |
         [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Addresses https://github.com/microsoft/azuredatastudio/issues/24930. This reverts the changes to sql-product-build-win32.yml in https://github.com/microsoft/azuredatastudio/pull/21311. There no longer seems to be the issue with signing failing for `.node` files, and for some reason the minimatch pattern was not finding all the expected files. 

We'll need to keep an eye on this in case there are signing issues again due to the .node files, but vscode uses a [pattern](https://github.com/microsoft/vscode/blob/9be65968a46ecda4e4d91e4c53d58112f7647a9c/build/azure-pipelines/win32/product-build-win32.yml#L205) include that includes `*.node` (although using a differen task), so I'm less concerned about that.