### PR TITLE
Fix Mac update loop

### DIFF
--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -81,23 +81,26 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 	}
 
 	protected buildUpdateFeedUrl(quality: string): string | undefined {
-		let url: string;
+		let feedUrl: string;
 
 		// {{SQL CARBON EDIT}} - Use the metadata files from the Download Center as the update feed.
 		if (!this.productService.darwinUniversalAssetId) {
-			url = process.arch === 'x64' ? this.productService.updateMetadataMacUrl : this.productService.updateMetadataMacArmUrl;
+			feedUrl = process.arch === 'x64' ? this.productService.updateMetadataMacUrl : this.productService.updateMetadataMacArmUrl;
 		} else {
-			url = this.productService.updateMetadataMacUniversalUrl;
+			feedUrl = this.productService.updateMetadataMacUniversalUrl;
 		}
 
 		try {
-			electron.autoUpdater.setFeedURL({ url });
+			electron.autoUpdater.setFeedURL({
+				url: feedUrl,
+				serverType: 'json',
+			});
 		} catch (e) {
 			// application is very likely not signed
 			this.logService.error('Failed to set update feed URL', e);
 			return undefined;
 		}
-		return url;
+		return feedUrl;
 	}
 
 	protected doCheckForUpdates(context: any): void {


### PR DESCRIPTION
**Problem:**
After switching to static file based update feed, we are seeing infinite update loop on `macOS` when the current ADS is the latest version.

**Root cause:**
For `macOS`, ADS uses the [autoUpdater](https://www.electronjs.org/docs/latest/api/auto-updater) in `electron` for auto update, which is different from `windows`/`linux` update behavior. Previously we used an update server as the update feed for `autoUpdater`. In that case the update server would return `200` and the build metadata when an update is available and return `204(No Content)` if there's no update, the version check is done on the server side.

In my previous PR https://github.com/microsoft/azuredatastudio/pull/25677, I changed the updater feed url to a static metadata file that contains the latest build metadata. This means the feed url always returns `200` + build metadata, causing `autoUpdater` to think there's a new update available when ADS is already on the latest version.

**Fix:**
`autoUpdater` on `macOS` uses [Squirrel.Mac](https://github.com/Squirrel/Squirrel.Mac). `Squirrel.Mac` supports both dedicated update server (what we've been using) and static JSON file based update feed. We can just change the server type when calling `autoUpdater.setFeedUrl()` and make sure the static JSON file has the format `Squirrel.Mac` expects.
https://github.com/Squirrel/Squirrel.Mac?tab=readme-ov-file#update-file-json-format

**Manual Test:**
Tested with build: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=226872&view=results
For testing I used a static json file I pulished on Github, we'd need to upload the correct metadata file to Download Center and let the fwlink point to it during release process.
![image](https://github.com/microsoft/azuredatastudio/assets/21186993/996b89af-ef3e-4617-9a2b-cd965dd8a559)
