### PR TITLE
Add aria labels for browse files buttons

### DIFF
--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -58,6 +58,7 @@ export const DataFileLabel = localize('objectManagement.dataFileLabel', "Data");
 export const LogFileLabel = localize('objectManagement.logFileLabel', "Log");
 export const BackButtonLabel = localize('objectManagement.backButtonLabel', "Back");
 export const NoSecurableObjectsFoundInfoMessage: string = localize('objectManagement.noSecurableObjectsFoundInfoMessage', "No securable objects could be found for the specified selection.");
+export const BrowseFilesLabel = localize('objectManagement.browseFilesLabel', "Browse files");
 
 export function ExplicitPermissionsTableLabelSelected(name: string): string { return localize('objectManagement.explicitPermissionsTableLabelSelected', "Explicit permissions for: {0}", name); }
 export function EffectivePermissionsTableLabelSelected(name: string): string { return localize('objectManagement.effectivePermissionsTableLabelSelected', "Effective permissions for: {0}", name); }

--- a/extensions/mssql/src/objectManagement/ui/databaseFileDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseFileDialog.ts
@@ -180,7 +180,7 @@ export class DatabaseFileDialog extends DialogBase<DatabaseFile> {
 			value: this.options.databaseFile.path,
 			width: DefaultInputWidth - 30
 		});
-		this.filePathButton = this.createButton('...', '...', async () => { await this.createFileBrowser() }, this.options.isNewFile);
+		this.filePathButton = this.createButton('...', localizedConstants.BrowseFilesLabel, async () => { await this.createFileBrowser() }, this.options.isNewFile);
 		this.filePathButton.width = 25;
 		this.pathContainer = this.createLabelInputContainer(localizedConstants.PathText, this.filePathTextBox);
 		this.pathContainer.addItems([this.filePathButton], { flex: '10 0 auto' });

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -256,7 +256,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 			width: RestoreInputsWidth - 30,
 			placeHolder: localizedConstants.BackupFolderPathTitle
 		});
-		this.backupFilePathButton = this.createButton('...', '...', async () => {
+		this.backupFilePathButton = this.createButton('...', localizedConstants.BrowseFilesLabel, async () => {
 			this.restoreFrom.value === localizedConstants.RestoreFromUrlText
 				? await this.createBackupUrlFileBrowser() : await this.createBackupFileBrowser()
 		});
@@ -592,7 +592,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 			value: this.objectInfo.restorePlanResponse.planDetails.dataFileFolder.defaultValue,
 			width: SelectFolderInputWidth
 		});
-		this.dataFileFolderButton = this.createButton('...', '...', async () => { await this.createDataFileBrowser(this.dataFileFolder) });
+		this.dataFileFolderButton = this.createButton('...', localizedConstants.BrowseFilesLabel, async () => { await this.createDataFileBrowser(this.dataFileFolder) });
 		this.dataFileFolderButton.width = SelectFolderButtonWidth;
 		this.dataFileFolderButton.enabled = false;
 		this.dataFileFolderContainer = this.createLabelInputContainer(localizedConstants.DataFileFolderText, this.dataFileFolder);
@@ -610,7 +610,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 			value: this.objectInfo.restorePlanResponse.planDetails.logFileFolder.defaultValue,
 			width: SelectFolderInputWidth
 		});
-		this.logFileFolderButton = this.createButton('...', '...', async () => { await this.createDataFileBrowser(this.logFileFolder) });
+		this.logFileFolderButton = this.createButton('...', localizedConstants.BrowseFilesLabel, async () => { await this.createDataFileBrowser(this.logFileFolder) });
 		this.logFileFolderButton.width = SelectFolderButtonWidth;
 		this.logFileFolderButton.enabled = false;
 		this.logFileFolderContainer = this.createLabelInputContainer(localizedConstants.LogFileFolderText, this.logFileFolder);


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/25129

Adds a "Browse files" aria label for browse buttons that only have an ellipsis label ('...').
