### PR TITLE
Enable running commands with connection info passed through CLI arguments

### DIFF
--- a/src/sql/workbench/browser/actions.ts
+++ b/src/sql/workbench/browser/actions.ts
@@ -9,7 +9,7 @@ import { IAngularEventingService, AngularEventType } from 'sql/platform/angularE
 import { IInsightsDialogService } from 'sql/workbench/services/insights/browser/insightsDialogService';
 import { Task } from 'sql/workbench/services/tasks/browser/tasksRegistry';
 
-import { ObjectMetadata } from 'azdata';
+import * as azdata from 'azdata';
 
 import { Action } from 'vs/base/common/actions';
 import * as nls from 'vs/nls';
@@ -20,9 +20,13 @@ import { IAccountManagementService } from 'sql/platform/accounts/common/interfac
 import { ILogService } from 'vs/platform/log/common/log';
 import { IInsightsConfig } from 'sql/platform/extensions/common/extensions';
 
-export interface BaseActionContext {
-	object?: ObjectMetadata;
-	profile?: IConnectionProfile;
+export interface BaseActionContext extends azdata.ConnectedContext {
+	object?: azdata.ObjectMetadata;
+	/**
+	 * Override connectionProfile from ConnectedContext
+	 * with IConnectionProfile type
+	 */
+	connectionProfile?: IConnectionProfile | undefined;
 }
 
 export interface InsightActionContext extends BaseActionContext {
@@ -46,8 +50,8 @@ export class ManageAction extends Action {
 	}
 
 	override async run(actionContext: ManageActionContext): Promise<void> {
-		if (actionContext.profile) {
-			await this._connectionManagementService.connect(actionContext.profile, actionContext.uri, { showDashboard: true, saveTheConnection: false, showConnectionDialogOnError: false, showFirewallRuleOnError: true });
+		if (actionContext.connectionProfile) {
+			await this._connectionManagementService.connect(actionContext.connectionProfile, actionContext.uri, { showDashboard: true, saveTheConnection: false, showConnectionDialogOnError: false, showFirewallRuleOnError: true });
 			this._angularEventingService.sendAngularEvent(actionContext.uri, AngularEventType.NAV_DATABASE);
 		}
 	}
@@ -65,8 +69,8 @@ export class InsightAction extends Action {
 	}
 
 	override async run(actionContext: InsightActionContext): Promise<void> {
-		if (actionContext.profile) {
-			await this._insightsDialogService.show(actionContext.insight, actionContext.profile);
+		if (actionContext.connectionProfile) {
+			await this._insightsDialogService.show(actionContext.insight, actionContext.connectionProfile);
 		}
 	}
 }

--- a/src/sql/workbench/browser/scriptingActions.ts
+++ b/src/sql/workbench/browser/scriptingActions.ts
@@ -29,8 +29,8 @@ export class ScriptSelectAction extends Action {
 
 	public override async run(actionContext: BaseActionContext): Promise<void> {
 		await scriptSelect(
-			actionContext.profile!,
-			actionContext.object!,
+			actionContext.connectionProfile,
+			actionContext.object,
 			this._connectionManagementService,
 			this._queryEditorService,
 			this._scriptingService,
@@ -55,8 +55,8 @@ export class ScriptExecuteAction extends Action {
 
 	public override async run(actionContext: BaseActionContext): Promise<void> {
 		await script(
-			actionContext.profile!,
-			actionContext.object!,
+			actionContext.connectionProfile,
+			actionContext.object,
 			this._connectionManagementService,
 			this._queryEditorService,
 			this._scriptingService,
@@ -82,8 +82,8 @@ export class ScriptAlterAction extends Action {
 
 	public override async run(actionContext: BaseActionContext): Promise<void> {
 		await script(
-			actionContext.profile!,
-			actionContext.object!,
+			actionContext.connectionProfile,
+			actionContext.object,
 			this._connectionManagementService,
 			this._queryEditorService,
 			this._scriptingService,
@@ -109,8 +109,8 @@ export class EditDataAction extends Action {
 
 	public override async run(actionContext: BaseActionContext): Promise<void> {
 		await scriptEditSelect(
-			actionContext.profile!,
-			actionContext.object!,
+			actionContext.connectionProfile,
+			actionContext.object,
 			this._connectionManagementService,
 			this._queryEditorService,
 			this._scriptingService,
@@ -135,8 +135,8 @@ export class ScriptCreateAction extends Action {
 
 	public override async run(actionContext: BaseActionContext): Promise<void> {
 		await script(
-			actionContext.profile!,
-			actionContext.object!,
+			actionContext.connectionProfile,
+			actionContext.object,
 			this._connectionManagementService,
 			this._queryEditorService,
 			this._scriptingService,
@@ -162,8 +162,8 @@ export class ScriptDeleteAction extends Action {
 
 	public override async run(actionContext: BaseActionContext): Promise<void> {
 		await script(
-			actionContext.profile!,
-			actionContext.object!,
+			actionContext.connectionProfile,
+			actionContext.object,
 			this._connectionManagementService,
 			this._queryEditorService,
 			this._scriptingService,

--- a/src/sql/workbench/browser/scriptingUtils.ts
+++ b/src/sql/workbench/browser/scriptingUtils.ts
@@ -44,22 +44,26 @@ const ScriptingFailedDialogTitle = nls.localize('scriptingFailed', "Scripting Fa
  */
 export async function scriptSelect(connectionProfile: IConnectionProfile, metadata: azdata.ObjectMetadata, connectionService: IConnectionManagementService, queryEditorService: IQueryEditorService, scriptingService: IScriptingService, errorMessageService: IErrorMessageService): Promise<void> {
 	try {
-		const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
-		let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
-		const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails);
-		if (result && result.script) {
-			const owner = await queryEditorService.newSqlEditor({ initialContent: result.script }, connectionProfile?.providerName);
-			// Connect our editor to the input connection
-			let options: IConnectionCompletionOptions = {
-				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery, input: owner },
-				saveTheConnection: false,
-				showDashboard: false,
-				showConnectionDialogOnError: true,
-				showFirewallRuleOnError: true
-			};
-			await connectionService.connect(connectionProfile, owner.uri, options);
+		if (connectionProfile && metadata) {
+			const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
+			let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
+			const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails);
+			if (result && result.script) {
+				const owner = await queryEditorService.newSqlEditor({ initialContent: result.script }, connectionProfile?.providerName);
+				// Connect our editor to the input connection
+				let options: IConnectionCompletionOptions = {
+					params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery, input: owner },
+					saveTheConnection: false,
+					showDashboard: false,
+					showConnectionDialogOnError: true,
+					showFirewallRuleOnError: true
+				};
+				await connectionService.connect(connectionProfile, owner.uri, options);
+			} else {
+				throw new Error(nls.localize('selectScriptNotGeneratedError', "Failed to generate select script for the selected object."));
+			}
 		} else {
-			throw new Error(nls.localize('selectScriptNotGeneratedError', "Failed to generate select script for the selected object."));
+			throw new Error(nls.localize('noConnProfileForSelectScriptGeneration', "Could not retrieve connection and metadata information for generating select script for the selected object."));
 		}
 	} catch (err) {
 		errorMessageService.showDialog(Severity.Error, ScriptingFailedDialogTitle, err?.message ?? err);
@@ -71,22 +75,26 @@ export async function scriptSelect(connectionProfile: IConnectionProfile, metada
  */
 export async function scriptEditSelect(connectionProfile: IConnectionProfile, metadata: azdata.ObjectMetadata, connectionService: IConnectionManagementService, queryEditorService: IQueryEditorService, scriptingService: IScriptingService, errorMessageService: IErrorMessageService): Promise<void> {
 	try {
-		const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
-		let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata);
-		const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails!);
-		if (result && result.script) {
-			const owner = await queryEditorService.newEditDataEditor(metadata.schema, metadata.name, result.script);
-			// Connect our editor
-			let options: IConnectionCompletionOptions = {
-				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
-				saveTheConnection: false,
-				showDashboard: false,
-				showConnectionDialogOnError: true,
-				showFirewallRuleOnError: true
-			};
-			await connectionService.connect(connectionProfile, owner.uri, options);
+		if (connectionProfile && metadata) {
+			const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
+			let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata);
+			const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails!);
+			if (result && result.script) {
+				const owner = await queryEditorService.newEditDataEditor(metadata.schema, metadata.name, result.script);
+				// Connect our editor
+				let options: IConnectionCompletionOptions = {
+					params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
+					saveTheConnection: false,
+					showDashboard: false,
+					showConnectionDialogOnError: true,
+					showFirewallRuleOnError: true
+				};
+				await connectionService.connect(connectionProfile, owner.uri, options);
+			} else {
+				throw new Error(nls.localize('selectScriptForEditNotGeneratedError', "Failed to generate script for Edit Data editor."));
+			}
 		} else {
-			throw new Error(nls.localize('selectScriptForEditNotGeneratedError', "Failed to generate script for Edit Data editor."));
+			throw new Error(nls.localize('noConnProfileForSelectScriptEditGeneration', "Could not retrieve connection and metadata information for generating select script for the Edit Data editor."));
 		}
 	}
 	catch (err) {
@@ -125,39 +133,43 @@ export async function script(connectionProfile: IConnectionProfile, metadata: az
 	operation: ScriptOperation,
 	errorMessageService: IErrorMessageService): Promise<void> {
 	try {
-		const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
-		let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
-		const result = await scriptingService.script(connectionResult, metadata, operation, paramDetails);
-		if (result) {
-			let script: string = result.script;
+		if (connectionProfile && metadata) {
+			const connectionResult = await connectionService.connectIfNotConnected(connectionProfile);
+			let paramDetails = getScriptingParamDetails(connectionService, connectionResult, metadata)!;
+			const result = await scriptingService.script(connectionResult, metadata, operation, paramDetails);
+			if (result) {
+				let script: string = result.script;
 
-			if (script) {
-				let description = (metadata.schema && metadata.schema !== '') ? `${metadata.schema}.${metadata.name}` : metadata.name;
-				const owner = await queryEditorService.newSqlEditor({ initialContent: script, description }, connectionProfile.providerName);
-				// Connect our editor to the input connection
-				let options: IConnectionCompletionOptions = {
-					params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
-					saveTheConnection: false,
-					showDashboard: false,
-					showConnectionDialogOnError: true,
-					showFirewallRuleOnError: true
-				};
-				await connectionService.connect(connectionProfile, owner.uri, options);
+				if (script) {
+					let description = (metadata.schema && metadata.schema !== '') ? `${metadata.schema}.${metadata.name}` : metadata.name;
+					const owner = await queryEditorService.newSqlEditor({ initialContent: script, description }, connectionProfile.providerName);
+					// Connect our editor to the input connection
+					let options: IConnectionCompletionOptions = {
+						params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },
+						saveTheConnection: false,
+						showDashboard: false,
+						showConnectionDialogOnError: true,
+						showFirewallRuleOnError: true
+					};
+					await connectionService.connect(connectionProfile, owner.uri, options);
+				} else {
+					let scriptNotFoundMsg = nls.localize('scriptNotFoundForObject', "No script was returned when scripting as {0} on object {1}",
+						GetScriptOperationName(operation), metadata.metadataTypeName);
+					let messageDetail = '';
+					let operationResult = scriptingService.getOperationFailedResult(result.operationId);
+					if (operationResult && operationResult.hasError && operationResult.errorMessage) {
+						scriptNotFoundMsg = operationResult.errorMessage;
+						messageDetail = operationResult.errorDetails;
+					}
+					if (errorMessageService) {
+						errorMessageService.showDialog(Severity.Error, ScriptingFailedDialogTitle, scriptNotFoundMsg, messageDetail);
+					}
+				}
 			} else {
-				let scriptNotFoundMsg = nls.localize('scriptNotFoundForObject', "No script was returned when scripting as {0} on object {1}",
-					GetScriptOperationName(operation), metadata.metadataTypeName);
-				let messageDetail = '';
-				let operationResult = scriptingService.getOperationFailedResult(result.operationId);
-				if (operationResult && operationResult.hasError && operationResult.errorMessage) {
-					scriptNotFoundMsg = operationResult.errorMessage;
-					messageDetail = operationResult.errorDetails;
-				}
-				if (errorMessageService) {
-					errorMessageService.showDialog(Severity.Error, ScriptingFailedDialogTitle, scriptNotFoundMsg, messageDetail);
-				}
+				throw new Error(nls.localize('scriptNotFound', "No script was returned when scripting as {0}", GetScriptOperationName(operation)));
 			}
 		} else {
-			throw new Error(nls.localize('scriptNotFound', "No script was returned when scripting as {0}", GetScriptOperationName(operation)));
+			throw new Error(nls.localize('scriptConnProfileNotFound', "Could not retrieve connection and metadata information when scripting as {0}", GetScriptOperationName(operation)));
 		}
 	} catch (err) {
 		errorMessageService.showDialog(Severity.Error, ScriptingFailedDialogTitle, err?.message ?? err);

--- a/src/sql/workbench/contrib/backup/browser/backup.contribution.ts
+++ b/src/sql/workbench/contrib/backup/browser/backup.contribution.ts
@@ -75,7 +75,7 @@ const ExplorerBackUpActionID = 'explorer.backup';
 CommandsRegistry.registerCommand(ExplorerBackUpActionID, async (accessor, context: ManageActionContext) => {
 	const commandService = accessor.get(ICommandService);
 	const connectionService = accessor.get(IConnectionManagementService);
-	let profile = await connectionService.fixProfile(context.profile);
+	let profile = await connectionService.fixProfile(context.connectionProfile);
 	return commandService.executeCommand(BackupAction.ID, profile);
 });
 

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable.ts
@@ -132,11 +132,11 @@ export class ExplorerTable extends Disposable {
 		if (dataContext instanceof ObjectMetadataWrapper) {
 			context = {
 				object: dataContext,
-				profile: this.bootStrapService.connectionManagementService.connectionInfo.connectionProfile
+				connectionProfile: this.bootStrapService.connectionManagementService.connectionInfo.connectionProfile
 			};
 		} else {
 			context = {
-				profile: dataContext.toIConnectionProfile(),
+				connectionProfile: dataContext.toIConnectionProfile(),
 				uri: this.bootStrapService.getUnderlyingUri()
 			};
 		}

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions.ts
@@ -36,7 +36,7 @@ export class RunInsightQueryAction extends Action {
 		} else {
 			return;
 		}
-		await this.instantiationService.invokeFunction(openNewQuery, context.profile, queryString,
+		await this.instantiationService.invokeFunction(openNewQuery, context.connectionProfile, queryString,
 			RunQueryOnConnectionMode.executeQuery);
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component.ts
@@ -142,7 +142,7 @@ export class InsightsWidget extends DashboardWidget implements IDashboardWidget,
 			this._intervalTimer = new IntervalTimer();
 			this._register(this._intervalTimer);
 			this._intervalTimer.cancelAndSet(() => {
-				const autoRefresh = getWidgetAutoRefreshState(this.insightConfig.id, this.actionsContext.profile.id);
+				const autoRefresh = getWidgetAutoRefreshState(this.insightConfig.id, this.actionsContext.connectionProfile.id);
 				this.updateAutoRefreshStatus(autoRefresh);
 				if (!autoRefresh) {
 					return;

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -29,7 +29,7 @@ import { MssqlNodeContext } from 'sql/workbench/services/objectExplorer/browser/
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { TreeViewItemHandleArg } from 'sql/workbench/common/views';
-import { ConnectedContext, nb } from 'azdata';
+import { nb } from 'azdata';
 import { TreeNodeContextKey } from 'sql/workbench/services/objectExplorer/common/treeNodeContextKey';
 import { ObjectExplorerActionsContext } from 'sql/workbench/services/objectExplorer/browser/objectExplorerActions';
 import { ItemContextKey } from 'sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerContext';
@@ -159,8 +159,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 const ExplorerNotebookActionID = 'explorer.notebook';
 CommandsRegistry.registerCommand(ExplorerNotebookActionID, (accessor, context: ManageActionContext) => {
 	const instantiationService = accessor.get(IInstantiationService);
-	const connectedContext: ConnectedContext = { connectionProfile: context.profile };
-	instantiationService.createInstance(NewNotebookAction).run(accessor, { connectionProfile: connectedContext.connectionProfile, isConnectionNode: false, nodeInfo: undefined });
+	instantiationService.createInstance(NewNotebookAction).run(accessor, { connectionProfile: context.connectionProfile, isConnectionNode: false, nodeInfo: undefined });
 });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerWidgetContext, {

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -93,7 +93,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 const ExplorerNewQueryActionID = 'explorer.query';
 CommandsRegistry.registerCommand(ExplorerNewQueryActionID, (accessor, context: ManageActionContext) => {
 	const commandService = accessor.get(ICommandService);
-	return commandService.executeCommand(NewQueryTask.ID, context.profile);
+	return commandService.executeCommand(NewQueryTask.ID, context.connectionProfile);
 });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerWidgetContext, {

--- a/src/sql/workbench/contrib/restore/browser/restore.contribution.ts
+++ b/src/sql/workbench/contrib/restore/browser/restore.contribution.ts
@@ -77,7 +77,7 @@ const ExplorerRestoreActionID = 'explorer.restore';
 CommandsRegistry.registerCommand(ExplorerRestoreActionID, async (accessor, context: ManageActionContext) => {
 	const commandService = accessor.get(ICommandService);
 	const connectionService = accessor.get(IConnectionManagementService);
-	let profile = await connectionService.fixProfile(context.profile);
+	let profile = await connectionService.fixProfile(context.connectionProfile);
 	return commandService.executeCommand(RestoreAction.ID, profile);
 });
 

--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -53,7 +53,7 @@ CommandsRegistry.registerCommand({
 			let payload = await connectionService.fixProfile(args.$treeItem.payload);
 			const profile = new ConnectionProfile(capabilitiesService, payload);
 			const baseContext: BaseActionContext = {
-				profile: profile,
+				connectionProfile: profile,
 				object: oeShimService.getNodeInfoForTreeItem(args.$treeItem)!.metadata
 			};
 			const scriptCreateAction = new ScriptCreateAction(ScriptCreateAction.ID, ScriptCreateAction.LABEL,
@@ -79,7 +79,7 @@ CommandsRegistry.registerCommand({
 			let payload = await connectionService.fixProfile(args.$treeItem.payload);
 			const profile = new ConnectionProfile(capabilitiesService, payload);
 			const baseContext: BaseActionContext = {
-				profile: profile,
+				connectionProfile: profile,
 				object: oeShimService.getNodeInfoForTreeItem(args.$treeItem)!.metadata
 			};
 			const scriptDeleteAction = new ScriptDeleteAction(ScriptDeleteAction.ID, ScriptDeleteAction.LABEL,
@@ -105,7 +105,7 @@ CommandsRegistry.registerCommand({
 			let payload = await connectionService.fixProfile(args.$treeItem.payload);
 			const profile = new ConnectionProfile(capabilitiesService, payload);
 			const baseContext: BaseActionContext = {
-				profile: profile,
+				connectionProfile: profile,
 				object: oeShimService.getNodeInfoForTreeItem(args.$treeItem)!.metadata
 			};
 			const scriptSelectAction = new ScriptSelectAction(ScriptSelectAction.ID, ScriptSelectAction.LABEL,
@@ -131,7 +131,7 @@ CommandsRegistry.registerCommand({
 			let payload = await connectionService.fixProfile(args.$treeItem.payload);
 			const profile = new ConnectionProfile(capabilitiesService, payload);
 			const baseContext: BaseActionContext = {
-				profile: profile,
+				connectionProfile: profile,
 				object: oeShimService.getNodeInfoForTreeItem(args.$treeItem)!.metadata
 			};
 			const scriptExecuteAction = new ScriptExecuteAction(ScriptExecuteAction.ID, ScriptExecuteAction.LABEL,
@@ -157,7 +157,7 @@ CommandsRegistry.registerCommand({
 			let payload = await connectionService.fixProfile(args.$treeItem.payload);
 			const profile = new ConnectionProfile(capabilitiesService, payload);
 			const baseContext: BaseActionContext = {
-				profile: profile,
+				connectionProfile: profile,
 				object: oeShimService.getNodeInfoForTreeItem(args.$treeItem)!.metadata
 			};
 			const scriptAlterAction = new ScriptAlterAction(ScriptAlterAction.ID, ScriptAlterAction.LABEL,
@@ -183,7 +183,7 @@ CommandsRegistry.registerCommand({
 			let payload = await connectionService.fixProfile(args.$treeItem.payload);
 			const profile = new ConnectionProfile(capabilitiesService, payload);
 			const baseContext: BaseActionContext = {
-				profile: profile,
+				connectionProfile: profile,
 				object: oeShimService.getNodeInfoForTreeItem(args.$treeItem)!.metadata
 			};
 			const editDataAction = new EditDataAction(EditDataAction.ID, EditDataAction.LABEL,

--- a/src/sql/workbench/services/insights/browser/insightsDialogView.ts
+++ b/src/sql/workbench/services/insights/browser/insightsDialogView.ts
@@ -499,7 +499,7 @@ export class InsightsDialogView extends Modal {
 
 		let cellData = element[this._bottomColumns[cell.cell].id];
 
-		return { profile: undefined, cellData };
+		return { connectionProfile: undefined, cellData };
 	}
 
 	private _enableTaskButtons(val: boolean): void {


### PR DESCRIPTION
Fixes #25068

This fix will enable developers/extensions to design commands for ADS startup to work with passed-in connection information in CLI arguments.

e.g. `azuredatastudio --command=explorer.query --server={servername} --user={username}`
launches a query editor connected to server passed in CLI.

![connProfileFix](https://github.com/microsoft/azuredatastudio/assets/13396919/79a94616-05bc-48eb-8b84-b1eec289d829)
