### PR TITLE
vbump 1.5.1 for sql migration to inside gallery

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3979,14 +3979,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.0",
-							"lastUpdated": "11/06/2023",
+							"version": "1.5.1",
+							"lastUpdated": "11/22/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.5.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.5.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the insider extension gallery to the latest version 1.5.1 of the SQL Migration extension. sql-migration-1.5.1.vsix

Link to Azure Data Studio - Extensions Product pipeline run off main: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=216779&view=results

VSIX Link: https://mssqltools.visualstudio.com/_apis/resources/Containers/6419380/drop?itemPath=drop%2Fextensions%2Fsql-migration-1.5.1.vsix
