### PR TITLE
Fixes azure account detection to work with email address

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1071,8 +1071,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 		const azureAccounts = accounts.filter(a => a.key.providerId.startsWith('azure'));
 		if (azureAccounts && azureAccounts.length > 0) {
-			let accountId = (connection.authenticationType === Constants.AuthenticationType.AzureMFA || connection.authenticationType === Constants.AuthenticationType.AzureMFAAndUser) ? connection.azureAccount : connection.userName;
-			let account = azureAccounts.find(account => account.key.accountId === accountId);
+			let accountId = (connection.authenticationType === Constants.AuthenticationType.AzureMFA || connection.authenticationType === Constants.AuthenticationType.AzureMFAAndUser) ? connection.azureAccount ?? connection.userName : connection.userName;
+			let account = azureAccounts.find(account => account.key.accountId === accountId || account.displayInfo.email === accountId);
 			if (account) {
 				this._logService.debug(`Getting security token for Azure account ${account.key.accountId}`);
 				if (account.isStale) {


### PR DESCRIPTION
Fixes command-line behavior where email address wouldn't work when trying to connect using Azure MFA.

E.g. 
`azuredatastudio --server <serverName> --authenticationType AzureMFA --user <email address> --command connect`

Before:
Launches ADS, but doesn't connect immediately, opens connection dialog instead. Below errors are captured in logs:
```
Could not find Azure account with name undefined
Failed to connect due to error: Error
```

After:
Launches ADS and creates a new connection if email address is found associated with an Azure account.