### PR TITLE
Add Restore Database command to Databases folder

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -737,6 +737,11 @@
           "group": "1_objectManagement@3"
         },
         {
+          "command": "mssql.restoreDatabase",
+          "when": "connectionProvider == MSSQL && nodeType == Folder && objectType == Databases && !isCloud && engineEdition != 11 && config.workbench.enablePreviewFeatures",
+          "group": "1_objectManagement@3"
+        },
+        {
           "command": "mssql.backupDatabase",
           "when": "connectionProvider == MSSQL && nodeType == Database && !isCloud && engineEdition != 11 && config.workbench.enablePreviewFeatures",
           "group": "1_objectManagement@3"

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -236,7 +236,7 @@ export const EditionText = localize('objectManagement.editionLabel', "Edition");
 export const MaxSizeText = localize('objectManagement.maxSizeLabel', "Max Size");
 export const AzurePricingLinkText = localize('objectManagement.azurePricingLink', "Azure SQL Database pricing calculator");
 export const DetachDatabaseDialogTitle = (dbName: string) => localize('objectManagement.detachDatabaseDialogTitle', "Detach Database - {0} (Preview)", dbName);
-export const RestoreDatabaseDialogTitle = (dbName: string) => localize('objectManagement.restoreDatabaseDialogTitle', dbName ? "Restore Database - {0} (Preview)" : "Restore Database (Preview)", dbName);
+export const RestoreDatabaseDialogTitle = localize('objectManagement.restoreDatabaseDialogTitle', "Restore Database (Preview)");
 export const DetachDropConnections = localize('objectManagement.detachDropConnections', "Drop connnections");
 export const DetachUpdateStatistics = localize('objectManagement.detachUpdateStatistics', "Update statistics");
 export const DatabaseFilesLabel = localize('objectManagement.databaseFiles', "Database Files");

--- a/extensions/mssql/src/objectManagement/localizedConstants.ts
+++ b/extensions/mssql/src/objectManagement/localizedConstants.ts
@@ -236,7 +236,7 @@ export const EditionText = localize('objectManagement.editionLabel', "Edition");
 export const MaxSizeText = localize('objectManagement.maxSizeLabel', "Max Size");
 export const AzurePricingLinkText = localize('objectManagement.azurePricingLink', "Azure SQL Database pricing calculator");
 export const DetachDatabaseDialogTitle = (dbName: string) => localize('objectManagement.detachDatabaseDialogTitle', "Detach Database - {0} (Preview)", dbName);
-export const RestoreDatabaseDialogTitle = (dbName: string) => localize('objectManagement.restoreDatabaseDialogTitle', "Restore Database - {0} (Preview)", dbName);
+export const RestoreDatabaseDialogTitle = (dbName: string) => localize('objectManagement.restoreDatabaseDialogTitle', dbName ? "Restore Database - {0} (Preview)" : "Restore Database (Preview)", dbName);
 export const DetachDropConnections = localize('objectManagement.detachDropConnections', "Drop connnections");
 export const DetachUpdateStatistics = localize('objectManagement.detachUpdateStatistics', "Update statistics");
 export const DatabaseFilesLabel = localize('objectManagement.databaseFiles', "Database Files");

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -272,10 +272,9 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 			: this.createDropdown(localizedConstants.DatabaseText, async (newValue) => {
 				if (this.restoreFrom.value !== localizedConstants.RestoreFromUrlText) {
 					this.objectInfo.restorePlanResponse.planDetails.sourceDatabaseName.currentValue = newValue;
-					this.targetDatabase.value = newValue;
 					await this.updateNewRestorePlanToDialog();
 				}
-			}, this.viewInfo.restoreDatabaseInfo.sourceDatabaseNames, this.objectInfo.restorePlanResponse.planDetails.sourceDatabaseName.currentValue, true, RestoreInputsWidth, false);
+			}, this.viewInfo.restoreDatabaseInfo.sourceDatabaseNames, this.objectInfo.restorePlanResponse?.planDetails.sourceDatabaseName.currentValue, true, RestoreInputsWidth, false);
 		const restoreDatabaseContainer = this.createLabelInputContainer(localizedConstants.DatabaseText, this.restoreDatabase);
 		restoreDatabaseContainer.CSSStyles = { 'margin-left': this.isManagedInstance ? '20px' : '0px' };
 		containers.push(restoreDatabaseContainer);
@@ -290,7 +289,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 			if (this.objectInfo.restorePlanResponse !== null) {
 				this.objectInfo.restorePlanResponse.planDetails.targetDatabaseName.currentValue = newValue;
 			}
