### PR TITLE
Adding banner to notify users of Azure Data Studio's retirement announcement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Azure Data Studio
 
+> [!IMPORTANT]
+> Azure Data Studio will be retired on **February 28, 2026**.  [Read more](https://aka.ms/ads-retirement)
+
+----
+
 [![Join the chat at https://gitter.im/Microsoft/sqlopsstudio](https://badges.gitter.im/Microsoft/sqlopsstudio.svg)](https://gitter.im/Microsoft/sqlopsstudio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://dev.azure.com/ms/azuredatastudio/_apis/build/status/AzureDataStudio-Localization-CI?branchName=main)](https://dev.azure.com/ms/azuredatastudio/_build/latest?definitionId=453&branchName=main)
 [![Twitter Follow](https://img.shields.io/twitter/follow/azuredatastudio?style=social)](https://twitter.com/azuredatastudio)

--- a/src/sql/workbench/contrib/welcome/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/browser/az_data_welcome_page.ts
@@ -31,6 +31,17 @@ export default () => `
 								</div>
 							</div>
 						</div>
+						<div class="row" id="retirement-announcement-container">
+							<div class="retirement-banner">
+								<p>
+									${escape(localize('welcomePage.adsRetirementAnnouncement', "Azure Data Studio will be retired on February 28, 2026."))}
+									<a class="link" href="https://aka.ms/ads-retirement">
+										${escape(localize('welcomePage.adsRetirementAnnouncementLink', "Read more"))}
+										<span class="icon-link themed-icon-alt"></span>
+									</a>
+								</p>
+							</div>
+						</div>
 						<div class="row header-bottom-nav-tiles ads-grid">
 							<div class="col">
 								<a role="button" class="header-bottom-nav-tile-link ads-welcome-page-link" href="command:${AddServerAction.ID}">

--- a/src/sql/workbench/contrib/welcome/browser/retirementAnnouncement.contribution.ts
+++ b/src/sql/workbench/contrib/welcome/browser/retirementAnnouncement.contribution.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { RetirementAnnouncement } from 'sql/workbench/contrib/welcome/browser/retirementAnnouncement';
+
+Registry
+	.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+	.registerWorkbenchContribution(RetirementAnnouncement, LifecyclePhase.Eventually);

--- a/src/sql/workbench/contrib/welcome/browser/retirementAnnouncement.ts
+++ b/src/sql/workbench/contrib/welcome/browser/retirementAnnouncement.ts
@@ -28,7 +28,7 @@ export class RetirementAnnouncement {
 			retirementNotice,
 			[
 				{
-					label: localize('okay', "Okay"),
+					label: localize('okay', "OK"),
 					run: () => { /* no-op, just an ack */ }
 				},
 				{

--- a/src/sql/workbench/contrib/welcome/browser/retirementAnnouncement.ts
+++ b/src/sql/workbench/contrib/welcome/browser/retirementAnnouncement.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { IHostService } from 'vs/workbench/services/host/browser/host';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { localize } from 'vs/nls';
+
+export class RetirementAnnouncement {
+	private static DO_NOT_SHOW_RETIREMENT_PROMPT = 'workbench.doNotShowRetirementPrompt';
+
+	constructor(
+		@IStorageService private storageService: IStorageService,
+		@INotificationService private notificationService: INotificationService,
+		@IHostService hostService: IHostService,
+		@IConfigurationService configurationService: IConfigurationService
+	) {
+		if (this.storageService.get(RetirementAnnouncement.DO_NOT_SHOW_RETIREMENT_PROMPT, StorageScope.APPLICATION)) {
+			return;
+		}
+
+		const retirementNotice = localize('prompt.adsRetirementAnnouncement', "Azure Data Studio will be retired on February 28, 2026.  [Read more](https://aka.ms/ads-retirement)");
+		this.notificationService.prompt(
+			Severity.Info,
+			retirementNotice,
+			[
+				{
+					label: localize('okay', "Okay"),
+					run: () => { /* no-op, just an ack */ }
+				},
+				{
+					label: localize('never', "Don't show again"),
+					run: () => {
+						this.storageService.store(RetirementAnnouncement.DO_NOT_SHOW_RETIREMENT_PROMPT, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+					}
+				}
+			]
+		);
+	}
+
+}

--- a/src/sql/workbench/contrib/welcome/browser/welcomePage.css
+++ b/src/sql/workbench/contrib/welcome/browser/welcomePage.css
@@ -828,6 +828,17 @@
 	background-repeat: no-repeat
 }
 
+.ads-homepage .retirement-banner {
+	width: 100%;
+	padding: 20px;
+	background-color: #ffcc00;
+	color: #000;
+	text-align: center;
+	font-size: 16px;
+	font-weight: bold;
+	border-radius: 4px;
+}
+
 .ads-homepage .middle-section {
 	display: flex;
 	flex-direction: column;

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -205,3 +205,6 @@ import 'sql/workbench/contrib/commandLine/electron-sandbox/commandLine.contribut
 
 //getting started
 import 'sql/workbench/contrib/welcome/electron-sandbox/gettingStarted.contribution';
+
+// Azure Data Studio Retirement announcent
+import 'sql/workbench/contrib/welcome/browser/retirementAnnouncement.contribution';

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -225,4 +225,7 @@ import 'sql/workbench/contrib/welcome/browser/gettingStarted.contribution';
 // Telemetry Opt Out
 import 'sql/workbench/contrib/telemetry/browser/telemetryOptOut.contribution';
 
+// Azure Data Studio Retirement announcent
+import 'sql/workbench/contrib/welcome/browser/retirementAnnouncement.contribution';
+
 //#endregion


### PR DESCRIPTION
Added a visible yellow banner to the welcome page and a notification that pops up each launch until the user selects "Don't show again".

![image](https://github.com/user-attachments/assets/3d41ee98-8fca-4be7-835f-cf53cd96e3a1)