### PR TITLE
fix incorrect header in sql migration files

### DIFF
--- a/extensions/sql-migration/src/dialog/assessment/assessmentUtils.ts
+++ b/extensions/sql-migration/src/dialog/assessment/assessmentUtils.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { MigrationTargetType } from '../../api/utils';
 import { IssueCategory } from '../../constants/helper';

--- a/extensions/sql-migration/src/dialog/assessment/importAssessmentDialog.ts
+++ b/extensions/sql-migration/src/dialog/assessment/importAssessmentDialog.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The hygiene checks started failing after https://github.com/microsoft/azuredatastudio/pull/24811 got checked in. The license was recently updated, so the headers of the files in this repo should have `MIT License` in the header now, not `Source EULA`