### PR TITLE
Updated extension SqlDataInspector to 0.7.2

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3918,14 +3918,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.7.1",
-							"lastUpdated": "10/13/2023",
+							"version": "0.7.2",
+							"lastUpdated": "01/05/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/ernstc/SqlDataInspector/releases/tag/0.7.1"
+									"source": "https://github.com/ernstc/SqlDataInspector/releases/tag/0.7.2"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3918,14 +3918,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.7.1",
-							"lastUpdated": "10/13/2023",
+							"version": "0.7.2",
+							"lastUpdated": "01/05/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/ernstc/SqlDataInspector/releases/tag/0.7.1"
+									"source": "https://github.com/ernstc/SqlDataInspector/releases/tag/0.7.2"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
### New Features

* Added extension settings that will let the user to customize the extension behaviour. 
* Columns ordering can be changed from the extension settings. Since now the columns have been ordered alphabetically by default. From now on, the default ordering will be the ordinal ordering, but from the extension settings is possible to enable the alphabetical ordering. It also possible to choose if the primary key columns must be shown as first columns. 
* Columns ordering can also be changed by clicking on the columns name header. This overrides the settings, but once enabled, can be disabled repeating clicking on the header until the sorting icon disappears. 
* The status of some controls is now persisted in the extension settings. The persisted controls are: `page size`, `show tables`, `show views`, `live monitoring refresh rate`. 

### Fixes

* Fixed behaviour when changing the page size when no object has already been selected. 