### PR TITLE
Add write permissions to PR labelling action (#25356)

### DIFF
--- a/.github/workflows/on-pr-open.yml
+++ b/.github/workflows/on-pr-open.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - release/**
+permissions:
+  pull-requests: write
 
 jobs:
   main:


### PR DESCRIPTION
Porting action fix to release branch. This action only runs for release port request PRs, so we need it here.

Fixes https://github.com/microsoft/azuredatastudio/issues/25360
