### PR TITLE
Use python v3.11 for Darwin

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -23,6 +23,11 @@ steps:
     inputs:
       versionSpec: "1.x"
 
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.11.x'
+      addToPath: true
+
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: Get Secrets'
     inputs:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR sets the Darwin pipeline's python version to 3.11 to make it consistent with the other pipelines and seemed to fix an error about distutils missing that would cause the build to fail during the install dependencies step.