### PR TITLE
Release new version of mongo migration extension (3.1.1)

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4914,14 +4914,14 @@
 					},
 					"versions": [
 						{
-							"version": "3.1.0",
-							"lastUpdated": "07/12/2024",
+							"version": "3.1.1",
+							"lastUpdated": "08/01/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-3.1.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-3.1.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4914,14 +4914,14 @@
 					},
 					"versions": [
 						{
-							"version": "3.1.0",
-							"lastUpdated": "07/12/2024",
+							"version": "3.1.1",
+							"lastUpdated": "08/01/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-3.1.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-3.1.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This is the link to download new extension
[Mongo migration 3.1.1](https://artprodeussu2.artifacts.visualstudio.com/A8b119ea1-2e2a-4839-8db7-8c9e8d50f6fa/ba574a88-a171-48e0-8fcb-5fef6d23739c/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL21zZGF0YS9wcm9qZWN0SWQvYmE1NzRhODgtYTE3MS00OGUwLThmY2ItNWZlZjZkMjM3MzljL2J1aWxkSWQvMTM1NTg4ODk2L2FydGlmYWN0TmFtZS9kcm9wX2J1aWxkX21haW41/content?format=file&subPath=%2FProduct%2FAdsMongoMigration%2Fbin%2Fads-extension-mongo-migration-3.1.1.vsix)