### PR TITLE
Add missing check before calling toString

### DIFF
--- a/src/sql/workbench/contrib/connection/browser/connectionStatus.ts
+++ b/src/sql/workbench/contrib/connection/browser/connectionStatus.ts
@@ -104,7 +104,7 @@ export class ConnectionStatusbarItem extends Disposable implements IWorkbenchCon
 	 * Helper function for getting the connection info of the current editor.
 	 */
 	private getCurrentActiveEditorInfo(): ConnectionManagementInfo | undefined {
-		if (this._editorService.activeEditor && this._editorService.activeEditor.resource) {
+		if (this._editorService?.activeEditor?.resource) {
 			return this._connectionManagementService.getConnectionInfo(this._editorService.activeEditor.resource.toString());
 		}
 		return undefined;

--- a/src/sql/workbench/contrib/connection/browser/connectionStatus.ts
+++ b/src/sql/workbench/contrib/connection/browser/connectionStatus.ts
@@ -104,7 +104,7 @@ export class ConnectionStatusbarItem extends Disposable implements IWorkbenchCon
 	 * Helper function for getting the connection info of the current editor.
 	 */
 	private getCurrentActiveEditorInfo(): ConnectionManagementInfo | undefined {
-		if (this._editorService.activeEditor) {
+		if (this._editorService.activeEditor && this._editorService.activeEditor.resource) {
 			return this._connectionManagementService.getConnectionInfo(this._editorService.activeEditor.resource.toString());
 		}
 		return undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #25409

The PR makes sure the `resource` property on the `activeEditor` contains a truthy value before `toString` is invoked.