### PR TITLE
Modal dialogs become unreadable after applying max zoom

### DIFF
--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -49,6 +49,8 @@
 	right: 0;
 	position: absolute;
 	overflow-y: hidden;
+	overflow-x: auto;
+	display: contents;
 }
 
 .modal.flyout-dialog .modal-dialog.narrow-dialog {
@@ -345,26 +347,4 @@
 
 .modal-dialog form {
 	height: 100%;
-}
-
-.modal.fade.flyout-dialog[aria-label*="Database Properties"] {
-	max-width: 750px;
-	margin-left: auto;
-	margin-right: 0;
-}
-
-.modal.fade.flyout-dialog[aria-label*="Database Properties"] > .modal-dialog {
-	display: contents;
-	overflow-x: auto;
-}
-
-.modal.fade.flyout-dialog[aria-label*="Server Properties"] {
-	max-width: 750px;
-	margin-left: auto;
-	margin-right: 0;
-}
-
-.modal.fade.flyout-dialog[aria-label*="Server Properties"] > .modal-dialog {
-	display: contents;
-	overflow-x: auto;
 }

--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -346,3 +346,25 @@
 .modal-dialog form {
 	height: 100%;
 }
+
+.modal.fade.flyout-dialog[aria-label*="Database Properties"] {
+	max-width: 750px;
+	margin-left: auto;
+	margin-right: 0;
+}
+
+.modal.fade.flyout-dialog[aria-label*="Database Properties"] > .modal-dialog {
+	display: contents;
+	overflow-x: auto;
+}
+
+.modal.fade.flyout-dialog[aria-label*="Server Properties"] {
+	max-width: 750px;
+	margin-left: auto;
+	margin-right: 0;
+}
+
+.modal.fade.flyout-dialog[aria-label*="Server Properties"] > .modal-dialog {
+	display: contents;
+	overflow-x: auto;
+}

--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -43,14 +43,18 @@
 }
 
 /** FLYOUT **/
+.modal.flyout-dialog .modal-dialog .modal-dialog-container {
+	display: contents;
+	overflow-x: auto;
+}
+
 .modal.flyout-dialog .modal-dialog {
-	margin: auto auto auto auto;
+	margin: auto 0 auto auto;
 	height: 100%;
+	max-width: 100%;
 	right: 0;
 	position: absolute;
 	overflow-y: hidden;
-	overflow-x: auto;
-	display: contents;
 }
 
 .modal.flyout-dialog .modal-dialog.narrow-dialog {

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -138,6 +138,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	private _dialogExteriorBorder?: Color;
 	private _dialogShadowColor?: Color;
 
+	private _modalDialogContainer?: HTMLElement;
 	private _modalDialog?: HTMLElement;
 	private _modalContent?: HTMLElement;
 	private _modalHeaderSection?: HTMLElement;
@@ -236,7 +237,8 @@ export abstract class Modal extends Disposable implements IThemable {
 		}
 		this._bodyContainer.style.top = `${top}px`;
 		this._modalDialog = DOM.append(this._bodyContainer, DOM.$('.modal-dialog'));
-		const formElement = DOM.append(this._modalDialog, DOM.$('form'));
+		this._modalDialogContainer = DOM.append(this._modalDialog, DOM.$('.modal-dialog-container'));
+		const formElement = DOM.append(this._modalDialogContainer, DOM.$('form'));
 
 		if (this._modalOptions.dialogStyle === 'normal') {
 			// set the height based on the available space and the expected height.


### PR DESCRIPTION
For: https://github.com/microsoft/azuredatastudio/issues/25124

I needed to add an extra div to include the scrollbar to the dialog content and the dialog footer.

![image](https://github.com/microsoft/azuredatastudio/assets/34872381/4985e3d6-0370-4dac-bb15-27f450147eef)

![image](https://github.com/microsoft/azuredatastudio/assets/34872381/a693d9d8-e464-47b4-97a0-b0f3ed623281)


Adding more examples of this: 

Adding a database user
![image](https://github.com/microsoft/azuredatastudio/assets/34872381/34d5aef6-f0d3-4c83-8e93-97b234c8f976)

![image](https://github.com/microsoft/azuredatastudio/assets/34872381/949dee06-8e41-4e12-8f5f-cd19b8460eab)


Restore database
![image](https://github.com/microsoft/azuredatastudio/assets/34872381/42109a27-7620-446e-9d2a-a77d25c20a34)

![image](https://github.com/microsoft/azuredatastudio/assets/34872381/54add7ee-d1f0-488b-8300-2301014a28e2)

Deployment options wizard:

![image](https://github.com/microsoft/azuredatastudio/assets/34872381/e6c7808a-3853-4d12-be31-41f53ba8edf9)

![image](https://github.com/microsoft/azuredatastudio/assets/34872381/c9d910dd-51aa-4554-8ad5-66db6d5db3f3)

