### PR TITLE
Remove empty Provided Books view

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -473,16 +473,6 @@
           "group": "inline"
         },
         {
-          "command": "notebook.command.searchProvidedBook",
-          "when": "view == providedBooksView && viewItem == providedBook",
-          "group": "inline"
-        },
-        {
-          "command": "notebook.command.saveBook",
-          "when": "view == providedBooksView && viewItem == providedBook",
-          "group": "inline"
-        },
-        {
           "command": "notebook.command.closeBook",
           "when": "view == bookTreeView && viewItem == savedBook && listMultiSelection == false"
         },
@@ -561,10 +551,6 @@
         {
           "id": "bookTreeView",
           "name": "%title.SavedBooks%"
-        },
-        {
-          "id": "providedBooksView",
-          "name": "%title.ProvidedBooks%"
         }
       ]
     },

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -45,7 +45,6 @@
 	"title.trustBook": "Trust Jupyter Book",
 	"title.searchJupyterBook": "Search Jupyter Book",
 	"title.SavedBooks": "Notebooks",
-	"title.ProvidedBooks": "Provided Jupyter Books",
 	"title.PinnedBooks": "Pinned notebooks",
 	"title.PreviewLocalizedBook": "Get localized SQL Server 2019 guide",
 	"title.openJupyterBook": "Open Jupyter Book",

--- a/extensions/notebook/src/common/appContext.ts
+++ b/extensions/notebook/src/common/appContext.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { NotebookUtils } from './notebookUtils';
 import { BookTreeViewProvider } from '../book/bookTreeView';
-import { NavigationProviders, BOOKS_VIEWID, PROVIDED_BOOKS_VIEWID, PINNED_BOOKS_VIEWID, extensionOutputChannelName } from './constants';
+import { NavigationProviders, BOOKS_VIEWID, PINNED_BOOKS_VIEWID, extensionOutputChannelName } from './constants';
 
 /**
  * Global context for the application
@@ -15,7 +15,6 @@ export class AppContext {
 
 	public readonly notebookUtils: NotebookUtils;
 	public readonly bookTreeViewProvider: BookTreeViewProvider;
-	public readonly providedBookTreeViewProvider: BookTreeViewProvider;
 	public readonly pinnedBookTreeViewProvider: BookTreeViewProvider;
 	public readonly outputChannel: vscode.OutputChannel;
 
@@ -24,7 +23,6 @@ export class AppContext {
 
 		let workspaceFolders = vscode.workspace.workspaceFolders?.slice() ?? [];
 		this.bookTreeViewProvider = new BookTreeViewProvider(workspaceFolders, extensionContext, false, BOOKS_VIEWID, NavigationProviders.NotebooksNavigator);
-		this.providedBookTreeViewProvider = new BookTreeViewProvider([], extensionContext, true, PROVIDED_BOOKS_VIEWID, NavigationProviders.ProvidedBooksNavigator);
 		this.pinnedBookTreeViewProvider = new BookTreeViewProvider([], extensionContext, false, PINNED_BOOKS_VIEWID, NavigationProviders.PinnedNotebooksNavigator);
 		this.outputChannel = vscode.window.createOutputChannel(extensionOutputChannelName);
 	}

--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -48,7 +48,6 @@ export const powershellDisplayName = 'PowerShell';
 export const allKernelsName = 'All Kernels';
 
 export const BOOKS_VIEWID = 'bookTreeView';
-export const PROVIDED_BOOKS_VIEWID = 'providedBooksView';
 export const PINNED_BOOKS_VIEWID = 'pinnedBooksView';
 
 export const visitedNotebooksMementoKey = 'notebooks.visited';

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -50,16 +50,13 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	 * If changes are made to bookTreeView.openBook, please ensure backwards compatibility with its current state.
 	 * This is the command used in the extension generator to open a Jupyter Book.
 	 */
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openBook', (bookPath: string, openAsUntitled: boolean, urlToOpen?: string) => openAsUntitled ? providedBookTreeViewProvider.openBook(bookPath, urlToOpen, true) : bookTreeViewProvider.openBook(bookPath, urlToOpen, true)));
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openBook', (bookPath: string, openAsUntitled: boolean, urlToOpen?: string) => bookTreeViewProvider.openBook(bookPath, urlToOpen, true)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.addFileToView', (resource: string) => bookTreeViewProvider.openBook(resource, resource, true, true)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openNotebook', (resource: string) => bookTreeViewProvider.openNotebook(resource)));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openUntitledNotebook', (resource: string) => providedBookTreeViewProvider.openNotebookAsUntitled(resource)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openMarkdown', (resource: string) => bookTreeViewProvider.openMarkdown(resource)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openExternalLink', (resource: string) => bookTreeViewProvider.openExternalLink(resource)));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.saveBook', () => providedBookTreeViewProvider.saveJupyterBooks()));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.trustBook', async (item: BookTreeItem) => await bookTreeViewProvider.trustBook(item)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.searchBook', (item: BookTreeItem) => bookTreeViewProvider.searchJupyterBooks(item)));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.searchProvidedBook', () => providedBookTreeViewProvider.searchJupyterBooks()));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.openBook', () => bookTreeViewProvider.openNewBook()));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.closeBook', (book: BookTreeItem) => bookTreeViewProvider.closeBook(book)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.closeNotebook', (notebook: BookTreeItem) => bookTreeViewProvider.closeBook(notebook)));
@@ -162,17 +159,11 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 
 	const bookTreeViewProvider = appContext.bookTreeViewProvider;
 	await bookTreeViewProvider.initialized;
-	const providedBookTreeViewProvider = appContext.providedBookTreeViewProvider;
-	await providedBookTreeViewProvider.initialized;
 	const pinnedBookTreeViewProvider = appContext.pinnedBookTreeViewProvider;
 	await pinnedBookTreeViewProvider.initialized;
 
 	extensionContext.subscriptions.push(azdata.nb.onDidChangeActiveNotebookEditor(e => {
-		if (e.document.uri.scheme === 'untitled') {
-			void providedBookTreeViewProvider.revealDocumentInTreeView(e.document.uri, false, false);
-		} else {
-			void bookTreeViewProvider.revealDocumentInTreeView(e.document.uri, false, false);
-		}
+		void bookTreeViewProvider.revealDocumentInTreeView(e.document.uri, false, false);
 	}));
 
 	extensionContext.subscriptions.push(azdata.nb.onDidOpenNotebookDocument(async e => {

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -2092,6 +2092,11 @@ export class SearchView extends ViewPane {
 	}
 
 	private _saveSearchHistoryService() {
+		// {{SQL CARBON EDIT}}
+		if (!this.searchWidget) {
+			return;
+		}
+
 		const history: ISearchHistoryValues = Object.create(null);
 
 		const searchHistory = this.searchWidget.getSearchHistory();


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24427

Also fixed an issue I was seeing in the console log where errors were being thrown due to `searchWidget` being undefined in `searchView.ts`. A similar fix was already made in vscode here: https://github.com/microsoft/vscode/commit/c410d555fb1ce20646d3e54c44ebaca512acbe44