### PR TITLE
Adding Fabric SQL Mirrored support to the SQL Projects

### DIFF
--- a/extensions/sql-database-projects/README.md
+++ b/extensions/sql-database-projects/README.md
@@ -35,7 +35,7 @@ Learn more about the SQL Database Projects extension in the documentation: https
 
 ### General Settings
 - `sqlDatabaseProjects.dotnetSDK Location`: The path to the folder containing the `dotnet` folder for the .NET SDK. If not set, the extension will attempt to find the .NET SDK on the system.
-- `sqlDatabaseProjects.microsoftBuildSqlVersion`: Version of Microsoft.Build.Sql binaries used when building SQL projects that are not SDK-style SQL projects. If not set, the extension will use Microsoft.Build.Sql 0.1.12-preview.
+- `sqlDatabaseProjects.microsoftBuildSqlVersion`: Version of Microsoft.Build.Sql binaries used when building SQL projects that are not SDK-style SQL projects. If not set, the extension will use Microsoft.Build.Sql 0.2.0-preview.
 - `sqlDatabaseProjects.netCoreDoNotAsk`: When true, no longer prompts to install .NET SDK when a supported installation is not found.
 - `sqlDatabaseProjects.collapseProjectNodes`: Option to set the default state of the project nodes in the database projects view to collapsed. If not set, the extension will default to expanded.
 

--- a/extensions/sql-database-projects/resources/templates/newSdkSqlProjectTemplate.xml
+++ b/extensions/sql-database-projects/resources/templates/newSdkSqlProjectTemplate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="0.1.7-preview" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.2.0-preview" />
   <PropertyGroup>
     <Name>@@PROJECT_NAME@@</Name>
     <ProjectGuid>{@@PROJECT_GUID@@}</ProjectGuid>

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -625,7 +625,8 @@ export const targetPlatformToVersion: Map<string, string> = new Map<string, stri
 	[SqlTargetPlatform.sqlAzure, 'AzureV12'],
 	[SqlTargetPlatform.sqlDW, 'Dw'],
 	[SqlTargetPlatform.sqlDwServerless, 'Serverless'],
