### PR TITLE
Remove Azure VM from infra types - Source tracking

### DIFF
--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -61,7 +61,6 @@ export enum SourceInfrastructureType {
 	AWSVirtualMachine = 'AWSVirtualMachine',
 	AzureKubernetesService = 'AzureKubernetesService',
 	AzureVMWareVirtualMachine = 'AzureVMWareVirtualMachine',
-	AzureVirtualMachine = 'AzureVirtualMachine',
 	Container = 'Container',
 	GCPKubernetesService = 'GCPKubernetesService',
 	GCPVMWareVirtualMachine = 'GCPVMWareVirtualMachine',

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -1533,7 +1533,6 @@ export interface LookupTable<T> {
 }
 
 export const SourceInfrastructureTypeLookup: LookupTable<string> = {
-	[SourceInfrastructureType.AzureVirtualMachine]: localize('sql.migration.status.azurevmarc', 'Azure Virtual Machine'),
 	[SourceInfrastructureType.AzureKubernetesService]: localize('sql.migration.status.azurekubernetesservice', 'Azure Kubernetes Service'),
 	[SourceInfrastructureType.AzureVMWareVirtualMachine]: localize('sql.migration.status.azurevmwarevm', 'Azure VMWare Virtual Machine'),
 	[SourceInfrastructureType.AWSVirtualMachine]: localize('sql.migration.status.awsvm', 'AWS Virtual Machine'),


### PR DESCRIPTION
-Why are we doing this?
 Remove Azure Vm from list of source infra types as Arc resources with Registered state of Azure VM is not supported.