### PR TITLE
Only allow PNG icons in gallery and use commit link for pieces-azure-data-studio

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -5421,19 +5421,19 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/pieces-app/documentation/main/docs/assets/pfd_logo.png"
+									"source": "https://raw.githubusercontent.com/pieces-app/documentation/ffe5010dcbb30d01dffba3daaddf03d1c96dc6d5/docs/assets/pfd_logo.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/pieces-app/documentation/main/docs/assets/_azuredatastudio_out/readme.ads.md"
+									"source": "https://raw.githubusercontent.com/pieces-app/documentation/ffe5010dcbb30d01dffba3daaddf03d1c96dc6d5/docs/assets/_azuredatastudio_out/readme.ads.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/pieces-app/documentation/main/docs/assets/_azuredatastudio_out/package.json"
+									"source": "https://raw.githubusercontent.com/pieces-app/documentation/ffe5010dcbb30d01dffba3daaddf03d1c96dc6d5/docs/assets/_azuredatastudio_out/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/pieces-app/documentation/main/docs/assets/_azuredatastudio_out/LICENSE.txt"
+									"source": "https://raw.githubusercontent.com/pieces-app/documentation/ffe5010dcbb30d01dffba3daaddf03d1c96dc6d5/docs/assets/_azuredatastudio_out/LICENSE.txt"
 								}
 							],
 							"properties": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -5355,19 +5355,19 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/pieces-app/documentation/main/docs/assets/pfd_logo.png"
+									"source": "https://raw.githubusercontent.com/pieces-app/documentation/ffe5010dcbb30d01dffba3daaddf03d1c96dc6d5/docs/assets/pfd_logo.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/pieces-app/documentation/main/docs/assets/_azuredatastudio_out/readme.ads.md"
+									"source": "https://raw.githubusercontent.com/pieces-app/documentation/ffe5010dcbb30d01dffba3daaddf03d1c96dc6d5/docs/assets/_azuredatastudio_out/readme.ads.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/pieces-app/documentation/main/docs/assets/_azuredatastudio_out/package.json"
+									"source": "https://raw.githubusercontent.com/pieces-app/documentation/ffe5010dcbb30d01dffba3daaddf03d1c96dc6d5/docs/assets/_azuredatastudio_out/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/pieces-app/documentation/main/docs/assets/_azuredatastudio_out/LICENSE.txt"
+									"source": "https://raw.githubusercontent.com/pieces-app/documentation/ffe5010dcbb30d01dffba3daaddf03d1c96dc6d5/docs/assets/_azuredatastudio_out/LICENSE.txt"
 								}
 							],
 							"properties": [

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -363,6 +363,10 @@ async function validateHasRequiredAssets(galleryFilePath, extensionName, publish
         throw new Error(`${galleryFilePath} - ${extensionName} - Must have an icon file`);
     }
 
+    if (iconFile && !iconFile.source.toLowerCase().endsWith('png')) {
+        throw new Error(`${galleryFilePath} - ${extensionName} - Icon must be a PNG file`);
+    }
+
     // Details
     const detailsFile = filesJson.find(file => file.assetType === 'Microsoft.VisualStudio.Services.Content.Details');
     if (!detailsFile) {


### PR DESCRIPTION
VS Code requires PNG (since SVGs can contain code) so enforcing that for us as well.

Also updating the pieces-azure-data-studio extension to use a direct commit link n(follow up from https://github.com/microsoft/azuredatastudio/pull/25173) to reduce the chance of changes to master breaking the gallery. I'm trying to think of a good way to enforce this as well and will follow up with adding a check for that if I come up with one - but for now we'll just ask people to update them as they submit new extensions.

FYI @caleb-at-pieces