### PR TITLE
bump STS

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "5.0.20241206.1",
+	"version": "5.0.20241218.1",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net8.0.zip",
 		"Windows_64": "win-x64-net8.0.zip",


### PR DESCRIPTION
This PR bumps STS to a new version with updated signing cert.

https://github.com/microsoft/sqltoolsservice/compare/5.0.20241206.1...5.0.20241218.1
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/550a8419-f417-495b-acc8-ff0183c1872c" />
