### PR TITLE
Fix pipeline to not sign deb/rpm if built for extensions only

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -232,9 +232,9 @@ steps:
         ]
       SessionTimeout: 120
     displayName: 'Signing deb and rpm'
-    condition: and(succeeded(), eq(variables['signed'], true))
+    condition: and(succeeded(), ne(variables['EXTENSIONS_ONLY'], 'true'), eq(variables['signed'], true))
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: EsrpCodeSigning@3
     inputs:
       ConnectedServiceName: 'Code Signing'
       FolderPath: '$(Build.SourcesDirectory)/.build'


### PR DESCRIPTION
Fixes extension pipeline builds, recently affected by #24977 
+Update code signing task version