### PR TITLE
Fix custom options selection event

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -327,8 +327,8 @@ export class ConnectionWidget extends lifecycle.Disposable {
 	private _registerSelectionChangeEvents(collections: AdsWidget[][], option: azdata.ConnectionOption, widget: SelectBox) {
 		if (option.onSelectionChange) {
 			option.onSelectionChange.forEach((event) => {
-				this._register(widget.onDidSelect(value => {
-					let selectedValue = value.selected;
+				this._register(widget.onDidSelect(_ => {
+					let selectedValue = widget.value;
 					event?.dependentOptionActions?.forEach((optionAction) => {
 						let defaultValue: string | undefined = this._customOptions.find(o => o.name === optionAction.optionName)?.defaultValue;
 						let widget: AdsWidget | undefined = this._findWidget(collections, optionAction.optionName);


### PR DESCRIPTION
Addresses #25378 

Use Widget's value instead of value provided by selection event, which is diaplay value by design.

![image](https://github.com/microsoft/azuredatastudio/assets/13396919/966d810b-634d-4d5f-b197-fcfa6a24622b)
