### PR TITLE
vbump 1.5.3 sql-migration (Hot Fix ) to InsiderGallery

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3979,14 +3979,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.5.2",
-							"lastUpdated": "01/23/2024",
+							"version": "1.5.3",
+							"lastUpdated": "01/26/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.5.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-migration/sql-migration-1.5.3.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR updates the insider extension gallery to the latest version 1.5.3 of the SQL Migration extension. sql-migration-1.5.3.vsix

Link to Azure Data Studio - Extensions Product pipeline run off main: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=220472&view=results

VSIX Link: https://mssqltools.visualstudio.com/_apis/resources/Containers/6717657/drop?itemPath=drop%2Flangpacks&%24format=zip&saveAbsolutePath=false