### PR TITLE
Use DomParser for xml parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",
     "vscode-textmate": "9.0.0",
-    "xml2js": "^0.6.2",
+    "@xmldom/xmldom": "^0.8.10",
     "xterm": "5.3.0-beta.61",
     "xterm-addon-canvas": "0.5.0-beta.22",
     "xterm-addon-image": "0.6.0-beta.14",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "temp-write": "^3.4.0",
     "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
-    "tsec": "0.2.7",
+    "tsec": "0.2.8",
     "typemoq": "^0.3.2",
     "typescript": "^5.3.0-dev.20230824",
     "typescript-formatter": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",
     "vscode-textmate": "9.0.0",
-    "@xmldom/xmldom": "^0.8.10",
     "xterm": "5.3.0-beta.61",
     "xterm-addon-canvas": "0.5.0-beta.22",
     "xterm-addon-image": "0.6.0-beta.14",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.48.0",
-  "distro": "c7516ffaf758f77c4c9c621f2ec650550714afff",
+  "distro": "b0465c719e5666cda86a2ae1083752ae50cb491b",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -60,7 +60,6 @@ import { IComponentContextService } from 'sql/workbench/services/componentContex
 import { GridRange } from 'sql/base/common/gridRange';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { defaultTableFilterStyles, defaultTableStyles } from 'sql/platform/theme/browser/defaultStyles';
-import { DOMParser } from '@xmldom/xmldom';
 
 const ROW_HEIGHT = 29;
 const HEADER_HEIGHT = 26;
