### PR TITLE
Fix to not connect when opening connection dialog

### DIFF
--- a/src/sql/workbench/contrib/commandLine/electron-sandbox/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-sandbox/commandLine.ts
@@ -122,7 +122,8 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 			return;
 		}
 		let connectedContext: azdata.ConnectedContext = undefined;
-		if (profile) {
+		// Need not connect when opening connection dialog explicitly.
+		if (profile && commandName !== Command.openConnectionDialog) {
 			if (this._notificationService) {
 				this._notificationService.status(localize('connectingLabel', "Connecting: {0}", profile.serverName), { hideAfter: 2500 });
 			}


### PR DESCRIPTION
Discussed here: https://github.com/microsoft/azuredatastudio/issues/25055#issuecomment-1830834739

Fixes an issue where command line interface always connects connection profile despite user specifying 'openConnectionDialog'.

![open](https://github.com/microsoft/azuredatastudio/assets/13396919/d2d1ed91-177f-45da-a76e-f4246773b547)