### PR TITLE
Fix restore dialog not showing a message after clicking Script

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -308,6 +308,8 @@ export const CompressBackup = localize('objectManagement.compressBackup', "Compr
 export const DontCompressBackup = localize('objectManagement.dontCompressBackup', "Do not compress backup");
 export const RecoveryModelSimple = localize('objectManagement.recoveryModelSimple', "Simple");
 export const PathAlreadyAddedError = localize('objectManagement.pathAlreadyAddedError', "Provided path has already been added to the files list.");
+export const ScriptingFailedError = localize('objectManagement.scriptingFailedError', "Script operation failed.");
+export const BackupFailedError = localize('objectManagement.backupFailedError', "Backup operation failed.");
 
 // Login
 export const BlankPasswordConfirmationText: string = localize('objectManagement.blankPasswordConfirmation', "Creating a login with a blank password is a security risk.  Are you sure you want to continue?");
@@ -329,7 +331,7 @@ export const SQLAuthenticationTypeDisplayText = localize('objectManagement.login
 export const AADAuthenticationTypeDisplayText = localize('objectManagement.login.aadAuthenticationType', "Microsoft Entra ID Authentication");
 export const OldPasswordCannotBeEmptyError = localize('objectManagement.login.oldPasswordCannotBeEmptyError', "Old password cannot be empty.");
 
-//Restore Database
+// Restore Database
 export const RestoreFromText = localize('objectManagement.restoreDatabase.restoreFromText', "Restore from");
 export const BackupFilePathText = localize('objectManagement.restoreDatabase.backupFilePathText', "Backup file path");
 export const DatabaseText = localize('objectManagement.restoreDatabase.databaseText', "Database");

--- a/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
@@ -363,7 +363,7 @@ export class BackupDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		let backupInfo = this.createBackupInfo();
 		let response = await this.objectManagementService.backupDatabase(this.options.connectionUri, backupInfo, TaskExecutionMode.script);
 		if (!response.result) {
-			throw new Error('Script operation failed.');
+			throw new Error(loc.ScriptingFailedError);
 		}
 		// The backup call will open its own query window, so don't return any script here.
 		return undefined;
@@ -373,7 +373,7 @@ export class BackupDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		let backupInfo = this.createBackupInfo();
 		let response = await this.objectManagementService.backupDatabase(this.options.connectionUri, backupInfo, TaskExecutionMode.execute);
 		if (!response.result) {
-			throw new Error('Backup operation failed.');
+			throw new Error(loc.BackupFailedError);
 		}
 	}
 

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -62,7 +62,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 	}
 
 	protected override get helpUrl(): string {
-		return this.RestoreDialogDocUrl;
+		return this.restoreDialogDocUrl;
 	}
 
 	protected override get saveChangesTaskLabel(): string {
@@ -73,7 +73,11 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 		return this.objectInfo.restorePlanResponse.backupSetsToRestore?.filter(plan => plan.isSelected === true).length > 0;
 	}
 
-	private get RestoreDialogDocUrl(): string {
+	protected override get opensEditorSeparately(): boolean {
+		return true;
+	}
+
+	private get restoreDialogDocUrl(): string {
 		let helpUrl = '';
 		switch (this.activeTabId) {
 			case this.generalTabId:


### PR DESCRIPTION
When clicking script in the Restore Database dialog, it kept showing a message saying there was no action to be scripted even though a script window was being opened in the background. The dialog needed to have its opensEditorSeparately flag set to true, since the Restore scripting operation opens an editor separately from the usual object management workflow.

Also fixed some unlocalized strings in the backup dialog while I was at it.
