### PR TITLE
Provide proxy options to Blob Service Client

### DIFF
--- a/extensions/azurecore/src/constants.ts
+++ b/extensions/azurecore/src/constants.ts
@@ -35,6 +35,10 @@ export const EnableArcFeaturesSection = 'enableArcFeatures';
 
 export const ServiceName = 'azuredatastudio';
 
+export const HttpConfigSection = 'http';
+
+export const Proxy = 'proxy';
+
 export const TenantSection = 'tenant';
 
 export const NoSystemKeyChainSection = 'noSystemKeychain';
@@ -54,8 +58,6 @@ export const AccountVersion = '2.0';
 
 export const Bearer = 'Bearer';
 
-/** HTTP Client */
-export const httpConfigSectionName = 'http';
 
 /**
  * Use SHA-256 algorithm

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -83,7 +83,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 
 	}
 	updatePiiLoggingLevel();
-
+	let proxyUrl: string | undefined = vscode.workspace.getConfiguration(Constants.HttpConfigSection).get(Constants.Proxy);
 	let eventEmitter: vscode.EventEmitter<azurecore.CacheEncryptionKeys>;
 	// Create the provider service and activate
 	let providerService = await initAzureAccountProvider(extensionContext, storagePath).catch((err) => Logger.error(err));
@@ -186,7 +186,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 			storageAccount: azurecore.azureResource.AzureGraphResource,
 			containerName: string,
 			ignoreErrors: boolean): Promise<azurecore.GetBlobsResult> {
-			return azureResourceUtils.getBlobs(account, subscription, storageAccount, containerName, ignoreErrors);
+			return azureResourceUtils.getBlobs(account, subscription, storageAccount, containerName, ignoreErrors, proxyUrl);
 		},
 		createResourceGroup(account: azurecore.AzureAccount,
 			subscription: azurecore.azureResource.AzureResourceSubscription,
@@ -285,3 +285,4 @@ function updatePiiLoggingLevel(): void {
 	const piiLogging: boolean = vscode.workspace.getConfiguration(Constants.AzureSection).get('piiLogging', false);
 	Logger.piiLogging = piiLogging;
 }
+

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -83,7 +83,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 
 	}
 	updatePiiLoggingLevel();
-	let proxyUrl: string | undefined = vscode.workspace.getConfiguration(Constants.HttpConfigSection).get(Constants.Proxy);
+	const proxyUrl: string | undefined = vscode.workspace.getConfiguration(Constants.HttpConfigSection).get(Constants.Proxy);
 	let eventEmitter: vscode.EventEmitter<azurecore.CacheEncryptionKeys>;
 	// Create the provider service and activate
 	let providerService = await initAzureAccountProvider(extensionContext, storagePath).catch((err) => Logger.error(err));


### PR DESCRIPTION
Ensures proxy options are provided to Blob Service Client to make it work in a proxy-enabled environment.
More details internally communicated.