### PR TITLE
Consuming Latest Sql Tools Service

### DIFF
--- a/extensions/sql-migration/config.json
+++ b/extensions/sql-migration/config.json
@@ -1,7 +1,7 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.migration-{#fileName#}",
 	"useDefaultLinuxRuntime": true,
-	"version": "5.0.0.5",
+	"version": "5.0.20241003.1",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net8.0.zip",
 		"Windows": "win-x64-net8.0.zip",


### PR DESCRIPTION
This PR consumes the latest STS release having the latest login nuget that modifies the AAD errors to MicrosoftEntraDomain Errors (due to the name change)
![image](https://github.com/user-attachments/assets/f52a19f0-c948-43d2-8752-a7d142e74ef9)
![image](https://github.com/user-attachments/assets/8251b30c-9cdc-4cce-a4f7-ab82ee344a7b)
