### PR TITLE
Adding HTTP(S) over HTTP(S) proxy support to add accounts.

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -462,11 +462,11 @@ export abstract class AzureAuth implements vscode.Disposable {
 		};
 
 		const httpConfig = vscode.workspace.getConfiguration("http");
-		const proxy = this.loadEnvironmentProxyValue() || httpConfig["proxy"] as string;
+		const proxy = httpConfig["proxy"] as string || this.loadEnvironmentProxyValue();
 		if (proxy) {
 			const agent = this.createProxyAgent(requestUrl, proxy, httpConfig["proxyStrictSSL"]);
 
-			if (proxy.includes("https")) {
+			if (proxy.startsWith("https")) {
 				config.httpsAgent = agent;
 			}
 			else {
@@ -524,8 +524,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 			};
 		}
 
-		const isRequestHttps = requestUrl.includes("https");
-		const isProxyHttps = proxy.includes("https");
+		const isRequestHttps = requestUrl.startsWith("https");
+		const isProxyHttps = proxy.startsWith("https");
 		const proxyAgent = {
 			isHttps: isRequestHttps,
 			agent: this.createTunnelingAgent(isRequestHttps, isProxyHttps, tunnelOptions),

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -496,6 +496,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 			return response;
 		}
 
+		Logger.verbose("No proxy endpoint found in the HTTP_PROXY, HTTPS_PROXY environment variables or workspace configuration.");
 		const response: AxiosResponse = await axios.get<T>(requestUrl, config);
 		Logger.piiSanitized('GET request ', [{ name: 'response', objOrArray: response.data?.value as TenantResponse[] ?? response.data as GetTenantsResponseData }], [], requestUrl,);
 		return response;

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -461,11 +461,11 @@ export abstract class AzureAuth implements vscode.Disposable {
 		};
 
 		const httpConfig = vscode.workspace.getConfiguration("http");
-		let proxy = this.loadEnvironmentProxyValue();
+		let proxy: string | undefined = httpConfig['proxy'] as string;
 		if (!proxy) {
-			Logger.verbose("Checking workspace HTTP configuration for proxy endpoint.");
+			Logger.verbose("Workspace HTTP config didn't contain a proxy endpoint. Checking environment variables.");
 
-			proxy = httpConfig['proxy'] as string;
+			proxy = this.loadEnvironmentProxyValue();
 		}
 
 		if (proxy) {
@@ -503,23 +503,23 @@ export abstract class AzureAuth implements vscode.Disposable {
 	}
 
 	private loadEnvironmentProxyValue(): string | undefined {
-		const HTTPS_PROXY = "HTTPS_PROXY";
 		const HTTP_PROXY = "HTTP_PROXY";
+		const HTTPS_PROXY = "HTTPS_PROXY";
 
 		if (!process) {
 			Logger.verbose("No process object found, unable to read environment variables for proxy.");
 			return undefined;
 		}
 
-		if (process.env[HTTPS_PROXY] || process.env[HTTPS_PROXY.toLowerCase()]) {
-			Logger.verbose("Loading proxy value from HTTPS_PROXY environment variable.");
-
-			return process.env[HTTPS_PROXY] || process.env[HTTPS_PROXY.toLowerCase()];
-		}
-		else if (process.env[HTTP_PROXY] || process.env[HTTP_PROXY.toLowerCase()]) {
+		if (process.env[HTTP_PROXY] || process.env[HTTP_PROXY.toLowerCase()]) {
 			Logger.verbose("Loading proxy value from HTTP_PROXY environment variable.");
 
 			return process.env[HTTP_PROXY] || process.env[HTTP_PROXY.toLowerCase()];
+		}
+		else if (process.env[HTTPS_PROXY] || process.env[HTTPS_PROXY.toLowerCase()]) {
+			Logger.verbose("Loading proxy value from HTTPS_PROXY environment variable.");
+
+			return process.env[HTTPS_PROXY] || process.env[HTTPS_PROXY.toLowerCase()];
 		}
 
 		Logger.verbose("No proxy value found in either HTTPS_PROXY or HTTP_PROXY environment variables.");

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -28,7 +28,7 @@ import { AccountInfo, AuthError, AuthenticationResult, InteractionRequiredAuthEr
 import { errorToPromptFailedResult } from './networkUtils';
 import { MsalCachePluginProvider } from '../utils/msalCachePlugin';
 import { isErrorResponseBodyWithError } from '../../azureResource/utils';
-import axios, { AxiosResponse, AxiosRequestConfig, AxiosInstance } from 'axios';
+import axios, { AxiosResponse, AxiosRequestConfig } from 'axios';
 import { getProxyAgentOptions } from '../../proxy';
 const localize = nls.loadMessageBundle();
 

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -457,10 +457,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 				'Content-Type': 'application/json',
 				'Authorization': `Bearer ${token}`,
 			},
-			validateStatus: () => true, // Never throw
-			// Turning off automatic proxy detection to avoid issues with tunneling agent by setting proxy to false.
-			// https://github.com/axios/axios/blob/bad6d8b97b52c0c15311c92dd596fc0bff122651/lib/adapters/http.js#L85
-			proxy: false
+			validateStatus: () => true // Never throw
 		};
 
 		const httpConfig = vscode.workspace.getConfiguration("http");
@@ -473,6 +470,10 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 		if (proxy) {
 			Logger.verbose("Proxy endpoint found in environment variables or workspace configuration.");
+
+			// Turning off automatic proxy detection to avoid issues with tunneling agent by setting proxy to false.
+			// https://github.com/axios/axios/blob/bad6d8b97b52c0c15311c92dd596fc0bff122651/lib/adapters/http.js#L85
+			config.proxy = false;
 
 			const agent = this.createProxyAgent(requestUrl, proxy, httpConfig["proxyStrictSSL"]);
 			if (agent.isHttps) {

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -480,7 +480,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 	private createProxyAgent(requestUrl: string, proxy: string, proxyStrictSSL: boolean): ProxyAgent {
 		const agentOptions = getProxyAgentOptions(url.parse(requestUrl), proxy, proxyStrictSSL);
-		if (!agentOptions) {
+		if (!agentOptions || !agentOptions.host || !agentOptions.port) {
 			throw new Error("Unable to read proxy agent options to create proxy agent.");
 		}
 

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -496,7 +496,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 			return response;
 		}
 
-		Logger.verbose("No proxy endpoint found in the HTTP_PROXY, HTTPS_PROXY environment variables or workspace configuration.");
+		Logger.verbose("No proxy endpoint was found in the HTTP_PROXY, HTTPS_PROXY environment variables or in the workspace HTTP configuration.");
 		const response: AxiosResponse = await axios.get<T>(requestUrl, config);
 		Logger.piiSanitized('GET request ', [{ name: 'response', objOrArray: response.data?.value as TenantResponse[] ?? response.data as GetTenantsResponseData }], [], requestUrl,);
 		return response;

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -29,7 +29,7 @@ import { errorToPromptFailedResult } from './networkUtils';
 import { MsalCachePluginProvider } from '../utils/msalCachePlugin';
 import { isErrorResponseBodyWithError } from '../../azureResource/utils';
 import axios, { AxiosResponse, AxiosRequestConfig } from 'axios';
-import { getProxyAgent, getProxyAgentOptions } from '../../proxy';
+import { getProxyAgentOptions } from '../../proxy';
 const localize = nls.loadMessageBundle();
 
 export type GetTenantsResponseData = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/25990, 

The PR configures Axios, an HTTP client that Azure Data Studio has a dependency on, to successfully make requests from a proxied environment. In cases where an HTTP proxy is used, the request to get tenants is unable to go through when a proxy only supports HTTP traffic. This can result in the request to hang and prevent completion. To avoid hanging an HTTPS request from a HTTP proxy, an HTTPS over HTTP tunnel is needed, which is what this PR adds.

I validated my changes, by having Azure Data Studio connect to the proxy endpoint set up by ProxyMan, and reviewed the following resources to identify that when Axios makes requests in proxy environments, it can result in errors that stop the request from completing.
https://janmolak.com/node-js-axios-behind-corporate-proxies-8b17a6f31f9d
https://github.com/axios/axios/issues/925
https://github.com/axios/axios/issues/3384 
https://stackoverflow.com/questions/43433380/socket-hang-up-when-using-axios-get-but-not-when-using-https-get
