### PR TITLE
Update SQL Tools migration service version.

### DIFF
--- a/extensions/sql-migration/config.json
+++ b/extensions/sql-migration/config.json
@@ -1,7 +1,7 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.migration-{#fileName#}",
 	"useDefaultLinuxRuntime": true,
-	"version": "4.12.0.2",
+	"version": "4.12.0.4",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net7.0.zip",
 		"Windows": "win-x64-net7.0.zip",


### PR DESCRIPTION
Taking latest version of sqltoolservice which having fix for SKU recommendation issues.

Issue: Recommending SKU way higher than the requirements in EU region due to Double parsing in local culture. Format mismatch was the root-cause.
