### PR TITLE
Sorting the projects in sql database projects pane based on the project name

### DIFF
--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -147,12 +147,14 @@ export class WorkspaceService implements IWorkspaceService {
 		// remove excluded projects specified in workspace file
 		this.excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
 		this.openedProjects = this.openedProjects.filter(project => !this.excludedProjects?.find(excludedProject => excludedProject === vscode.workspace.asRelativePath(project)));
+
 		// Sort the projects based on the project name extracted from the path property
-		this.openedProjects = this.openedProjects.sort(function (a, b) {
-			const aProjectName = a?.path?.split('/').pop() ?? '';
-			const bProjectName = b?.path?.split('/').pop() ?? '';
-			return aProjectName < bProjectName ? -1 : (aProjectName >= bProjectName ? 1 : 0);
+		this.openedProjects = this.openedProjects.sort((a, b) => {
+			const projectA = path.basename(a?.path ?? '');
+			const projectB = path.basename(b?.path ?? '');
+			return projectA.localeCompare(projectB);
 		});
+
 		Logger.log(`Finished looking for projects in workspace. Opened: ${this.openedProjects.length}. Excluded: ${this.excludedProjects.length}. Total time = ${new Date().getTime() - startTime}ms`);
 
 		// filter by specified extension

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -147,7 +147,12 @@ export class WorkspaceService implements IWorkspaceService {
 		// remove excluded projects specified in workspace file
 		this.excludedProjects = this.getWorkspaceConfigurationValue<string[]>(ExcludedProjectsConfigurationName);
 		this.openedProjects = this.openedProjects.filter(project => !this.excludedProjects?.find(excludedProject => excludedProject === vscode.workspace.asRelativePath(project)));
-
+		// Sort the projects based on the project name extracted from the path property
+		this.openedProjects = this.openedProjects.sort(function (a, b) {
+			const aProjectName = a?.path?.split('/').pop() ?? '';
+			const bProjectName = b?.path?.split('/').pop() ?? '';
+			return aProjectName < bProjectName ? -1 : (aProjectName >= bProjectName ? 1 : 0);
+		});
 		Logger.log(`Finished looking for projects in workspace. Opened: ${this.openedProjects.length}. Excluded: ${this.excludedProjects.length}. Total time = ${new Date().getTime() - startTime}ms`);
 
 		// filter by specified extension

--- a/extensions/data-workspace/src/test/workspaceService.test.ts
+++ b/extensions/data-workspace/src/test/workspaceService.test.ts
@@ -53,23 +53,24 @@ suite('WorkspaceService', function (): void {
 		should.strictEqual(projects.length, 0, 'no projects should be returned when projects are present in the workspace file');
 		workspaceFoldersStub.restore();
 
-		// Projects are present
+		// Projects are present - Not in order
 		sinon.stub(vscode.workspace, 'workspaceFolders').value([{ uri: vscode.Uri.file('') }]);
-		sinon.stub(service, 'getAllProjectsInFolder').resolves([vscode.Uri.file('/test/folder/abc.sqlproj'), vscode.Uri.file('/test/folder/folder1/abc1.sqlproj'), vscode.Uri.file('/test/folder/folder2/abc2.sqlproj')]);
+		sinon.stub(service, 'getAllProjectsInFolder').resolves([
+			vscode.Uri.file('/test/folder/folder2/abc2.sqlproj'),
+			vscode.Uri.file('/test/folder/abc.sqlproj'),
+			vscode.Uri.file('/test/folder/folder1/abc1.sqlproj')
+		]);
+
 		projects = await service.getProjectsInWorkspace(undefined, true);
 		should.strictEqual(projects.length, 3, 'there should be 3 projects');
 		const project1 = vscode.Uri.file('/test/folder/abc.sqlproj');
 		const project2 = vscode.Uri.file('/test/folder/folder1/abc1.sqlproj');
 		const project3 = vscode.Uri.file('/test/folder/folder2/abc2.sqlproj');
+
+		// Verify if the projects are sorted correctly by their paths
 		should.strictEqual(projects[0].path, project1.path);
 		should.strictEqual(projects[1].path, project2.path);
 		should.strictEqual(projects[2].path, project3.path);
-
-		// Verify if the projects are sorted correctly by their paths
-		const sortedProjects = projects.sort((a, b) => a.path.localeCompare(b.path));
-		should.strictEqual(sortedProjects[0].path, project1.path);
-		should.strictEqual(sortedProjects[1].path, project2.path);
-		should.strictEqual(sortedProjects[2].path, project3.path);
 	});
 
 	test('getAllProjectTypes', async () => {

--- a/extensions/data-workspace/src/test/workspaceService.test.ts
+++ b/extensions/data-workspace/src/test/workspaceService.test.ts
@@ -64,6 +64,12 @@ suite('WorkspaceService', function (): void {
 		should.strictEqual(projects[0].path, project1.path);
 		should.strictEqual(projects[1].path, project2.path);
 		should.strictEqual(projects[2].path, project3.path);
+
+		// Verify if the projects are sorted correctly by their paths
+		const sortedProjects = projects.sort((a, b) => a.path.localeCompare(b.path));
+		should.strictEqual(sortedProjects[0].path, project1.path);
+		should.strictEqual(sortedProjects[1].path, project2.path);
+		should.strictEqual(sortedProjects[2].path, project3.path);
 	});
 
 	test('getAllProjectTypes', async () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Projects to the SQL database projects pane are not ordered. This change sorts the projects based on the project name.

Before:
![projectsOrderPriorFix](https://github.com/user-attachments/assets/fbd54493-56dc-418a-84b5-bdaae31153ba)

After:
![projectsOrderAfterFix](https://github.com/user-attachments/assets/7a3732be-5c85-4643-b067-c64e2b6465be)
