### PR TITLE
import assessment wizard fix

### DIFF
--- a/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetailsHeader.ts
+++ b/extensions/sql-migration/src/wizard/assessmentDetailsPage/assessmentDetailsHeader.ts
@@ -243,9 +243,9 @@ export class AssessmentDetailsHeader {
 		// this value is populated to handle the case when user selects a target type and want to resume later.
 		this._targetSelectionDropdown.value = this.getTargetTypeBasedOnModel(migrationStateModel._targetType);
 
-		await this._viewDetailsLink.updateCssStyles({ 'display': 'none' });
-		await this._generateTemplateLink.updateCssStyles({ 'display': 'none' });
-		await this._separator.updateCssStyles({ 'display': 'none' });
+		await this._viewDetailsLink?.updateCssStyles({ 'display': 'none' });
+		await this._generateTemplateLink?.updateCssStyles({ 'display': 'none' });
+		await this._separator?.updateCssStyles({ 'display': 'none' });
 
 
 
@@ -276,9 +276,9 @@ export class AssessmentDetailsHeader {
 			this._valueContainers[0].value = configurationValue;
 
 			if (configurationValue !== "--") {
-				await this._viewDetailsLink.updateCssStyles({ 'display': 'block' });
-				await this._generateTemplateLink.updateCssStyles({ 'display': 'block' });
-				await this._separator.updateCssStyles({ 'display': 'block' });
+				await this._viewDetailsLink?.updateCssStyles({ 'display': 'block' });
+				await this._generateTemplateLink?.updateCssStyles({ 'display': 'block' });
+				await this._separator?.updateCssStyles({ 'display': 'block' });
 			}
 
 			await this._azureRecommendationLoadingText.updateCssStyles({ 'display': 'none' });


### PR DESCRIPTION
Import assessment Wizard failed to load because the fields _viewDetailsLink , _generateTemplateLink , _separator were undefined
Added a null check for the fields to fix the issue.

ADO task - https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/3297592/?view=edit

The import assesment wizard is loading now - 
![image](https://github.com/user-attachments/assets/1bb66a54-d5b8-4548-9467-b0e26bc4b608)
