### PR TITLE
Fill mandatory fields to run validations.

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1010,7 +1010,7 @@ export function VALIDATION_IR_BUTTON_MISSING_ERROR_MESSAGE(details: string[]): s
 	const missingDetails = details.join(', ');
 	return localize(
 		'sql.migration.validate.ir.error.message',
-		"Error: Details for {0} are mandatory and missing.",
+		"Details for {0} are mandatory and missing.",
 		missingDetails);
 }
 

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1002,6 +1002,18 @@ export function VALIDATE_IR_SQLDB_VALIDATION_RESULT_ERROR(sourceDatabaseName: st
 		error.message);
 }
 
+export const NETWORK_SHARE_USER_ACCOUNT_LABEL = localize('sql.migration.network.share.user.account.label', "User account");
+export const NETWORK_SHARE_PASSWORD_LABEL = localize('sql.migration.network.share.password.label', "Password");
+export const STORAGE_ACCOUNT_RESOURCE_GROUP_LABEL = localize('sql.migration.storage.account.resource.group.label', "Resource group");
+export const STORAGE_ACCOUNT_DETAILS_LABEL = localize('sql.migration.storage.account.details.label', "Storage account");
+export function VALIDATION_IR_BUTTON_MISSING_ERROR_MESSAGE(details: string[]): string {
+	const missingDetails = details.join(', ');
+	return localize(
+		'sql.migration.validate.ir.error.message',
+		"Error: Details for {0} are mandatory and missing.",
+		missingDetails);
+}
+
 // common strings
 export const WARNING = localize('sql.migration.warning', "Warning");
 export const ERROR = localize('sql.migration.error', "Error");

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -1335,6 +1335,29 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 			this.wizard.message = { text: '' };
 		}
 
+		const errorDetails: string[] = [];
+		if (this._windowsUserAccountText.value === undefined || this._windowsUserAccountText.value === '') {
+			errorDetails.push(constants.NETWORK_SHARE_USER_ACCOUNT_LABEL);
+		}
+		if (this._passwordText.value === undefined || this._passwordText.value === '') {
+			errorDetails.push(constants.NETWORK_SHARE_PASSWORD_LABEL);
+		}
+		if (this._networkShareStorageAccountResourceGroupDropdown.value === undefined || this._networkShareStorageAccountResourceGroupDropdown.value === '') {
+			errorDetails.push(constants.STORAGE_ACCOUNT_RESOURCE_GROUP_LABEL);
+		}
+		if (this._networkShareContainerStorageAccountDropdown.value === undefined || this._networkShareContainerStorageAccountDropdown.value === '') {
+			errorDetails.push(constants.STORAGE_ACCOUNT_DETAILS_LABEL);
+		}
+
+		if (errorDetails.length > 0) {
+			var errorMessage = constants.VALIDATION_IR_BUTTON_MISSING_ERROR_MESSAGE(errorDetails);
+			this.wizard.message = {
+				text: errorMessage,
+				level: azdata.window.MessageLevel.Error
+			};
+			return;
+		}
+
 		const dialog = new ValidateIrDialog(
 			this.migrationStateModel,
 			() => this.updateValidationResultUI());


### PR DESCRIPTION
Change - 
If the user clicks on the "Validation Button"  before entering mandatory data such as Storage account details, Network share credentials, etc. It does not validation, instead, it throws an error that data in some fields are missing.