### PR TITLE
vBump sql-migration 1.5.1

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3979,14 +3979,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.0",
-							"lastUpdated": "11/13/2023",
+							"version": "1.5.1",
+							"lastUpdated": "11/30/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.5.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.5.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION

This PR updates the SQL Migration extension version to 1.5.1 into stable gallery.

Insider Gallery vBump PR: https://github.com/microsoft/azuredatastudio/pull/25028 