### PR TITLE
Convert to string before locale lower case

### DIFF
--- a/src/sql/platform/connection/common/providerConnectionInfo.ts
+++ b/src/sql/platform/connection/common/providerConnectionInfo.ts
@@ -375,7 +375,7 @@ export class ProviderConnectionInfo implements azdata.ConnectionInfo {
 	 * Also allows for getting the non default options for this profile. (this function is used for changing the title).
 	 * @param needSpecial include all the special options key besides connection name or password in case we have multiple
 	 * distinct connections sharing the same connection name (for connection trees mainly).
-	 * @param getNonDefault get only the non default options (for individual connections) to be used for identfying different properties
+	 * @param getNonDefault get only the non default options (for individual connections) to be used for identifying different properties
 	 * among connections sharing the same title.
 	 */
 	public getConnectionOptionsList(needSpecial: boolean, getNonDefault: boolean): azdata.ConnectionOption[] {
@@ -391,7 +391,7 @@ export class ProviderConnectionInfo implements azdata.ConnectionInfo {
 					element.specialValueType !== ConnectionOptionSpecialType.password) {
 					if (getNonDefault) {
 						let value = this.getOptionValue(element.name);
-						if (value && value.toString().toLocaleLowerCase() !== element.defaultValue?.toLocaleLowerCase()) {
+						if (value && value.toString().toLocaleLowerCase() !== element.defaultValue?.toString().toLocaleLowerCase()) {
 							connectionOptions.push(element);
 						}
 					}


### PR DESCRIPTION
Potentially addresses #25078 
Default values could be non-strings, it seems to cause #25078 for some connection profiles.