### PR TITLE
Handle undefined source database name in restore dialog

### DIFF
--- a/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
+++ b/extensions/mssql/src/objectManagement/ui/restoreDatabaseDialog.ts
@@ -235,7 +235,6 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 		// Restore from
 		const restoreFromDropdownOptions = this.isManagedInstance ? [localizedConstants.RestoreFromUrlText, localizedConstants.RestoreFromS3UrlText] : [localizedConstants.RestoreFromDatabaseOptionText, localizedConstants.RestoreFromBackupFileOptionText, localizedConstants.RestoreFromUrlText, localizedConstants.RestoreFromS3UrlText];
 		this.restoreFrom = this.createDropdown(localizedConstants.RestoreFromText, async (newValue) => {
-			this.backupFilePath = this.backupURLPath = '';
 			if (newValue === localizedConstants.RestoreFromBackupFileOptionText || newValue === localizedConstants.RestoreFromUrlText) {
 				this.backupFilePathContainer.display = 'inline-flex';
 				this.restoreDatabase.enabled = false;
@@ -248,8 +247,7 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 			} else if (newValue === localizedConstants.RestoreFromDatabaseOptionText) {
 				this.backupFilePathContainer.display = 'none';
 				this.restoreDatabase.enabled = true;
-			}
-			if (newValue === localizedConstants.RestoreFromS3UrlText) {
+			} else if (newValue === localizedConstants.RestoreFromS3UrlText) {
 				this.backupFilePathInput.enabled = true;
 				this.backupFilePathContainer.display = 'inline-flex';
 				this.restoreDatabase.enabled = false;
@@ -528,13 +526,16 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 	 */
 	private async updateNewRestorePlanToDialog(): Promise<void> {
 		this.dialogObject.loading = true;
-		// Get the new restore plan for the selected file
-		const restorePlanInfo = this.setRestoreOption();
-		const restorePlan = await this.restoreProvider.getRestorePlan(this.options.connectionUri, restorePlanInfo);
+		try {
+			// Get the new restore plan for the selected file
+			const restorePlanInfo = this.setRestoreOption();
+			const restorePlan = await this.restoreProvider.getRestorePlan(this.options.connectionUri, restorePlanInfo);
 
-		// Update the dialog values with the new restore plan
-		await this.updateRestoreDialog(restorePlan);
-		this.dialogObject.loading = false;
+			// Update the dialog values with the new restore plan
+			await this.updateRestoreDialog(restorePlan);
+		} finally {
+			this.dialogObject.loading = false;
+		}
 	}
 
 	/**
@@ -576,9 +577,10 @@ export class RestoreDatabaseDialog extends ObjectManagementDialogBase<Database, 
 				value: restorePlan.planDetails?.sourceDatabaseName?.currentValue
 			});
 		} else {
+			let sourceDB = restorePlan.planDetails?.sourceDatabaseName?.currentValue ?? '';
 			await this.restoreDatabase.updateProperties({
-				values: [restorePlan.planDetails?.sourceDatabaseName?.currentValue],
-				value: restorePlan.planDetails?.sourceDatabaseName?.currentValue
+				values: [sourceDB],
+				value: sourceDB
 			});
 		}
 


### PR DESCRIPTION
When first switching to File mode in the Restore dialog, the loading spinner in the corner would keep running forever without any data showing up in the table. This is because an error was being thrown (from the ModelView code) due to an undefined value in the source database dropdown, and so resetting the loading state would get skipped. This change fixes that undefined string issue and also adds a try-finally block for the loading logic so it doesn't get stuck on error.
