### PR TITLE
Speed up query results copying

### DIFF
--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -209,7 +209,7 @@
     "update-grammar": "node ../../build/npm/update-grammar.js Microsoft/vscode-azuremonitor ./syntaxes/azuremonitor.tmLanguage"
   },
   "dependencies": {
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.0",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.1",
     "figures": "^2.0.0",
     "find-remove": "1.2.1",
     "@microsoft/ads-service-downloader": "^1.2.1",

--- a/extensions/azuremonitor/yarn.lock
+++ b/extensions/azuremonitor/yarn.lock
@@ -75,9 +75,9 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.0":
-  version "2.0.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/39d7544771a4f44e707d0a38eb2fda1f08793d08"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.1":
+  version "2.0.1"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/7e8dff4aee7e674516367421a3e84fe9a1aa37b1"
   dependencies:
     vscode-languageclient "5.2.1"
 

--- a/extensions/datavirtualization/package.json
+++ b/extensions/datavirtualization/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.0",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.1",
     "vscode-nls": "^5.2.0"
   },
   "devDependencies": {

--- a/extensions/datavirtualization/yarn.lock
+++ b/extensions/datavirtualization/yarn.lock
@@ -504,9 +504,9 @@ crypt@0.0.2:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.0":
-  version "2.0.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/39d7544771a4f44e707d0a38eb2fda1f08793d08"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.1":
+  version "2.0.1"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/7e8dff4aee7e674516367421a3e84fe9a1aa37b1"
   dependencies:
     vscode-languageclient "5.2.1"
 

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -77,7 +77,7 @@
     }
   },
   "dependencies": {
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.0",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.1",
     "htmlparser2": "^3.10.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
     "@microsoft/ads-extension-telemetry": "^3.0.1",

--- a/extensions/import/src/test/utils.test.ts
+++ b/extensions/import/src/test/utils.test.ts
@@ -78,7 +78,7 @@ export class TestQueryProvider implements azdata.QueryProvider {
 	saveResults(requestParams: azdata.SaveResultsRequestParams): Thenable<azdata.SaveResultRequestResult> {
 		throw new Error('Method not implemented.');
 	}
-	copyResults(requestParams: azdata.CopyResultsRequestParams): Thenable<azdata.CopyResultsRequestResult> {
+	copyResults(requestParams: azdata.CopyResultsRequestParams): Thenable<void> {
 		throw new Error('Method not implemented.');
 	}
 	setQueryExecutionOptions(ownerUri: string, options: azdata.QueryExecutionOptions): Thenable<void> {

--- a/extensions/import/yarn.lock
+++ b/extensions/import/yarn.lock
@@ -559,9 +559,9 @@ crypt@0.0.2:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.0":
-  version "2.0.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/39d7544771a4f44e707d0a38eb2fda1f08793d08"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.1":
+  version "2.0.1"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/7e8dff4aee7e674516367421a3e84fe9a1aa37b1"
   dependencies:
     vscode-languageclient "5.2.1"
 

--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -444,7 +444,7 @@
     }
   },
   "dependencies": {
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.0",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.1",
     "figures": "^2.0.0",
     "find-remove": "1.2.1",
     "@microsoft/ads-service-downloader": "^1.2.1",

--- a/extensions/kusto/yarn.lock
+++ b/extensions/kusto/yarn.lock
@@ -124,9 +124,9 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.0":
-  version "2.0.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/39d7544771a4f44e707d0a38eb2fda1f08793d08"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.1":
+  version "2.0.1"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/7e8dff4aee7e674516367421a3e84fe9a1aa37b1"
   dependencies:
     vscode-languageclient "5.2.1"
 

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "5.0.20240724.1",
+	"version": "5.0.20240912.2",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net8.0.zip",
 		"Windows_64": "win-x64-net8.0.zip",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1712,7 +1712,7 @@
     "@aws-sdk/client-s3": "^3.490.0",
     "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.0",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.1",
     "find-remove": "1.2.1",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^4.0.0"

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -1559,9 +1559,9 @@ crypt@0.0.2:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.0":
-  version "2.0.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/39d7544771a4f44e707d0a38eb2fda1f08793d08"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.1":
+  version "2.0.1"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/7e8dff4aee7e674516367421a3e84fe9a1aa37b1"
   dependencies:
     vscode-languageclient "5.2.1"
 

--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -174,7 +174,7 @@
     ]
   },
   "dependencies": {
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.0",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#2.0.1",
     "@microsoft/ads-service-downloader": "^1.2.1",
     "@microsoft/ads-extension-telemetry": "^3.0.1",
     "uuid": "^8.3.2",

--- a/extensions/sql-migration/yarn.lock
+++ b/extensions/sql-migration/yarn.lock
@@ -195,9 +195,9 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.0":
-  version "2.0.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/39d7544771a4f44e707d0a38eb2fda1f08793d08"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#2.0.1":
+  version "2.0.1"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/7e8dff4aee7e674516367421a3e84fe9a1aa37b1"
   dependencies:
     vscode-languageclient "5.2.1"
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -894,13 +894,6 @@ declare module 'azdata' {
 		selections: SelectionRange[];
 	}
 
-	export interface CopyResultsRequestResult {
-		/**
-		 * Result string from copy operation
-		 */
-		results: string;
-	}
-
 	export interface QueryProvider {
 		/**
 		 * Notify clients that the URI for a connection has been changed.
@@ -912,7 +905,7 @@ declare module 'azdata' {
 		 * ADS will use this if 'supportCopyResultsToClipboard' property is set to true in the provider contribution point in extension's package.json.
 		 * Otherwise, The default handler will load all the selected data to ADS and perform the copy operation.
 		 */
-		copyResults?(requestParams: CopyResultsRequestParams): Thenable<CopyResultsRequestResult>;
+		copyResults?(requestParams: CopyResultsRequestParams): Thenable<void>;
 	}
 
 	export enum DataProviderType {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -892,10 +892,6 @@ declare module 'azdata' {
 		 * The selected ranges to be copied.
 		 */
 		selections: SelectionRange[];
-		/**
-		 * Whether to copy results from the UI process.
-		 */
-		copyFromUIProcess?: boolean;
 	}
 
 	export interface CopyResultsRequestResult {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -892,6 +892,10 @@ declare module 'azdata' {
 		 * The selected ranges to be copied.
 		 */
 		selections: SelectionRange[];
+		/**
+		 * Whether to copy the results directly from the backend.
+		 */
+		copyInBackend: boolean;
 	}
 
 	export interface CopyResultsRequestResult {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -893,9 +893,9 @@ declare module 'azdata' {
 		 */
 		selections: SelectionRange[];
 		/**
-		 * Whether to copy the results directly from the backend.
+		 * Whether to copy results from the UI process.
 		 */
-		copyInBackend: boolean;
+		copyFromUIProcess?: boolean;
 	}
 
 	export interface CopyResultsRequestResult {

--- a/src/sql/workbench/api/browser/mainThreadDataProtocol.ts
+++ b/src/sql/workbench/api/browser/mainThreadDataProtocol.ts
@@ -161,7 +161,7 @@ export class MainThreadDataProtocol extends Disposable implements MainThreadData
 					return Promise.resolve(self._serializationService.saveAs(requestParams.resultFormat, requestParams.filePath, undefined, true));
 				}
 			},
-			copyResults(requestParams: azdata.CopyResultsRequestParams): Promise<azdata.CopyResultsRequestResult> {
+			copyResults(requestParams: azdata.CopyResultsRequestParams): Promise<void> {
 				return Promise.resolve(self._proxy.$copyResults(handle, requestParams));
 			},
 			initializeEdit(ownerUri: string, schemaName: string, objectName: string, objectType: string, rowLimit: number, queryString: string): Promise<void> {

--- a/src/sql/workbench/api/common/extHostDataProtocol.ts
+++ b/src/sql/workbench/api/common/extHostDataProtocol.ts
@@ -420,7 +420,7 @@ export class ExtHostDataProtocol extends ExtHostDataProtocolShape {
 		return this._resolveProvider<azdata.QueryProvider>(handle).saveResults(requestParams);
 	}
 
-	override $copyResults(handle: number, requestParams: azdata.CopyResultsRequestParams): Thenable<azdata.CopyResultsRequestResult> {
+	override $copyResults(handle: number, requestParams: azdata.CopyResultsRequestParams): Thenable<void> {
 		const provider = this._resolveProvider<azdata.QueryProvider>(handle);
 		if (provider.copyResults) {
 			return provider.copyResults(requestParams);

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -254,7 +254,7 @@ export abstract class ExtHostDataProtocolShape {
 	/**
 	 * Copies the selected data to clipboard.
 	 */
-	$copyResults(handle: number, requestParams: azdata.CopyResultsRequestParams): Thenable<azdata.CopyResultsRequestResult> { throw ni(); }
+	$copyResults(handle: number, requestParams: azdata.CopyResultsRequestParams): Thenable<void> { throw ni(); }
 
 	/**
 	 * Commits all pending edits in an edit session

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -335,8 +335,8 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.preferProvidersCopyHandler': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is true, except for linux where the default value is false, set this to false to force all copy handling to be done by Azure Data Studio."),
-			'default': process.platform !== 'linux' ? true : false,
+			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is true, set this to false to force all copy handling to be done by Azure Data Studio."),
+			'default': true
 		},
 		'queryEditor.results.inMemoryDataProcessingThreshold': {
 			'type': 'number',

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -335,8 +335,8 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.preferProvidersCopyHandler': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is true, set this to false to force all copy handling to be done by Azure Data Studio."),
-			'default': true
+			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is false, set this to true to force all copy handling to be done by the query provider."),
+			'default': false
 		},
 		'queryEditor.results.inMemoryDataProcessingThreshold': {
 			'type': 'number',

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -335,8 +335,8 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.preferProvidersCopyHandler': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is true, set this to false to force all copy handling to be done by Azure Data Studio."),
-			'default': true
+			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is true, except for linux where the default value is false, set this to false to force all copy handling to be done by Azure Data Studio."),
+			'default': process.platform !== 'linux' ? true : false,
 		},
 		'queryEditor.results.inMemoryDataProcessingThreshold': {
 			'type': 'number',

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -335,8 +335,8 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.preferProvidersCopyHandler': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is false, set this to true to force all copy handling to be done by the query provider."),
-			'default': false
+			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is true, set this to false to force all copy handling to be done by Azure Data Studio."),
+			'default': true
 		},
 		'queryEditor.results.inMemoryDataProcessingThreshold': {
 			'type': 'number',

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -9,6 +9,7 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { IConfigurationRegistry, Extensions as ConfigExtensions, IConfigurationNode } from 'vs/platform/configuration/common/configurationRegistry';
 import { MenuId, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
 import { KeyMod, KeyCode, KeyChord } from 'vs/base/common/keyCodes';
+import * as platform from 'vs/base/common/platform';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ContextKeyExpr, ContextKeyEqualsExpr } from 'vs/platform/contextkey/common/contextkey';
 
@@ -335,8 +336,8 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.preferProvidersCopyHandler': {
 			'type': 'boolean',
-			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is true, set this to false to force all copy handling to be done by Azure Data Studio."),
-			'default': true
+			'description': localize('queryEditor.results.preferProvidersCopyHandler', "Whether the copy result request should be handled by the query provider when it is supported. The default value is true for Windows and Mac, and false for Linux, set this to false to force all copy handling to be done by Azure Data Studio."),
+			'default': platform.isLinux ? false : true
 		},
 		'queryEditor.results.inMemoryDataProcessingThreshold': {
 			'type': 'number',

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -69,7 +69,7 @@ export interface IQueryManagementService {
 	changeConnectionUri(newUri: string, oldUri: string): Promise<void>;
 	saveResults(requestParams: azdata.SaveResultsRequestParams): Promise<azdata.SaveResultRequestResult>;
 	setQueryExecutionOptions(uri: string, options: azdata.QueryExecutionOptions): Promise<void>;
-	copyResults(params: azdata.CopyResultsRequestParams): Promise<azdata.CopyResultsRequestResult>;
+	copyResults(params: azdata.CopyResultsRequestParams): Promise<void>;
 
 	// Callbacks
 	onQueryComplete(result: azdata.QueryExecuteCompleteNotificationResult): void;
@@ -108,7 +108,7 @@ export interface IQueryRequestHandler {
 	disposeQuery(ownerUri: string): Promise<void>;
 	connectionUriChanged(newUri: string, oldUri: string): Promise<void>;
 	saveResults(requestParams: azdata.SaveResultsRequestParams): Promise<azdata.SaveResultRequestResult>;
-	copyResults(requestParams: azdata.CopyResultsRequestParams): Promise<azdata.CopyResultsRequestResult>;
+	copyResults(requestParams: azdata.CopyResultsRequestParams): Promise<void>;
 	setQueryExecutionOptions(ownerUri: string, options: azdata.QueryExecutionOptions): Promise<void>;
 
 	// Edit Data actions
@@ -364,7 +364,7 @@ export class QueryManagementService implements IQueryManagementService {
 		});
 	}
 
-	public copyResults(requestParams: azdata.CopyResultsRequestParams): Promise<azdata.CopyResultsRequestResult> {
+	public copyResults(requestParams: azdata.CopyResultsRequestParams): Promise<void> {
 		return this._runAction(requestParams.ownerUri, (runner) => {
 			return runner.copyResults(requestParams);
 		});

--- a/src/sql/workbench/services/query/common/queryModelService.ts
+++ b/src/sql/workbench/services/query/common/queryModelService.ts
@@ -22,7 +22,6 @@ import Severity from 'vs/base/common/severity';
 import EditQueryRunner from 'sql/workbench/services/editData/common/editQueryRunner';
 import { IRange } from 'vs/editor/common/core/range';
 import { ServerConnID } from 'sql/workbench/services/query/common/query';
-import { ClipboardData, IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IQueryManagementService } from 'sql/workbench/services/query/common/queryManagement';
 
 const selectionSnippetMaxLen = 100;
@@ -88,7 +87,6 @@ export class QueryModelService implements IQueryModelService {
 		@IQueryManagementService protected queryManagementService: IQueryManagementService,
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@INotificationService private _notificationService: INotificationService,
-		@IClipboardService private _clipboardService: IClipboardService,
 		@ILogService private _logService: ILogService
 	) {
 		this._queryInfoMap = new Map<string, QueryInfo>();
@@ -178,11 +176,7 @@ export class QueryModelService implements IQueryModelService {
 
 	public async copyResults(uri: string, selection: Slick.Range[], batchId: number, resultId: number, includeHeaders?: boolean): Promise<void> {
 		if (this._queryInfoMap.has(uri)) {
-			const results = await this._queryInfoMap.get(uri)!.queryRunner!.copyResults(selection, batchId, resultId, includeHeaders);
-			let clipboardData: ClipboardData = {
-				text: results.results
-			};
-			this._clipboardService.write(clipboardData);
+			return this._queryInfoMap.get(uri)!.queryRunner!.copyResults(selection, batchId, resultId, includeHeaders);
 		}
 	}
 

--- a/src/sql/workbench/services/query/common/queryRunner.ts
+++ b/src/sql/workbench/services/query/common/queryRunner.ts
@@ -11,7 +11,7 @@ import { ResultSerializer, SaveFormat } from 'sql/workbench/services/query/commo
 
 import * as azdata from 'azdata';
 import * as nls from 'vs/nls';
-import { ClipboardData, IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import * as types from 'vs/base/common/types';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -494,8 +494,8 @@ export default class QueryRunner extends Disposable {
 	 * @param resultId The result id of the result to copy from
 	 * @param includeHeaders [Optional]: Should column headers be included in the copy selection
 	 */
-	async copyResults(selections: Slick.Range[], batchId: number, resultId: number, includeHeaders?: boolean): Promise<azdata.CopyResultsRequestResult> {
-		return this.queryManagementService.copyResults({
+	async copyResults(selections: Slick.Range[], batchId: number, resultId: number, includeHeaders?: boolean): Promise<void> {
+		await this.queryManagementService.copyResults({
 			ownerUri: this.uri,
 			batchIndex: batchId,
 			resultSetIndex: resultId,
@@ -617,11 +617,7 @@ export class QueryGridDataProvider implements IGridDataProvider {
 
 	private async handleCopyRequestByProvider(selections: Slick.Range[], includeHeaders?: boolean): Promise<void> {
 		executeCopyWithNotification(this._notificationService, this._configurationService, selections, async () => {
-			let results = await this.queryRunner.copyResults(selections, this.batchId, this.resultSetId, this.shouldIncludeHeaders(includeHeaders));
-			let clipboardData: ClipboardData = {
-				text: results.results
-			}
-			this._clipboardService.write(clipboardData);
+			await this.queryRunner.copyResults(selections, this.batchId, this.resultSetId, this.shouldIncludeHeaders(includeHeaders));
 		});
 	}
 

--- a/src/sql/workbench/services/query/common/queryRunner.ts
+++ b/src/sql/workbench/services/query/common/queryRunner.ts
@@ -32,7 +32,6 @@ import { ITextResourcePropertiesService } from 'vs/editor/common/services/textRe
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { ServerConnID } from 'sql/workbench/services/query/common/query';
-import { getRemoteAuthority, getRemoteName } from 'vs/platform/remote/common/remoteHosts';
 
 /*
 * Query Runner class which handles running a query, reports the results to the content manager,
@@ -496,19 +495,11 @@ export default class QueryRunner extends Disposable {
 	 * @param includeHeaders [Optional]: Should column headers be included in the copy selection
 	 */
 	async copyResults(selections: Slick.Range[], batchId: number, resultId: number, includeHeaders?: boolean): Promise<azdata.CopyResultsRequestResult> {
-		let copyInBackend = false;
-		const remoteAuthority = getRemoteAuthority(URI.parse(this.uri));
-		const remoteName = getRemoteName(remoteAuthority);
-		if (!remoteName) {
-			copyInBackend = true;
-		}
-
 		return this.queryManagementService.copyResults({
 			ownerUri: this.uri,
 			batchIndex: batchId,
 			resultSetIndex: resultId,
 			includeHeaders: includeHeaders,
-			copyInBackend: copyInBackend,
 			selections: selections.map(selection => {
 				return {
 					fromRow: selection.fromRow,

--- a/src/sql/workbench/services/query/common/queryRunner.ts
+++ b/src/sql/workbench/services/query/common/queryRunner.ts
@@ -618,12 +618,10 @@ export class QueryGridDataProvider implements IGridDataProvider {
 	private async handleCopyRequestByProvider(selections: Slick.Range[], includeHeaders?: boolean): Promise<void> {
 		executeCopyWithNotification(this._notificationService, this._configurationService, selections, async () => {
 			let results = await this.queryRunner.copyResults(selections, this.batchId, this.resultSetId, this.shouldIncludeHeaders(includeHeaders));
-			if (results.results) {
-				let clipboardData: ClipboardData = {
-					text: results.results
-				}
-				this._clipboardService.write(clipboardData);
+			let clipboardData: ClipboardData = {
+				text: results.results
 			}
+			this._clipboardService.write(clipboardData);
 		});
 	}
 

--- a/src/sql/workbench/services/query/test/common/testQueryManagementService.ts
+++ b/src/sql/workbench/services/query/test/common/testQueryManagementService.ts
@@ -66,7 +66,7 @@ export class TestQueryManagementService implements IQueryManagementService {
 	saveResults(requestParams: azdata.SaveResultsRequestParams): Promise<azdata.SaveResultRequestResult> {
 		throw new Error('Method not implemented.');
 	}
-	copyResults(params: azdata.CopyResultsRequestParams): Promise<azdata.CopyResultsRequestResult> {
+	copyResults(params: azdata.CopyResultsRequestParams): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
 	setQueryExecutionOptions(uri: string, options: azdata.QueryExecutionOptions): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR will fix https://github.com/microsoft/azuredatastudio/issues/25632

The other PR's needed for this PR:
sqlops-dataprotocolclient - https://github.com/microsoft/sqlops-dataprotocolclient/pull/101
sqltoolsservice - https://github.com/microsoft/sqltoolsservice/pull/2385

The reason copying was very slow from the SQL Tools Service was because `ToString` was repeatedly being called on the `StringBuilder` before `EndsWith`: https://github.com/microsoft/sqltoolsservice/blob/18ffbe6d76c511881a76f636d2e59467dfe8c4d6/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs#L866

In the PR for the SQL Tools Service `ToString` is only called once to correct this issue. With this correction in place, copying from STS is significantly faster, as can be seen in this gif where copying is done in the SQL Tools Service process.

In this gif 100,000 query results are being copied Through the SQL Tools Service:
![Copy 100000 query results STS](https://github.com/user-attachments/assets/8d337da9-850f-4b09-8075-9d2db88797c7)

For comparison, this is what copying 100,000 query results from SSMS looks like:
![Copy 100000 query results SSMS](https://github.com/user-attachments/assets/2dd83d04-08a3-4d29-a363-15473f95d434)

Without the changes associated with this PR and the related PR's were made, it takes a very long time to copy query results. this following gif runs for over a minute and doesn't complete the copy operation for 100,000 query results.
![Copy 100000 query results STS before change](https://github.com/user-attachments/assets/db05e4ad-4e85-4177-b673-7ca0ca615845)

## Copying on Linux

To ensure that copying works on the Linux platform and to avoid repeating this issue (https://github.com/microsoft/azuredatastudio/issues/24043), copying defaults to the UI process. This is because the backend SQL Tools Service uses a NuGet package named `TextCopy` to copy query results. When copying on Linux, `TextCopy` depends on `xsel` and not all Linux users may have that installed, and as a result will find that copying doesn't work without `xsel`:
![image](https://github.com/user-attachments/assets/9fdca510-a73f-4d1c-aa4c-0dcf3dd0f61d)


## Time Differences between copying from ADS UI and STS
### 6 Column Query Results:

>SELECT TOP [25000|50000|75000|100000] sys.all_columns.name, column_id, system_type_id, user_type_id, max_length, [precision]
FROM sys.all_columns, sys.all_views;

Copying results with 6 columns from the UI:
ADS UI Copy with 25,000 rows: 813.864013671875 ms
ADS UI Copy with 50,000 rows: 1506.052001953125 ms
ADS UI Copy with 75,000 rows: 2277.085205078125 ms
ADS UI Copy with 100,000 rows: 2966.846923828125 ms

Copying results with 6 columns from STS:
STS Copy with 25,000 rows: 0.379150390625 ms
STS Copy with 50,000 rows: 0.408935546875 ms
STS Copy with 75,000 rows: 0.454833984375 ms
STS Copy with 100,000 rows: 0.570068359375 ms



### 53 Column Query Results:
> SELECT TOP [25000|50000|75000|100000] *
FROM sys.all_columns, sys.all_views;

Copying results with 53 columns from the UI:
ADS UI Copy with 25,000 rows: 12446.373046875 ms
ADS UI Copy with 50,000 rows: 24727.3408203125 ms
ADS UI Copy with 75,000 rows: 38170.3740234375 ms
ADS UI Copy with 100,000 rows: 51372.80810546875 ms


Copying results with 53 columns from STS:
STS Copy with 25,000 rows: 0.575927734375 ms
STS Copy with 50,000 rows: 0.652099609375 ms
STS Copy with 75,000 rows: 0.81201171875 ms
STS Copy with 100,000 rows: 1.3330078125 ms