### PR TITLE
Fix SQL version determination logic for Fabric DW

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -729,8 +729,10 @@ export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.
 		const engineEdition = serverInfo.engineEditionId;
 		const azdataApi = getAzdataApi();
 		if (azdataApi) {
-			if (engineEdition === azdataApi.DatabaseEngineEdition.SqlOnDemand) {
-				targetPlatform = isSqlDwUnifiedServer(serverUrl) ? SqlTargetPlatform.sqlDwUnified : SqlTargetPlatform.sqlDwServerless;
+			if (isSqlDwUnifiedServer(serverUrl)) {
+				targetPlatform = SqlTargetPlatform.sqlDwUnified;
+			} else if (engineEdition === azdataApi.DatabaseEngineEdition.SqlOnDemand) {
+				targetPlatform = SqlTargetPlatform.sqlDwServerless;
 			} else if (engineEdition === azdataApi.DatabaseEngineEdition.SqlDbFabric) {
 				targetPlatform = SqlTargetPlatform.sqlDbFabric;
 			} else if (engineEdition === azdataApi.DatabaseEngineEdition.SqlDataWarehouse) {
@@ -739,8 +741,10 @@ export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.
 				targetPlatform = SqlTargetPlatform.sqlAzure;
 			}
 		} else {
-			if (engineEdition === vscodeMssql.DatabaseEngineEdition.SqlOnDemand) {
-				targetPlatform = isSqlDwUnifiedServer(serverUrl) ? SqlTargetPlatform.sqlDwUnified : SqlTargetPlatform.sqlDwServerless;
+			if (isSqlDwUnifiedServer(serverUrl)) {
+				targetPlatform = SqlTargetPlatform.sqlDwUnified;
+			} else if (engineEdition === vscodeMssql.DatabaseEngineEdition.SqlOnDemand) {
+				targetPlatform = SqlTargetPlatform.sqlDwServerless;
 			} else if (engineEdition === vscodeMssql.DatabaseEngineEdition.SqlDbFabric) {
 				targetPlatform = SqlTargetPlatform.sqlDbFabric;
 			} else if (engineEdition === vscodeMssql.DatabaseEngineEdition.SqlDataWarehouse) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The mssql API returns the engine edition to be 5 (SqlDatabase) for Fabric DW, which might be a bug in itself. Since the server name check would only be applicable to the 2 valid Fabric DW domain, this change should be fine.

Fixes #25811 