### PR TITLE
Add null checks for undefined include/exclude patterns in search view

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1827,7 +1827,7 @@ export class SearchView extends ViewPane {
 					this.keybindingService.lookupKeybinding(Constants.OpenInEditorCommandId));
 				const openInEditorButton = this.messageDisposables.add(new SearchLinkButton(
 					nls.localize('openInEditor.message', "Open in editor"),
-					() => this.instantiationService.invokeFunction(createEditorFromSearchResult, this.searchResult, this.searchIncludePattern.getValue(), this.searchExcludePattern.getValue(), this.searchIncludePattern.onlySearchInOpenEditors()),
+					() => this.instantiationService.invokeFunction(createEditorFromSearchResult, this.searchResult, this.searchIncludePattern?.getValue(), this.searchExcludePattern?.getValue(), this.searchIncludePattern?.onlySearchInOpenEditors()), // {{SQL CARBON EDIT}} Check for undefined patterns
 					openInEditorTooltip));
 				dom.append(messageEl, openInEditorButton.element);
 			}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/24877

The search bar used in the notebook viewlet overrides the default search view rendering behavior, which means the include/exclude pattern objects in the base class never get created. This was causing undefined errors when trying to open the notebook find results in the editor, so the fix here was just to add some optional chaining operators. We weren't using include & exclude patterns for notebook searches, so there's no issue leaving those as undefined. I checked the console log and no errors were getting reported from passing undefined values either.
