### PR TITLE
Dev/llali/sdkdefaultversion

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "Enables users to develop and publish database schemas for MSSQL Databases",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "publisher": "Microsoft",
   "preview": false,
   "engines": {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -202,12 +202,13 @@ export class ProjectsController {
 		let result: azdataType.ResultStatus | mssqlVscode.ResultStatus;
 
 		const sqlProjectsService = await utils.getSqlProjectsService();
+		const microsoftBuildSqlSDKStyleDefaultVersion = '1.0.0'; // default version of Microsoft.Build.Sql for SDK style projects, update in README when updating this
 		if (utils.getAzdataApi()) {
 			const projectStyle = creationParams.sdkStyle ? mssql.ProjectType.SdkStyle : mssql.ProjectType.LegacyStyle;
-			result = await (sqlProjectsService as mssql.ISqlProjectsService).createProject(newProjFilePath, projectStyle, targetPlatform);
+			result = await (sqlProjectsService as mssql.ISqlProjectsService).createProject(newProjFilePath, projectStyle, targetPlatform, microsoftBuildSqlSDKStyleDefaultVersion);
 		} else {
 			const projectStyle = creationParams.sdkStyle ? mssqlVscode.ProjectType.SdkStyle : mssqlVscode.ProjectType.LegacyStyle;
-			result = await (sqlProjectsService as mssqlVscode.ISqlProjectsService).createProject(newProjFilePath, projectStyle, targetPlatform);
+			result = await (sqlProjectsService as mssqlVscode.ISqlProjectsService).createProject(newProjFilePath, projectStyle, targetPlatform, microsoftBuildSqlSDKStyleDefaultVersion);
 		}
 
 		utils.throwIfFailed(result);


### PR DESCRIPTION
Passing the default version of SQL Build SDK to create SQL Project in STS. If that version is not passed, STS would get the default from SQLProject which has the older version of the SDK. having the default value here makes it easier to keep it updated and we don't need to update STS to release new version of extension
