### PR TITLE
Bump GitHub Copilot extension version to 1.128.504

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4979,14 +4979,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.95.239",
-							"lastUpdated": "07/12/2023",
+							"version": "1.128.504",
+							"lastUpdated": "10/20/2023",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.95.239/GitHub.copilot-1.95.239.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/GitHub.copilot-1.128.504.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4994,15 +4994,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.95.239/README.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.95.239/CHANGELOG.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.95.239/package.json"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR bumps the GitHub Copilot extension to 1.128.504, which was released in October 2023, and matches the latest version found in the insiders extension gallery for Azure Data Studio.

The PR that updated the extension in the insiders extension gallery for Azure Data Studio is here: https://github.com/microsoft/azuredatastudio/pull/24745