### PR TITLE
[SQL Migration] Add schema migration validation

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -533,6 +533,10 @@ export async function getSqlMigrationServiceMonitoringData(account: azdata.Accou
 	return response.response!.data;
 }
 
+export async function getIrNodes(account: azdata.Account, subscription: Subscription, resourceGroupName: string, regionName: string, sqlMigrationService: string): Promise<IntegrationRuntimeNode[]> {
+	return (await getSqlMigrationServiceMonitoringData(account, subscription, resourceGroupName, regionName, sqlMigrationService)).nodes;
+}
+
 export async function startDatabaseMigration(
 	account: azdata.Account,
 	subscription: Subscription,
@@ -919,7 +923,9 @@ export interface IntegrationRuntimeNode {
 	cpuUtilization: number,
 	nodeName: string
 	receivedBytes: number
-	sentBytes: number
+	sentBytes: number,
+	status: string,
+	version: string
 }
 
 export interface StartDatabaseMigrationRequest {

--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -137,7 +137,7 @@ export interface LoginTableInfo {
 
 export const SchemaMigrationRequiredIntegrationRuntimeMinimumVersion: IntegrationRuntimeVersionInfo = {
 	major: "5",
-	minor: "37",
+	minor: "35",
 	build: "8686",
 	revision: "1"
 }

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -9,6 +9,7 @@ import { MigrationSourceAuthenticationType } from '../models/stateMachine';
 import { BackupTypeCodes, formatNumber, InternalManagedDatabaseRestoreDetailsBackupSetStatusCodes, InternalManagedDatabaseRestoreDetailsStatusCodes, ParallelCopyTypeCodes, PipelineStatusCodes } from './helper';
 import { ValidationError } from '../api/azure';
 import { AzureManagedDiskType, ErrorModel } from '../service/contracts';
+import { IntegrationRuntimeVersionInfo } from '../api/sqlUtils';
 const localize = nls.loadMessageBundle();
 
 export const serviceName = 'Sql Migration Service';
@@ -667,7 +668,8 @@ export const DATABASE_BACKUP_MIGRATION_MODE_LABEL = localize('sql.migration.data
 export const DATABASE_BACKUP_MIGRATION_MODE_DESCRIPTION = localize('sql.migration.database.migration.mode.description', "To migrate to the Azure SQL target, choose a migration mode based on your downtime requirements.");
 export const DATABASE_TABLE_SELECTION_LABEL = localize('sql.migration.database.table.selection.label', "Table selection");
 export const DATABASE_TABLE_SELECTION_DESCRIPTION = localize('sql.migration.database.table.selection.description', "For each database below, click Edit to select the tables to migrate from source to target. Then, before clicking Next, validate the provided configuration by clicking 'Run validation'.");
-export const DATABASE_SCHEMA_MIGRATION_HELP = localize('sql.migration.database.schema.migration.help', "Ensure to migrate the database schema from source to target before starting the migration by using the Database Schema Migration feature (Public Preview) or {0} or the {1} in Azure Data Studio before selecting the list of tables to migrate.");
+export const DATABASE_SCHEMA_MIGRATION_HELP = localize('sql.migration.database.schema.migration.help', "Ensure to migrate the database schema from source to target before starting the migration by using the Database Schema Migration feature ({0}) or {1} or the {2} in Azure Data Studio before selecting the list of tables to migrate.");
+export const DATABASE_SCHEMA_MIGRATION_PUBLIC_PREVIEW = localize('sql.migration.database.schema.migration.public.preview', "Public Preview");
 export const DATABASE_SCHEMA_MIGRATION_DACPAC_EXTENSION = localize('sql.migration.database.schema.migration.dacpac', "SQL Server dacpac extension");
 export const DATABASE_SCHEMA_MIGRATION_PROJECTS_EXTENSION = localize('sql.migration.database.schema.migration.project', "SQL Database Projects extension");
 
@@ -1802,3 +1804,25 @@ export const SchemaMigrationStatusLookup: LookupTable<string | undefined> = {
 	[MigrationState.CompletedWithError]: localize('sql.migration.status.completedwitherrors', 'Completed with errors'),
 	default: undefined
 };
+export function SCHEMA_MIGRATION_UPDATE_IR_VERSION_ERROR_MESSAGE(minIrVersion: IntegrationRuntimeVersionInfo, irVersions: IntegrationRuntimeVersionInfo[]): string {
+	const irVersionStrings: string[] = irVersions.map(v => `${v.major}.${v.minor}.${v.build}.${v.revision}`);
+	return localize(
+		'sql.schema.migration.update.ir.version.error',
+		"Schema migration requires an Integration Runtime version of [{0}] or higher. The current node version(s) are: [{1}]. Please install a newer version of the Integration Runtime to enable schema migration support.",
+		minIrVersion.major + "." + minIrVersion.minor,
+		irVersionStrings.join(", ")
+	);
+}
+export function SQLDB_MIGRATION_DIFFERENT_IR_VERSION_ERROR_MESSAGE(irVersions: IntegrationRuntimeVersionInfo[]): string {
+	const irVersionStrings: string[] = irVersions.map(v => `${v.major}.${v.minor}.${v.build}.${v.revision}`);
+	return localize(
+		'sql.migration.different.ir.version.error',
+		"Integration Runtime versions [{0}] are not the same. Please have the same version of Integration Runtime across all nodes for consistency and optimal performance.",
+		irVersionStrings.join(", ")
+	);
+}
+export const SCHEMA_MIGRATION_WINDOWS_AUTH_ERROR_MESSAGE = localize('sql.schema.migration.windows.auth.error', "Schema migration is not currently supported for connectivity to source instance using Windows Authentication. Please use SQL Authentication to enable schema migration support.");
+export const SCHEMA_MIGRATION_INFORMATION_MESSAGE = localize(
+	'sql.schema.migration.information',
+	"Schema migration is in {0} in Step 6. It requires an Integration Runtime version of [5.35.8686.1] or higher. Schema migration is not currently supported for connections to source instance using Windows Authentication. Please use SQL Authentication.",
+);

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -278,6 +278,8 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 
 	public tdeMigrationConfig: TdeMigrationModel = new TdeMigrationModel();
 
+	public isSchemaMigrationSupported: boolean = true;
+
 	private _stateChangeEventEmitter = new vscode.EventEmitter<StateChangeEvent>();
 	private _currentState: State;
 	private _gatheringInformationError: string | undefined;

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -6,7 +6,7 @@
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import { EOL } from 'os';
-import { getStorageAccountAccessKeys, SqlVMServer } from '../api/azure';
+import { getIrNodes, getResourceName, getStorageAccountAccessKeys, SqlVMServer } from '../api/azure';
 import { MigrationWizardPage } from '../models/migrationWizardPage';
 import { MigrationMode, MigrationSourceAuthenticationType, MigrationStateModel, NetworkContainerType, NetworkShare, StateChangeEvent, ValidateIrState, ValidationResult } from '../models/stateMachine';
 import * as constants from '../constants/strings';
@@ -18,7 +18,7 @@ import { logError, TelemetryViews } from '../telemetry';
 import * as styles from '../constants/styles';
 import { TableMigrationSelectionDialog } from '../dialog/tableMigrationSelection/tableMigrationSelectionDialog';
 import { ValidateIrDialog } from '../dialog/validationResults/validateIrDialog';
-import { canTargetConnectToStorageAccount, getSourceConnectionCredentials, getSourceConnectionProfile, getSourceConnectionQueryProvider, getSourceConnectionUri } from '../api/sqlUtils';
+import { areVersionsSame, canTargetConnectToStorageAccount, getActiveIrVersions, getSourceConnectionCredentials, getSourceConnectionProfile, getSourceConnectionQueryProvider, getSourceConnectionUri, isSchemaMigrationSupportedByActiveNodes, SchemaMigrationRequiredIntegrationRuntimeMinimumVersion, TargetDatabaseInfo } from '../api/sqlUtils';
 import { SchemaMigrationAssessmentDialog } from '../dialog/tableMigrationSelection/schemaMigrationAssessmentDialog';
 
 const WIZARD_TABLE_COLUMN_WIDTH = '200px';
@@ -81,6 +81,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 	private _refreshButton!: azdata.ButtonComponent;
 	private _databaseTable!: azdata.TableComponent;
 	private _migrationTableSection!: azdata.FlexContainer;
+	private _sqlDbWarnings: string[] = [];
 
 	constructor(wizard: azdata.window.Wizard, migrationStateModel: MigrationStateModel) {
 		super(wizard, azdata.window.createWizardPage(constants.DATA_SOURCE_CONFIGURATION_PAGE_TITLE), migrationStateModel);
@@ -849,16 +850,28 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		});
 
 		this.wizard.customButtons[VALIDATE_IR_CUSTOM_BUTTON_INDEX].hidden = !this.migrationStateModel.isIrMigration;
+		if (this.migrationStateModel._targetType === MigrationTargetType.SQLDB && !this.migrationStateModel.refreshDatabaseBackupPage) {
+			await this._checkIfSchemaMigrationIsSupported();
+		}
 		await this._updatePageControlsVisibility();
 
 		if (this.migrationStateModel.refreshDatabaseBackupPage) {
-			const isSqlDbTarget = this.migrationStateModel.isSqlDbTarget;
-			if (isSqlDbTarget) {
-				this.wizardPage.title = constants.DATABASE_TABLE_SELECTION_LABEL;
-				this.wizardPage.description = constants.DATABASE_TABLE_SELECTION_LABEL;
-				await this._loadTableData();
-			}
 			try {
+				const isSqlDbTarget = this.migrationStateModel.isSqlDbTarget;
+				const connectionProfile = await getSourceConnectionProfile();
+				this.migrationStateModel._authenticationType =
+					connectionProfile.authenticationType === azdata.connection.AuthenticationType.SqlLogin
+						? MigrationSourceAuthenticationType.Sql
+						: connectionProfile.authenticationType === azdata.connection.AuthenticationType.Integrated
+							? MigrationSourceAuthenticationType.Integrated
+							: undefined!;
+
+				if (isSqlDbTarget) {
+					this.wizardPage.title = constants.DATABASE_TABLE_SELECTION_LABEL;
+					this.wizardPage.description = constants.DATABASE_TABLE_SELECTION_LABEL;
+					await this._loadTableData();
+				}
+
 				const isOfflineMigration = this.migrationStateModel._databaseBackup?.migrationMode === MigrationMode.OFFLINE;
 
 				// for offline migrations, show last backup file column
@@ -883,7 +896,6 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 				}
 				this._blobContainerTargetDatabaseNamesTable.columns[folderColumnIndex].hidden = folderColumnNewHidden;
 
-				const connectionProfile = await getSourceConnectionProfile();
 				const queryProvider = await getSourceConnectionQueryProvider();
 				let username = '';
 				try {
@@ -895,12 +907,6 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 					username = connectionProfile.userName;
 				}
 
-				this.migrationStateModel._authenticationType =
-					connectionProfile.authenticationType === azdata.connection.AuthenticationType.SqlLogin
-						? MigrationSourceAuthenticationType.Sql
-						: connectionProfile.authenticationType === azdata.connection.AuthenticationType.Integrated
-							? MigrationSourceAuthenticationType.Integrated
-							: undefined!;
 				this._sourceHelpText.value = constants.SQL_SOURCE_DETAILS(
 					this.migrationStateModel._authenticationType,
 					connectionProfile.serverName,
@@ -1232,7 +1238,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 												level: azdata.window.MessageLevel.Warning,
 												text: constants.DATABASE_BACKUP_BLOB_FOLDER_STRUCTURE_WARNING,
 											};
-										} else {
+										} else if (this._sqlDbWarnings.length === 0) {
 											this.wizard.message = {
 												text: ''
 											};
@@ -1324,7 +1330,10 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 	}
 
 	private async _validateIr(): Promise<void> {
-		this.wizard.message = { text: '' };
+		if (this._sqlDbWarnings.length === 0) {
+			this.wizard.message = { text: '' };
+		}
+
 		const dialog = new ValidateIrDialog(
 			this.migrationStateModel,
 			() => this.updateValidationResultUI());
@@ -1699,6 +1708,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 				width: WIZARD_INPUT_COMPONENT_WIDTH,
 				CSSStyles: { ...styles.BODY_CSS, 'margin': '5px 0 0 0' },
 				links: [
+					{ text: constants.DATABASE_SCHEMA_MIGRATION_PUBLIC_PREVIEW, url: 'https://techcommunity.microsoft.com/t5/microsoft-data-migration-blog/public-preview-schema-migration-for-target-azure-sql-db/ba-p/3990463' },
 					{ text: constants.DATABASE_SCHEMA_MIGRATION_DACPAC_EXTENSION, url: 'https://learn.microsoft.com/sql/azure-data-studio/extensions/sql-server-dacpac-extension' },
 					{ text: constants.DATABASE_SCHEMA_MIGRATION_PROJECTS_EXTENSION, url: 'https://learn.microsoft.com/sql/azure-data-studio/extensions/sql-database-project-extension' },
 				]
@@ -1837,6 +1847,10 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		this.wizard.message = { text: '' };
 		const data: any[][] = [];
 
+		// Check if schema migration is supported
+		await this._checkIfSchemaMigrationIsSupported();
+
+		// Get source target mapping table
 		this.migrationStateModel._sourceTargetMapping.forEach((targetDatabaseInfo, sourceDatabaseName) => {
 			if (sourceDatabaseName) {
 				const tableCount = targetDatabaseInfo?.sourceTables.size ?? 0;
@@ -1851,14 +1865,8 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 					sourceDatabaseName,
 					targetDatabaseInfo?.databaseName,
 					<azdata.HyperlinkColumnCellValue>{
-						icon: targetDatabaseInfo?.enableSchemaMigration
-							? this._hasSchemaMigraitonBlockerIssues(sourceDatabaseName) ? IconPathHelper.warning : IconPathHelper.completedMigration
-							: IconPathHelper.cancel,
-						title: targetDatabaseInfo?.enableSchemaMigration
-							? this._hasSchemaMigraitonBlockerIssues(sourceDatabaseName)
-								? "Assessment results"
-								: hasSelectedTables ? "" : 'Schema only'
-							: targetDatabaseInfo?.hasMissingTables ? "Not selected" : "Not needed",
+						icon: this._getSchemaMigrationColumnIcon(targetDatabaseInfo, sourceDatabaseName),
+						title: this._getSchemaMigrationColumnTitle(targetDatabaseInfo, sourceDatabaseName, hasSelectedTables),
 					},
 					<azdata.HyperlinkColumnCellValue>{				// table selection
 						icon: hasSelectedTables
@@ -1878,5 +1886,62 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 	private _hasSchemaMigraitonBlockerIssues(sourceDatabaseName: string): boolean {
 		var assessmentResults = this.migrationStateModel._assessmentResults?.databaseAssessments?.find(r => r.name === sourceDatabaseName)?.issues?.filter(i => i.appliesToMigrationTargetPlatform === MigrationTargetType.SQLDB) ?? [];
 		return assessmentResults?.find(i => constants.SchemaMigrationFailedRulesLookup[i.ruleId] !== undefined) !== undefined;
+	}
+
+	private _getSchemaMigrationColumnIcon(targetDatabaseInfo: TargetDatabaseInfo | undefined, sourceDatabaseName: string): azdata.IconPath {
+		if (targetDatabaseInfo?.enableSchemaMigration) {
+			return this._hasSchemaMigraitonBlockerIssues(sourceDatabaseName) ? IconPathHelper.warning : IconPathHelper.completedMigration;
+		} else if (!targetDatabaseInfo?.isSchemaMigrationSupported) {
+			return IconPathHelper.warning;
+		} else {
+			return IconPathHelper.cancel;
+		}
+	}
+
+	private _getSchemaMigrationColumnTitle(targetDatabaseInfo: TargetDatabaseInfo | undefined, sourceDatabaseName: string, hasSelectedTables: boolean): azdata.IconPath {
+		if (targetDatabaseInfo?.enableSchemaMigration) {
+			return this._hasSchemaMigraitonBlockerIssues(sourceDatabaseName)
+				? "Assessment results"
+				: hasSelectedTables ? "" : 'Schema only'
+		} else if (!targetDatabaseInfo?.isSchemaMigrationSupported) {
+			return "Not supported";
+		} else {
+			return targetDatabaseInfo?.hasMissingTables ? "Not selected" : "Not needed";
+		}
+	}
+
+	private async _checkIfSchemaMigrationIsSupported(): Promise<void> {
+		this._sqlDbWarnings.length = 0;
+		// Check if schema migration is supported
+		const irNodes = await getIrNodes(
+			this.migrationStateModel._azureAccount,
+			this.migrationStateModel._sqlMigrationServiceSubscription,
+			getResourceName(this.migrationStateModel._resourceGroup.id),
+			this.migrationStateModel._location.name,
+			this.migrationStateModel._sqlMigrationService!.name);
+		const irVersions = getActiveIrVersions(irNodes);
+		this.migrationStateModel.isSchemaMigrationSupported = isSchemaMigrationSupportedByActiveNodes(irNodes);
+
+		// Check if current IR node(s) support schema migration
+		if (!this.migrationStateModel.isSchemaMigrationSupported) {
+			this._sqlDbWarnings.push(constants.SCHEMA_MIGRATION_UPDATE_IR_VERSION_ERROR_MESSAGE(SchemaMigrationRequiredIntegrationRuntimeMinimumVersion, irVersions));
+		}
+
+		// Check if multiple IR nodes have different versions.
+		if (!areVersionsSame(irVersions)) {
+			this._sqlDbWarnings.push(constants.SQLDB_MIGRATION_DIFFERENT_IR_VERSION_ERROR_MESSAGE(irVersions));
+		}
+
+		// Check if source is using Windows authentication.
+		if (this.migrationStateModel._authenticationType === MigrationSourceAuthenticationType.Integrated) {
+			this._sqlDbWarnings.push(constants.SCHEMA_MIGRATION_WINDOWS_AUTH_ERROR_MESSAGE);
+		}
+
+		if (this._sqlDbWarnings.length > 0) {
+			this.wizard.message = {
+				text: this._sqlDbWarnings.join(EOL),
+				level: azdata.window.MessageLevel.Warning
+			};
+		}
 	}
 }

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -634,6 +634,16 @@ export class TargetSelectionPage extends MigrationWizardPage {
 				},
 			})
 			.component();
+		const schemaMigrationInfoBox = this._view.modelBuilder.infoBox()
+			.withProps({
+				text: constants.SCHEMA_MIGRATION_INFORMATION_MESSAGE,
+				style: 'information',
+				width: WIZARD_INPUT_COMPONENT_WIDTH,
+				CSSStyles: { ...styles.BODY_CSS, 'margin': '5px 0 0 0' },
+				links: [
+					{ text: constants.DATABASE_SCHEMA_MIGRATION_PUBLIC_PREVIEW, url: 'https://techcommunity.microsoft.com/t5/microsoft-data-migration-blog/public-preview-schema-migration-for-target-azure-sql-db/ba-p/3990463' },
+				]
+			}).component();
 		this._azureResourceTable = this._createResourceTable();
 
 		return this._view.modelBuilder.flexContainer()
@@ -645,6 +655,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 				connectionContainer,
 				mapSourceHeading,
 				mapSourceDetails,
+				schemaMigrationInfoBox,
 				this._azureResourceTable])
 			.withLayout({ flexFlow: 'column' })
 			.withProps({ CSSStyles: { 'margin': '15px 0 0 0' } })


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
1. adding IR version validation. Before going to RP, if users enable schema migration and the IR node doesn't support schema migration, disable the schema migration option. The SQLDB migration validation failure rate will have significant reduction.
2. Windows login is currently supported in SHIR. Therefore, if users use WIndows auth to connect the source instance for schema mgiration, disable the schema migration option. The SQLDB migration failure due to "login failed for user" will have significant reduction.

In Step 4, adding infor banner
![image](https://github.com/microsoft/azuredatastudio/assets/13447151/7a292779-1a79-4833-80eb-f32504eeec7a)

In Step 6, check the IR nodes version and windows login. If true, show the warning message on the top and disable the schema migration option.
![image](https://github.com/microsoft/azuredatastudio/assets/13447151/dfaeace3-0908-425b-a4c3-6196c3ca8aaa)

![image](https://github.com/microsoft/azuredatastudio/assets/13447151/20423f2e-fd54-4590-acd4-f25e1630feed)
