### PR TITLE
Handle empty package list during python installation

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -189,8 +189,10 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 				if (!this._usingExistingPython && process.platform === constants.winPlatform) {
 					let packages: PythonPkgDetails[] = await this.getInstalledPipPackages(this._pythonExecutable);
 					let pip: PythonPkgDetails = packages.find(x => x.name === 'pip');
-					let cmd = `"${this._pythonExecutable}" -m pip install --force-reinstall pip=="${pip.version}"`;
-					await this.executeBufferedCommand(cmd);
+					if (pip) {
+						let cmd = `"${this._pythonExecutable}" -m pip install --force-reinstall pip=="${pip.version}"`;
+						await this.executeBufferedCommand(cmd);
+					}
 				}
 			}
 			await this.upgradePythonPackages(forceInstall, packages);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/25049

If there's an error when retrieving the list of python packages we return an empty array instead. In most places we iterate over this list, so being empty isn't an issue. In this spot we were using a `find` call though, which would return undefined when the array is empty. This change adds an undefined check before using the results of that find call.
