### PR TITLE
Disable new Backup Database dialog for managed instances

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -698,7 +698,7 @@
         },
         {
           "command": "mssql.backupDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
+          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && mssql:engineedition != 8 && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
           "group": "1_objectManagement@3"
         },
         {

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -698,7 +698,7 @@
         },
         {
           "command": "mssql.backupDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && mssql:engineedition != 8 && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
+          "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && engineEdition != 8 && engineEdition != 11 && config.workbench.enablePreviewFeatures && (productQualityType =~ /^(insider|dev)$/ || isDevelopment)",
           "group": "1_objectManagement@3"
         },
         {
@@ -724,7 +724,7 @@
         },
         {
           "command": "mssql.objectProperties",
-          "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType =~ /^(Database|Server)$/ && mssql:engineedition != 11 && config.workbench.enablePreviewFeatures",
+          "when": "connectionProvider == MSSQL && serverInfo && !isCloud && nodeType =~ /^(Database|Server)$/ && engineEdition != 11 && config.workbench.enablePreviewFeatures",
           "group": "z_objectexplorer@3"
         },
         {


### PR DESCRIPTION
Managed instances require URL mode for backups which isn't supported in the new backup dialog yet. I also updated usage of the engineEdition context key, since "mssql:engineedition" was returning undefined.