### PR TITLE
Release new version of mongo migration extension (3.1.6)

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -4849,14 +4849,14 @@
 					},
 					"versions": [
 						{
-							"version": "3.1.5",
-							"lastUpdated": "12/12/2024",
+							"version": "3.1.6",
+							"lastUpdated": "12/17/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-3.1.5.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-3.1.6.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -4849,14 +4849,14 @@
 					},
 					"versions": [
 						{
-							"version": "3.1.5",
-							"lastUpdated": "12/12/2024",
+							"version": "3.1.6",
+							"lastUpdated": "12/17/2024",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-3.1.5.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ads-extension-mongo-migration/ads-extension-mongo-migration-3.1.6.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This is the link to download new extension
[Mongo migration 3.1.6](https://artprodeussu2.artifacts.visualstudio.com/A8b119ea1-2e2a-4839-8db7-8c9e8d50f6fa/ba574a88-a171-48e0-8fcb-5fef6d23739c/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL21zZGF0YS9wcm9qZWN0SWQvYmE1NzRhODgtYTE3MS00OGUwLThmY2ItNWZlZjZkMjM3MzljL2J1aWxkSWQvMTUzMzMyMjAzL2FydGlmYWN0TmFtZS9kcm9wX2J1aWxkX21haW41/content?format=file&subPath=%2FProduct%2FAdsMongoMigration%2Fbin%2Fads-extension-mongo-migration-3.1.6.vsix)