### PR TITLE
Update intellicode VSIX to 1.3.1

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -2669,14 +2669,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.3.0",
-							"lastUpdated": "03/21/2024",
+							"version": "1.3.1",
+							"lastUpdated": "03/22/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/vscodeintellicode-1.3.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/vscodeintellicode-1.3.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -2669,14 +2669,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.3.0",
-							"lastUpdated": "03/21/2024",
+							"version": "1.3.1",
+							"lastUpdated": "03/22/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/vscodeintellicode-1.3.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/vscodeintellicode-1.3.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
There was an issue on yesterday's release.
This is a patch to fix it.

New VSIX Location: https://artprodscussu1.artifacts.visualstudio.com/A011b8bdf-6d56-4f87-be0d-0092136884d9/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2RldmRpdi9wcm9qZWN0SWQvMGJkYmM1OTAtYTA2Mi00YzNmLWIwZjYtOTM4M2Y2Nzg2NWVlL2J1aWxkSWQvOTI5MjkzNS9hcnRpZmFjdE5hbWUvdnNpeA2/content?format=file&subPath=%2Fvscodeintellicode-1.3.1.vsix