### PR TITLE
Skip starting a separate task for backup and restore operations

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
@@ -83,6 +83,10 @@ export class BackupDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		return true;
 	}
 
+	protected override get startsTaskSeparately(): boolean {
+		return true;
+	}
+
 	private get encryptionSupported(): boolean {
 		return this._encryptorOptions.length > 0;
 	}

--- a/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/backupDatabaseDialog.ts
@@ -83,8 +83,8 @@ export class BackupDatabaseDialog extends ObjectManagementDialogBase<Database, D
 		return true;
 	}
 
-	protected override get startsTaskSeparately(): boolean {
-		return true;
+	protected override get startTaskOnApply(): boolean {
+		return false; // The underlying backup operation in the SQL Tools Service starts its own task separately
 	}
 
 	private get encryptionSupported(): boolean {

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -117,7 +117,7 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 		if (this.startsTaskSeparately) {
 			await this.saveChangesAndRefresh();
 		} else {
-			this.dialogObject.registerOperation({
+			azdata.tasks.startBackgroundOperation({
 				displayName: this.saveChangesTaskLabel,
 				description: '',
 				isCancelable: false,
@@ -126,7 +126,8 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 				}
 			});
 		}
-		return super.handleDialogClosed(reason);
+		let result = await super.handleDialogClosed(reason);
+		return result;
 	}
 
 	protected get viewInfo(): ViewInfoType {

--- a/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
+++ b/extensions/mssql/src/objectManagement/ui/objectManagementDialogBase.ts
@@ -113,18 +113,20 @@ export abstract class ObjectManagementDialogBase<ObjectInfoType extends ObjectMa
 	}
 
 	protected override async handleDialogClosed(reason: azdata.window.CloseReason): Promise<any> {
-		// Skip registering a task here if one already gets started in the background, like for the Backup & Restore dialogs
-		if (this.startsTaskSeparately) {
-			await this.saveChangesAndRefresh();
-		} else {
-			azdata.tasks.startBackgroundOperation({
-				displayName: this.saveChangesTaskLabel,
-				description: '',
-				isCancelable: false,
-				operation: async (operation: azdata.BackgroundOperation): Promise<void> => {
-					await this.saveChangesAndRefresh(operation);
-				}
-			});
+		if (reason === 'ok') {
+			// Skip registering a task here if one already gets started in the background, like for the Backup & Restore dialogs
+			if (this.startsTaskSeparately) {
+				await this.saveChangesAndRefresh();
+			} else {
+				azdata.tasks.startBackgroundOperation({
+					displayName: this.saveChangesTaskLabel,
+					description: '',
+					isCancelable: false,
+					operation: async (operation: azdata.BackgroundOperation): Promise<void> => {
+						await this.saveChangesAndRefresh(operation);
+					}
+				});
+			}
 		}
 		let result = await super.handleDialogClosed(reason);
 		return result;

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -83,8 +83,8 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 		return true;
 	}
 
-	protected override get startsTaskSeparately(): boolean {
-		return true;
+	protected override get startTaskOnApply(): boolean {
+		return false; // The underlying restore operation in the SQL Tools Service starts its own task separately
 	}
 
 	private get restoreDialogDocUrl(): string {

--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -83,6 +83,10 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 		return true;
 	}
 
+	protected override get startsTaskSeparately(): boolean {
+		return true;
+	}
+
 	private get restoreDialogDocUrl(): string {
 		let helpUrl = '';
 		switch (this.activeTabId) {

--- a/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
@@ -92,12 +92,14 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 
 	constructor(objectManagementService: IObjectManagementService, options: ObjectManagementDialogOptions) {
 		super(objectManagementService, options);
-		this.disposables.push(this.dialogObject.onClosed(async (reason: azdata.window.CloseReason) => {
-			if (reason === 'ok') {
-				// only show message if user apply changes
-				await this.notifyServerRestart();
-			}
-		}));
+	}
+
+	protected override async handleDialogClosed(reason: azdata.window.CloseReason): Promise<any> {
+		if (reason === 'ok') {
+			// only show message if user apply changes
+			await this.notifyServerRestart();
+		}
+		return super.handleDialogClosed(reason);
 	}
 
 	protected override get helpUrl(): string {

--- a/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/serverPropertiesDialog.ts
@@ -99,7 +99,8 @@ export class ServerPropertiesDialog extends ObjectManagementDialogBase<Server, S
 			// only show message if user apply changes
 			await this.notifyServerRestart();
 		}
-		return super.handleDialogClosed(reason);
+		let result = await super.handleDialogClosed(reason);
+		return result;
 	}
 
 	protected override get helpUrl(): string {

--- a/extensions/mssql/src/ui/dialogBase.ts
+++ b/extensions/mssql/src/ui/dialogBase.ts
@@ -61,11 +61,15 @@ export abstract class DialogBase<DialogResult> {
 		});
 		this._closePromise = new Promise<DialogResult | undefined>(resolve => {
 			this.disposables.push(this.dialogObject.onClosed(async (reason: azdata.window.CloseReason) => {
-				await this.dispose(reason);
-				const result = reason === 'ok' ? this.dialogResult : undefined;
+				let result = await this.handleDialogClosed(reason);
 				resolve(result);
 			}));
 		});
+	}
+
+	protected async handleDialogClosed(reason: azdata.window.CloseReason): Promise<any> {
+		await this.dispose(reason);
+		return reason === 'ok' ? this.dialogResult : undefined;
 	}
 
 	public waitForClose(): Promise<DialogResult | undefined> {


### PR DESCRIPTION
When performing backup & restore operations from the new admin dialogs, two tasks were being started in the tasks pane. This is because STS starts its own task in the background when doing the restore operation, in addition to the one that always gets started when clicking OK in an admin dialog. This change skips starting a background task on OK if the dialog is a backup or restore one. I refactored the submit logic for the dialogs so that they start a background task in the Dialog `onClosed` callback, rather than registering a background task up front in `initialize` that then gets started after closing. Subclass dialogs then extend the `handleDialogClosed` callback method registered for `onClosed` to add more functionality.

Fixes https://github.com/microsoft/azuredatastudio/issues/25105
