### PR TITLE
Fix apostrophe escape issue in table designer

### DIFF
--- a/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
+++ b/src/sql/workbench/services/tableDesigner/browser/tableDesignerComponentInput.ts
@@ -103,6 +103,7 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 		// If there is already an edit being processed, the new edit will be skipped if the previous edit is not accepted.
 		const checkPreviousEditResult = this._editQueue.size !== 0;
 		this._editQueue.queue(async () => {
+			this.escapeAllApostrophes(edit);
 			await this.doProcessEdit(edit, checkPreviousEditResult);
 		});
 	}
@@ -936,5 +937,11 @@ export class TableDesignerComponentInput implements DesignerComponentInput {
 			}
 		}
 		return typeArray.join('/');
+	}
+
+	private escapeAllApostrophes(edit: DesignerEdit): void {
+		if (typeof edit.value === 'string' && edit.value.includes('\'')) {
+			edit.value = edit.value.replace(/'/g, '\'\'');
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR will fix #25536

Before:
![image](https://github.com/user-attachments/assets/9be65e24-f972-4e85-8aa5-eeab499fe7fd)


After:
![image](https://github.com/user-attachments/assets/1f882141-5fc6-4827-8290-43fbccb931ad)
