### PR TITLE
[Release/1.47] Use python v3.11 for Darwin (#24976)

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -23,6 +23,11 @@ steps:
     inputs:
       versionSpec: "1.x"
 
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.11.x'
+      addToPath: true
+
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: Get Secrets'
     inputs:


### PR DESCRIPTION
Ports #24976 to release/1.47 to fix ADO macOS issues.