### PR TITLE
[Release/1.47] Use python 3.11.x in GitHub workflows (#25019)

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -18,6 +18,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
 
       # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
       - name: Setup Build Environment
@@ -29,9 +35,6 @@ jobs:
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.15
 
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
@@ -81,10 +84,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
 
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
@@ -153,8 +158,7 @@ jobs:
   #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   #   steps:
   #     - uses: actions/checkout@v4
-
-  #     - uses: actions/setup-node@v3
+  #     - uses: actions/setup-node@v4
   #       with:
   #         node-version: 18.15
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.15
       - uses: actions/setup-python@v4
@@ -86,6 +86,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
 
       # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
       - name: Setup Build Environment
@@ -97,9 +103,6 @@ jobs:
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.15
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
         # {{ SQL Carbon Edit}} Use sql-computeNodeModulesCacheKey
@@ -172,9 +175,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
         # {{ SQL Carbon Edit}} Use sql-computeNodeModulesCacheKey
@@ -233,9 +239,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.15
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.x"
 
       - name: Compute node modules cache key
         id: nodeModulesCacheKey


### PR DESCRIPTION
Ports #25019 to release/1.47 branch to fix GitHub CI workflows.