### PR TITLE
Select all databases to migrate by default and Import feedback.

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -99,6 +99,7 @@ export const XEVENTS_ASSESSMENT_OPEN_FOLDER = localize('sql.migration.database.a
 export const ASSESSMENT_RESULTS_PAGE_TITLE = localize('sql.migration.assessment.results.title', "Target platform & assessment results");
 export const ASSESSMENT_RESULTS_SUMMARY_LABEL_CAPS = localize('sql.migration.assessment.results.summary.label.caps', "ASSESSMENT RESULTS");
 export const ASSESSMENT_RESULTS_PAGE_HEADER = localize('sql.migration.assessment.results.header', "Choose target platform, view assessment results and select database(s) for migration.");
+export const IMPORT_ASSESSMENT_PAGE_HEADER = localize('sql.migration.import.assessment.header', "Choose target platform and view assessment results.");
 export const ASSESSMENT_RESULTS_SUMMARY_LABEL_DESCRIPTION = localize('sql.migration.assessment.results.summary.label.description', "Assessment results shows the migration readiness of the database(s)");
 export const DATABASES_ASSESSED_LABEL = localize('sql.migration.database.assessed.label', "Database(s) assessed");
 export const MIGRATION_TIME_LABEL = localize('sql.migration.migration.time.label', "Ready for migration");

--- a/extensions/sql-migration/src/dialog/assessment/importAssessmentDialog.ts
+++ b/extensions/sql-migration/src/dialog/assessment/importAssessmentDialog.ts
@@ -49,24 +49,24 @@ export class ImportAssessmentDialog {
 							...styles.PAGE_TITLE_CSS,
 							'margin': '0px 15px 0px 15px'
 						},
-						value: constants.ASSESSMENT_RESULTS_PAGE_HEADER
+						value: constants.IMPORT_ASSESSMENT_PAGE_HEADER
 					}).component();
 
 					const headerSection = this._header.createAssessmentDetailsHeader(view);
 
 					this._bodySection = await this._body.createAssessmentDetailsBodyAsync(view);
 
-					await this.shouldNoTargetSelectionDisplayAsync(this.model._targetType === undefined);
-
-					if (this.model._targetType !== undefined) {
-						await this._header.populateAssessmentDetailsHeader(this.model);
-						await this._body.populateAssessmentBodyAsync();
+					if (this.model._targetType === undefined) {
+						// by default set the target type to SQLMI
+						this.model._targetType = MigrationTargetType.SQLMI;
 					}
+					await this.displayAssessmentAsync();
+					await this._header.populateAssessmentDetailsHeader(this.model);
+					await this._body.populateAssessmentBodyAsync();
 
 					this._disposables.push(this._header.targetTypeDropdown.onValueChanged(async (value) => {
 						if (value) {
 							const selectedTargetType = this.getTargetTypeBasedOnSelection(value);
-							await this.shouldNoTargetSelectionDisplayAsync(false);
 							this.model._targetType = selectedTargetType;
 							await this._header.populateAssessmentDetailsHeader(this.model);
 							await this._body.populateAssessmentBodyAsync();
@@ -123,17 +123,10 @@ export class ImportAssessmentDialog {
 		}
 	}
 
-	private async shouldNoTargetSelectionDisplayAsync(visible: boolean) {
-		if (visible) {
-			await utils.updateControlDisplay(this._bodySection, false);
-			await utils.updateControlDisplay(this._header.headerCardsContainer, false);
-			await utils.updateControlDisplay(this._header.noTargetSelectedContainer, true, 'flex');
-		}
-		else {
-			await utils.updateControlDisplay(this._header.noTargetSelectedContainer, false);
-			await utils.updateControlDisplay(this._bodySection, true, 'flex');
-			await utils.updateControlDisplay(this._header.headerCardsContainer, true, 'flex');
-		}
+	private async displayAssessmentAsync() {
+		await utils.updateControlDisplay(this._header.noTargetSelectedContainer, false);
+		await utils.updateControlDisplay(this._bodySection, true, 'flex');
+		await utils.updateControlDisplay(this._header.headerCardsContainer, true, 'flex');
 	}
 
 	private getTargetTypeBasedOnSelection(targetType: string): MigrationTargetType {

--- a/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetailsPage.ts
+++ b/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetailsPage.ts
@@ -26,7 +26,7 @@ export class AssessmentDetailsPage extends MigrationWizardPage {
 	private _body;
 	private _disposables: vscode.Disposable[] = [];
 	private static readonly _assessmentReportName: string = 'SqlAssessmentReport.json';
-	private _previousTargetTypeUndefined: boolean = false;
+	private _previousTargetTypeUndefined: boolean = true;
 
 	constructor(
 		wizard: azdata.window.Wizard,

--- a/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetailsPage.ts
+++ b/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetailsPage.ts
@@ -26,6 +26,7 @@ export class AssessmentDetailsPage extends MigrationWizardPage {
 	private _body;
 	private _disposables: vscode.Disposable[] = [];
 	private static readonly _assessmentReportName: string = 'SqlAssessmentReport.json';
+	private _previousTargetTypeUndefined: boolean = false;
 
 	constructor(
 		wizard: azdata.window.Wizard,
@@ -125,6 +126,7 @@ export class AssessmentDetailsPage extends MigrationWizardPage {
 		this.wizard.customButtons[2].hidden = false;
 		if (this.migrationStateModel._targetType === undefined) {
 			await this.shouldNoTargetSelectionDisplayAsync(true);
+			this._previousTargetTypeUndefined = true;
 		}
 		else {
 			await this.executeChange(this.migrationStateModel._targetType);
@@ -166,7 +168,13 @@ export class AssessmentDetailsPage extends MigrationWizardPage {
 
 	// function to execute when user changes target type for the selected databases.
 	private async executeChange(newTargetType: string): Promise<void> {
-		const selectedDbs = this._body.treeComponent.selectedDbs();
+		let selectedDbs = this._body.treeComponent.selectedDbs();
+
+		// This condition is handled to select all the databases chosen for assessment by default(when page opens for the first time) to migrate as well.
+		if (this._previousTargetTypeUndefined) {
+			selectedDbs = this.migrationStateModel._databasesForAssessment;
+			this._previousTargetTypeUndefined = false;
+		}
 		switch (newTargetType) {
 			case MigrationTargetType.SQLMI:
 				this.didUpdateDatabasesForMigration(this.migrationStateModel._miDbs, selectedDbs);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR has two changes:

1. Select all databases by default to migrate on Assessment results page. (changes in` assessmentDetailsPage.ts `file)
<img width="642" alt="image" src="https://github.com/microsoft/azuredatastudio/assets/87131830/eac5ca32-6489-42cd-b35d-d17e2e25e54f">


2. Import feedback by Abhishek -  (changes in` importAssessmentDialog.ts` file)
       a. Change Import heading.
       b. Select MI as default on import page and don't show no target selection page.
       
<img width="620" alt="image" src="https://github.com/microsoft/azuredatastudio/assets/87131830/e44d3269-8a3e-4d64-a563-721dd3adb478">
 