### PR TITLE
vbump 1.5.0 for sql migration on stable

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4036,14 +4036,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.4.11",
-							"lastUpdated": "10/30/2023",
+							"version": "1.5.0",
+							"lastUpdated": "11/13/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.4.11.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.5.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
vbump 1.5.0 for sql migration on stable (Insider Addws with PR #24892)

This PR updates the stable extension gallery to the latest version 1.5.0 of the SQL Migration extension. 

sql-migration-1.5.0.vsix
Link to Azure Data Studio - Extensions Product pipeline run off main: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=215652&view=artifacts&pathAsName=false&type=publishedArtifacts

VSIX: https://mssqltools.visualstudio.com/_apis/resources/Containers/6336540/drop?itemPath=drop%2Fextensions%2Fsql-migration-1.5.0.vsix
