### PR TITLE
 Fixing nvda browse mode in query plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
     "applicationinsights": "1.4.2",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.59",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.62",
     "chart.js": "^4.3.0",
     "chartjs-adapter-moment": "^1.0.1",
     "chokidar": "3.5.1",

--- a/remote/package.json
+++ b/remote/package.json
@@ -22,7 +22,7 @@
     "applicationinsights": "1.4.2",
     "angular2-grid": "2.0.6",
     "ansi_up": "^5.1.0",
-    "azdataGraph": "github:Microsoft/azdataGraph#0.0.59",
+    "azdataGraph": "github:Microsoft/azdataGraph#0.0.62",
     "chart.js": "^4.3.0",
     "chartjs-adapter-moment": "^1.0.1",
     "@vscode/windows-process-tree": "^0.5.0",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -17,7 +17,7 @@
 		"@vscode/vscode-languagedetection": "1.0.21",
 		"angular2-grid": "2.0.6",
 		"ansi_up": "^5.1.0",
-		"azdataGraph": "github:Microsoft/azdataGraph#0.0.59",
+		"azdataGraph": "github:Microsoft/azdataGraph#0.0.62",
 		"chart.js": "^4.3.0",
     "chartjs-adapter-moment": "^1.0.1",
 		"gridstack": "^3.1.3",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -115,9 +115,9 @@ array-uniq@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.59":
-  version "0.0.59"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/d8eebd0e0af55fae332a5922971c52772df7792d"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.62":
+  version "0.0.62"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/03b2b6c1ab55281d26033d4faf2d78aca6d85f66"
 
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -224,9 +224,9 @@ async-listener@^0.6.0:
     semver "^5.3.0"
     shimmer "^1.1.0"
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.59":
-  version "0.0.59"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/d8eebd0e0af55fae332a5922971c52772df7792d"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.62":
+  version "0.0.62"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/03b2b6c1ab55281d26033d4faf2d78aca6d85f66"
 
 base64-js@^1.3.1:
   version "1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,9 +2200,9 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-"azdataGraph@github:Microsoft/azdataGraph#0.0.59":
-  version "0.0.59"
-  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/d8eebd0e0af55fae332a5922971c52772df7792d"
+"azdataGraph@github:Microsoft/azdataGraph#0.0.62":
+  version "0.0.62"
+  resolved "https://codeload.github.com/Microsoft/azdataGraph/tar.gz/03b2b6c1ab55281d26033d4faf2d78aca6d85f66"
 
 bach@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
For some reason, nvda browse mode wasn't working when I set query plan's role as tree view. However, changing the role to 'group' made it work.
Issue: #20777 