### PR TITLE
Remove inline commands for dropping objects

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -795,16 +795,6 @@
           "command": "mssql.objectProperties",
           "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && config.workbench.enablePreviewFeatures",
           "group": "inline@2"
-        },
-        {
-          "command": "mssql.dropDatabase",
-          "when": "connectionProvider == MSSQL && nodeType == Database && !(nodePath =~ /^.*\\/System Databases\\/.*$/) && config.workbench.enablePreviewFeatures",
-          "group": "inline@3"
-        },
-        {
-          "command": "mssql.dropObject",
-          "when": "connectionProvider == MSSQL && nodeType =~ /^(ServerLevelLogin|User|ServerLevelServerRole|ApplicationRole|DatabaseRole)$/ && !(nodePath =~ /^.*\\/System Databases\\/.*$/)  && config.workbench.enablePreviewFeatures",
-          "group": "inline@3"
         }
       ],
       "dataExplorer/context": [


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/25366

We already have Drop commands in the context menu, so the inline commands are unnecessary and can be clicked accidentally.