### PR TITLE
[SQL Migration] [Bugfix] Not able to migrate few of the assessed DBs, it always selects all assessed. 

### DIFF
--- a/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetailsPage.ts
+++ b/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetailsPage.ts
@@ -166,7 +166,6 @@ export class AssessmentDetailsPage extends MigrationWizardPage {
 
 	// function to execute when user changes target type for the selected databases.
 	private async executeChange(newTargetType: string): Promise<void> {
-		await this._body.treeComponent.initialize(this.migrationStateModel);
 		const selectedDbs = this._body.treeComponent.selectedDbs();
 		switch (newTargetType) {
 			case MigrationTargetType.SQLMI:

--- a/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetialsBody.ts
+++ b/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetialsBody.ts
@@ -32,7 +32,7 @@ export class AssessmentDetailsBody {
 	constructor(public migrationStateModel: MigrationStateModel,
 		public wizard: azdata.window.Wizard,
 		readonly: boolean = false) {
-		this._treeComponent = new TreeComponent(wizard, readonly);
+		this._treeComponent = new TreeComponent(wizard, migrationStateModel, readonly);
 		this._instanceSummary = new InstanceSummary(migrationStateModel);
 	}
 
@@ -71,7 +71,7 @@ export class AssessmentDetailsBody {
 
 	// function to populate data for body section
 	public async populateAssessmentBodyAsync(): Promise<void> {
-		await this._treeComponent.initialize(this.migrationStateModel);
+		await this._treeComponent.initialize();
 		this._activeIssues = this.migrationStateModel._assessmentResults?.issues.filter(issue => issue.appliesToMigrationTargetPlatform === this.migrationStateModel?._targetType);
 		await this.refreshResultsAsync();
 		await this._instanceSummary.populateInstanceSummaryContainerAsync();

--- a/extensions/sql-migration/src/wizard/assessmentDetailsPage/treeComponent.ts
+++ b/extensions/sql-migration/src/wizard/assessmentDetailsPage/treeComponent.ts
@@ -57,9 +57,9 @@ export class TreeComponent {
 	private _dbNames!: string[];
 	private _databaseCount!: azdata.TextComponent;
 	private _disposables: vscode.Disposable[] = [];
-	private _model!: MigrationStateModel;
 
-	constructor(public wizard: azdata.window.Wizard, private _readOnly: boolean = false) { }
+	constructor(public wizard: azdata.window.Wizard,
+		public model: MigrationStateModel, private _readOnly: boolean = false) { }
 
 	public get instanceTable() {
 		return this._instanceTable;
@@ -219,7 +219,8 @@ export class TreeComponent {
 		).component();
 
 		this._disposables.push(this._databaseTable.onDataChanged(async () => {
-			await this.updateValuesOnSelectionAsync(this._model);
+			await this.updateValuesOnSelectionAsync(this.model);
+			this.model._databasesForMigration = this.selectedDbs();
 		}));
 
 		const tableContainer = this._view.modelBuilder.divContainer().withItems([this._databaseTable]).withProps({
@@ -264,17 +265,16 @@ export class TreeComponent {
 	}
 
 	// populates tree component values.
-	public async initialize(migrationStateModel: MigrationStateModel): Promise<void> {
-		this._model = migrationStateModel;
+	public async initialize(): Promise<void> {
 		let instanceTableValues: azdata.DeclarativeTableCellValue[][] = [];
 		this._databaseTableValues = [];
-		this._dbNames = migrationStateModel._databasesForAssessment;
+		this._dbNames = this.model._databasesForAssessment;
 		this._serverName = (await getSourceConnectionProfile()).serverName;
 
 		// pre-select the entire list
-		const selectedDbs = this._dbNames.filter(db => migrationStateModel._databasesForAssessment.includes(db));
+		const selectedDbs = this._dbNames.filter(db => this.model._databasesForMigration.includes(db));
 
-		if (migrationStateModel._targetType === MigrationTargetType.SQLVM || !migrationStateModel._assessmentResults) {
+		if (this.model._targetType === MigrationTargetType.SQLVM || !this.model._assessmentResults) {
 			instanceTableValues = [[
 				{
 					value: this.createIconTextCell(IconPathHelper.sqlServerLogo, this._serverName),
@@ -303,7 +303,7 @@ export class TreeComponent {
 			});
 		} else {
 
-			if (!this._readOnly && migrationStateModel._targetType === MigrationTargetType.SQLMI && selectedDbs?.length > AZURE_SQL_MI_DB_COUNT_THRESHOLD) {
+			if (!this._readOnly && this.model._targetType === MigrationTargetType.SQLMI && selectedDbs?.length > AZURE_SQL_MI_DB_COUNT_THRESHOLD) {
 				this.wizard.nextButton.enabled = false;
 				this.wizard.message = {
 					level: azdata.window.MessageLevel.Error,
@@ -317,18 +317,18 @@ export class TreeComponent {
 					style: styleLeft
 				},
 				{
-					value: migrationStateModel._assessmentResults?.issues?.filter(issue => issue.appliesToMigrationTargetPlatform === migrationStateModel._targetType).length,
+					value: this.model._assessmentResults?.issues?.filter(issue => issue.appliesToMigrationTargetPlatform === this.model._targetType).length,
 					style: styleRight
 				}
 			]];
-			migrationStateModel._assessmentResults?.databaseAssessments
+			this.model._assessmentResults?.databaseAssessments
 				.sort((db1, db2) => db2.issues?.length - db1.issues?.length);
 
 			// Reset the dbName list so that it is in sync with the table
-			this._dbNames = migrationStateModel._assessmentResults?.databaseAssessments.map(da => da.name);
-			migrationStateModel._assessmentResults?.databaseAssessments.forEach((db) => {
+			this._dbNames = this.model._assessmentResults?.databaseAssessments.map(da => da.name);
+			this.model._assessmentResults?.databaseAssessments.forEach((db) => {
 				let selectable = true;
-				if (db.issues.find(issue => issue.databaseRestoreFails && issue.appliesToMigrationTargetPlatform === migrationStateModel._targetType)) {
+				if (db.issues.find(issue => issue.databaseRestoreFails && issue.appliesToMigrationTargetPlatform === this.model._targetType)) {
 					selectable = false;
 				}
 				this._databaseTableValues.push([
@@ -342,7 +342,7 @@ export class TreeComponent {
 						style: styleLeft
 					},
 					{
-						value: db.issues.filter(v => v.appliesToMigrationTargetPlatform === migrationStateModel._targetType)?.length,
+						value: db.issues.filter(v => v.appliesToMigrationTargetPlatform === this.model._targetType)?.length,
 						style: styleRight
 					}
 				]);
@@ -350,10 +350,10 @@ export class TreeComponent {
 		}
 		await this._instanceTable.setDataValues(instanceTableValues);
 
-		this._databaseTableValues = selectDatabasesFromList(migrationStateModel._databasesForMigration, this._databaseTableValues);
+		this._databaseTableValues = selectDatabasesFromList(this.model._databasesForMigration, this._databaseTableValues);
 		await this._databaseTable.setDataValues(this._databaseTableValues);
-		await this.updateValuesOnSelectionAsync(migrationStateModel);
-		this._databaseCount.value = constants.DATABASES(0, migrationStateModel._databasesForAssessment?.length);
+		await this.updateValuesOnSelectionAsync(this.model);
+		this._databaseCount.value = constants.DATABASES(selectedDbs.length, this.model._databasesForAssessment?.length);
 	}
 
 	private createIconTextCell(icon: IconPath, text: string): string {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Bug : [Bug 2824863](https://dev.azure.com/msdata/Database%20Systems/_workitems/edit/2824863): We are not able to migrate few of the assessed DBs, it always selects all assessed.

Fix:  Change1 : remove `await this._body.treeComponent.initialize(this.migrationStateModel);` from `executechange` method &
 change `const selectedDbs = this._dbNames.filter(db => this.model._databasesForAssessments.includes(db));` to 
  `const selectedDbs = this._dbNames.filter(db => this.model._databasesForMigration.includes(db));`
  
Change 2: Due to above change, when a tde enabled db is selected, tde info container was not showing up.
Fix:  Update `this.model._databasesForMigration = this.selectedDbs();` whenever any db is selected or unselected. This require pass of `migrationstatemodel` to treecomponent.

Change 3: Update select db count whenever a db is selected or unselected.
` this._databaseCount.value = constants.DATABASES(selectedDbs.length, this.model._databasesForAssessment?.length)`


Change2 & change3 are done to accomodate bugfix change

