### PR TITLE
[Bug fix] Update Import model while importing assessment

### DIFF
--- a/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
+++ b/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
@@ -551,6 +551,7 @@ export class DashboardWidget {
 						await this.clearSavedInfo(loc.importAssessmentKey);
 						if (importSavedInfo.serverAssessment !== null) {
 							this.stateModel._assessmentResults = importSavedInfo.serverAssessment;
+							this.stateModel.savedInfo = importSavedInfo;
 							await this.stateModel.loadSavedInfo();
 
 							serverName = importSavedInfo.serverAssessment?.issues[0]?.serverName ??


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Bug: When assessment is imported first time it imports correct. When another assessment is imported after it, the previously imported assessment is shown again and not the new one. 

Fix: Model to new imported assessment was not updated.