### PR TITLE
[SQL Migration] Fix schema migration table selection issue

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1725,8 +1725,8 @@ export function TDE_COMPLETED_STATUS(completed: number, total: number): string {
 }
 
 // Schema migration
-export const FULL_SCHEMA_MISSING_ON_TARGET = localize('sql.migration.schema.full.missing', "No schema was found on target. This option must be selected to migrate this database. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.");
-export const PARTIAL_SCHEMA_ON_TARGET = localize('sql.migration.schema.partial.missing', "Missing schemas on the target. Some tables are disabled and cannot be migrated unless this option is selected. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.");
+export const FULL_SCHEMA_MISSING_ON_TARGET = localize('sql.migration.schema.full.missing', "No schema was found on target. This option must be selected to migrate this database. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration. No tables selected will migrate missing schema only.");
+export const PARTIAL_SCHEMA_ON_TARGET = localize('sql.migration.schema.partial.missing', "Missing schemas on the target. Some tables are disabled and cannot be migrated unless this option is selected. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.  No tables selected will migrate missing schema only.");
 export const FULL_SCHEMA_ON_TARGET = localize('sql.migration.schema.no.missing', "Schema was found on target. Schema migration is not required.");
 export const ALL_SOURCE_TABLES_EMPTY = localize('sql.migration.all.source.tables.empty', "All of source tables are empty. No table is available to select for data migration. But they are available for schema migration if they do not exist on target.");
 export const SCHEMA_MIGRATION_INFO = localize('sql.migration.schema.migration.info', "Select this option to migrate missing tables on your Azure SQL target");
