### PR TITLE
Re-enable extension unit tests on linux build

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -140,50 +140,48 @@ steps:
     displayName: Run core integration tests
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'), ne(variables['EXTENSIONS_ONLY'], 'true'))
 
-  # {{SQL CARBON TODO}} - disable extension unit tests while investigating post merge (6/26/2023)
-  # - script: |
-  #     # Figure out the full absolute path of the product we just built
-  #     # including the remote server and configure the unit tests
-  #     # to run with these builds instead of running out of sources.
-  #     set -e
-  #     APP_ROOT=$(agent.builddirectory)/azuredatastudio-linux-x64
-  #     APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
-  #     INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
-  #     NO_CLEANUP=1 \
-  #     VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-linux-x64" \
-  #     DISPLAY=:10 ./scripts/test-extensions-unit.sh --build --tfs "Extension Unit Tests"
-  #   displayName: Run Extension Unit Tests (Continue on Error)
-  #   continueOnError: true
-  #   condition: and(succeeded(), and(eq(variables['RUN_TESTS'], 'true'), eq(variables['EXTENSION_UNIT_TESTS_FAIL_ON_ERROR'], 'false')))
+  - script: |
+      # Figure out the full absolute path of the product we just built
+      # including the remote server and configure the unit tests
+      # to run with these builds instead of running out of sources.
+      set -e
+      APP_ROOT=$(agent.builddirectory)/azuredatastudio-linux-x64
+      APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
+      INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
+      NO_CLEANUP=1 \
+      VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-linux-x64" \
+      DISPLAY=:10 ./scripts/test-extensions-unit.sh --build --tfs "Extension Unit Tests"
+    displayName: Run Extension Unit Tests (Continue on Error)
+    continueOnError: true
+    condition: and(succeeded(), and(eq(variables['RUN_TESTS'], 'true'), eq(variables['EXTENSION_UNIT_TESTS_FAIL_ON_ERROR'], 'false')))
 
-  # - script: |
-  #     # Figure out the full absolute path of the product we just built
-  #     # including the remote server and configure the unit tests
-  #     # to run with these builds instead of running out of sources.
-  #     set -e
-  #     APP_ROOT=$(agent.builddirectory)/azuredatastudio-linux-x64
-  #     APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
-  #     INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
-  #     NO_CLEANUP=1 \
-  #     VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-linux-x64" \
-  #     DISPLAY=:10 ./scripts/test-extensions-unit.sh --build --tfs "Extension Unit Tests"
-  #   displayName: Run Extension Unit Tests (Fail on Error)
-  #   condition: and(succeeded(), and(eq(variables['RUN_TESTS'], 'true'), ne(variables['EXTENSION_UNIT_TESTS_FAIL_ON_ERROR'], 'false')))
+  - script: |
+      # Figure out the full absolute path of the product we just built
+      # including the remote server and configure the unit tests
+      # to run with these builds instead of running out of sources.
+      set -e
+      APP_ROOT=$(agent.builddirectory)/azuredatastudio-linux-x64
+      APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
+      INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
+      NO_CLEANUP=1 \
+      VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-linux-x64" \
+      DISPLAY=:10 ./scripts/test-extensions-unit.sh --build --tfs "Extension Unit Tests"
+    displayName: Run Extension Unit Tests (Fail on Error)
+    condition: and(succeeded(), and(eq(variables['RUN_TESTS'], 'true'), ne(variables['EXTENSION_UNIT_TESTS_FAIL_ON_ERROR'], 'false')))
 
-  # - bash: |
-  #     set -e
-  #     mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
-  #     cd /tmp
-  #     for folder in adsuser*/
-  #     do
-  #     folder=${folder%/}
-  #     # Only archive directories we want for debugging purposes
-  #     tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/$folder.tar.gz $folder/User $folder/logs
-  #     done
-  #   displayName: Archive Logs
-  #   continueOnError: true
-  #   condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
-  # {{SQL CARBON TODO}} - end disable extension unit tests while investigating post merge (6/26/2023)
+  - bash: |
+      set -e
+      mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
+      cd /tmp
+      for folder in adsuser*/
+      do
+      folder=${folder%/}
+      # Only archive directories we want for debugging purposes
+      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/$folder.tar.gz $folder/User $folder/logs
+      done
+    displayName: Archive Logs
+    continueOnError: true
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
   - script: |
         set -e


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The extension unit tests were disabled back in June for the vscode merge. I ran an adhoc build with the extension unit tests re-enabled and they all passed, so it doesn't look like any other changes need to be made before enabling them again: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=216436&view=logs&j=4d2898ab-dfbe-557e-92e7-aaac158fdd2f&t=b2ac4860-fb3b-5a51-42a7-7423ead0721b