### PR TITLE
cosmetic SDK GA changes

### DIFF
--- a/extensions/sql-database-projects/README.md
+++ b/extensions/sql-database-projects/README.md
@@ -33,6 +33,7 @@ The extension will prompt to install the [.NET SDK](https://aka.ms/sqlprojects-d
 
 ## Features
 
+- [Microsoft.Build.Sql SDK-style projects](https://aka.ms/sqlprojects)
 - [Develop and validate database objects using T-SQL](https://learn.microsoft.com/sql/tools/sql-database-projects/sql-database-projects#validation)
 - [Start from an existing database to get it in source control](https://learn.microsoft.com/sql/tools/sql-database-projects/tutorials/start-from-existing-database?pivots=sq1-visual-studio-code)
 - [Publish the database objects to a SQL Server or Azure SQL instance](https://learn.microsoft.com/sql/tools/sql-database-projects/sql-database-projects#deployment)
@@ -45,7 +46,6 @@ The extension will prompt to install the [.NET SDK](https://aka.ms/sqlprojects-d
 
 ### Preview Features
 
-- Microsoft.Build.Sql SDK-style projects
 - Generate SQL projects from OpenAPI/Swagger specs
 
 ## Settings

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -40,7 +40,7 @@ export const edgeProjectTypeDescription = localize('edgeProjectTypeDescription',
 
 export const emptySqlDatabaseSdkProjectTypeId = 'EmptySqlDbSdkProj';
 export const emptySdkProjectTypeDisplayName = localize('emptySdkProjectTypeDisplayName', "SQL Database (SDK)");
-export const emptySdkProjectTypeDescription = localize('emptySdkProjectTypeDescription', "Develop and publish schemas for SQL databases with Microsoft.Build.Sql (preview), starting from an empty SDK-style project.");
+export const emptySdkProjectTypeDescription = localize('emptySdkProjectTypeDescription', "Develop and publish schemas for SQL databases with Microsoft.Build.Sql, starting from an empty SDK-style project.");
 
 export const emptyAzureDbSqlDatabaseProjectTypeId = 'EmptyAzureSqlDbProj';
 export const emptyAzureDbProjectTypeDisplayName = localize('emptyAzureDbProjectTypeDisplayName', "Azure SQL Database");

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -341,7 +341,7 @@ export const includePermissionsLabel = localize('includePermissionsLabel', "Incl
 export const includePermissionsInProject = localize('includePermissionsInProject', "Include permissions in project");
 export const browseEllipsisWithIcon = `$(folder) ${localize('browseEllipsis', "Browse...")}`;
 export const selectProjectLocation = localize('selectProjectLocation', "Select project location");
-export const sdkStyleProject = localize('sdkStyleProject', 'SDK-style project (Preview)');
+export const sdkStyleProject = localize('sdkStyleProject', 'SDK-style project');
 export const YesRecommended = localize('yesRecommended', "Yes (Recommended)");
 export const SdkLearnMorePlaceholder = localize('sdkLearnMorePlaceholder', "Click \"Learn More\" button for more information about SDK-style projects");
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -324,7 +324,7 @@ declare module 'sqldbproj' {
 		sqlEdge = 'Azure SQL Edge',
 		sqlDwServerless = 'Azure Synapse Serverless SQL Pool',
 		sqlDwUnified = 'Synapse Data Warehouse in Microsoft Fabric',
-		sqlDbFabric = 'Fabric Mirrored SQL Database (Preview)'
+		sqlDbFabric = 'SQL database in Fabric (preview)'
 	}
 
 	export interface ISqlConnectionProperties {


### PR DESCRIPTION
1. modifies a dialog that displays `(preview)` when creating a project

![image](https://github.com/user-attachments/assets/ede449ff-bda2-4f8a-b64a-bac21ce4d42b)

2. updates sqlproj extension readme to move SDK-style projects out of preview list

3. corrects target platform description for SQL database in Fabric