### PR TITLE
Use the correct version variable for file metadata

### DIFF
--- a/build/gulpfile.vscode.win32.js
+++ b/build/gulpfile.vscode.win32.js
@@ -196,16 +196,16 @@ function updateExeIconAndMetadata(arch) {
 
 		var patch = {
 			"version-string": {
-				CompanyName: config.companyName || "GitHub, Inc.",
+				CompanyName: config.companyName || "Microsoft",
 				FileDescription: config.productAppName || opts.productName,
 				LegalCopyright:
 					config.copyright ||
-					"Copyright (C) 2014 GitHub, Inc. All rights reserved",
+					"Copyright (C) 2024 Microsoft, All rights reserved",
 				ProductName: config.productAppName || config.productName,
-				ProductVersion: config.productVersion,
+				ProductVersion: pkg.version,
 			},
-			"file-version": config.productVersion,
-			"product-version": config.productVersion,
+			"file-version": pkg.version,
+			"product-version": pkg.version,
 			"icon": config.winIcon
 		};
 


### PR DESCRIPTION
This fixes issue https://github.com/microsoft/azuredatastudio/issues/25804.

![image](https://github.com/user-attachments/assets/d38d0973-8287-4d21-9c99-cbd246a7e981)