@@ -983,6 +982,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView, IQue
 		try {
 			if (value && !value.isNull && value.displayValue.trim() !== '') {
 				var parser = new DOMParser();
+				// Script elements if any are not evaluated during parsing
 				var doc = parser.parseFromString(value.displayValue, 'text/xml');
 				isXML = doc.documentElement.tagName !== 'parsererror';
 			}

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -60,7 +60,7 @@ import { IComponentContextService } from 'sql/workbench/services/componentContex
 import { GridRange } from 'sql/base/common/gridRange';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { defaultTableFilterStyles, defaultTableStyles } from 'sql/platform/theme/browser/defaultStyles';
-import { parseString as parseXMLString } from 'xml2js';
+import { DOMParser } from '@xmldom/xmldom';
 
 const ROW_HEIGHT = 29;
 const HEADER_HEIGHT = 26;
@@ -445,10 +445,10 @@ export abstract class GridTableBase<T> extends Disposable implements IView, IQue
 					: escape(c.columnName),
 				field: i.toString(),
 				formatter: c.isXml || c.isJson ? hyperLinkFormatter : (row: number | undefined, cell: any | undefined, value: ICellValue, columnDef: any | undefined, dataContext: any | undefined): string | { text: string, addClasses: string } => {
-					if (isXmlCell(value)) {
+					if (this.isXmlCell(value)) {
 						this.resultSet.columnInfo[i].isXml = true;
 						return hyperLinkFormatter(row, cell, value, columnDef, dataContext);
-					} else if (this.gridConfig.showJsonAsLink && isJsonCell(value)) {
+					} else if (this.gridConfig.showJsonAsLink && this.isJsonCell(value)) {
 						this.resultSet.columnInfo[i].isJson = true;
 						return hyperLinkFormatter(row, cell, value, columnDef, dataContext);
 					} else {
@@ -884,7 +884,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView, IQue
 		if (column) {
 			const subset = await this.getRowData(event.cell.row, 1);
 			const value = subset[0][event.cell.cell - 1];
-			if (column.isXml || (this.gridConfig.showJsonAsLink && isJsonCell(value))) {
+			if (column.isXml || (this.gridConfig.showJsonAsLink && this.isJsonCell(value))) {
 				if (column.isXml && this.providerId) {
 					const result = await this.executionPlanService.isExecutionPlan(this.providerId, value.displayValue);
 					if (result.isExecutionPlan) {
@@ -972,6 +972,25 @@ export abstract class GridTableBase<T> extends Disposable implements IView, IQue
 			this.instantiationService.createInstance(SaveResultAction, SaveResultAction.SAVEMARKDOWN_ID, SaveResultAction.SAVEMARKDOWN_LABEL, SaveResultAction.SAVEMARKDOWN_ICON, SaveFormat.MARKDOWN),
 			this.instantiationService.createInstance(SaveResultAction, SaveResultAction.SAVEXML_ID, SaveResultAction.SAVEXML_LABEL, SaveResultAction.SAVEXML_ICON, SaveFormat.XML)
 		];
+	}
+
+	private isJsonCell(value: ICellValue): boolean {
+		return !!(value && !value.isNull && value.displayValue?.match(IsJsonRegex));
+	}
+
+	private isXmlCell(value: ICellValue): boolean {
+		let isXML = false;
+		try {
+			if (value && !value.isNull && value.displayValue.trim() !== '') {
+				var parser = new DOMParser();
+				var doc = parser.parseFromString(value.displayValue, 'text/xml');
+				isXML = doc.documentElement.tagName !== 'parsererror';
+			}
+		} catch (e) {
+			// Ignore errors when parsing cell content, log and continue
+			this.logService.debug(`An error occurred when parsing data as XML: ${e}`);
+		}
+		return isXML;
 	}
 
 	protected abstract getContextActions(): IAction[];
@@ -1165,18 +1184,4 @@ class GridTable<T> extends GridTableBase<T> {
 	protected getContextActions(): IAction[] {
 		return [];
 	}
-}
-
-function isJsonCell(value: ICellValue): boolean {
-	return !!(value && !value.isNull && value.displayValue?.match(IsJsonRegex));
-}
-
-function isXmlCell(value: ICellValue): boolean {
-	let isXML = false;
-	if (value && !value.isNull && value.displayValue.trim() !== '') {
-		parseXMLString(value.displayValue, (err, _) => {
-			isXML = err === null;
-		});
-	}
-	return isXML;
 }

--- a/src/tsec.exemptions.json
+++ b/src/tsec.exemptions.json
@@ -33,7 +33,9 @@
 	],
 	"ban-domparser-parsefromstring": [
 		"vs/base/browser/markdownRenderer.ts",
-		"vs/base/test/browser/markdownRenderer.test.ts"
+		"vs/base/test/browser/markdownRenderer.test.ts",
+		// {{SQL CARBON EDIT}} Add our exemption
+		"sql/workbench/contrib/query/browser/gridPanel.ts"
 	],
 	"ban-element-setattribute": [
 		"**/*.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,6 +1702,11 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.4.tgz#3982ee6f8b42845437fc4d391e93ac5d9da52f0f"
   integrity sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==
 
+"@xmldom/xmldom@^0.8.10":
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
+  integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -10844,14 +10849,6 @@ xml2js@^0.4.19, xml2js@^0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
-xml2js@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
-  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,11 +1702,6 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.4.tgz#3982ee6f8b42845437fc4d391e93ac5d9da52f0f"
   integrity sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==
 
-"@xmldom/xmldom@^0.8.10":
-  version "0.8.10"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
-  integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10125,10 +10125,10 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tsec@0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.2.7.tgz#be530025907037ed57f37fc7625b6a7e3658fe43"
-  integrity sha512-Pj9DuBBWLEo8p7QsbrEdXzW/u6QJBcib0ZGOTXkeSDx+PLXFY7hwyZE9Tfhp3TA3LQNpYouyT0WmzXRyUW4otQ==
+tsec@0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.2.8.tgz#a9e7492b144fcff14f1f36327fa84a2d54c4e211"
+  integrity sha512-d2vdTEtLbPzTs57ygzzPk6QrdW1lA8SBAoHZCVvAyC3R1LTjsQ2eGg/XRmtoCpXOVIflVtMsxtzk7eTHwT+DjQ==
   dependencies:
     glob "^7.1.1"
     minimatch "^3.0.3"


### PR DESCRIPTION
Fixes #25004 and potentially other issues related to XML data formatting, where rows are not being rendered..

Xml2js is failing to parse cell data like below, due to likely a parsing bug, failing as root node error:

```xml
'<p>What the heck?</p><p> </p><p>&nbsp;</p>'
```

Parsing Error:

```
[error] Text data outside of root node.
Line: 0
Column: 33
Char: &: Error: Text data outside of root node.
Line: 0
Column: 33
Char: &
    at error (C:\Users\cmalhotra\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\node_modules.asar\sax\lib\sax.js:651:10) [<root>]
    at strictFail (C:\Users\cmalhotra\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\node_modules.asar\sax\lib\sax.js:677:7) [<root>]
    at SAXParser.write (C:\Users\cmalhotra\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\node_modules.asar\sax\lib\sax.js:1035:15) [<root>]
    at exports.Parser.Parser.parseString (C:\Users\cmalhotra\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\node_modules.asar\xml2js\lib\parser.js:337:31) [<root>]
    at Parser.parseString (C:\Users\cmalhotra\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\node_modules.asar\xml2js\lib\parser.js:5:59) [<root>]
    at exports.parseString (C:\Users\cmalhotra\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\node_modules.asar\xml2js\lib\parser.js:383:19) [<root>]
```

Below XML works instead, which is pointing to a parsing bug in Xml2js when encountering an empty element:
```xml
<p>What the heck?</p><p>hello ?</p><p>world !</p><p>&nbsp;</p>
```


This PR changes the library to use DomParsr instead, to parse XML based on XML doc elements, which should be the most accurate XML parser for JS.