### PR TITLE
Fix no source tracking for SQL Migrations

### DIFF
--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -1150,7 +1150,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			if (error.message && error.message.includes("403")) {
 				this._arcRpRegistrationStatus = forbiddenStatusCode;
 			}
-			logError(TelemetryViews.DatabaseBackupPage, 'ErrorRegisteringArcResourceProvider', error);
+			logError(TelemetryViews.DatabaseSelectorPage, 'ErrorRegisteringArcResourceProvider', error);
 		}
 	}
 
@@ -1176,7 +1176,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 			);
 			this._arcSqlServer = response.arcSqlServer;
 		} catch (error) {
-			logError(TelemetryViews.DatabaseBackupPage, 'ErrorCreatingOrUpdatingArcSqlServerInstance', error);
+			logError(TelemetryViews.DatabaseSelectorPage, 'ErrorCreatingOrUpdatingArcSqlServerInstance', error);
 		}
 	}
 
@@ -1189,7 +1189,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 				fullInstanceName,
 			);
 		} catch (error) {
-			logError(TelemetryViews.DatabaseBackupPage, 'ErrorGettingArcSqlServerInstance', error);
+			logError(TelemetryViews.DatabaseSelectorPage, 'ErrorGettingArcSqlServerInstance', error);
 		}
 	}
 

--- a/extensions/sql-migration/src/telemetry.ts
+++ b/extensions/sql-migration/src/telemetry.ts
@@ -18,6 +18,7 @@ export const TelemetryReporter = new AdsTelemetryReporter<TelemetryViews, Teleme
 export enum TelemetryViews {
 	SqlServerDashboard = 'SqlServerDashboard',
 	CreateDataMigrationServiceDialog = 'CreateDataMigrationServiceDialog',
+	DatabaseSelectorPage = 'DatabaseSelectorPage',
 	AssessmentsDialog = 'AssessmentsDialog',
 	DatabaseBackupPage = 'DatabaseBackupPage',
 	IntegrationRuntimePage = 'IntegrationRuntimePage',

--- a/extensions/sql-migration/src/wizard/databaseSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseSelectorPage.ts
@@ -122,7 +122,7 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 				return false;
 			}
 
-			if (!this.migrationStateModel._isSqlServerEnabledByArc) {
+			if (!this.migrationStateModel._isSqlServerEnabledByArc && this.migrationStateModel._trackMigration) {
 				const fullInstanceName = await this.migrationStateModel.getFullArcInstanceName();
 				const getArcSqlServerResponse = await this.migrationStateModel.getArcSqlServerInstance(fullInstanceName);
 				if (this.migrationStateModel._arcSqlServer) {

--- a/extensions/sql-migration/src/wizard/databaseSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseSelectorPage.ts
@@ -56,9 +56,6 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 
 		await view.initializeModel(flex);
 		await this._sourceSelection.populateAzureAccountsDropdown();
-		await this._sourceSelection.populateSubscriptionDropdown();
-		await this._sourceSelection.populateLocationDropdown();
-		await this._sourceSelection.populateResourceGroupDropdown();
 	}
 
 	public async onPageEnter(): Promise<void> {

--- a/extensions/sql-migration/src/wizard/skuRecommendation/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendation/skuRecommendationPage.ts
@@ -284,7 +284,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 				this._arcResourceIcon.iconPath = IconPathHelper.completedMigration;
 
 				await this._arcServerLink.updateProperties({
-					label: `${arcSqlServer.name}.`,
+					label: arcSqlServer.name,
 					url: `https://portal.azure.com/#resource/${arcSqlServer.id}`,
 				});
 			}

--- a/extensions/sql-migration/src/wizard/sourceSelectionSection.ts
+++ b/extensions/sql-migration/src/wizard/sourceSelectionSection.ts
@@ -33,7 +33,6 @@ export class SourceSelectionSection {
 
 	public async populateAzureAccountsDropdown(): Promise<void> {
 		try {
-			this._azureAccountsDropdown.loading = true;
 			this.migrationStateModel._azureAccounts = await utils.getAzureAccounts();
 
 			const accountId =
@@ -51,14 +50,13 @@ export class SourceSelectionSection {
 			this.migrationStateModel._azureAccount = (selectedAccount)
 				? utils.deepClone(selectedAccount)!
 				: undefined!;
-		} finally {
-			this._azureAccountsDropdown.loading = false;
+		} catch (e) {
+			console.log(e);
 		}
 	}
 
 	public async populateSubscriptionDropdown(): Promise<void> {
 		try {
-			this._azureSubscriptionDropdown.loading = true;
 			this.migrationStateModel._subscriptions = await utils.getAzureSubscriptions(this.migrationStateModel._azureAccount);
 			const subscriptionId = this.migrationStateModel._arcResourceSubscription?.id;
 			this._azureSubscriptionDropdown.values = await utils.getAzureSubscriptionsDropdownValues(this.migrationStateModel._subscriptions);
@@ -76,15 +74,11 @@ export class SourceSelectionSection {
 			this.migrationStateModel.refreshDatabaseBackupPage = true;
 		} catch (e) {
 			console.log(e);
-		} finally {
-			this._azureSubscriptionDropdown.loading = false;
 		}
 	}
 
 	public async populateLocationDropdown(): Promise<void> {
 		try {
-			this._azureLocationDropdown.loading = true;
-
 			this.migrationStateModel._locations = await utils.getAzureArcLocations(
 				this.migrationStateModel._arcResourceAzureAccount,
 				this.migrationStateModel._arcResourceSubscription);
@@ -104,15 +98,11 @@ export class SourceSelectionSection {
 				: undefined!;
 		} catch (e) {
 			console.log(e);
-		} finally {
-			this._azureLocationDropdown.loading = false;
 		}
 	}
 
 	public async populateResourceGroupDropdown(): Promise<void> {
 		try {
-			this._azureResourceGroupDropdown.loading = true;
-
 			this.migrationStateModel._resourceGroups = await utils.getAllResourceGroups(
 				this.migrationStateModel._azureAccount,
 				this.migrationStateModel._arcResourceSubscription);
@@ -137,14 +127,11 @@ export class SourceSelectionSection {
 				: undefined!;
 		} catch (e) {
 			console.log(e);
-		} finally {
-			this._azureResourceGroupDropdown.loading = false;
 		}
 	}
 
 	private async populateArcSqlServerDropdown(): Promise<void> {
 		try {
-			this._azureArcSqlServerDropdown.loading = true;
 			const arcSqlServer = this.migrationStateModel._arcSqlServer?.name;
 
 			this.migrationStateModel._sourceArcSqlServers = await utils.getAzureSqlArcServersByLocation(
@@ -165,8 +152,6 @@ export class SourceSelectionSection {
 				true);
 		} catch (e) {
 			console.log(e);
-		} finally {
-			this._azureArcSqlServerDropdown.loading = false;
 		}
 	}
 


### PR DESCRIPTION

Bugs and fixes:

1) Remove dot after arc server link name.
2) Next button not enabled on No tracking migration option. 
Fix: The button is disabled due to loading states of dropdowns. Temporary fix - Remove loaders in all dropdowns as setting loading = false or marking button enabled has no effect on behavior.
3) Avoid arc resource creation and handling when user chooses not to track migrations. 
