### PR TITLE
[SQL Migration] Schema migration support Windows login

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -859,7 +859,7 @@ export function getBlobContainerId(resourceGroupId: string, storageAccountName: 
 }
 
 export function getMigrationErrors(migration: DatabaseMigration): string {
-	const errors = [];
+	var errors = [];
 
 	if (migration?.properties) {
 		errors.push(migration.properties.provisioningError);
@@ -875,9 +875,16 @@ export function getMigrationErrors(migration: DatabaseMigration): string {
 	}
 
 	// remove undefined and duplicate error entries
-	return errors
+	var combinedError = errors
 		.filter((e, i, arr) => e !== undefined && i === arr.indexOf(e))
 		.join(EOL);
+
+	// add troubleshooting link if there are any errors
+	if (combinedError !== undefined && combinedError !== "") {
+		combinedError = combinedError.concat(constants.SQL_MIGRATION_TROUBLESHOOTING_LINK);
+	}
+
+	return combinedError;
 }
 
 export interface SqlMigrationServiceProperties {

--- a/extensions/sql-migration/src/api/sqlUtils.ts
+++ b/extensions/sql-migration/src/api/sqlUtils.ts
@@ -137,9 +137,9 @@ export interface LoginTableInfo {
 
 export const SchemaMigrationRequiredIntegrationRuntimeMinimumVersion: IntegrationRuntimeVersionInfo = {
 	major: "5",
-	minor: "35",
-	build: "8686",
-	revision: "1"
+	minor: "37",
+	build: "8767",
+	revision: "4"
 }
 
 export interface IntegrationRuntimeVersionInfo {
@@ -670,9 +670,26 @@ export function getActiveIrVersions(irNodes: IntegrationRuntimeNode[]): Integrat
 	return irVersions;
 }
 
-export function isSchemaMigrationSupportedByActiveNodes(irNodes: IntegrationRuntimeNode[]): boolean {
-	const irVersions = getActiveIrVersions(irNodes);
-	return irVersions.some(v => isSchemaMigrationSupportedByVersion(v));
+export function getActiveIrVersionsSupportingSchemaMigration(irNodes: IntegrationRuntimeNode[]): IntegrationRuntimeVersionInfo[] {
+	var irVersions = getActiveIrVersions(irNodes);
+	var irVersionsSupportingSchema: IntegrationRuntimeVersionInfo[] = [];
+	irVersions.forEach(version => {
+		if (isSchemaMigrationSupportedByVersion(version)) {
+			irVersionsSupportingSchema.push(version);
+		}
+	})
+	return irVersionsSupportingSchema;
+}
+
+export function getActiveIrVersionsNotSupportingSchemaMigration(irNodes: IntegrationRuntimeNode[]): IntegrationRuntimeVersionInfo[] {
+	var irVersions = getActiveIrVersions(irNodes);
+	var irVersionsNotSupportingSchema: IntegrationRuntimeVersionInfo[] = [];
+	irVersions.forEach(version => {
+		if (!isSchemaMigrationSupportedByVersion(version)) {
+			irVersionsNotSupportingSchema.push(version);
+		}
+	})
+	return irVersionsNotSupportingSchema;
 }
 
 export function isSchemaMigrationSupportedByVersion(version: IntegrationRuntimeVersionInfo): boolean {

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1827,6 +1827,5 @@ export const SCHEMA_MIGRATION_INFORMATION_MESSAGE = localize(
 	"Schema migration is in {0} in Step 6. It requires an Integration Runtime version of [{1}] or higher. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.",
 );
 export function MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION(minIrVersion: IntegrationRuntimeVersionInfo): string {
-	const minIrVersionString = `${minIrVersion.major}.${minIrVersion.minor}.${minIrVersion.build}.${minIrVersion.revision}`;
-	return localize('sql.schema.migration.min.version', minIrVersionString);
+	return localize('sql.schema.migration.min.version', minIrVersion.major + "." + minIrVersion.minor + "." + minIrVersion.build + "." + minIrVersion.revision);
 }

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -9,7 +9,7 @@ import { MigrationSourceAuthenticationType } from '../models/stateMachine';
 import { BackupTypeCodes, formatNumber, InternalManagedDatabaseRestoreDetailsBackupSetStatusCodes, InternalManagedDatabaseRestoreDetailsStatusCodes, ParallelCopyTypeCodes, PipelineStatusCodes } from './helper';
 import { ValidationError } from '../api/azure';
 import { AzureManagedDiskType, ErrorModel } from '../service/contracts';
-import { IntegrationRuntimeVersionInfo, SchemaMigrationRequiredIntegrationRuntimeMinimumVersion } from '../api/sqlUtils';
+import { IntegrationRuntimeVersionInfo } from '../api/sqlUtils';
 const localize = nls.loadMessageBundle();
 
 export const serviceName = 'Sql Migration Service';
@@ -1826,4 +1826,7 @@ export const SCHEMA_MIGRATION_INFORMATION_MESSAGE = localize(
 	'sql.schema.migration.information',
 	"Schema migration is in {0} in Step 6. It requires an Integration Runtime version of [{1}] or higher. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.",
 );
-export const MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION = localize('sql.schema.migration.min.version', `${SchemaMigrationRequiredIntegrationRuntimeMinimumVersion.major}.${SchemaMigrationRequiredIntegrationRuntimeMinimumVersion.minor}.${SchemaMigrationRequiredIntegrationRuntimeMinimumVersion.build}.${SchemaMigrationRequiredIntegrationRuntimeMinimumVersion.revision}`);
+export function MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION(minIrVersion: IntegrationRuntimeVersionInfo): string {
+	const minIrVersionString = `${minIrVersion.major}.${minIrVersion.minor}.${minIrVersion.build}.${minIrVersion.revision}`;
+	return localize('sql.schema.migration.min.version', minIrVersionString);
+}

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1826,6 +1826,4 @@ export const SCHEMA_MIGRATION_INFORMATION_MESSAGE = localize(
 	'sql.schema.migration.information',
 	"Schema migration is in {0} in Step 6. It requires an Integration Runtime version of [{1}] or higher. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.",
 );
-export function MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION(minIrVersion: IntegrationRuntimeVersionInfo): string {
-	return localize('sql.schema.migration.min.version', minIrVersion.major + "." + minIrVersion.minor + "." + minIrVersion.build + "." + minIrVersion.revision);
-}
+export const MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION = localize('sql.schema.migration.min.version', "5.37.8767.4");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -9,7 +9,7 @@ import { MigrationSourceAuthenticationType } from '../models/stateMachine';
 import { BackupTypeCodes, formatNumber, InternalManagedDatabaseRestoreDetailsBackupSetStatusCodes, InternalManagedDatabaseRestoreDetailsStatusCodes, ParallelCopyTypeCodes, PipelineStatusCodes } from './helper';
 import { ValidationError } from '../api/azure';
 import { AzureManagedDiskType, ErrorModel } from '../service/contracts';
-import { IntegrationRuntimeVersionInfo } from '../api/sqlUtils';
+import { IntegrationRuntimeVersionInfo, SchemaMigrationRequiredIntegrationRuntimeMinimumVersion } from '../api/sqlUtils';
 const localize = nls.loadMessageBundle();
 
 export const serviceName = 'Sql Migration Service';
@@ -554,7 +554,7 @@ export function SQL_TARGET_SOURCE_COLLATION_NOT_SAME(
 		targetDatabaseCollation);
 }
 
-export const SQL_MIGRATION_TROUBLESHOOTING_LINK = localize('sql.migration.wizard.troubleshooting', 'Learn more: https://aka.ms/dms-migrations-troubleshooting.');
+export const SQL_MIGRATION_TROUBLESHOOTING_LINK = localize('sql.migration.wizard.troubleshooting', 'See link for more troubleshooting steps: https://aka.ms/dms-migrations-troubleshooting.');
 
 // Managed Instance
 export const AZURE_SQL_DATABASE_MANAGED_INSTANCE = localize('sql.migration.azure.sql.database.managed.instance', "Azure SQL Managed Instance");
@@ -1727,8 +1727,8 @@ export function TDE_COMPLETED_STATUS(completed: number, total: number): string {
 }
 
 // Schema migration
-export const FULL_SCHEMA_MISSING_ON_TARGET = localize('sql.migration.schema.full.missing', "No schema was found on target. This option must be selected to migrate this database. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration. No tables selected will migrate missing schema only.");
-export const PARTIAL_SCHEMA_ON_TARGET = localize('sql.migration.schema.partial.missing', "Missing schemas on the target. Some tables are disabled and cannot be migrated unless this option is selected. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.  No tables selected will migrate missing schema only.");
+export const FULL_SCHEMA_MISSING_ON_TARGET = localize('sql.migration.schema.full.missing', "No schema was found on target. This option must be selected to migrate this database. No tables selected will migrate missing schema only.");
+export const PARTIAL_SCHEMA_ON_TARGET = localize('sql.migration.schema.partial.missing', "Missing schemas on the target. Some tables are disabled and cannot be migrated unless this option is selected. No tables selected will migrate missing schema only.");
 export const FULL_SCHEMA_ON_TARGET = localize('sql.migration.schema.no.missing', "Schema was found on target. Schema migration is not required.");
 export const ALL_SOURCE_TABLES_EMPTY = localize('sql.migration.all.source.tables.empty', "All of source tables are empty. No table is available to select for data migration. But they are available for schema migration if they do not exist on target.");
 export const SCHEMA_MIGRATION_INFO = localize('sql.migration.schema.migration.info', "Select this option to migrate missing tables on your Azure SQL target");
@@ -1824,5 +1824,6 @@ export function SQLDB_MIGRATION_DIFFERENT_IR_VERSION_ERROR_MESSAGE(irVersions: I
 export const SCHEMA_MIGRATION_WINDOWS_AUTH_ERROR_MESSAGE = localize('sql.schema.migration.windows.auth.error', "Schema migration is not currently supported for connectivity to source instance using Windows Authentication. Please use SQL Authentication to enable schema migration support.");
 export const SCHEMA_MIGRATION_INFORMATION_MESSAGE = localize(
 	'sql.schema.migration.information',
-	"Schema migration is in {0} in Step 6. It requires an Integration Runtime version of [5.35.8686.1] or higher. Schema migration is not currently supported for connections to source instance using Windows Authentication. Please use SQL Authentication.",
+	"Schema migration is in {0} in Step 6. It requires an Integration Runtime version of [{1}] or higher. Schema deployment will make a best effort to deploy database objects. Schema deployment errors will not prevent data migration.",
 );
+export const MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION = localize('sql.schema.migration.min.version', `${SchemaMigrationRequiredIntegrationRuntimeMinimumVersion.major}.${SchemaMigrationRequiredIntegrationRuntimeMinimumVersion.minor}.${SchemaMigrationRequiredIntegrationRuntimeMinimumVersion.build}.${SchemaMigrationRequiredIntegrationRuntimeMinimumVersion.revision}`);

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -18,7 +18,7 @@ import { logError, TelemetryViews } from '../telemetry';
 import * as styles from '../constants/styles';
 import { TableMigrationSelectionDialog } from '../dialog/tableMigrationSelection/tableMigrationSelectionDialog';
 import { ValidateIrDialog } from '../dialog/validationResults/validateIrDialog';
-import { areVersionsSame, canTargetConnectToStorageAccount, getActiveIrVersions, getSourceConnectionCredentials, getSourceConnectionProfile, getSourceConnectionQueryProvider, getSourceConnectionUri, isSchemaMigrationSupportedByActiveNodes, SchemaMigrationRequiredIntegrationRuntimeMinimumVersion, TargetDatabaseInfo } from '../api/sqlUtils';
+import { areVersionsSame, canTargetConnectToStorageAccount, getActiveIrVersions, getActiveIrVersionsNotSupportingSchemaMigration, getActiveIrVersionsSupportingSchemaMigration, getSourceConnectionCredentials, getSourceConnectionProfile, getSourceConnectionQueryProvider, getSourceConnectionUri, SchemaMigrationRequiredIntegrationRuntimeMinimumVersion, TargetDatabaseInfo } from '../api/sqlUtils';
 import { SchemaMigrationAssessmentDialog } from '../dialog/tableMigrationSelection/schemaMigrationAssessmentDialog';
 
 const WIZARD_TABLE_COLUMN_WIDTH = '200px';
@@ -851,7 +851,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 
 		this.wizard.customButtons[VALIDATE_IR_CUSTOM_BUTTON_INDEX].hidden = !this.migrationStateModel.isIrMigration;
 		if (this.migrationStateModel._targetType === MigrationTargetType.SQLDB && !this.migrationStateModel.refreshDatabaseBackupPage) {
-			await this._checkIfSchemaMigrationIsSupported();
+			await this._validateIrVersions();
 		}
 		await this._updatePageControlsVisibility();
 
@@ -1848,7 +1848,7 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		const data: any[][] = [];
 
 		// Check if schema migration is supported
-		await this._checkIfSchemaMigrationIsSupported();
+		await this._validateIrVersions();
 
 		// Get source target mapping table
 		this.migrationStateModel._sourceTargetMapping.forEach((targetDatabaseInfo, sourceDatabaseName) => {
@@ -1910,9 +1910,9 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		}
 	}
 
-	private async _checkIfSchemaMigrationIsSupported(): Promise<void> {
+	private async _validateIrVersions(): Promise<void> {
 		this._sqlDbWarnings.length = 0;
-		// Check if schema migration is supported
+		// Check if schema migration is supported and if multiple IR nodes versions are different.
 		const irNodes = await getIrNodes(
 			this.migrationStateModel._azureAccount,
 			this.migrationStateModel._sqlMigrationServiceSubscription,
@@ -1920,28 +1920,29 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 			this.migrationStateModel._location.name,
 			this.migrationStateModel._sqlMigrationService!.name);
 		const irVersions = getActiveIrVersions(irNodes);
-		this.migrationStateModel.isSchemaMigrationSupported = isSchemaMigrationSupportedByActiveNodes(irNodes);
+		const irVersionsSupportingSchemaMigration = getActiveIrVersionsSupportingSchemaMigration(irNodes);
+		this.migrationStateModel.isSchemaMigrationSupported = irVersionsSupportingSchemaMigration.length > 0;
 
-		// Check if current IR node(s) support schema migration
+		// Check if current IR node(s) support schema migration is supported
 		if (!this.migrationStateModel.isSchemaMigrationSupported) {
-			this._sqlDbWarnings.push(constants.SCHEMA_MIGRATION_UPDATE_IR_VERSION_ERROR_MESSAGE(SchemaMigrationRequiredIntegrationRuntimeMinimumVersion, irVersions));
+			const irVersionsNotSupportingSchemaMigration = getActiveIrVersionsNotSupportingSchemaMigration(irNodes);
+			this._sqlDbWarnings.push(constants.SCHEMA_MIGRATION_UPDATE_IR_VERSION_ERROR_MESSAGE(SchemaMigrationRequiredIntegrationRuntimeMinimumVersion, irVersionsNotSupportingSchemaMigration));
 		}
 
 		// Check if multiple IR nodes have different versions.
 		if (!areVersionsSame(irVersions)) {
 			this._sqlDbWarnings.push(constants.SQLDB_MIGRATION_DIFFERENT_IR_VERSION_ERROR_MESSAGE(irVersions));
 		}
-
-		// Check if source is using Windows authentication.
-		if (this.migrationStateModel._authenticationType === MigrationSourceAuthenticationType.Integrated) {
-			this._sqlDbWarnings.push(constants.SCHEMA_MIGRATION_WINDOWS_AUTH_ERROR_MESSAGE);
-		}
-
 		if (this._sqlDbWarnings.length > 0) {
 			this.wizard.message = {
 				text: this._sqlDbWarnings.join(EOL),
 				level: azdata.window.MessageLevel.Warning
 			};
+		} else {
+			this.wizard.message = {
+				text: '',
+				level: azdata.window.MessageLevel.Information
+			}
 		}
 	}
 }

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -15,7 +15,7 @@ import * as utils from '../api/utils';
 import { MigrationTargetType } from '../api/utils';
 import { azureResource } from 'azurecore';
 import { AzureSqlDatabaseServer, getVMInstanceView, SqlVMServer } from '../api/azure';
-import { collectTargetDatabaseInfo, SchemaMigrationRequiredIntegrationRuntimeMinimumVersion, TargetDatabaseInfo } from '../api/sqlUtils';
+import { collectTargetDatabaseInfo, TargetDatabaseInfo } from '../api/sqlUtils';
 import { MigrationLocalStorage, MigrationServiceContext } from '../models/migrationLocalStorage';
 import { ValidationErrorCodes } from '../constants/helper';
 import { TdeMigrationDialog } from '../dialog/tdeConfiguration/tdeMigrationDialog';

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -642,6 +642,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 				CSSStyles: { ...styles.BODY_CSS, 'margin': '5px 0 0 0' },
 				links: [
 					{ text: constants.DATABASE_SCHEMA_MIGRATION_PUBLIC_PREVIEW, url: 'https://techcommunity.microsoft.com/t5/microsoft-data-migration-blog/public-preview-schema-migration-for-target-azure-sql-db/ba-p/3990463' },
+					{ text: constants.MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION, url: 'https://www.microsoft.com/en-my/download/details.aspx?id=39717' },
 				]
 			}).component();
 		this._azureResourceTable = this._createResourceTable();

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -15,7 +15,7 @@ import * as utils from '../api/utils';
 import { MigrationTargetType } from '../api/utils';
 import { azureResource } from 'azurecore';
 import { AzureSqlDatabaseServer, getVMInstanceView, SqlVMServer } from '../api/azure';
-import { collectTargetDatabaseInfo, TargetDatabaseInfo } from '../api/sqlUtils';
+import { collectTargetDatabaseInfo, SchemaMigrationRequiredIntegrationRuntimeMinimumVersion, TargetDatabaseInfo } from '../api/sqlUtils';
 import { MigrationLocalStorage, MigrationServiceContext } from '../models/migrationLocalStorage';
 import { ValidationErrorCodes } from '../constants/helper';
 import { TdeMigrationDialog } from '../dialog/tdeConfiguration/tdeMigrationDialog';
@@ -642,7 +642,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 				CSSStyles: { ...styles.BODY_CSS, 'margin': '5px 0 0 0' },
 				links: [
 					{ text: constants.DATABASE_SCHEMA_MIGRATION_PUBLIC_PREVIEW, url: 'https://techcommunity.microsoft.com/t5/microsoft-data-migration-blog/public-preview-schema-migration-for-target-azure-sql-db/ba-p/3990463' },
-					{ text: constants.MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION, url: 'https://www.microsoft.com/en-my/download/details.aspx?id=39717' },
+					{ text: constants.MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION(SchemaMigrationRequiredIntegrationRuntimeMinimumVersion), url: 'https://www.microsoft.com/en-my/download/details.aspx?id=39717' },
 				]
 			}).component();
 		this._azureResourceTable = this._createResourceTable();

--- a/extensions/sql-migration/src/wizard/targetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/targetSelectionPage.ts
@@ -642,7 +642,7 @@ export class TargetSelectionPage extends MigrationWizardPage {
 				CSSStyles: { ...styles.BODY_CSS, 'margin': '5px 0 0 0' },
 				links: [
 					{ text: constants.DATABASE_SCHEMA_MIGRATION_PUBLIC_PREVIEW, url: 'https://techcommunity.microsoft.com/t5/microsoft-data-migration-blog/public-preview-schema-migration-for-target-azure-sql-db/ba-p/3990463' },
-					{ text: constants.MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION(SchemaMigrationRequiredIntegrationRuntimeMinimumVersion), url: 'https://www.microsoft.com/en-my/download/details.aspx?id=39717' },
+					{ text: constants.MIN_IR_VERSION_SUPPORT_SCHEMA_MIGRATION, url: 'https://www.microsoft.com/en-my/download/details.aspx?id=39717' },
 				]
 			}).component();
 		this._azureResourceTable = this._createResourceTable();


### PR DESCRIPTION
Background:
SHIR 5.37.8767.4 (Will be released on 1/12/2024) supports Windows login to connect source instance. Therefore, update the schema migration info message and validation.

Changes:
1. Update the info message in step 4.
![image](https://github.com/microsoft/azuredatastudio/assets/13447151/f99bece4-9801-4955-86cf-ca8c25971c4d)

2. Update the schema migration validation. 5.37 is the min version supporting schema migration.
![image](https://github.com/microsoft/azuredatastudio/assets/13447151/67624f1c-d12a-4a6c-b841-afcbf0b76cea)
![image](https://github.com/microsoft/azuredatastudio/assets/13447151/2e7d3da8-2689-43bd-9e06-c639ed96ca00)



