### PR TITLE
Updating SQL MI dashboard extension to 0.4.3

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1596,14 +1596,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.4.2",
-							"lastUpdated": "09/25/2020",
+							"version": "0.4.3",
+							"lastUpdated": "05/29/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/managed-instance-dashboard/managed-instance-dashboard-0.4.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/managed-instance-dashboard/managed-instance-dashboard-0.4.3.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1596,14 +1596,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.4.2",
-							"lastUpdated": "09/25/2020",
+							"version": "0.4.3",
+							"lastUpdated": "05/29/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/managed-instance-dashboard/managed-instance-dashboard-0.4.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/managed-instance-dashboard/managed-instance-dashboard-0.4.3.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Updating SQL MI dashboard extension to 0.4.3

This version introduces support for Next-Gen General Purpose edition, as well as aligns the extension with the increased limits for log rate, as well as new hardware generations and their memory limitations