### PR TITLE
Added support of MI public endpoint in Login Migration

### DIFF
--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -207,6 +207,48 @@ function getSqlDbConnectionProfile(
 	};
 }
 
+/**
+ * This function returns the Target Connection profile with port
+ * @param serverName Target server name
+ * @param azureResourceId Azure resource Id
+ * @param userName Target username
+ * @param password Target password
+ * @param port Target port
+ * @param encryptConnection Encrypt connection
+ * @param trustServerCert Trust server certificate
+ * @returns Target Connection Profile
+ */
+export function getTargetConnectionProfileWithPort(
+	serverName: string,
+	azureResourceId: string,
+	userName: string,
+	password: string,
+	port: string,
+	encryptConnection: boolean,
+	trustServerCert: boolean): azdata.IConnectionProfile {
+
+	let targetConnectionProfile = getTargetConnectionProfile(
+		serverName,
+		azureResourceId,
+		userName,
+		password,
+		encryptConnection,
+		trustServerCert);
+
+	targetConnectionProfile.options.port = port;
+	return targetConnectionProfile
+}
+
+/**
+ * This function returns the Target Connection profile
+ * @param serverName Target server name
+ * @param azureResourceId Azure resource Id
+ * @param userName Target username
+ * @param password Target password
+ * @param encryptConnection Encrypt connection
+ * @param trustServerCert Trust server certificate
+ * @returns Target Connection Profile
+ */
 export function getTargetConnectionProfile(
 	serverName: string,
 	azureResourceId: string,
@@ -255,14 +297,16 @@ export async function getTargetConnectionString(
 	azureResourceId: string,
 	username: string,
 	password: string,
+	port: string,
 	encryptConnection: boolean,
 	trustServerCertificate: boolean): Promise<string> {
 
-	const connectionProfile = getTargetConnectionProfile(
+	const connectionProfile = getTargetConnectionProfileWithPort(
 		serverName,
 		azureResourceId,
 		username,
 		password,
+		port,
 		encryptConnection,
 		trustServerCertificate);
 
@@ -470,13 +514,15 @@ export async function collectTargetLogins(
 	azureResourceId: string,
 	userName: string,
 	password: string,
+	port: string,
 	includeWindowsAuth: boolean = true): Promise<string[]> {
 
-	const connectionProfile = getTargetConnectionProfile(
+	const connectionProfile = getTargetConnectionProfileWithPort(
 		serverName,
 		azureResourceId,
 		userName,
 		password,
+		port,
 		// for login migration, connect to target Azure SQL with true/true
 		// to-do: take as input from the user, should be true/false for DB/MI but true/true for VM
 		true /* encryptConnection */,

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -579,6 +579,7 @@ export const TARGET_SUBSCRIPTION_INFO = localize('sql.migration.sku.subscription
 export const TARGET_LOCATION_INFO = localize('sql.migration.sku.location', "Azure region for your Azure SQL target. Only regions that contain a target eligible for migration will be shown.");
 export const TARGET_RESOURCE_GROUP_INFO = localize('sql.migration.sku.resource_group', "Resource group for your Azure SQL target. Only resource groups that contain a target eligible for migration will be shown.");
 export const TARGET_RESOURCE_INFO = localize('sql.migration.sku.resource', "Your Azure SQL target resource name");
+export const TARGET_RESOURCE_PORT_INFO = localize('sql.migration.sku.resource.port', "Your Azure SQL target resource port number");
 
 // DMS tooltip
 export const DMS_SUBSCRIPTION_INFO = localize('sql.migration.dms.subscription', "Subscription name for your Azure Database Migration Service");
@@ -711,10 +712,12 @@ export function STORAGE_ACCOUNT_CONNECTIVITY_WARNING(targetServer: string, datab
 
 export const TARGET_TABLE_NOT_EMPTY = localize('sql.migration.target.table.not.empty', "Target table is not empty.");
 export const TARGET_TABLE_MISSING = localize('sql.migration.target.table.missing', "Target table does not exist");
-export const TARGET_USERNAME_LAbEL = localize('sql.migration.username.label', "Target user name");
+export const TARGET_USERNAME_LABEL = localize('sql.migration.username.label', "Target user name");
 export const TARGET_USERNAME_PLACEHOLDER = localize('sql.migration.username.placeholder', "Enter the target user name");
-export const TARGET_PASSWORD_LAbEL = localize('sql.migration.password.label', "Target password");
+export const TARGET_PASSWORD_LABEL = localize('sql.migration.password.label', "Target password");
 export const TARGET_PASSWORD_PLACEHOLDER = localize('sql.migration.password.placeholder', "Enter the target password");
+export const TARGET_PORT_LABEL = localize('sql.migration.port.label', "Port");
+export const TARGET_PORT_PLACEHOLDER = localize('sql.migration.port.placeholder', "Enter the target port");
 export const TARGET_CONNECTION_LABEL = localize('sql.migration.connection.label', "Connect");
 export const MAP_SOURCE_TARGET_HEADING = localize('sql.migration.map.target.heading', "Map selected source databases to target databases for migration");
 export const MAP_SOURCE_TARGET_DESCRIPTION = localize('sql.migration.map.target.description', "Select the target database where you would like to migrate your source database to.  You can choose a target database for only one source database.");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -579,7 +579,7 @@ export const TARGET_SUBSCRIPTION_INFO = localize('sql.migration.sku.subscription
 export const TARGET_LOCATION_INFO = localize('sql.migration.sku.location', "Azure region for your Azure SQL target. Only regions that contain a target eligible for migration will be shown.");
 export const TARGET_RESOURCE_GROUP_INFO = localize('sql.migration.sku.resource_group', "Resource group for your Azure SQL target. Only resource groups that contain a target eligible for migration will be shown.");
 export const TARGET_RESOURCE_INFO = localize('sql.migration.sku.resource', "Your Azure SQL target resource name");
-export const TARGET_RESOURCE_PORT_INFO = localize('sql.migration.sku.resource.port', "Your Azure SQL target resource port number");
+export const TARGET_RESOURCE_PORT_INFO = localize('sql.migration.sku.resource.port', "Your Azure SQL target resource port number : 0 - 65535");
 
 // DMS tooltip
 export const DMS_SUBSCRIPTION_INFO = localize('sql.migration.dms.subscription', "Subscription name for your Azure Database Migration Service");

--- a/extensions/sql-migration/src/models/loginMigrationModel.ts
+++ b/extensions/sql-migration/src/models/loginMigrationModel.ts
@@ -326,6 +326,7 @@ export class LoginMigrationModel {
 			stateMachine._targetServerInstance.id,
 			stateMachine._targetUserName,
 			stateMachine._targetPassword,
+			stateMachine._targetPort,
 			// for login migration, connect to target Azure SQL with true/true
 			// to-do: take as input from the user, should be true/false for DB/MI but true/true for VM
 			true /* encryptConnection */,

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -394,6 +394,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 					stateMachine._targetServerInstance.id,
 					stateMachine._targetUserName,
 					stateMachine._targetPassword,
+					stateMachine._targetPort,
 					stateMachine.isWindowsAuthMigrationSupported));
 				stateMachine._loginMigrationModel.collectedTargetLogins = true;
 				stateMachine._loginMigrationModel.loginsOnTarget = targetLogins;

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -504,7 +504,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 		// target user name
 		const targetUserNameLabel = this._view.modelBuilder.text()
 			.withProps({
-				value: constants.TARGET_USERNAME_LAbEL,
+				value: constants.TARGET_USERNAME_LABEL,
 				requiredIndicator: true,
 				CSSStyles: { ...styles.LABEL_CSS, 'margin-top': '-1em' }
 			}).component();
@@ -527,7 +527,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 		// target password
 		const targetPasswordLabel = this._view.modelBuilder.text()
 			.withProps({
-				value: constants.TARGET_PASSWORD_LAbEL,
+				value: constants.TARGET_PASSWORD_LABEL,
 				requiredIndicator: true,
 				title: '',
 				CSSStyles: { ...styles.LABEL_CSS, 'margin-top': '-1em' }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- This PR adds the support for public endpoint for SQL Managed instance in login migration by providing a target port field along with the existing target username and password. The port was defaulted to 1433 in the backend previously which is a private endpoint default port. By provided a field to enter the port, we are adding the flexibility to enter the user desired port. The port 3342, the public endpoint default port. can also be entered now. 

![image](https://github.com/microsoft/azuredatastudio/assets/126583651/0ae7c3d9-96cc-4e08-9092-31424c8aca52)

![image](https://github.com/microsoft/azuredatastudio/assets/126583651/08039971-8db6-4bbc-81a0-f73a5d4626af)

- Added Port validation - the port number is a required field and the value entered should be a valid number in the range of 0-65535. The connect button gets enabled on the valid port value along with existing checks.

- Added logic to generate MI target server name based on the endpoint selected (public or private)
  Public endpoint format: <mi_name>.public.<dns_zone>.database.windows.net
  Private endpoint format: <mi_name>.<dns_zone>.database.windows.net

Testing on SQL migration extension on ADS
- Verified successful validation checks for target Port field.
- Verified successful connection to Public and Private MI endpoint.
- Verified successful fetch of target login for Public and Private MI endpoint.
- Verified the successful creation of connection string for Public and Private MI endpoint.
- Verified the successful login migrations for MI with private and public endpoint.
