### PR TITLE
Fix download path for Microsoft.Build.Sql binaries

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "Enables users to develop and publish database schemas for MSSQL Databases",
-  "version": "1.4.8",
+  "version": "1.5.0",
   "publisher": "Microsoft",
   "preview": false,
   "engines": {

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -461,8 +461,8 @@ export const publishProfileFriendlyName = localize('publishProfileFriendlyName',
 //#endregion
 
 //#region Build
-export const DotnetInstallationConfirmation: string = localize('sqlDatabaseProjects.DotnetInstallationConfirmation', "The .NET SDK cannot be located. Project build will not work. Please install .NET 6 SDK or higher or update the .NET SDK location in settings if already installed.");
-export function NetCoreSupportedVersionInstallationConfirmation(installedVersion: string) { return localize('sqlDatabaseProjects.NetCoreSupportedVersionInstallationConfirmation', "Currently installed .NET SDK version is {0}, which is not supported. Project build will not work. Please install .NET 6 SDK or higher or update the .NET SDK supported version location in settings if already installed.", installedVersion); }
+export const DotnetInstallationConfirmation: string = localize('sqlDatabaseProjects.DotnetInstallationConfirmation', "The .NET SDK cannot be located. Project build will not work. Please install .NET 8 SDK or higher or update the .NET SDK location in settings if already installed.");
+export function NetCoreSupportedVersionInstallationConfirmation(installedVersion: string) { return localize('sqlDatabaseProjects.NetCoreSupportedVersionInstallationConfirmation', "Currently installed .NET SDK version is {0}, which is not supported. Project build will not work. Please install .NET 8 SDK or higher or update the .NET SDK supported version location in settings if already installed.", installedVersion); }
 export const UpdateDotnetLocation: string = localize('sqlDatabaseProjects.UpdateDotnetLocation', "Update Location");
 export const projectsOutputChannel = localize('sqlDatabaseProjects.outputChannel', "Database Projects");
 

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -76,14 +76,14 @@ export class BuildHelper {
 		const microsoftBuildSqlVersionConfig = vscode.workspace.getConfiguration(DBProjectConfigurationKey)[constants.microsoftBuildSqlVersionKey];
 		const sdkVersion = !!microsoftBuildSqlVersionConfig ? microsoftBuildSqlVersionConfig : microsoftBuildSqlDefaultVersion;
 
-		const microsoftBuildSqlDllLocation = path.join('tools', 'netstandard2.1');
+		const microsoftBuildSqlDllLocation = path.join('tools', 'net8.0');
 		return this.ensureNugetAndFilesPresence(sdkName, sdkVersion, dacFxBuildFiles, microsoftBuildSqlDllLocation, outputChannel);
 	}
 
 	public async ensureScriptDomDllPresence(outputChannel: vscode.OutputChannel): Promise<boolean> {
 		const scriptdomNugetPkgName = 'Microsoft.SqlServer.TransactSql.ScriptDom';
 		const scriptDomDll = 'Microsoft.SqlServer.TransactSql.ScriptDom.dll';
-		const scriptDomNugetVersion = '161.8910.0'; // TODO: make this a configurable setting, like the Microsoft.Build.Sql version
+		const scriptDomNugetVersion = '161.9142.1'; // TODO: make this a configurable setting, like the Microsoft.Build.Sql version
 		const scriptDomDllLocation = path.join('lib', 'netstandard2.1');
 
 		return this.ensureNugetAndFilesPresence(scriptdomNugetPkgName, scriptDomNugetVersion, [scriptDomDll], scriptDomDllLocation, outputChannel);

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -25,7 +25,7 @@ export const NetCoreLinuxDefaultPath = '/usr/share';
 export const winPlatform: string = 'win32';
 export const macPlatform: string = 'darwin';
 export const linuxPlatform: string = 'linux';
-export const minSupportedNetCoreVersionForBuild: string = '3.1.0'; // TODO: watch out for EOL support in Dec 2022 https://github.com/microsoft/azuredatastudio/issues/17800
+export const minSupportedNetCoreVersionForBuild: string = '8.0';
 
 export const enum netCoreInstallState {
 	netCoreNotPresent,

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -25,7 +25,7 @@ export const NetCoreLinuxDefaultPath = '/usr/share';
 export const winPlatform: string = 'win32';
 export const macPlatform: string = 'darwin';
 export const linuxPlatform: string = 'linux';
-export const minSupportedNetCoreVersionForBuild: string = '8.0';
+export const minSupportedNetCoreVersionForBuild: string = '8.0.0';
 
 export const enum netCoreInstallState {
 	netCoreNotPresent,


### PR DESCRIPTION
Addresses #26254 

Projects extension uses binaries from Microsoft.Build.Sql to build non-SDK style projects, but SDK 1.0.0 has a breaking change that is shipping net8.0 DLLs instead of netstandard2.1. Updating the binaries path here and also updating the corresponding ScriptDom version to 161.9142.1.

SDK 1.0.0 release notes: https://github.com/microsoft/DacFx/blob/main/release-notes/Microsoft.Build.Sql/1.0.0.md