### PR TITLE
Displaying non-default columns for local .xel files

### DIFF
--- a/src/sql/workbench/browser/editor/profiler/profilerInput.ts
+++ b/src/sql/workbench/browser/editor/profiler/profilerInput.ts
@@ -314,9 +314,11 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 			data['TextData'] = ' ';
 			for (let key in e.values) {
 				let columnName = this._columnMapping[key];
+				let value = e.values[key];
 				if (columnName) {
-					let value = e.values[key];
 					data[columnName] = value;
+				} else {
+					data[key] = value;
 				}
 			}
 			newEvents.push(data);


### PR DESCRIPTION
A .xel file produced outside of SQL Server may contain a different set of columns. Since Azure Data Studio's SQL Server Profiler has its own set of display columns, these non-default ones are simply ignored.

This PR adds support for displaying non-default columns in the details section while preserving the default behavior that fixes #25906 issue.

Before:
![before](https://github.com/user-attachments/assets/19e2b4ac-86d6-4635-9817-a58e454c5563)

After:
![after](https://github.com/user-attachments/assets/7049815e-4956-4672-bee2-65e79c4cfeb4)