### PR TITLE
Update Powershell extension and correct publisher

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1352,14 +1352,14 @@
 					},
 					"versions": [
 						{
-							"version": "2024.0.0",
-							"lastUpdated": "01/17/2024",
+							"version": "2024.3.2",
+							"lastUpdated": "08/15/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2024.0.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/microsoft.PowerShell-2024.3.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1352,14 +1352,14 @@
 					},
 					"versions": [
 						{
-							"version": "2024.0.0",
-							"lastUpdated": "01/17/2024",
+							"version": "2024.3.2",
+							"lastUpdated": "08/15/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2024.0.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/microsoft.PowerShell-2024.3.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
Update Powershell extension and correct publisher.  The mismatched publisher value in extension manifest and extension gallery file is causing issues with update checks with latest Extension Manager changes in hotfix.  https://github.com/microsoft/azuredatastudio/issues/25843.