### PR TITLE
Add tabs in login - separate for system and non-system logins

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -449,6 +449,8 @@ export const LOGIN_MIGRATIONS_VM_TEXT = localize('sql.login.migration.vm.title',
 export const LOGIN_MIGRATIONS_AZURE_SQL_TARGET_PAGE_TITLE = localize('sql.login.migration.target.title', "Azure SQL target");
 export const LOGIN_MIGRATIONS_SELECT_LOGINS_PAGE_TITLE = localize('sql.login.migration.select.page.title', "Select login(s) to migrate");
 export const LOGIN_MIGRATIONS_SELECT_LOGINS_WINDOWS_AUTH_WARNING = localize('sql.login.migration.select.logins.windows.auth.warning', "Please note that this wizard does not display windows authentication login types because migrating that type is currently not supported. Capability for migrating windows authentication logins is coming soon.");
+export const LOGIN_MIGRATIONS_SELECT_LOGINS_TAB_NON_SYSTEM_LOGIN_TITLE = localize('sql.login.migration.select.logins.tab.non.system.title', "Logins ready for migration");
+export const LOGIN_MIGRATIONS_SELECT_LOGINS_TAB_SYSTEM_LOGIN_TITLE = localize('sql.login.migration.select.logins.tab.system.title', "System type logins");
 export const LOGIN_MIGRATIONS_STATUS_PAGE_TITLE = localize('sql.login.migration.status.page.title', "Migration Status");
 export function LOGIN_MIGRATIONS_STATUS_PAGE_DESCRIPTION(numLogins: number, targetType: string, targetName: string): string {
 	return localize('sql.login.migration.status.page.description', "Migrating {0} logins to target {1} '{2}'", numLogins, targetType, targetName);

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -450,7 +450,8 @@ export const LOGIN_MIGRATIONS_AZURE_SQL_TARGET_PAGE_TITLE = localize('sql.login.
 export const LOGIN_MIGRATIONS_SELECT_LOGINS_PAGE_TITLE = localize('sql.login.migration.select.page.title', "Select login(s) to migrate");
 export const LOGIN_MIGRATIONS_SELECT_LOGINS_WINDOWS_AUTH_WARNING = localize('sql.login.migration.select.logins.windows.auth.warning', "Please note that this wizard does not display windows authentication login types because migrating that type is currently not supported. Capability for migrating windows authentication logins is coming soon.");
 export const LOGIN_MIGRATIONS_SELECT_LOGINS_TAB_NON_SYSTEM_LOGIN_TITLE = localize('sql.login.migration.select.logins.tab.non.system.title', "Logins ready for migration");
-export const LOGIN_MIGRATIONS_SELECT_LOGINS_TAB_SYSTEM_LOGIN_TITLE = localize('sql.login.migration.select.logins.tab.system.title', "System type logins");
+export const LOGIN_MIGRATIONS_SELECT_LOGINS_TAB_SYSTEM_LOGIN_TITLE = localize('sql.login.migration.select.logins.tab.system.title', "Excluded login/s");
+export const LOGIN_MIGRATIONS_SELECT_LOGINS_SYSTEM_LOGIN_INFO_BOX = localize('sql.login.migration.select.logins.system.info.box', "Below login/s is/are excluded from login migration as they are either local service or system accounts at the source.");
 export const LOGIN_MIGRATIONS_STATUS_PAGE_TITLE = localize('sql.login.migration.status.page.title', "Migration Status");
 export function LOGIN_MIGRATIONS_STATUS_PAGE_DESCRIPTION(numLogins: number, targetType: string, targetName: string): string {
 	return localize('sql.login.migration.status.page.description', "Migrating {0} logins to target {1} '{2}'", numLogins, targetType, targetName);

--- a/extensions/sql-migration/src/models/loginMigrationModel.ts
+++ b/extensions/sql-migration/src/models/loginMigrationModel.ts
@@ -67,6 +67,7 @@ export class LoginMigrationModel {
 	public collectedSourceLogins: boolean = false;
 	public collectedTargetLogins: boolean = false;
 	public loginsOnSource: LoginTableInfo[] = [];
+	public systemLoginsOnSource: LoginTableInfo[] = [];
 	public loginsOnTarget: string[] = [];
 	public loginMigrationsResult!: contracts.StartLoginMigrationResult;
 	public loginMigrationsError: any;

--- a/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/loginMigrationTargetSelectionPage.ts
@@ -360,11 +360,11 @@ export class LoginMigrationTargetSelectionPage extends MigrationWizardPage {
 			var sourceSystemLoginsName: string[] = [];
 
 			if (validateLoginEligibilityResult !== undefined) {
-				sourceSystemLoginsName = Object.keys(validateLoginEligibilityResult.exceptionMap);
+				sourceSystemLoginsName = Object.keys(validateLoginEligibilityResult.exceptionMap).map(loginName => loginName.toLocaleLowerCase());
 			}
 
-			const sourceSystemLogins: LoginTableInfo[] = sourceLogins.filter(login => sourceSystemLoginsName.includes(login.loginName));
-			sourceLogins = sourceLogins.filter(login => !sourceSystemLoginsName.includes(login.loginName));
+			const sourceSystemLogins: LoginTableInfo[] = sourceLogins.filter(login => sourceSystemLoginsName.includes(login.loginName.toLocaleLowerCase()));
+			sourceLogins = sourceLogins.filter(login => !sourceSystemLoginsName.includes(login.loginName.toLocaleLowerCase()));
 
 			this.migrationStateModel._loginMigrationModel.systemLoginsOnSource = sourceSystemLogins;
 

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -214,8 +214,8 @@ export class LoginSelectorPage extends MigrationWizardPage {
 				CSSStyles: { ...styles.BODY_CSS, 'display': 'none', }
 			}).component();
 
-		await this._createNonSystemLoginTablesTab(view);
 		await this._createSystemLoginTablesTab(view);
+		await this._createNonSystemLoginTablesTab(view);
 
 		this._tabs = view.modelBuilder.tabbedPanel()
 			.withTabs([this._nonSystemloginTablesTab, this._systemLoginTablesTab])
@@ -323,15 +323,10 @@ export class LoginSelectorPage extends MigrationWizardPage {
 	}
 
 	private async _createSystemLoginTablesTab(view: azdata.ModelView): Promise<void> {
-		const headingText = view.modelBuilder.text()
-			.withProps({ value: constants.UNAVAILABLE_SOURCE_TABLES_HEADING })
-			.component();
-
 		this._systemLoginTable = this._createSystemLoginTablesTable(view);
 
 		const flex = view.modelBuilder.flexContainer()
 			.withItems([
-				headingText,
 				this._systemLoginTable],
 				{ flex: '0 0 auto' })
 			.withProps({ CSSStyles: { 'margin': '10px 0 0 15px' } })
@@ -627,6 +622,23 @@ export class LoginSelectorPage extends MigrationWizardPage {
 		}) || [];
 
 		await this._filterTableList(this._filterTableValue);
+
+		var systemLoginTableValues = sourceSystemLogins.map(row => {
+			const isLoginOnTarget = targetLogins.some(targetLogin => targetLogin.toLowerCase() === row.loginName.toLowerCase());
+			return [
+				row.loginName,
+				row.loginType,
+				row.defaultDatabaseName,
+				row.status,
+				<azdata.HyperlinkColumnCellValue>{
+					icon: getLoginStatusImage(isLoginOnTarget),
+					title: getLoginStatusMessage(isLoginOnTarget),
+				},
+			];
+		}) || [];
+
+		await this._systemLoginTable.updateProperty('data', systemLoginTableValues);
+
 		this._markRefreshDataComplete(sourceLogins.length, targetLogins.length);
 	}
 

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -36,6 +36,9 @@ export class LoginSelectorPage extends MigrationWizardPage {
 
 	private _tabs!: azdata.TabbedPanelComponent;
 	private _nonSystemloginTablesTab!: Tab;
+	private _systemLoginTablesTab!: Tab;
+	private _systemLoginTable!: azdata.TableComponent;
+
 
 	constructor(wizard: azdata.window.Wizard, migrationStateModel: MigrationStateModel, private wizardController: WizardController) {
 		super(wizard, azdata.window.createWizardPage(constants.LOGIN_MIGRATIONS_SELECT_LOGINS_PAGE_TITLE), migrationStateModel);
@@ -203,9 +206,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 		await this.updateValuesOnSelection();
 	}
 
-
 	public async createRootContainer(view: azdata.ModelView): Promise<azdata.FlexContainer> {
-
 		this._windowsAuthInfoBox = this._view.modelBuilder.infoBox()
 			.withProps({
 				style: 'information',
@@ -214,9 +215,10 @@ export class LoginSelectorPage extends MigrationWizardPage {
 			}).component();
 
 		await this._createNonSystemLoginTablesTab(view);
+		await this._createSystemLoginTablesTab(view);
 
 		this._tabs = view.modelBuilder.tabbedPanel()
-			.withTabs([this._nonSystemloginTablesTab])
+			.withTabs([this._nonSystemloginTablesTab, this._systemLoginTablesTab])
 			.component();
 
 		const flex = view.modelBuilder.flexContainer().withLayout({
@@ -316,12 +318,96 @@ export class LoginSelectorPage extends MigrationWizardPage {
 		this._nonSystemloginTablesTab = {
 			content: flex,
 			id: 'tableSelectionTab',
-			title: 'System Logins',
+			title: 'Logins ready for migration',
 		};
 	}
 
+	private async _createSystemLoginTablesTab(view: azdata.ModelView): Promise<void> {
+		const headingText = view.modelBuilder.text()
+			.withProps({ value: constants.UNAVAILABLE_SOURCE_TABLES_HEADING })
+			.component();
+
+		this._systemLoginTable = this._createSystemLoginTablesTable(view);
+
+		const flex = view.modelBuilder.flexContainer()
+			.withItems([
+				headingText,
+				this._systemLoginTable],
+				{ flex: '0 0 auto' })
+			.withProps({ CSSStyles: { 'margin': '10px 0 0 15px' } })
+			.withLayout({
+				flexFlow: 'column',
+				height: '100%',
+				width: 550,
+			}).component();
+
+		this._systemLoginTablesTab = {
+			content: flex,
+			id: 'tableSelectionTab',
+			title: 'System type logins',
+		};
+	}
 
 	private _createNonSystemLoginTablesTable(view: azdata.ModelView): azdata.TableComponent {
+		const cssClass = 'no-borders';
+		const table = this._view.modelBuilder.table()
+			.withProps({
+				data: [],
+				width: 650,
+				height: '600px',
+				display: 'flex',
+				forceFitColumns: azdata.ColumnSizingMode.ForceFit,
+				columns: [
+					{
+						name: constants.SOURCE_LOGIN,
+						value: 'sourceLogin',
+						type: azdata.ColumnType.text,
+						width: 250,
+						cssClass: cssClass,
+						headerCssClass: cssClass,
+					},
+					{
+						name: constants.LOGIN_TYPE,
+						value: 'loginType',
+						type: azdata.ColumnType.text,
+						width: 90,
+						cssClass: cssClass,
+						headerCssClass: cssClass,
+					},
+					{
+						name: constants.DEFAULT_DATABASE,
+						value: 'defaultDatabase',
+						type: azdata.ColumnType.text,
+						width: 130,
+						cssClass: cssClass,
+						headerCssClass: cssClass,
+					},
+					{
+						name: constants.LOGIN_STATUS_COLUMN,
+						value: 'status',
+						type: azdata.ColumnType.text,
+						width: 90,
+						cssClass: cssClass,
+						headerCssClass: cssClass,
+					},
+					<azdata.HyperlinkColumn>{
+						name: constants.LOGIN_TARGET_STATUS_COLUMN,
+						value: 'targetStatus',
+						width: 150,
+						type: azdata.ColumnType.hyperlink,
+						icon: IconPathHelper.inProgressMigration,
+						showText: true,
+						cssClass: cssClass,
+						headerCssClass: cssClass,
+					},
+				]
+			})
+			.component();
+
+		return table;
+	}
+
+	private _createSystemLoginTablesTable(view: azdata.ModelView): azdata.TableComponent {
 		const cssClass = 'no-borders';
 		const table = this._view.modelBuilder.table()
 			.withProps({

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -235,34 +235,6 @@ export class LoginSelectorPage extends MigrationWizardPage {
 	}
 
 	public async createRootContainer(view: azdata.ModelView): Promise<azdata.FlexContainer> {
-		this._windowsAuthInfoBox = this._view.modelBuilder.infoBox()
-			.withProps({
-				style: 'information',
-				text: constants.LOGIN_MIGRATIONS_SELECT_LOGINS_WINDOWS_AUTH_WARNING,
-				CSSStyles: { ...styles.BODY_CSS, 'display': 'none', }
-			}).component();
-
-		await this._createSystemLoginTablesTab(view);
-		await this._createNonSystemLoginTablesTab(view);
-
-		this._tabs = view.modelBuilder.tabbedPanel()
-			.withTabs([this._nonSystemloginTablesTab, this._systemLoginTablesTab])
-			.component();
-
-		const flex = view.modelBuilder.flexContainer().withLayout({
-			flexFlow: 'column',
-			height: '100%',
-		}).withProps({
-			CSSStyles: {
-				'margin': '-20px 28px 0px 28px'
-			}
-		}).component();
-		flex.addItem(this._windowsAuthInfoBox, { flex: '0 0 auto' });
-		flex.addItem(this._tabs, { flex: '0 0 auto' });
-		return flex;
-	}
-
-	private async _createNonSystemLoginTablesTab(view: azdata.ModelView): Promise<void> {
 		this._refreshButton = this._view.modelBuilder.button()
 			.withProps({
 				buttonType: azdata.ButtonType.Normal,
@@ -308,6 +280,39 @@ export class LoginSelectorPage extends MigrationWizardPage {
 			})
 			.component();
 
+		this._windowsAuthInfoBox = this._view.modelBuilder.infoBox()
+			.withProps({
+				style: 'information',
+				text: constants.LOGIN_MIGRATIONS_SELECT_LOGINS_WINDOWS_AUTH_WARNING,
+				CSSStyles: { ...styles.BODY_CSS, 'display': 'none', }
+			}).component();
+
+		await this._createSystemLoginTablesTab(view);
+		await this._createNonSystemLoginTablesTab(view);
+
+		this._tabs = view.modelBuilder.tabbedPanel()
+			.withTabs([this._nonSystemloginTablesTab, this._systemLoginTablesTab])
+			.withProps({
+				CSSStyles: { 'margin-top': '8px', }
+			})
+			.component();
+
+		const flex = view.modelBuilder.flexContainer().withLayout({
+			flexFlow: 'column',
+			height: '100%',
+		}).withProps({
+			CSSStyles: {
+				'margin': '-20px 28px 0px 28px'
+			}
+		}).component();
+		flex.addItem(this._windowsAuthInfoBox, { flex: '0 0 auto' });
+		flex.addItem(refreshContainer, { flex: '0 0 auto' });
+		flex.addItem(this._tabs, { flex: '0 0 auto' });
+		return flex;
+	}
+
+	private async _createNonSystemLoginTablesTab(view: azdata.ModelView): Promise<void> {
+
 		await this._loadLoginList();
 		this._loginCount = this._view.modelBuilder.text().withProps({
 			value: constants.LOGINS_SELECTED(
@@ -337,7 +342,6 @@ export class LoginSelectorPage extends MigrationWizardPage {
 				width: 550,
 			}).component();
 
-		flex.addItem(refreshContainer, { flex: '0 0 auto' });
 		flex.addItem(this.createSearchComponent(false), { flex: '0 0 auto' });
 		flex.addItem(this._loginCount, { flex: '0 0 auto' });
 		flex.addItem(this._loginSelectorTable);
@@ -493,7 +497,8 @@ export class LoginSelectorPage extends MigrationWizardPage {
 						cssClass: cssClass,
 						headerCssClass: cssClass,
 					},
-				]
+				],
+				CSSStyles: { 'margin-top': '8px' }
 			})
 			.component();
 

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -350,7 +350,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 		this._nonSystemloginTablesTab = {
 			content: flex,
 			id: 'tableSelectionTab',
-			title: 'Logins ready for migration',
+			title: constants.LOGIN_MIGRATIONS_SELECT_LOGINS_TAB_NON_SYSTEM_LOGIN_TITLE,
 		};
 	}
 
@@ -373,7 +373,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 		this._systemLoginTablesTab = {
 			content: flex,
 			id: 'tableSelectionTab',
-			title: 'System type logins',
+			title: constants.LOGIN_MIGRATIONS_SELECT_LOGINS_TAB_SYSTEM_LOGIN_TITLE,
 		};
 	}
 

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -111,6 +111,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 
 		// load unfiltered table list and pre-select list of logins saved in state
 		await this._filterTableList('', this.migrationStateModel._loginMigrationModel.loginsForMigration);
+		await this._filterSystemTableList('');
 	}
 
 	public async onPageLeave(): Promise<void> {
@@ -351,6 +352,8 @@ export class LoginSelectorPage extends MigrationWizardPage {
 
 	private async _createSystemLoginTablesTab(view: azdata.ModelView): Promise<void> {
 		this._systemLoginTable = this._createSystemLoginTablesTable(view);
+
+		await this._filterSystemTableList('');
 
 		const flex = view.modelBuilder.flexContainer()
 			.withProps({ CSSStyles: { 'margin': '10px 0 0 15px' } })

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -107,11 +107,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 		await utils.updateControlDisplay(this._windowsAuthInfoBox, !this.migrationStateModel.isWindowsAuthMigrationSupported);
 
 		// Refresh login list
-		await this._loadLoginList(false);
-
-		// load unfiltered table list for both system and non-system and pre-select list of logins saved in state
-		await this._filterTableList('', this.migrationStateModel._loginMigrationModel.loginsForMigration);
-		await this._filterSystemTableList('');
+		await this._loadLoginList();
 	}
 
 	public async onPageLeave(): Promise<void> {
@@ -359,6 +355,15 @@ export class LoginSelectorPage extends MigrationWizardPage {
 
 		await this._filterSystemTableList('');
 
+		const systemLoginInfoBox = view.modelBuilder.infoBox().withProps({
+			text: constants.LOGIN_MIGRATIONS_SELECT_LOGINS_SYSTEM_LOGIN_INFO_BOX,
+			style: 'information',
+			width: 650,
+			CSSStyles: {
+				...styles.BODY_CSS
+			}
+		}).component();
+
 		const flex = view.modelBuilder.flexContainer()
 			.withProps({ CSSStyles: { 'margin': '10px 0 0 15px' } })
 			.withLayout({
@@ -367,6 +372,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 				width: 550,
 			}).component();
 
+		flex.addItem(systemLoginInfoBox, { flex: '0 0 auto' });
 		flex.addItem(this.createSearchComponent(true), { flex: '0 0 auto' });
 		flex.addItem(this._systemLoginTable, { flex: '0 0 auto' });
 

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -10,7 +10,7 @@ import { MigrationStateModel, StateChangeEvent } from '../models/stateMachine';
 import * as constants from '../constants/strings';
 import { debounce, getLoginStatusImage, getLoginStatusMessage } from '../api/utils';
 import * as styles from '../constants/styles';
-import { collectSourceLogins, collectTargetLogins, getSourceConnectionId, getSourceConnectionString, getTargetConnectionString, LoginTableInfo } from '../api/sqlUtils';
+import { collectSourceLogins, collectTargetLogins, getSourceConnectionId, getSourceConnectionString, LoginTableInfo } from '../api/sqlUtils';
 import { IconPathHelper } from '../constants/iconPathHelper';
 import * as utils from '../api/utils';
 import * as contracts from '../service/contracts';
@@ -29,14 +29,14 @@ export class LoginSelectorPage extends MigrationWizardPage {
 	private _refreshLoading!: azdata.LoadingComponent;
 	private _aadDomainNameContainer!: azdata.FlexContainer;
 	private _tabs!: azdata.TabbedPanelComponent;
-
+	// variables for source non-system type logins
 	private _nonSystemloginTablesTab!: Tab;
 	private _loginSelectorTable!: azdata.TableComponent;
 	private _loginNames!: string[];
 	private _loginCount!: azdata.TextComponent;
 	private _loginTableValues!: any[];
 	private _filterTableValue!: string;
-
+	// variables for source system type logins
 	private _systemLoginTablesTab!: Tab;
 	private _systemLoginTable!: azdata.TableComponent;
 	private _systemLoginTableValues!: any[];
@@ -109,7 +109,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 		// Refresh login list
 		await this._loadLoginList(false);
 
-		// load unfiltered table list and pre-select list of logins saved in state
+		// load unfiltered table list for both system and non-system and pre-select list of logins saved in state
 		await this._filterTableList('', this.migrationStateModel._loginMigrationModel.loginsForMigration);
 		await this._filterSystemTableList('');
 	}
@@ -617,6 +617,8 @@ export class LoginSelectorPage extends MigrationWizardPage {
 
 		var sourceLogins: LoginTableInfo[] = stateMachine._loginMigrationModel.loginsOnSource;
 
+		// validate Login Eligibility result contains system logins in Exception map from which system login names can be extracted.
+		// These system logins are not to be displayed in the source logins list
 		var validateLoginEligibilityResult: contracts.StartLoginMigrationPreValidationResult | undefined = await this.migrationStateModel.migrationService.validateLoginEligibility(
 			await getSourceConnectionString(),
 			"",
@@ -630,6 +632,7 @@ export class LoginSelectorPage extends MigrationWizardPage {
 			sourceSystemLoginsName = Object.keys(validateLoginEligibilityResult.exceptionMap).map(loginName => loginName.toLocaleLowerCase());
 		}
 
+		// separate out system logins from non system logins
 		const sourceSystemLogins: LoginTableInfo[] = sourceLogins.filter(login => sourceSystemLoginsName.includes(login.loginName.toLocaleLowerCase()));
 		sourceLogins = sourceLogins.filter(login => !sourceSystemLoginsName.includes(login.loginName.toLocaleLowerCase()));
 

--- a/extensions/sql-migration/src/wizard/loginSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/loginSelectorPage.ts
@@ -358,6 +358,15 @@ export class LoginSelectorPage extends MigrationWizardPage {
 				display: 'flex',
 				forceFitColumns: azdata.ColumnSizingMode.ForceFit,
 				columns: [
+					<azdata.CheckboxColumn>{
+						value: '',
+						width: 10,
+						type: azdata.ColumnType.checkBox,
+						action: azdata.ActionOnCellCheckboxCheck.selectRow,
+						resizable: false,
+						cssClass: cssClass,
+						headerCssClass: cssClass,
+					},
 					{
 						name: constants.SOURCE_LOGIN,
 						value: 'sourceLogin',


### PR DESCRIPTION
Separate source logins into two tabs - system and non-system logins. Since non-system logins cannot be migrated.
Created separate tabs for both.
![image](https://github.com/microsoft/azuredatastudio/assets/32814075/b390e0b2-45bc-44ad-85f5-062142bed23c)
![image](https://github.com/microsoft/azuredatastudio/assets/32814075/20b4e9fc-2fa4-441c-8fa6-b4c691a24596)

