### PR TITLE
Update Kusto STS version to 5.0.0.2

### DIFF
--- a/extensions/kusto/config.json
+++ b/extensions/kusto/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "5.0.0.1",
+	"version": "5.0.0.2",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net8.0.zip",
 		"Windows_64": "win-x64-net8.0.zip",

--- a/extensions/kusto/config.json
+++ b/extensions/kusto/config.json
@@ -1,13 +1,13 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.11.0.20",
+	"version": "5.0.0.1",
 	"downloadFileNames": {
-		"Windows_86": "win-x86-net7.0.zip",
-		"Windows_64": "win-x64-net7.0.zip",
-		"Windows_ARM64": "win-arm64-net7.0.zip",
-		"OSX": "osx-x64-net7.0.tar.gz",
-		"OSX_ARM64": "osx-arm64-net7.0.tar.gz",
-		"Linux": "rhel-x64-net7.0.tar.gz"
+		"Windows_86": "win-x86-net8.0.zip",
+		"Windows_64": "win-x64-net8.0.zip",
+		"Windows_ARM64": "win-arm64-net8.0.zip",
+		"OSX": "osx-x64-net8.0.tar.gz",
+		"OSX_ARM64": "osx-arm64-net8.0.tar.gz",
+		"Linux": "rhel-x64-net8.0.tar.gz"
 	},
 	"installDirectory": "./sqltoolsservice/{#platform#}/{#version#}",
 	"executableFiles": [

--- a/extensions/kusto/config.json
+++ b/extensions/kusto/config.json
@@ -7,7 +7,7 @@
 		"Windows_ARM64": "win-arm64-net8.0.zip",
 		"OSX": "osx-x64-net8.0.tar.gz",
 		"OSX_ARM64": "osx-arm64-net8.0.tar.gz",
-		"Linux": "rhel-x64-net8.0.tar.gz"
+		"Linux": "linux-x64-net8.0.tar.gz"
 	},
 	"installDirectory": "./sqltoolsservice/{#platform#}/{#version#}",
 	"executableFiles": [

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,13 +1,13 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "4.12.0.3",
+	"version": "5.0.0.2",
 	"downloadFileNames": {
-		"Windows_86": "win-x86-net7.0.zip",
-		"Windows_64": "win-x64-net7.0.zip",
-		"Windows_ARM64": "win-arm64-net7.0.zip",
-		"OSX": "osx-x64-net7.0.tar.gz",
-		"OSX_ARM64": "osx-arm64-net7.0.tar.gz",
-		"Linux": "rhel-x64-net7.0.tar.gz"
+		"Windows_86": "win-x86-net8.0.zip",
+		"Windows_64": "win-x64-net8.0.zip",
+		"Windows_ARM64": "win-arm64-net8.0.zip",
+		"OSX": "osx-x64-net8.0.tar.gz",
+		"OSX_ARM64": "osx-arm64-net8.0.tar.gz",
+		"Linux": "linux-x64-net8.0.tar.gz"
 	},
 	"installDirectory": "./sqltoolsservice/{#platform#}/{#version#}",
 	"executableFiles": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Updating the version of STS that the Kusto extension uses to one that has signed dlls, since it got flagged in the new ADS Extensions pipeline. I did a quick check locally to make sure it downloads and the Kusto Service starts, but I'm not planning on releasing a new version of the Kusto extension. This change is just necessary to unblock the new ADS extension pipeline.

Too many differences to screenshot, but here's a link to the differences for the STS used by the Kusto extension: https://github.com/microsoft/sqltoolsservice/compare/4.11.0.20...5.0.0.2

Also updating STS in mssql for consistency. Differences for STS used by mssql: https://github.com/microsoft/sqltoolsservice/compare/4.12.0.3...5.0.0.2