### PR TITLE
add aria label for issue reporter's description text area

### DIFF
--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -729,6 +729,8 @@ export class IssueReporter extends Disposable {
 			return;
 		}
 
+		const stepsToReproduce = localize('stepsToReproduce', "Steps to Reproduce"); // {{SQL CARBON EDIT}} Declare variable to be used in labels and aria labels later
+
 		if (issueType === IssueType.Bug) {
 			if (!fileOnMarketplace) {
 				show(blockContainer);
@@ -739,8 +741,9 @@ export class IssueReporter extends Disposable {
 				}
 			}
 
-			reset(descriptionTitle, localize('stepsToReproduce', "Steps to Reproduce") + ' ', $('span.required-input', undefined, '*'));
+			reset(descriptionTitle, stepsToReproduce + ' ', $('span.required-input', undefined, '*'));  // {{SQL CARBON EDIT}} use stepsToReproduce variable
 			reset(descriptionSubtitle, localize('bugDescription', "Share the steps needed to reliably reproduce the problem. Please include actual and expected results. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
+			descriptionTextArea.ariaLabel = stepsToReproduce; // {{SQL CARBON EDIT}} set aria label
 		} else if (issueType === IssueType.PerformanceIssue) {
 			if (!fileOnMarketplace) {
 				show(blockContainer);
@@ -756,11 +759,14 @@ export class IssueReporter extends Disposable {
 				show(extensionsBlock);
 			}
 
-			reset(descriptionTitle, localize('stepsToReproduce', "Steps to Reproduce") + ' ', $('span.required-input', undefined, '*'));
+			reset(descriptionTitle, stepsToReproduce + ' ', $('span.required-input', undefined, '*')); // {{SQL CARBON EDIT}} use stepsToReproduce variable
 			reset(descriptionSubtitle, localize('performanceIssueDesciption', "When did this performance issue happen? Does it occur on startup or after a specific series of actions? We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
+			descriptionTextArea.ariaLabel = stepsToReproduce; // {{SQL CARBON EDIT}} set aria label
 		} else if (issueType === IssueType.FeatureRequest) {
-			reset(descriptionTitle, localize('description', "Description") + ' ', $('span.required-input', undefined, '*'));
+			const description = localize('description', "Description"); // {{SQL CARBON EDIT}}  Declare variable to be used in labels and aria labels later
+			reset(descriptionTitle, description + ' ', $('span.required-input', undefined, '*')); // {{SQL CARBON EDIT}} use description variable
 			reset(descriptionSubtitle, localize('featureRequestDescription', "Please describe the feature you would like to see. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
+			descriptionTextArea.ariaLabel = localize('description', "Description"); // {{SQL CARBON EDIT}} set aria label
 		}
 	}
 

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -766,7 +766,7 @@ export class IssueReporter extends Disposable {
 			const description = localize('description', "Description"); // {{SQL CARBON EDIT}}  Declare variable to be used in labels and aria labels later
 			reset(descriptionTitle, description + ' ', $('span.required-input', undefined, '*')); // {{SQL CARBON EDIT}} use description variable
 			reset(descriptionSubtitle, localize('featureRequestDescription', "Please describe the feature you would like to see. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
-			descriptionTextArea.ariaLabel = localize('description', "Description"); // {{SQL CARBON EDIT}} set aria label
+			descriptionTextArea.ariaLabel = description; // {{SQL CARBON EDIT}} set aria label
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Addresses https://github.com/microsoft/azuredatastudio/issues/24219.

This adds an aria label to the description area in the issue reporter. The title changes between "Steps to Reproduce" and "Description" depending on if it's a bug or a feature request.

Description:
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/f2265687-a57f-4e1e-a120-d9d5b3b645d1)
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/be47cc96-f018-491c-8920-135e06fbab2e)


Steps to Reproduce:
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/84095572-2215-4af9-8e85-8df4f331aa20)
![image](https://github.com/microsoft/azuredatastudio/assets/31145923/5084774b-8f21-4343-bea9-cc9d837a1eee)
