### PR TITLE
add Catppuccin theme extension

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -5336,6 +5336,67 @@
 					],
 					"statistics": [],
 					"flags": ""
+				},
+				{
+					"extensionId": "105",
+					"extensionName": "catppuccin-vsc",
+					"displayName": "Catppuccin for Azure Data Studio",
+					"shortDescription": "🦌 Soothing pastel theme for Azure Data Studio",
+					"publisher": {
+						"displayName": "Catppuccin",
+						"publisherId": "Catppuccin",
+						"publisherName": "Catppuccin"
+					},
+					"versions": [
+						{
+							"version": "3.8.0",
+							"lastUpdated": "11/30/2023",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.SQLOps.DownloadPage",
+									"source": "https://github.com/catppuccin/vscode/releases/download/v3.8.0/catppuccin-ads-3.8.0.vsix"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/catppuccin/vscode/main/assets/icon.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/catppuccin/vscode/main/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/catppuccin/vscode/main/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/catppuccin/vscode/main/LICENSE"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": "*"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/catppuccin/vscode"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": ""
 				}
 			],
 			"resultMetadata": [
@@ -5344,7 +5405,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 87
+							"count": 88
 						}
 					]
 				}

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -5270,6 +5270,67 @@
 				],
 				"statistics": [],
 				"flags": ""
+			},
+			{
+				"extensionId": "105",
+				"extensionName": "catppuccin-vsc",
+				"displayName": "Catppuccin for Azure Data Studio",
+				"shortDescription": "🦌 Soothing pastel theme for Azure Data Studio",
+				"publisher": {
+					"displayName": "Catppuccin",
+					"publisherId": "Catppuccin",
+					"publisherName": "Catppuccin"
+				},
+				"versions": [
+					{
+						"version": "3.8.0",
+						"lastUpdated": "11/30/2023",
+						"assetUri": "",
+						"fallbackAssetUri": "fallbackAssetUri",
+						"files": [
+							{
+								"assetType": "Microsoft.SQLOps.DownloadPage",
+								"source": "https://github.com/catppuccin/vscode/releases/download/v3.8.0/catppuccin-ads-3.8.0.vsix"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+								"source": "https://raw.githubusercontent.com/catppuccin/vscode/main/assets/icon.png"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+								"source": "https://raw.githubusercontent.com/catppuccin/vscode/main/README.md"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Code.Manifest",
+								"source": "https://raw.githubusercontent.com/catppuccin/vscode/main/package.json"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Content.License",
+								"source": "https://raw.githubusercontent.com/catppuccin/vscode/main/LICENSE"
+							}
+						],
+						"properties": [
+							{
+								"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+								"value": ""
+							},
+							{
+								"key": "Microsoft.VisualStudio.Code.Engine",
+								"value": "*"
+							},
+							{
+								"key": "Microsoft.AzDataEngine",
+								"value": "*"
+							},
+							{
+								"key": "Microsoft.VisualStudio.Services.Links.Source",
+								"value": "https://github.com/catppuccin/vscode"
+							}
+						]
+					}
+				],
+				"statistics": [],
+				"flags": ""
 			}
 			],
 			"resultMetadata": [
@@ -5278,7 +5339,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 86
+							"count": 87
 						}
 					]
 				}


### PR DESCRIPTION
Adds [Catppuccin for Azure Data Studio](https://github.com/catppuccin/vscode) to both `extensionsGallery` and `extensionsGallery-insider`.
It's pulling from our VSCode theme, but the VSIX is a special build for ADS.