### PR TITLE
update import and data virtualization extensions

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -746,14 +746,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.6",
-							"lastUpdated": "8/14/2023",
+							"version": "1.6.0",
+							"lastUpdated": "1/10/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-1.5.6.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-1.6.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2730,14 +2730,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.13.2",
-							"lastUpdated": "3/8/2023",
+							"version": "1.14.0",
+							"lastUpdated": "1/10/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/datavirtualization-1.13.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/datavirtualization-1.14.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -746,14 +746,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.5",
-							"lastUpdated": "5/25/2023",
+							"version": "1.6.0",
+							"lastUpdated": "1/10/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-1.5.5.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-1.6.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2730,14 +2730,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.13.2",
-							"lastUpdated": "3/8/2023",
+							"version": "1.14.0",
+							"lastUpdated": "1/10/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/datavirtualization-1.13.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/datavirtualization-1.14.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Updating import and data virtualization extensions to bring in the MDS update in their services. I tested installing these two extensions from this build and that the correct services versions were downloaded and the wizards started up.

Build with vsixes: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=219502&view=artifacts&pathAsName=false&type=publishedArtifacts