### PR TITLE
Fix bugs blocking extension upgrade

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -756,8 +756,14 @@ abstract class AbstractExtensionGalleryService implements IExtensionGalleryServi
 
 		if (compatible) {
 			try {
+				// {{SQL CARBON EDIT}} - fix the version checks to use VSCode & ADS values
 				const engine = await this.getEngine(rawGalleryExtensionVersion);
-				if (!isEngineValid(engine, this.productService.version, this.productService.date)) {
+				if (!isEngineValid(engine, this.productService.vscodeVersion, this.productService.date)) {
+					return false;
+				}
+
+				const adsEngine = await this.getAzureDataStudioEngine(rawGalleryExtensionVersion);
+				if (!isEngineValid(adsEngine, this.productService.version, this.productService.date)) {
 					return false;
 				}
 			} catch (error) {
@@ -1369,6 +1375,18 @@ abstract class AbstractExtensionGalleryService implements IExtensionGalleryServi
 				throw new Error('Manifest was not found');
 			}
 			engine = manifest.engines.vscode;
+		}
+		return engine;
+	}
+
+	private async getAzureDataStudioEngine(rawExtensionVersion: IRawGalleryExtensionVersion): Promise<string> {
+		let engine = getAzureDataStudioEngine(rawExtensionVersion);
+		if (!engine) {
+			const manifest = await this.getManifestFromRawExtensionVersion(rawExtensionVersion, CancellationToken.None);
+			if (!manifest) {
+				throw new Error('Manifest was not found');
+			}
+			engine = manifest.engines.azdata;
 		}
 		return engine;
 	}

--- a/src/vs/platform/extensionManagement/common/extensionManagementUtil.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementUtil.ts
@@ -15,9 +15,11 @@ import { arch } from 'vs/base/common/process';
 import { TelemetryTrustedValue } from 'vs/platform/telemetry/common/telemetryUtils';
 
 export function areSameExtensions(a: IExtensionIdentifier, b: IExtensionIdentifier): boolean {
-	if (a.uuid && b.uuid) {
-		return a.uuid === b.uuid;
-	}
+	// {{SQL CARBON EDIT}} - Bug in extension gallery metadata breaks this assumption
+	// {{SQL CARBON EDIT}} - Specifically, Copilot 1.82.15 has incorrect ID in package.json
+	// if (a.uuid && b.uuid) {
+	// 	return a.uuid === b.uuid;
+	// }
 	if (a.id === b.id) {
 		return true;
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/25819.  There are two issues, first is that the vscode & ads engine versions are being incorrectly checked during update scan and second the Copilot extension has inconsistent ID values in package.json and extensionsGallery.json files causing uninstall of current extension version to fail during update process.