### PR TITLE
Increase max size of DB Scoped Config table to remove table scrollbar

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/databaseDialog.ts
@@ -17,7 +17,7 @@ import * as vscode from 'vscode';
 
 const MAXDOP_Max_Limit = 32767;
 const PAUSED_RESUMABLE_INDEX_Max_Limit = 71582;
-const DscTableRowLength = 20;
+const DscTableMaxRowCount = 40;
 
 export class DatabaseDialog extends ObjectManagementDialogBase<Database, DatabaseViewInfo> {
 	// Database Properties tabs
@@ -1380,7 +1380,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 				metaData.valueForPrimary,
 				secondaryUnsupportedConfigsSet.has(metaData.id) ? localizedConstants.NotAvailableText : metaData.valueForSecondary]
 			}),
-			height: getTableHeight(this.objectInfo.databaseScopedConfigurations.length, 1, DscTableRowLength),
+			height: getTableHeight(this.objectInfo.databaseScopedConfigurations.length, 1, DscTableMaxRowCount),
 			width: DefaultTableWidth
 		}).component();
 
@@ -1667,7 +1667,7 @@ export class DatabaseDialog extends ObjectManagementDialogBase<Database, Databas
 	private async updateDscTable(data: any[][], inputToBeFocused: azdata.InputBoxComponent = undefined): Promise<void> {
 		// Set the focus to the selected input box
 		this.setFocusToInput = inputToBeFocused;
-		await this.setTableData(this.dscTable, data, DscTableRowLength);
+		await this.setTableData(this.dscTable, data, DscTableMaxRowCount);
 		// Restore the focus to previously selected row.
 		this.dscTable.setActiveCell(this.currentRowId, 0);
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24193

I increased the max number of rows in the table before it will create an internal scrollbar. The dialog instead becomes scrollable if the table is too large. This prevents the table from "flickering" after updating due to having to reselect the previously selected row after updating it, causing the whole table to refresh and then immediately scroll down for items at the bottom.

Screenshots:
![ScopedConfig1](https://github.com/microsoft/azuredatastudio/assets/12820011/815764d8-82e5-48cb-9cee-c7fc7d00a8ad)

![ScopedConfig2](https://github.com/microsoft/azuredatastudio/assets/12820011/e7e376c0-8d1e-4257-82f1-f54c55b8a2d7)

