### PR TITLE
Add missing client telemetry for source tracking

### DIFF
--- a/extensions/sql-migration/src/telemetry.ts
+++ b/extensions/sql-migration/src/telemetry.ts
@@ -99,7 +99,8 @@ export enum TelemetryAction {
 	CopyArmTemplateSuccess = 'CopyArmTemplateSuccess',
 	OpenCustomDeploymentPortalSuccess = 'OpenCustomDeploymentPortalSuccess',
 	OpenTargetProvisioningWizard = 'OpenTargetProvisioningWizard',
-	OpenDeployArmTemplateDialog = 'OpenDeployArmTemplateDialog'
+	OpenDeployArmTemplateDialog = 'OpenDeployArmTemplateDialog',
+	OnArcAssessmentLinkClick = 'OnArcAssessmentLinkClick'
 }
 
 export function logError(telemetryView: TelemetryViews, err: string, error: any): void {
@@ -124,6 +125,7 @@ export function getTelemetryProps(migrationStateModel: MigrationStateModel): Tel
 		'subscriptionId': migrationStateModel._targetSubscription?.id,
 		'resourceGroup': migrationStateModel._resourceGroup?.name,
 		'targetType': migrationStateModel._targetType,
+		'isSqlServerTrackedInAzure': String(migrationStateModel._isSqlServerEnabledByArc),
 		'sourceInfrastructureType': constants.SourceInfrastructureTypeLookup[migrationStateModel._sourceInfrastructureType],
 		'tenantId': tenantId,
 		'migrationTracked': String(migrationStateModel._trackMigration)

--- a/extensions/sql-migration/src/wizard/skuRecommendation/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendation/skuRecommendationPage.ts
@@ -17,7 +17,7 @@ import { IconPathHelper } from '../../constants/iconPathHelper';
 import { FlexContainer } from 'azdata';
 import { AssessmentSummaryCard } from './assessmentSummaryCard';
 import { MigrationTargetType } from '../../api/utils';
-import { logError, TelemetryViews } from '../../telemetry';
+import { sendSqlMigrationActionEvent, TelemetryAction, TelemetryViews, logError } from '../../telemetry';
 import { getSourceConnectionProfile } from '../../api/sqlUtils';
 import { forbiddenStatusCode, IssueCategory } from '../../constants/helper';
 import { WizardController } from '../wizardController';
@@ -95,6 +95,16 @@ export class SKURecommendationPage extends MigrationWizardPage {
 					...styles.BODY_CSS,
 				}
 			}).component();
+
+		this._arcServerLink.onDidClick(() => {
+			sendSqlMigrationActionEvent(
+				TelemetryViews.SkuRecommendationWizard,
+				TelemetryAction.OnArcAssessmentLinkClick,
+				{
+					'sessionId': this.migrationStateModel._sessionId,
+				},
+				{});
+		})
 
 		this._textAfterArcServerLink = this._view.modelBuilder.text().withProps({
 			value: constants.ARC_RESOURCE_CREATED_AFTER_TEXT,


### PR DESCRIPTION
Captured the following info into telemetry:
1) If SQL Server is enabled by Arc or not
2) If user has clicked the Arc assessment link