### PR TITLE
Release new version of mongo migration extension (2.0.0)

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4972,7 +4972,7 @@
 					"versions": [
 						{
 							"version": "2.0.0",
-							"lastUpdated": "13/11/2023",
+							"lastUpdated": "11/13/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -5012,7 +5012,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.39.0"
+									"value": ">=1.41.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4971,14 +4971,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.1.0",
-							"lastUpdated": "06/26/2023",
+							"version": "2.0.0",
+							"lastUpdated": "13/11/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-1.1.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-2.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4972,7 +4972,7 @@
 					"versions": [
 						{
 							"version": "2.0.0",
-							"lastUpdated": "13/11/2023",
+							"lastUpdated": "11/13/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -5012,7 +5012,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.39.0"
+									"value": ">=1.41.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4971,14 +4971,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.1.0",
-							"lastUpdated": "06/26/2023",
+							"version": "2.0.0",
+							"lastUpdated": "13/11/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-1.1.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-2.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This is the link to download new extension
[Mongo migration 2.0.0](https://artprodeussu2.artifacts.visualstudio.com/A8b119ea1-2e2a-4839-8db7-8c9e8d50f6fa/ba574a88-a171-48e0-8fcb-5fef6d23739c/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL21zZGF0YS9wcm9qZWN0SWQvYmE1NzRhODgtYTE3MS00OGUwLThmY2ItNWZlZjZkMjM3MzljL2J1aWxkSWQvMTEwNDIxNjMzL2FydGlmYWN0TmFtZS9kcm9wX2J1aWxkX21haW41/content?format=file&subPath=%2FProduct%2FAdsMongoMigration%2Fbin%2Fads-extension-mongo-migration-2.0.0.vsix)