### PR TITLE
Update to latest STS

### DIFF
--- a/extensions/kusto/config.json
+++ b/extensions/kusto/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "5.0.20240709.1",
+	"version": "5.0.20240716.2",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net8.0.zip",
 		"Windows_64": "win-x64-net8.0.zip",

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "5.0.20240709.1",
+	"version": "5.0.20240716.2",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net8.0.zip",
 		"Windows_64": "win-x64-net8.0.zip",


### PR DESCRIPTION
Update to latest STS to 5.0.20240716.2 to pickup transaction isolation level and Azure Identity vbump.