### PR TITLE
Bump Copilot extension to 1.199.0

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4979,14 +4979,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.128.504",
-							"lastUpdated": "10/20/2023",
+							"version": "1.199.0",
+							"lastUpdated": "6/5/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/GitHub.copilot-1.128.504.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.199.0/GitHub.copilot-1.199.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4994,15 +4994,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/README.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.199.0/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/CHANGELOG.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.199.0/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/package.json"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.199.0/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4979,14 +4979,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.128.504",
-							"lastUpdated": "10/20/2023",
+							"version": "1.199.0",
+							"lastUpdated": "6/5/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/GitHub.copilot-1.128.504.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.199.0/GitHub.copilot-1.199.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -4994,15 +4994,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/README.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.199.0/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/CHANGELOG.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.199.0/CHANGELOG.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.128.504/package.json"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/copilot/1.199.0/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",


### PR DESCRIPTION
Update extension gallery metadata to use the latest stable release of Copilot extension.