### PR TITLE
[SQL Migration] Populate schema migration errors to UI

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -871,9 +871,7 @@ export function getMigrationErrors(migration: DatabaseMigration): string {
 		errors.push(migration.properties.migrationStatusWarnings?.completeRestoreErrorMessage);
 		errors.push(migration.properties.migrationStatusWarnings?.restoreBlockingReason);
 		errors.push(...migration.properties.migrationStatusDetails?.listOfCopyProgressDetails?.flatMap(cp => cp.errors) ?? []);
-		errors.push(...migration.properties.migrationStatusDetails?.sqlSchemaMigrationStatus?.sqlSchemaCopyErrors ?? []);
-		errors.push(...migration.properties.migrationStatusDetails?.sqlSchemaMigrationStatus.scriptGeneration?.errors ?? []);
-		errors.push(...migration.properties.migrationStatusDetails?.sqlSchemaMigrationStatus?.scriptDeployment?.errors ?? []);
+		errors.push(...migration.properties.migrationStatusDetails?.sqlSchemaMigrationStatus?.errors ?? []);
 	}
 
 	// remove undefined and duplicate error entries
@@ -1157,7 +1155,7 @@ export interface CopyProgressDetail {
 }
 
 export interface SqlSchemaMigrationStatus {
-	sqlSchemaCopyErrors: string[];
+	errors: string[];
 	status: 'CollectionCompleted' | 'PrefetchObjects' | 'GetDependency' | 'ScriptObjects' | 'ScriptViewIndexes' | 'ScriptOwnership' | 'GeneratingScript' | 'GeneratingScriptCompleted' | 'DeployingSchema' | 'DeploymentCompleted' | 'Completed' | 'CompletedWithError';
 	objectsCollection: ObjectsCollection;
 	scriptGeneration: ScriptGeneration;

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -872,6 +872,8 @@ export function getMigrationErrors(migration: DatabaseMigration): string {
 		errors.push(migration.properties.migrationStatusWarnings?.restoreBlockingReason);
 		errors.push(...migration.properties.migrationStatusDetails?.listOfCopyProgressDetails?.flatMap(cp => cp.errors) ?? []);
 		errors.push(...migration.properties.migrationStatusDetails?.sqlSchemaMigrationStatus?.sqlSchemaCopyErrors ?? []);
+		errors.push(...migration.properties.migrationStatusDetails?.sqlSchemaMigrationStatus.scriptGeneration?.errors ?? []);
+		errors.push(...migration.properties.migrationStatusDetails?.sqlSchemaMigrationStatus?.scriptDeployment?.errors ?? []);
 	}
 
 	// remove undefined and duplicate error entries


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
RP saves the schema migration errors in the errors list of SqlSchemaMigrationStatus. 