### PR TITLE
delete compilation.tar.gz after extracting for windows pipeline

### DIFF
--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -28,6 +28,7 @@ steps:
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
       exec { tar -xf $(Pipeline.Workspace)/compilation.tar.gz }
+      exec { rm $(Pipeline.Workspace)/compilation.tar.gz }
     displayName: Extract compilation output
 
   - powershell: |

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -28,6 +28,7 @@ steps:
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
       exec { tar -xf $(Pipeline.Workspace)/compilation.tar.gz }
+      # Delete compiled tarball now that we've extracted the files since it takes up a lot of space
       exec { rm $(Pipeline.Workspace)/compilation.tar.gz }
     displayName: Extract compilation output
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The windows builds started consistently failing on the initial run over a week ago with the error "There is not enough space on the disk". This should free up space, similar to fix made a couple months ago for linux builds in https://github.com/microsoft/azuredatastudio/pull/24539.

Adhoc build (with signing enabled like the nightly product build): https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=219026&view=logs&j=471dc74f-2452-533b-c058-e43cd1b98abf&t=69447ecb-e768-5cc0-89bc-3e5a8b725059