### PR TITLE
Remove sqlDropStoredProc snippet which conflicts with DESC keyword

### DIFF
--- a/extensions/mssql/snippets/mssql.json
+++ b/extensions/mssql/snippets/mssql.json
@@ -185,22 +185,6 @@
 		"description": "Create a stored procedure"
 	},
 
-	"Drop a stored procedure": {
-		"prefix": "sqlDropStoredProc",
-		"body": [
-			"-- Drop the stored procedure called '${1:StoredProcedureName}' in schema '${2:dbo}'",
-			"IF EXISTS (",
-			"SELECT *",
-			"\tFROM INFORMATION_SCHEMA.ROUTINES",
-			"WHERE SPECIFIC_SCHEMA = N'${2:dbo}'",
-			"\tAND SPECIFIC_NAME = N'${1:StoredProcedureName}'",
-			")",
-			"DROP PROCEDURE ${2:dbo}.${1:StoredProcedureName}",
-			"GO"
-		],
-		"description": "Drop a stored procedure"
-	},
-
 	"List tables": {
 		"prefix": "sqlListTablesAndViews",
 		"body": [


### PR DESCRIPTION
This snippet in particular is conflicting with DESC keyword and causing a problem that has been reported a few times, e.g., https://github.com/microsoft/azuredatastudio/issues/25762. This doesn't fix the underlying issue with the keyword & snippets conflicting all-up, but it resolved the most common rough spot. And the snippet isn't really that useful (compared to DESC keyword)