### PR TITLE
[Release/1.47] Updating signing tasks to use .NET 6 (#25021)

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin-signing.yml
@@ -17,14 +17,7 @@ steps:
       mv azuredatastudio-darwin-$(VSCODE_ARCH)-unsigned.zip azuredatastudio-darwin-$(VSCODE_ARCH).zip
     displayName: 'Rename the file'
 
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core sdk for signing'
-    inputs:
-      packageType: sdk
-      version: 2.1.x
-      installationPath: $(Agent.ToolsDirectory)/dotnet
-
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: EsrpCodeSigning@3
     displayName: 'ESRP CodeSigning'
     inputs:
       ConnectedServiceName: 'Code Signing'
@@ -51,7 +44,7 @@ steps:
     displayName: Clean Archive
     condition: and(succeeded(), eq(variables['signed'], true))
 
-  - task: EsrpCodeSigning@1
+  - task: EsrpCodeSigning@3
     displayName: 'ESRP Notarization'
     inputs:
       ConnectedServiceName: 'Code Signing'

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -210,13 +210,13 @@ steps:
     condition: and(succeeded(), ne(variables['EXTENSIONS_ONLY'], 'true'))
 
   - task: UseDotNet@2
-    displayName: 'Install .NET Core sdk for signing'
+    displayName: 'Install .NET SDK for signing'
     inputs:
       packageType: sdk
-      version: 5.0.x
+      version: 6.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: EsrpCodeSigning@3
     inputs:
       ConnectedServiceName: 'Code Signing'
       FolderPath: '$(Build.SourcesDirectory)/.build'

--- a/build/azure-pipelines/web/sql-product-build-web.yml
+++ b/build/azure-pipelines/web/sql-product-build-web.yml
@@ -181,13 +181,13 @@ steps:
   displayName: Build Rpm
 
 - task: UseDotNet@2
-  displayName: 'Install .NET Core sdk for signing'
+  displayName: 'Install .NET SDK for signing'
   inputs:
     packageType: sdk
-    version: 5.0.x
+    version: 6.0.x
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: EsrpCodeSigning@3
   inputs:
     ConnectedServiceName: 'Code Signing'
     FolderPath: '$(Build.SourcesDirectory)/.build'

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -173,7 +173,7 @@ steps:
     displayName: Run core integration tests (arm64)
     condition: and(succeeded(), and(eq(variables['RUN_TESTS'], 'true'), eq(variables['VSCODE_ARCH'], 'arm64')))
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: EsrpCodeSigning@3
     displayName: 'Sign out code'
     inputs:
       ConnectedServiceName: 'Code Signing'
@@ -256,7 +256,7 @@ steps:
       exec { yarn gulp "vscode-win32-$(VSCODE_ARCH)-archive" }
     displayName: Archive & User & System setup
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: EsrpCodeSigning@3
     displayName: 'Sign installers'
     inputs:
       ConnectedServiceName: 'Code Signing'


### PR DESCRIPTION
Ports #25021 to release/1.47 branch

* Updating signing tasks to EsrpCodeSigning@3

* Updating .NET versions

* removing UseDotNet steps

* Restoring UseDotNet for linux builds