@@ -1754,7 +1754,6 @@ export const DEPLOYMENT_ENDED = localize('sql.migration.schema.script.deployment
 export const DEPLOYMENT_COUNT = localize('sql.migration.schema.script.deployment.count', "Deployment count");
 export const DEPLOYMENT_ERROR_COUNT = localize('sql.migration.schema.script.deployment.error.count', "Deployment error count");
 export const SCHEMA_MIGRATION_ASSESSMENT_WARNING_MESSAGE = localize('sql.migration.schema.assessment.warning.message', "The detected issues shown below might fail the schema migration. Some of them might be entirely unsupported and the others might be partially supported in Azure SQL Database. \nTherefore, please review the assessment results and make sure all of the issues will not fail the schema migration.\nHowever, it is allowed to proceed the schema migration and Azure Database Migration Service will migrate the objects as possible as it can.");
-
 export const SchemaMigrationFailedRulesLookup: LookupTable<string | undefined> = {
 	["ComputeClause"]: localize('sql.migration.schema.rule.compute', 'COMPUTE'),
 	["CrossDatabaseReferences"]: localize('sql.migration.schema.rule.crossdatabasereferences', 'CROSS DATABASE REFERENCE'),
@@ -1784,7 +1783,7 @@ export function MISSING_TARGET_TABLES_COUNT(missingCount: number): string {
 export function UNAVAILABLE_SOURCE_TABLES_COUNT(unavailableCount: number): string {
 	return localize('sql.migration.table.unavailable.count', "Unavailable for data migration ({0})", formatNumber(unavailableCount));
 }
-export const MISSING_TABLES_HEADING = localize('sql.migration.missing.tables.heading', 'All of tables below are missing on target. To migrate the data in these tables, select the migrate schema option above. If the migration schema option is selected and no tables are selected, migrate schema only.');
+export const MISSING_TABLES_HEADING = localize('sql.migration.missing.tables.heading', 'All of tables below are missing on target. To migrate the data in these tables, select the migrate schema option above.');
 export const UNAVAILABLE_SOURCE_TABLES_HEADING = localize('sql.migration.unavailable.source.tables.heading', 'All of tables below are empty. No table is available to select for data migration. But if they do not exist on target, schema migration is available.');
 export const DATABASE_MISSING_TABLES = localize('sql.migration.database.missing.tables', "0 tables on source database found on target database. To migrate the data in the tables select the migrate schema option above.");
 export const MIGRATION_TYPE_TOOL_TIP = localize('sql.migration.database.migration.migration.type.tool.tip', "Migration type includes: Schema only migration, Data only migration, Schema and data migration.");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1784,7 +1784,7 @@ export function MISSING_TARGET_TABLES_COUNT(missingCount: number): string {
 export function UNAVAILABLE_SOURCE_TABLES_COUNT(unavailableCount: number): string {
 	return localize('sql.migration.table.unavailable.count', "Unavailable for data migration ({0})", formatNumber(unavailableCount));
 }
-export const MISSING_TABLES_HEADING = localize('sql.migration.missing.tables.heading', 'All of tables below are missing on target. To migrate the data in these tables select the migrate schema option above.');
+export const MISSING_TABLES_HEADING = localize('sql.migration.missing.tables.heading', 'All of tables below are missing on target. To migrate the data in these tables, select the migrate schema option above. If the migration schema option is selected and no tables are selected, migrate schema only.');
 export const UNAVAILABLE_SOURCE_TABLES_HEADING = localize('sql.migration.unavailable.source.tables.heading', 'All of tables below are empty. No table is available to select for data migration. But if they do not exist on target, schema migration is available.');
 export const DATABASE_MISSING_TABLES = localize('sql.migration.database.missing.tables', "0 tables on source database found on target database. To migrate the data in the tables select the migrate schema option above.");
 export const MIGRATION_TYPE_TOOL_TIP = localize('sql.migration.database.migration.migration.type.tool.tip', "Migration type includes: Schema only migration, Data only migration, Schema and data migration.");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1725,8 +1725,8 @@ export function TDE_COMPLETED_STATUS(completed: number, total: number): string {
 }
 
 // Schema migration
-export const FULL_SCHEMA_MISSING_ON_TARGET = localize('sql.migration.schema.full.missing', "No schema was found on target. This option must be selected to migrate this database.");
-export const PARTIAL_SCHEMA_ON_TARGET = localize('sql.migration.schema.partial.missing', "Missing schemas on the target. Some tables are disabled and cannot be migrated unless this option is selected.");
+export const FULL_SCHEMA_MISSING_ON_TARGET = localize('sql.migration.schema.full.missing', "No schema was found on target. This option must be selected to migrate this database. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.");
+export const PARTIAL_SCHEMA_ON_TARGET = localize('sql.migration.schema.partial.missing', "Missing schemas on the target. Some tables are disabled and cannot be migrated unless this option is selected. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.");
 export const FULL_SCHEMA_ON_TARGET = localize('sql.migration.schema.no.missing', "Schema was found on target. Schema migration is not required.");
 export const ALL_SOURCE_TABLES_EMPTY = localize('sql.migration.all.source.tables.empty', "All of source tables are empty. No table is available to select for data migration. But they are available for schema migration if they do not exist on target.");
 export const SCHEMA_MIGRATION_INFO = localize('sql.migration.schema.migration.info', "Select this option to migrate missing tables on your Azure SQL target");

--- a/extensions/sql-migration/src/dialog/tableMigrationSelection/tableMigrationSelectionDialog.ts
+++ b/extensions/sql-migration/src/dialog/tableMigrationSelection/tableMigrationSelectionDialog.ts
@@ -143,6 +143,7 @@ export class TableMigrationSelectionDialog {
 					});
 				} else if (this._availableTablesSelectionMap.size === 0) {
 					// Full schema missing on the target
+					this._schemaMigrationCheckBox.enabled = true;
 					await this._schemaMigrationInfoBox.updateProperties(<azdata.InfoBoxComponentProperties>{
 						text: constants.FULL_SCHEMA_MISSING_ON_TARGET,
 						style: "warning",
@@ -152,6 +153,7 @@ export class TableMigrationSelectionDialog {
 					});
 				} else if (this._missingTablesSelectionMap.size > 0 || hasMissingUnavailableTables) {
 					// Partial schema found on the target
+					this._schemaMigrationCheckBox.enabled = true;
 					await this._schemaMigrationInfoBox.updateProperties(<azdata.InfoBoxComponentProperties>{
 						text: constants.PARTIAL_SCHEMA_ON_TARGET,
 						style: "warning",
@@ -182,7 +184,6 @@ export class TableMigrationSelectionDialog {
 			};
 		} finally {
 			this._refreshLoader.loading = false;
-			this._schemaMigrationCheckBox.enabled = true;
 			await this._dataMigrationHeader.updateProperty("description", constants.DATA_MIGRATION_INFO);
 			await updateControlDisplay(this._availableTablesSelectionTable, true, 'flex');
 			await updateControlDisplay(this._missingTablesSelectionTable, true, 'flex');
@@ -720,7 +721,7 @@ export class TableMigrationSelectionDialog {
 			})
 
 			targetDatabaseInfo.hasMissingTables = this._hasMissingTables;
-			targetDatabaseInfo.enableSchemaMigration = selectedRowsFromMissingTable.length > 0;
+			targetDatabaseInfo.enableSchemaMigration = this._schemaMigrationCheckBox.checked ?? selectedRowsFromMissingTable.length > 0;
 			this._model._sourceTargetMapping.set(this._sourceDatabaseName, targetDatabaseInfo);
 		}
 		await this._onSaveCallback();

--- a/extensions/sql-migration/src/dialog/tableMigrationSelection/tableMigrationSelectionDialog.ts
+++ b/extensions/sql-migration/src/dialog/tableMigrationSelection/tableMigrationSelectionDialog.ts
@@ -22,6 +22,7 @@ export class TableMigrationSelectionDialog {
 	private _refreshButton!: azdata.ButtonComponent;
 	private _schemaMigrationCheckBox!: azdata.CheckBoxComponent;
 	private _schemaMigrationInfoBox!: azdata.InfoBoxComponent;
+	private _dataMigrationHeader!: azdata.TextComponent;
 	private _filterInputBox!: azdata.InputBoxComponent;
 	private _availableTablesSelectionTable!: azdata.TableComponent;
 	private _missingTablesSelectionTable!: azdata.TableComponent;
@@ -181,6 +182,8 @@ export class TableMigrationSelectionDialog {
 			};
 		} finally {
 			this._refreshLoader.loading = false;
+			this._schemaMigrationCheckBox.enabled = true;
+			await this._dataMigrationHeader.updateProperty("description", constants.DATA_MIGRATION_INFO);
 			await updateControlDisplay(this._availableTablesSelectionTable, true, 'flex');
 			await updateControlDisplay(this._missingTablesSelectionTable, true, 'flex');
 			await updateControlDisplay(this._unavailableSourceTablesTable, true, 'flex');
@@ -219,6 +222,7 @@ export class TableMigrationSelectionDialog {
 
 		this._schemaMigrationCheckBox = view.modelBuilder.checkBox()
 			.withProps({
+				enabled: false,
 				checked: false,
 				label: constants.SCHEMA_MIGRATION_CHECKBOX_INFO,
 			}).component();
@@ -262,9 +266,8 @@ export class TableMigrationSelectionDialog {
 		)
 
 		// Data migration component
-		const dataMigrationHeader = view.modelBuilder.text()
+		this._dataMigrationHeader = view.modelBuilder.text()
 			.withProps({
-				description: constants.DATA_MIGRATION_INFO,
 				value: constants.DATA_MIGRATION_HEADER,
 				requiredIndicator: true,
 				CSSStyles: { ...styles.SECTION_HEADER_CSS, 'margin-top': '4px' }
@@ -288,7 +291,7 @@ export class TableMigrationSelectionDialog {
 		return view.modelBuilder
 			.flexContainer()
 			.withLayout({ flexFlow: 'column' })
-			.withItems([schemaMigrationHeader, this._schemaMigrationCheckBox, this._schemaMigrationInfoBox, dataMigrationHeader, this._tabs])
+			.withItems([schemaMigrationHeader, this._schemaMigrationCheckBox, this._schemaMigrationInfoBox, this._dataMigrationHeader, this._tabs])
 			.component();
 	}
 
@@ -610,6 +613,12 @@ export class TableMigrationSelectionDialog {
 		this._disposables.push(
 			table.onRowSelected(
 				async e => {
+					if (!(this._schemaMigrationCheckBox.checked ?? false) &&
+						(this._missingTablesSelectionTable.selectedRows?.length ?? 0) > 0) {
+						// If user selects missing table directly without selecting "Migrate schema to target" option,
+						// check schema migration checkbox automatically.
+						this._schemaMigrationCheckBox.checked = true;
+					}
 					this._updateRowSelection();
 				}));
 
@@ -711,6 +720,7 @@ export class TableMigrationSelectionDialog {
 			})
 
 			targetDatabaseInfo.hasMissingTables = this._hasMissingTables;
+			targetDatabaseInfo.enableSchemaMigration = selectedRowsFromMissingTable.length > 0;
 			this._model._sourceTargetMapping.set(this._sourceDatabaseName, targetDatabaseInfo);
 		}
 		await this._onSaveCallback();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Issue:
If tables in "Missing on target" tab are selected, schema migration option won't be checked automatically. It causes that the selected tables dont exist in target and fail the SqlInfoCollector validation.

Fix:
if users don't select schema migration option and just select the tables in "missing on target" tab, enable schema migration automatically.  

![image](https://github.com/microsoft/azuredatastudio/assets/13447151/60b80e66-773d-402f-81ce-7a302f46fe35)
