### PR TITLE
Fix account refresh issue + enable extHostTreeView tests

### DIFF
--- a/extensions/azurecore/src/azureResource/tree/connectionDialogTreeProvider.ts
+++ b/extensions/azurecore/src/azureResource/tree/connectionDialogTreeProvider.ts
@@ -88,7 +88,7 @@ export class ConnectionDialogTreeProvider implements vscode.TreeDataProvider<Tre
 			this.accounts = await azdata.accounts.getAllAccounts();
 			// System has been initialized
 			this.setSystemInitialized();
-			this._onDidChangeTreeData.fire(undefined);
+			this.notifyNodeChanged(undefined);
 		} catch (err) {
 			// Skip for now, we can assume that the accounts changed event will eventually notify instead
 			Logger.error('loadAccounts failed with the following error: {0}', err.message ?? err);
@@ -116,7 +116,7 @@ export class ConnectionDialogTreeProvider implements vscode.TreeDataProvider<Tre
 			}
 		}
 
-		this._onDidChangeTreeData.fire(node);
+		this.notifyNodeChanged(node);
 	}
 
 	public getTreeItem(element: TreeNode): vscode.TreeItem | Thenable<vscode.TreeItem> {

--- a/extensions/azurecore/src/azureResource/tree/treeProvider.ts
+++ b/extensions/azurecore/src/azureResource/tree/treeProvider.ts
@@ -18,14 +18,16 @@ import { AzureResourceErrorMessageUtil, equals } from '../utils';
 import { IAzureResourceTreeChangeHandler } from './treeChangeHandler';
 import { AzureAccount } from 'azurecore';
 
-export class AzureResourceTreeProvider implements vscode.TreeDataProvider<TreeNode>, IAzureResourceTreeChangeHandler {
+export class AzureResourceTreeProvider extends vscode.Disposable implements vscode.TreeDataProvider<TreeNode>, IAzureResourceTreeChangeHandler {
 	public isSystemInitialized: boolean = false;
-
 	private accounts: AzureAccount[] = [];
 	private _onDidChangeTreeData = new vscode.EventEmitter<TreeNode | undefined>();
 	private loadingAccountsPromise: Promise<void> | undefined;
 
 	public constructor(private readonly appContext: AppContext) {
+		super(() => {
+			this._onDidChangeTreeData.dispose();
+		});
 		azdata.accounts.onDidChangeAccounts(async (e: azdata.DidChangeAccountsParams) => {
 			// This event sends it per provider, we need to make sure we get all the azure related accounts
 			let accounts = await azdata.accounts.getAllAccounts();
@@ -73,7 +75,7 @@ export class AzureResourceTreeProvider implements vscode.TreeDataProvider<TreeNo
 			this.accounts = await azdata.accounts.getAllAccounts();
 			// System has been initialized
 			this.setSystemInitialized();
-			this._onDidChangeTreeData.fire(undefined);
+			this.notifyNodeChanged(undefined);
 		} catch (err) {
 			// Skip for now, we can assume that the accounts changed event will eventually notify instead
 			this.isSystemInitialized = false;
@@ -99,7 +101,7 @@ export class AzureResourceTreeProvider implements vscode.TreeDataProvider<TreeNo
 				node.clearCache();
 			}
 		}
-		this._onDidChangeTreeData.fire(node);
+		this.notifyNodeChanged(node);
 	}
 
 	public getTreeItem(element: TreeNode): vscode.TreeItem | Thenable<vscode.TreeItem> {

--- a/src/sql/workbench/api/common/extHostModelViewTree.ts
+++ b/src/sql/workbench/api/common/extHostModelViewTree.ts
@@ -111,8 +111,8 @@ export class ExtHostModelViewTreeViews implements ExtHostModelViewTreeViewsShape
 
 export class ExtHostTreeView<T> extends vsTreeExt.ExtHostTreeView<T> {
 
-	private _onNodeCheckedChanged = new Emitter<azdata.NodeCheckedEventParameters<T>>();
-	private _onChangeSelection = new Emitter<vscode.TreeViewSelectionChangeEvent<T>>();
+	private _onNodeCheckedChanged = this._register(new Emitter<azdata.NodeCheckedEventParameters<T>>());
+	private _onChangeSelection = this._register(new Emitter<vscode.TreeViewSelectionChangeEvent<T>>());
 	public readonly NodeCheckedChanged: vscode.Event<azdata.NodeCheckedEventParameters<T>> = this._onNodeCheckedChanged.event;
 	public readonly ChangeSelection: vscode.Event<vscode.TreeViewSelectionChangeEvent<T>> = this._onChangeSelection.event;
 	constructor(
@@ -150,7 +150,7 @@ export class ExtHostTreeView<T> extends vsTreeExt.ExtHostTreeView<T> {
 				.then(treeNode => i)));
 	}
 
-	protected refreshElements(elements: T[]): void {
+	public refreshElements(elements: T[]): void {
 		const hasRoot = elements.some(element => !element);
 		if (hasRoot) {
 			this.clearAll(); // clear cache

--- a/src/sql/workbench/api/test/browser/mainThreadBackgroundTaskManagement.test.ts
+++ b/src/sql/workbench/api/test/browser/mainThreadBackgroundTaskManagement.test.ts
@@ -54,6 +54,7 @@ suite('MainThreadBackgroundTaskManagement Tests', () => {
 		taskService.setup(x => x.onTaskComplete).returns(() => onTaskComplete.event);
 
 		mainThreadBackgroundTaskManagement = new MainThreadBackgroundTaskManagement(mainContext, taskService.object);
+		onTaskComplete.dispose();
 	});
 
 	test('RegisterTask should successfully create background task', () => {

--- a/src/sql/workbench/api/test/browser/mainThreadModelViewDialog.test.ts
+++ b/src/sql/workbench/api/test/browser/mainThreadModelViewDialog.test.ts
@@ -264,6 +264,11 @@ suite('MainThreadModelViewDialog Tests', () => {
 
 		// Verify that the correct button click notifications were sent to the proxy
 		assert.deepStrictEqual(pressedHandles, [button1Handle, button2Handle, okButtonHandle, cancelButtonHandle, button2Handle, cancelButtonHandle, button1Handle, okButtonHandle]);
+
+		okEmitter.dispose();
+		cancelEmitter.dispose();
+		button1Emitter.dispose();
+		button2Emitter.dispose();
 	});
 
 	test('Creating a wizard and calling open on it causes a wizard with correct pages and buttons to open', () => {

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -311,7 +311,7 @@ export interface TreeNode extends IDisposable { // {{SQL CARBON EDIT}} export in
 	disposableStore: DisposableStore;
 }
 
-// {{SQL CARBON EDIT}}
+// {{SQL CARBON EDIT}} Export class
 export class ExtHostTreeView<T> extends Disposable {
 
 	private static readonly LABEL_HANDLE_PREFIX = '0';
@@ -322,7 +322,7 @@ export class ExtHostTreeView<T> extends Disposable {
 
 	private roots: TreeNode[] | undefined = undefined;
 	private elements: Map<TreeItemHandle, T> = new Map<TreeItemHandle, T>();
-	// {{SQL CARBON EDIT}}
+	// {{SQL CARBON EDIT}} Make protected
 	protected nodes: Map<T, TreeNode> = new Map<T, TreeNode>();
 
 	private _visible: boolean = false;
@@ -377,7 +377,7 @@ export class ExtHostTreeView<T> extends Disposable {
 		this.dataProvider = options.treeDataProvider;
 		this.dndController = options.dragAndDropController;
 
-		// {{SQL CARBON EDIT}}
+		// {{SQL CARBON EDIT}} Register TreeView Data Provider
 		const dropMimeTypes = options.dragAndDropController?.dropMimeTypes ?? [];
 		const dragMimeTypes = options.dragAndDropController?.dragMimeTypes ?? [];
 		const hasHandleDrag = !!options.dragAndDropController?.handleDrag;
@@ -636,7 +636,8 @@ export class ExtHostTreeView<T> extends Disposable {
 		return undefined; // {{SQL CARBON EDIT}} strict-null-checks
 	}
 
-	protected resolveUnknownParentChain(element: T): Promise<TreeNode[]> { // {{SQL CARBON EDIT}}
+	// {{SQL CARBON EDIT}} Make method protected
+	protected resolveUnknownParentChain(element: T): Promise<TreeNode[]> {
 		return this.resolveParent(element)
 			.then((parent) => {
 				if (!parent) {
@@ -659,7 +660,7 @@ export class ExtHostTreeView<T> extends Disposable {
 		return asPromise(() => this.dataProvider.getParent!(element));
 	}
 
-	// {{SQL CARBON EDIT}}
+	// {{SQL CARBON EDIT}} Make method protected
 	protected resolveTreeNode(element: T, parent?: TreeNode): Promise<TreeNode> {
 		const node = this.nodes.get(element);
 		if (node) {
@@ -741,7 +742,7 @@ export class ExtHostTreeView<T> extends Disposable {
 		return Promise.resolve(undefined);
 	}
 
-	// {{SQL CARBON EDIT}}
+	// {{SQL CARBON EDIT}} Make method protected
 	protected getHandlesToRefresh(elements: T[]): TreeItemHandle[] {
 		const elementsToUpdate = new Set<TreeItemHandle>();
 		const elementNodes = elements.map(element => this.nodes.get(element));
@@ -774,7 +775,7 @@ export class ExtHostTreeView<T> extends Disposable {
 		return handlesToUpdate;
 	}
 
-	// {{SQL CARBON EDIT}}
+	// {{SQL CARBON EDIT}} Make method protected
 	protected refreshHandles(itemHandles: TreeItemHandle[]): Promise<void> {
 		const itemsToRefresh: { [treeItemHandle: string]: ITreeItem } = {};
 		return Promise.all(itemHandles.map(treeItemHandle =>
@@ -787,7 +788,7 @@ export class ExtHostTreeView<T> extends Disposable {
 			.then(() => Object.keys(itemsToRefresh).length ? this.proxy.$refresh(this.viewId, itemsToRefresh) : undefined);
 	}
 
-	// {{SQL CARBON EDIT}}
+	// {{SQL CARBON EDIT}} Make method protected
 	protected refreshNode(treeItemHandle: TreeItemHandle): Promise<TreeNode | null> {
 		const extElement = this.getExtensionElement(treeItemHandle);
 		if (extElement) {
@@ -797,6 +798,8 @@ export class ExtHostTreeView<T> extends Disposable {
 				return asPromise(() => this.dataProvider.getTreeItem(extElement))
 					.then(extTreeItem => {
 						if (extTreeItem) {
+							// {{ SQL CARBON EDIT }} To fix Azure tree view refresh error, delete existing element before creating new one based on it.
+							this.elements.delete(existing.item.handle);
 							const newNode = this.createTreeNode(extElement, extTreeItem, existing.parent);
 							this.updateNodeCache(extElement, newNode, existing, existing.parent);
 							existing.dispose();
@@ -951,8 +954,7 @@ export class ExtHostTreeView<T> extends Disposable {
 		this.nodes.set(element, node);
 	}
 
-	// {{SQL CARBON EDIT}}
-	protected updateNodeCache(element: T, newNode: TreeNode, existing: TreeNode, parentNode: TreeNode | Root): void {
+	private updateNodeCache(element: T, newNode: TreeNode, existing: TreeNode, parentNode: TreeNode | Root): void {
 		// Remove from the cache
 		this.elements.delete(newNode.item.handle);
 		this.nodes.delete(element);
@@ -1021,7 +1023,7 @@ export class ExtHostTreeView<T> extends Disposable {
 		}
 	}
 
-	protected clearAll(): void { // {{SQL CARBON EDIT}}
+	protected clearAll(): void {
 		this.roots = undefined;
 		this.elements.clear();
 		this.nodes.forEach(node => node.dispose());

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -798,8 +798,6 @@ export class ExtHostTreeView<T> extends Disposable {
 				return asPromise(() => this.dataProvider.getTreeItem(extElement))
 					.then(extTreeItem => {
 						if (extTreeItem) {
-							// {{ SQL CARBON EDIT }} To fix Azure tree view refresh error, delete existing element before creating new one based on it.
-							this.elements.delete(existing.item.handle);
 							const newNode = this.createTreeNode(extElement, extTreeItem, existing.parent);
 							this.updateNodeCache(extElement, newNode, existing, existing.parent);
 							existing.dispose();
@@ -954,6 +952,12 @@ export class ExtHostTreeView<T> extends Disposable {
 		this.nodes.set(element, node);
 	}
 
+	// {{ SQL Carbon Edit}} This method is used to update node in cache, after children are added.
+	private updateNodeInCache(node: TreeNode): void {
+		var element = this.elements.get(node.item.handle);
+		this.nodes.set(element, node);
+	}
+
 	private updateNodeCache(element: T, newNode: TreeNode, existing: TreeNode, parentNode: TreeNode | Root): void {
 		// Remove from the cache
 		this.elements.delete(newNode.item.handle);
@@ -979,6 +983,9 @@ export class ExtHostTreeView<T> extends Disposable {
 				parentNode.children = [];
 			}
 			parentNode.children.push(node);
+			// {{ SQL Carbon Edit }} Update Node in cache to make sure children are available when refreshing nodes later.
+			// This fixes issues during Refresh of Azure tree account nodes.
+			this.updateNodeInCache(parentNode);
 		} else {
 			if (!this.roots) {
 				this.roots = [];

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -954,8 +954,10 @@ export class ExtHostTreeView<T> extends Disposable {
 
 	// {{ SQL Carbon Edit}} This method is used to update node in cache, after children are added.
 	private updateNodeInCache(node: TreeNode): void {
-		var element = this.elements.get(node.item.handle);
-		this.nodes.set(element, node);
+		const element = this.elements.get(node.item.handle);
+		if (element) {
+			this.nodes.set(element, node);
+		}
 	}
 
 	private updateNodeCache(element: T, newNode: TreeNode, existing: TreeNode, parentNode: TreeNode | Root): void {

--- a/src/vs/workbench/api/test/browser/extHostTreeViews.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTreeViews.test.ts
@@ -22,7 +22,7 @@ import { nullExtensionDescription as extensionsDescription } from 'vs/workbench/
 import { runWithFakedTimers } from 'vs/base/test/common/timeTravelScheduler';
 import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
 
-suite.skip('ExtHostTreeView', function () { // {{SQL CARBON EDIT}} Skip suite
+suite('ExtHostTreeView', function () {
 
 	class RecordingShape extends mock<MainThreadTreeViewsShape>() {
 


### PR DESCRIPTION
Fixes #24994 

Noticed an issue with `extHostTreeViews` (vs), where refresh intends to clear children, but because child nodes are not registered in cached parent node, they don't clear and we face the issue above.

For more details: PR https://github.com/microsoft/vscode/pull/199061 addresses the same in VS Code.