-		}, this.viewInfo.restoreDatabaseInfo.targetDatabaseNames, this.objectInfo.restorePlanResponse.planDetails.targetDatabaseName.currentValue, true, RestoreInputsWidth, true, false);
+		}, this.viewInfo.restoreDatabaseInfo.targetDatabaseNames, this.objectInfo.restorePlanResponse?.planDetails.targetDatabaseName.currentValue, true, RestoreInputsWidth, true, false);
 		this.targetDatabase.fireOnTextChange = true;
 		this.targetDatabase.required = true;
 		containers.push(this.createLabelInputContainer(this.isManagedInstance ? localizedConstants.DatabaseText : localizedConstants.TargetDatabaseText, this.targetDatabase));

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -272,6 +272,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 			: this.createDropdown(localizedConstants.DatabaseText, async (newValue) => {
 				if (this.restoreFrom.value !== localizedConstants.RestoreFromUrlText) {
 					this.objectInfo.restorePlanResponse.planDetails.sourceDatabaseName.currentValue = newValue;
+					this.targetDatabase.value = newValue;
 					await this.updateNewRestorePlanToDialog();
 				}
 			}, this.viewInfo.restoreDatabaseInfo.sourceDatabaseNames, this.objectInfo.restorePlanResponse?.planDetails.sourceDatabaseName.currentValue, true, RestoreInputsWidth, false);

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -405,7 +405,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 				this.onFormFieldChange();
 			})
 		);
-		return this.createGroup(localizedConstants.SourceSectionText, [this.restorePlanTable], true);
+		return this.createGroup(localizedConstants.RestorePlanSectionText, [this.restorePlanTable], true);
 	}
 
 	/**
@@ -483,7 +483,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 		const restorePlanInfo = this.setRestoreOption();
 		const restorePlan = await this.restoreProvider.getRestorePlan(this.options.connectionUri, restorePlanInfo);
 
-		// Update the dailog values with the new restore plan
+		// Update the dialog values with the new restore plan
 		await this.updateRestoreDialog(restorePlan);
 		this.dialogObject.loading = false;
 	}

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -225,7 +225,6 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 	//#region General Tab
 	private initializeSourceSection(): azdata.GroupContainer {
 		let containers: azdata.Component[] = [];
-		this.objectInfo.name = this.options.database;
 
 		// Managed instance only supports URL mode, so disable unusable fields
 		this.isManagedInstance = this.viewInfo.isManagedInstance;
@@ -290,6 +289,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 			if (this.objectInfo.restorePlanResponse !== null) {
 				this.objectInfo.restorePlanResponse.planDetails.targetDatabaseName.currentValue = newValue;
 			}
+			this.objectInfo.name = newValue;
 		}, this.viewInfo.restoreDatabaseInfo.targetDatabaseNames, this.objectInfo.restorePlanResponse?.planDetails.targetDatabaseName.currentValue, true, RestoreInputsWidth, true, false);
 		this.targetDatabase.fireOnTextChange = true;
 		this.targetDatabase.required = true;

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -521,8 +521,13 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 		this.objectInfo.restorePlanResponse = restorePlan;
 
 		// Update Source database name
-		// If restoring from URL, cannot select any other database as source, but can select different database when restoring from a database
-		if (this.restoreFrom.value !== localizedConstants.RestoreFromDatabaseOptionText && restorePlan.canRestore) {
+		// If restoring from URL or File, cannot select any other database as source, but can select different database when restoring from a database
+		if (this.restoreFrom.value === localizedConstants.RestoreFromDatabaseOptionText) {
+			await this.restoreDatabase.updateProperties({
+				values: this.viewInfo.restoreDatabaseInfo.sourceDatabaseNames,
+				value: restorePlan.planDetails?.sourceDatabaseName?.currentValue
+			});
+		} else {
 			await this.restoreDatabase.updateProperties({
 				values: [restorePlan.planDetails?.sourceDatabaseName?.currentValue],
 				value: restorePlan.planDetails?.sourceDatabaseName?.currentValue

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -62,7 +62,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
 		options.width = Dialog_Width;
-		super(objectManagementService, options, loc.RestoreDatabaseDialogTitle(options.database), 'RestoreDatabase');
+		super(objectManagementService, options, loc.RestoreDatabaseDialogTitle, 'RestoreDatabase');
 		this.restoreProvider = azdata.dataprotocol.getProvider<azdata.RestoreProvider>('MSSQL', azdata.DataProviderType.RestoreProvider);
 		this.dialogObject.okButton.label = localizedConstants.RestoreText;
 	}


### PR DESCRIPTION
Closes https://github.com/microsoft/azuredatastudio/issues/25247

Adds the Restore Database command to the context menu for the Databases folder so a user doesn't need to create a database first before restoring it. I also fixed 2 other issues:
1. An incorrect section name for the restore plan section.
2. A bug where the source database dropdown would not get properly updated when switching between Database and File restore modes.
3. A bug where the target database name wasn't getting updated when switching between different restore sources.

Since there's no database context when opening the Restore dialog from a folder, the dialog will be initially populated with the first entry in the source database list.