### PR TITLE
Add condition for Fabric engine edition

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -753,6 +753,10 @@ export async function getTargetPlatformFromServerVersion(serverInfo: azdataType.
 				targetPlatform = SqlTargetPlatform.sqlAzure;
 			}
 		}
+	} else if (serverInfo.engineEditionId === vscodeMssql.DatabaseEngineEdition.SqlDbFabric || serverInfo.engineEditionId === getAzdataApi()?.DatabaseEngineEdition.SqlDbFabric) {
+		// Temporary workaround for https://github.com/microsoft/azuredatastudio/issues/26260
+		// SqlDbFabric is not grouped into isCloud properly, remove this condition when it is fixed in SqlToolsService
+		targetPlatform = SqlTargetPlatform.sqlDbFabric;
 	} else {
 		const serverMajorVersion = serverInfo.serverMajorVersion;
 		targetPlatform = serverMajorVersion ? constants.onPremServerVersionToTargetPlatform.get(serverMajorVersion) : undefined;


### PR DESCRIPTION
Addresses #26260 

Fixing this for March release, but correct fix would be to add SqlDbFabric to isCloud in SqlToolsService https://github.com/microsoft/sqltoolsservice/blob/65d6dd4c815813edebbd3ef7cc726c7b6feda7b8/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs#L38