### PR TITLE
MainVBump STS to 4.12.0.3

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.11.0.22",
+	"version": "4.12.0.3",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR adds the fix for the issue causing to the dacfx extensions to fail with DacFX-net8.0 version support. updating STS release version generated from the STS/main branch to ADS/main branch.

![image](https://github.com/microsoft/azuredatastudio/assets/74571829/79334d55-0af8-45f6-a4b4-33ca0ebd8379)

