### PR TITLE
Parity with Next-gen GP support to 500 DB

### DIFF
--- a/extensions/sql-migration/src/wizard/assessmentDetailsPage/treeComponent.ts
+++ b/extensions/sql-migration/src/wizard/assessmentDetailsPage/treeComponent.ts
@@ -14,7 +14,7 @@ import { selectDatabasesFromList } from '../../constants/helper';
 import { getSourceConnectionProfile } from '../../api/sqlUtils';
 import { SqlMigrationAssessmentResultItem } from '../../service/contracts';
 
-const AZURE_SQL_MI_DB_COUNT_THRESHOLD = 100;
+const AZURE_SQL_MI_DB_COUNT_THRESHOLD = 500;
 
 const styleLeft: azdata.CssStyles = {
 	'border': 'none',


### PR DESCRIPTION
ADO issue : https://msdata.visualstudio.com/Tina/_workitems/edit/3874670/
Use ADS to assess a SQL Instance with database count between 101 and 500. 
The following error is shown in step 3. 
"Error: Azure SQL Managed Instance supports maximum 100 user databases per instance. Select 100 or less database(s) to proceed further."

This should trigger at >500 databases and the error message strings need to be corrected for 500 databases.