### PR TITLE
[Port] Changing container image from custom to standard ubuntu

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -1,16 +1,9 @@
-resources:
-  containers:
-  - container: linux-x64
-    image: sqltoolscontainers.azurecr.io/linux-build-agent:9
-    endpoint: SqlToolsContainers
-
 stages:
   - stage: Compile
     jobs:
     - job: Compile
       pool:
-        vmImage: 'Ubuntu-20.04'
-      container: linux-x64
+        vmImage: 'ubuntu-latest'
       steps:
       - script: |
           set -e

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -58,6 +58,8 @@ steps:
 
 - script: |
     set -e
+    sudo apt-get update
+    sudo apt-get install -y build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev python-is-python3 libkrb5-dev fakeroot rpm
     CHILD_CONCURRENCY=1 yarn --frozen-lockfile
   displayName: Install dependencies
   condition: and(succeeded(), ne(variables['NODE_MODULES_RESTORED'], 'true'))


### PR DESCRIPTION
Since we've removed our custom infrastructure from Azure, the release branch needs to be updated.

This change was originally part of [this commit](https://github.com/microsoft/azuredatastudio/commit/11c8e67ea6c9e65be54790e76714a97980954ea4#diff-7d483a5cbd2f5f973879bdca17fd3f2695ade79289e63a5212934289381ca2d0), but I'm being more selective with the port to the release branch.