### PR TITLE
Use python 3.11.x in GitHub workflows

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -18,6 +18,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
 
       # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
       - name: Setup Build Environment
@@ -29,9 +35,6 @@ jobs:
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18.15
 
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
@@ -81,10 +84,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
 
       - name: Compute node modules cache key
         id: nodeModulesCacheKey

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
 
       # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
       - name: Setup Build Environment
@@ -97,9 +103,6 @@ jobs:
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18.15
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
         # {{ SQL Carbon Edit}} Use sql-computeNodeModulesCacheKey
@@ -175,6 +178,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
         # {{ SQL Carbon Edit}} Use sql-computeNodeModulesCacheKey


### PR DESCRIPTION
Fixes GH workflow errors related to 'disutils', e.g:
https://github.com/microsoft/azuredatastudio/actions/runs/6951032805/job/18912283805#step:8:72