### PR TITLE
Bumped `notebook` version to `7.2.2`

### DIFF
--- a/extensions/notebook/src/jupyter/requiredJupyterPackages.ts
+++ b/extensions/notebook/src/jupyter/requiredJupyterPackages.ts
@@ -18,10 +18,10 @@ export const requiredJupyterPackages: RequiredPackagesInfo = {
 		name: 'jupyter',
 		version: '1.0.0'
 	},
-	// Require notebook 6.5.6 for https://github.com/jupyter/notebook/issues/7048
+	// Require notebook 7.2.2 for https://github.com/microsoft/azuredatastudio/issues/25327
 	{
 		name: 'notebook',
-		version: '6.5.6',
+		version: '7.2.2',
 		installExactVersion: true
 	},
 	// Require ipykernel 5.5.5 for https://github.com/microsoft/azuredatastudio/issues/24405


### PR DESCRIPTION
Fixes #25327. Allows Python 3.12+ runtime configuration.

Related: https://github.com/zeromq/pyzmq/issues/2030#issuecomment-2337602511
