### PR TITLE
Added Login Migration Validation API RPC support

### DIFF
--- a/extensions/sql-migration/config.json
+++ b/extensions/sql-migration/config.json
@@ -1,7 +1,7 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.migration-{#fileName#}",
 	"useDefaultLinuxRuntime": true,
-	"version": "4.11.0.13",
+	"version": "4.11.0.17",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows": "win-x64-net7.0.zip",

--- a/extensions/sql-migration/src/service/contracts.ts
+++ b/extensions/sql-migration/src/service/contracts.ts
@@ -460,6 +460,13 @@ export interface StartLoginMigrationsParams {
 	aadDomainName: string;
 }
 
+export enum LoginMigrationPreValidationStep {
+	SysAdminValidation = 0,
+	AADDomainNameValidation = 1,
+	UserMappingValidation = 2,
+	LoginEligibilityValidation = 3,
+}
+
 export enum LoginMigrationStep {
 	StartValidations = 0,
 	MigrateLogins = 1,
@@ -468,6 +475,12 @@ export enum LoginMigrationStep {
 	EstablishServerRoleMapping = 4,
 	SetLoginPermissions = 5,
 	SetServerRolePermissions = 6,
+}
+
+export interface StartLoginMigrationPreValidationResult {
+	exceptionMap: { [login: string]: any };
+	completedStep: LoginMigrationPreValidationStep;
+	elapsedTime: string;
 }
 
 export interface StartLoginMigrationResult {
@@ -482,6 +495,26 @@ export namespace StartLoginMigrationRequest {
 
 export namespace ValidateLoginMigrationRequest {
 	export const type = new RequestType<StartLoginMigrationsParams, StartLoginMigrationResult, void, void>('migration/validateloginmigration');
+}
+
+export namespace ValidateSysAdminPermissionRequest {
+	export const type =
+		new RequestType<StartLoginMigrationsParams, StartLoginMigrationPreValidationResult, void, void>("migration/validatesysadminpermission");
+}
+
+export namespace ValidateUserMappingRequest {
+	export const type =
+		new RequestType<StartLoginMigrationsParams, StartLoginMigrationPreValidationResult, void, void>("migration/validateusermapping");
+}
+
+export namespace ValidateAADDomainNameRequest {
+	export const type =
+		new RequestType<StartLoginMigrationsParams, StartLoginMigrationPreValidationResult, void, void>("migration/validateaaddomainname");
+}
+
+export namespace ValidateLoginEligibilityRequest {
+	export const type =
+		new RequestType<StartLoginMigrationsParams, StartLoginMigrationPreValidationResult, void, void>("migration/validatelogineligibility");
 }
 
 export namespace MigrateLoginsRequest {
@@ -509,6 +542,10 @@ export interface ISqlMigrationService {
 	refreshPerfDataCollection(lastRefreshedTime: Date): Promise<RefreshPerfDataCollectionResult | undefined>;
 	startLoginMigration(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationResult | undefined>;
 	validateLoginMigration(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationResult | undefined>;
+	validateSysAdminPermission(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationPreValidationResult | undefined>;
+	validateUserMapping(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationPreValidationResult | undefined>;
+	validateAADDomainName(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationPreValidationResult | undefined>;
+	validateLoginEligibility(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationPreValidationResult | undefined>;
 	migrateLogins(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationResult | undefined>;
 	establishUserMapping(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationResult | undefined>;
 	migrateServerRolesAndSetPermissions(sourceConnectionString: string, targetConnectionString: string, loginList: string[], aadDomainName: string): Promise<StartLoginMigrationResult | undefined>;

--- a/extensions/sql-migration/src/service/features.ts
+++ b/extensions/sql-migration/src/service/features.ts
@@ -38,6 +38,10 @@ export class SqlMigrationService extends MigrationExtensionService implements co
 		contracts.SqlMigrationStopPerfDataCollectionRequest.type,
 		contracts.StartLoginMigrationRequest.type,
 		contracts.ValidateLoginMigrationRequest.type,
+		contracts.ValidateSysAdminPermissionRequest.type,
+		contracts.ValidateUserMappingRequest.type,
+		contracts.ValidateAADDomainNameRequest.type,
+		contracts.ValidateLoginEligibilityRequest.type,
 		contracts.MigrateLoginsRequest.type,
 		contracts.EstablishUserMappingRequest.type,
 		contracts.MigrateServerRolesAndSetPermissionsRequest.type,
@@ -210,6 +214,98 @@ export class SqlMigrationService extends MigrationExtensionService implements co
 		}
 		catch (e) {
 			this._client.logFailedRequest(contracts.ValidateLoginMigrationRequest.type, e);
+		}
+
+		return undefined;
+	}
+
+	async validateSysAdminPermission(
+		sourceConnectionString: string,
+		targetConnectionString: string,
+		loginList: string[],
+		aadDomainName: string): Promise<contracts.StartLoginMigrationPreValidationResult | undefined> {
+		let params: contracts.StartLoginMigrationsParams = {
+			sourceConnectionString,
+			targetConnectionString,
+			loginList,
+			aadDomainName
+		};
+
+		try {
+			return this._client.sendRequest(contracts.ValidateSysAdminPermissionRequest.type, params);
+
+		}
+		catch (e) {
+			this._client.logFailedRequest(contracts.ValidateSysAdminPermissionRequest.type, e);
+		}
+
+		return undefined;
+	}
+
+	async validateUserMapping(
+		sourceConnectionString: string,
+		targetConnectionString: string,
+		loginList: string[],
+		aadDomainName: string): Promise<contracts.StartLoginMigrationPreValidationResult | undefined> {
+		let params: contracts.StartLoginMigrationsParams = {
+			sourceConnectionString,
+			targetConnectionString,
+			loginList,
+			aadDomainName
+		};
+
+		try {
+			return this._client.sendRequest(contracts.ValidateUserMappingRequest.type, params);
+
+		}
+		catch (e) {
+			this._client.logFailedRequest(contracts.ValidateUserMappingRequest.type, e);
+		}
+
+		return undefined;
+	}
+
+	async validateAADDomainName(
+		sourceConnectionString: string,
+		targetConnectionString: string,
+		loginList: string[],
+		aadDomainName: string): Promise<contracts.StartLoginMigrationPreValidationResult | undefined> {
+		let params: contracts.StartLoginMigrationsParams = {
+			sourceConnectionString,
+			targetConnectionString,
+			loginList,
+			aadDomainName
+		};
+
+		try {
+			return this._client.sendRequest(contracts.ValidateAADDomainNameRequest.type, params);
+
+		}
+		catch (e) {
+			this._client.logFailedRequest(contracts.ValidateAADDomainNameRequest.type, e);
+		}
+
+		return undefined;
+	}
+
+	async validateLoginEligibility(
+		sourceConnectionString: string,
+		targetConnectionString: string,
+		loginList: string[],
+		aadDomainName: string): Promise<contracts.StartLoginMigrationPreValidationResult | undefined> {
+		let params: contracts.StartLoginMigrationsParams = {
+			sourceConnectionString,
+			targetConnectionString,
+			loginList,
+			aadDomainName
+		};
+
+		try {
+			return this._client.sendRequest(contracts.ValidateLoginEligibilityRequest.type, params);
+
+		}
+		catch (e) {
+			this._client.logFailedRequest(contracts.ValidateLoginEligibilityRequest.type, e);
 		}
 
 		return undefined;


### PR DESCRIPTION
- Updated the new version of SQL tools service from 4.11.0.13 to 4.11.0.17 that created 4 RPC corresponding to the below validation api's
1. ValidateSysAdminPermissions
2.  ValidateAADDomainName
3. ValidateLoginEligibility
4. ValidateAADDomainName

- Created the RPC requests for the validation API's 
1. ValidateSysAdminPermissionRequest
2. ValidateUserMappingRequest
3. ValidateAADDomainNameRequest
4. ValidateLoginEligibilityRequest

- Testing
Tested all the RPC calls to the validation API's by consuming the sqltoolsservice in the ADS client locally.