### PR TITLE
Remove path placeholder components in Configure Python dialog

### DIFF
--- a/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
@@ -45,7 +45,7 @@ export class ConfigurePathPage extends BasePage {
 		this.pythonDropdownLoader = this.view.modelBuilder.loadingComponent()
 			.withItem(this.pythonLocationDropdown)
 			.withProps({
-				loading: false
+				loading: true
 			})
 			.component();
 		let browseButton = this.view.modelBuilder.button()

--- a/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
@@ -18,7 +18,8 @@ export class ConfigurePathPage extends BasePage {
 	private pythonLocationDropdown: azdata.DropDownComponent;
 	private pythonDropdownLoader: azdata.LoadingComponent;
 
-	private usingCustomPath: boolean = false;
+	private usingCustomPath = false;
+	private noPathsFound = false;
 
 	public async initialize(): Promise<boolean> {
 		let wizardDescription: string;
@@ -116,6 +117,7 @@ export class ConfigurePathPage extends BasePage {
 						name: path.installDir
 					};
 				});
+				this.noPathsFound = false;
 			} else {
 				dropdownValues = [];
 			}
@@ -127,11 +129,13 @@ export class ConfigurePathPage extends BasePage {
 					displayName: localize('configurePythyon.existingInstance', "{0} (Current Python Instance)", this.model.pythonLocation),
 					name: this.model.pythonLocation
 				});
+				this.noPathsFound = false;
 			} else if (dropdownValues.length === 0) {
 				dropdownValues = [{
 					displayName: localize('configurePythyon.noVersionsFound', "No supported Python versions found."),
 					name: ''
 				}];
+				this.noPathsFound = true;
 			}
 
 			this.usingCustomPath = false;
@@ -166,7 +170,12 @@ export class ConfigurePathPage extends BasePage {
 			if (this.usingCustomPath) {
 				existingValues[0] = newValue;
 			} else {
-				existingValues.unshift(newValue);
+				if (this.noPathsFound) {
+					// Replace "No paths found" placeholder
+					existingValues[0] = newValue;
+				} else {
+					existingValues.unshift(newValue);
+				}
 				this.usingCustomPath = true;
 			}
 


### PR DESCRIPTION
The Configure Python dialog currently has a placeholder component where the install selection controls get hidden if a python instance is already setup. After removing the New Python Install option last week, there aren't many controls to hide behind that placeholder, so it would be better to remove it. Note that if python is already setup, the path selection dropdown will have the current python instance as its default first value.

How dialog opens when python is already setup:
![PathDropdown](https://github.com/microsoft/azuredatastudio/assets/12820011/18878aa5-d060-48f1-bf00-a7a94c8a4fe8)
