### PR TITLE
Update SQL "language-configuration.json" to support standard block folding

### DIFF
--- a/extensions/sql/language-configuration.json
+++ b/extensions/sql/language-configuration.json
@@ -27,8 +27,8 @@
 	"folding": {
 		"offSide": true,
 		"markers": {
-			"start": "^\\s*--\\s*#region\\s*.*$",
-			"end": "^\\s*--\\s*#endregion\\s*.*$"
+			"start": "^\\s*(?:(--\\s*#region)|(BEGIN))\\s*.*$",
+			"end": "^\\s*(?:(--\\s*#endregion)|(END))\\s*.*$"
 		}
 	}
 


### PR DESCRIPTION
Update SQL "language-configuration.json" to support standard block folding.

--#region comment block folding is nice, but enabling additional folding for the standard SQL BEGIN/END blocks that are used by many for a similar purpose (and that people are used to having fold in SSMS, Notepad++, etc) makes it even better!