-	[SqlTargetPlatform.sqlDwUnified, 'DwUnified']
+	[SqlTargetPlatform.sqlDwUnified, 'DwUnified'],
+	[SqlTargetPlatform.sqlDbFabric, 'DbFabric']
 ]);
 
 export const onPremServerVersionToTargetPlatform: Map<number, SqlTargetPlatform> = new Map<number, SqlTargetPlatform>([

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -729,20 +729,20 @@ export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.
 		const engineEdition = serverInfo.engineEditionId;
 		const azdataApi = getAzdataApi();
 		if (azdataApi) {
-			// TODO: Update this when Fabric DW gets its own engine edition
-			// https://github.com/microsoft/azuredatastudio/issues/24112
 			if (engineEdition === azdataApi.DatabaseEngineEdition.SqlOnDemand) {
 				targetPlatform = isSqlDwUnifiedServer(serverUrl) ? SqlTargetPlatform.sqlDwUnified : SqlTargetPlatform.sqlDwServerless;
+			} else if (engineEdition === azdataApi.DatabaseEngineEdition.SqlDbFabric) {
+				targetPlatform = SqlTargetPlatform.sqlDbFabric;
 			} else if (engineEdition === azdataApi.DatabaseEngineEdition.SqlDataWarehouse) {
 				targetPlatform = SqlTargetPlatform.sqlDW;
 			} else {
 				targetPlatform = SqlTargetPlatform.sqlAzure;
 			}
 		} else {
-			// TODO: Update this when Fabric DW gets its own engine edition
-			// https://github.com/microsoft/azuredatastudio/issues/24112
 			if (engineEdition === vscodeMssql.DatabaseEngineEdition.SqlOnDemand) {
 				targetPlatform = isSqlDwUnifiedServer(serverUrl) ? SqlTargetPlatform.sqlDwUnified : SqlTargetPlatform.sqlDwServerless;
+			} else if (engineEdition === vscodeMssql.DatabaseEngineEdition.SqlDbFabric) {
+				targetPlatform = SqlTargetPlatform.sqlDbFabric;
 			} else if (engineEdition === vscodeMssql.DatabaseEngineEdition.SqlDataWarehouse) {
 				targetPlatform = SqlTargetPlatform.sqlDW;
 			} else {

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -323,7 +323,8 @@ declare module 'sqldbproj' {
 		sqlDW = 'Azure Synapse SQL Pool',
 		sqlEdge = 'Azure SQL Edge',
 		sqlDwServerless = 'Azure Synapse Serverless SQL Pool',
-		sqlDwUnified = 'Synapse Data Warehouse in Microsoft Fabric'
+		sqlDwUnified = 'Synapse Data Warehouse in Microsoft Fabric',
+		sqlDbFabric = 'SQL Fabric'
 	}
 
 	export interface ISqlConnectionProperties {

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -324,7 +324,7 @@ declare module 'sqldbproj' {
 		sqlEdge = 'Azure SQL Edge',
 		sqlDwServerless = 'Azure Synapse Serverless SQL Pool',
 		sqlDwUnified = 'Synapse Data Warehouse in Microsoft Fabric',
-		sqlDbFabric = 'Fabric mirrored SQL database (preview)'
+		sqlDbFabric = 'Fabric Mirrored SQL Database (Preview)'
 	}
 
 	export interface ISqlConnectionProperties {

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -324,7 +324,7 @@ declare module 'sqldbproj' {
 		sqlEdge = 'Azure SQL Edge',
 		sqlDwServerless = 'Azure Synapse Serverless SQL Pool',
 		sqlDwUnified = 'Synapse Data Warehouse in Microsoft Fabric',
-		sqlDbFabric = 'SQL Fabric'
+		sqlDbFabric = 'Fabric mirrored SQL database (preview)'
 	}
 
 	export interface ISqlConnectionProperties {

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -56,7 +56,7 @@ export class BuildHelper {
 
 	public async ensureDacFxDllsPresence(outputChannel: vscode.OutputChannel): Promise<boolean> {
 		const sdkName = 'Microsoft.Build.Sql';
-		const microsoftBuildSqlDefaultVersion = '0.1.14-preview'; // default version of Microsoft.Build.Sql nuget to use for building legacy style projects, update in README when updating this
+		const microsoftBuildSqlDefaultVersion = '0.2.0-preview'; // default version of Microsoft.Build.Sql nuget to use for building legacy style projects, update in README when updating this
 
 		const dacFxBuildFiles: string[] = [
 			'Microsoft.Data.SqlClient.dll',

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -228,7 +228,8 @@ declare module 'vscode-mssql' {
 		SqlDataWarehouse = 6,
 		SqlStretchDatabase = 7,
 		SqlManagedInstance = 8,
-		SqlOnDemand = 11
+		SqlOnDemand = 11,
+		SqlDbFabric = 12
 	}
 
 	/**

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -595,7 +595,8 @@ declare module 'azdata' {
 		SqlDataWarehouse = 6,
 		SqlStretchDatabase = 7,
 		SqlManagedInstance = 8,
-		SqlOnDemand = 11
+		SqlOnDemand = 11,
+		SqlDbFabric = 12
 	}
 
 	export interface DataProvider {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -460,7 +460,8 @@ export enum DatabaseEngineEdition {
 	SqlDataWarehouse = 6,
 	SqlStretchDatabase = 7,
 	SqlManagedInstance = 8,
-	SqlOnDemand = 11
+	SqlOnDemand = 11,
+	SqlDbFabric = 12
 }
 
 export interface ToolbarLayout {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds the sql fabric database support to the sql projects extension. And also updating the BuildSdk version to 0.2.0-perview that supports the fabric platform.
![image](https://github.com/user-attachments/assets/ab7e9a98-dd3f-4014-9deb-607dcfa6d2f9)
![image](https://github.com/user-attachments/assets/d2d9e6fc-2e9d-4079-acf2-c3ab7363b8ea)



