### PR TITLE
bump Catppuccin theme to v3.14.0

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -5349,30 +5349,30 @@
 					},
 					"versions": [
 						{
-							"version": "3.8.0",
-							"lastUpdated": "11/30/2023",
+							"version": "3.14.0",
+							"lastUpdated": "05/13/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/catppuccin/vscode/releases/download/v3.8.0/catppuccin-ads-3.8.0.vsix"
+									"source": "https://github.com/catppuccin/vscode/releases/download/catppuccin-vsc-v3.14.0/catppuccin-ads-3.14.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/catppuccin/vscode/v3.8.0/assets/icon.png"
+									"source": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.14.0/packages/catppuccin-vsc/icon.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/catppuccin/vscode/v3.8.0/README.md"
+									"source": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.14.0/packages/catppuccin-vsc/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/catppuccin/vscode/v3.8.0/package.json"
+									"source": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.14.0/packages/catppuccin-vsc/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/catppuccin/vscode/v3.8.0/LICENSE"
+									"source": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.14.0/packages/catppuccin-vsc/LICENSE"
 								}
 							],
 							"properties": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -5283,30 +5283,30 @@
 				},
 				"versions": [
 					{
-						"version": "3.8.0",
-						"lastUpdated": "11/30/2023",
+						"version": "3.14.0",
+						"lastUpdated": "05/13/2024",
 						"assetUri": "",
 						"fallbackAssetUri": "fallbackAssetUri",
 						"files": [
 							{
 								"assetType": "Microsoft.SQLOps.DownloadPage",
-								"source": "https://github.com/catppuccin/vscode/releases/download/v3.8.0/catppuccin-ads-3.8.0.vsix"
+								"source": "https://github.com/catppuccin/vscode/releases/download/catppuccin-vsc-v3.14.0/catppuccin-ads-3.14.0.vsix"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-								"source": "https://raw.githubusercontent.com/catppuccin/vscode/v3.8.0/assets/icon.png"
+								"source": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.14.0/packages/catppuccin-vsc/icon.png"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-								"source": "https://raw.githubusercontent.com/catppuccin/vscode/v3.8.0/README.md"
+								"source": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.14.0/packages/catppuccin-vsc/README.md"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Code.Manifest",
-								"source": "https://raw.githubusercontent.com/catppuccin/vscode/v3.8.0/package.json"
+								"source": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.14.0/packages/catppuccin-vsc/package.json"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Content.License",
-								"source": "https://raw.githubusercontent.com/catppuccin/vscode/v3.8.0/LICENSE"
+								"source": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.14.0/packages/catppuccin-vsc/LICENSE"
 							}
 						],
 						"properties": [


### PR DESCRIPTION
Updates the Catppuccin theme initially added in #25077.
There are a few additional branch name & path changes, because the source repo changed to a monorepo.