### PR TITLE
Fixing the Generate SQL Project from OpenAPI preview option appears for all tabs menu options

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -233,7 +233,7 @@
         },
         {
           "command": "sqlDatabaseProjects.generateProjectFromOpenApiSpec",
-          "when": "view == dataworkspace.views.main && config.workbench.enablePreviewFeatures || config.sqlDatabaseProjects.enablePreviewFeatures",
+          "when": "view == dataworkspace.views.main && (config.workbench.enablePreviewFeatures || config.sqlDatabaseProjects.enablePreviewFeatures)",
           "group": "1_currentWorkspace@3"
         }
       ],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Issue: https://github.com/microsoft/azuredatastudio/issues/26297 : "Generate SQL Project from OpenAPI / Swagger Spec (preview) " appears as an overflow menu option when not in context 

Issue:
![GEnProjOpenApiIssue_Before](https://github.com/user-attachments/assets/06221f5a-2b27-42a6-9576-0f5a17fc2aec)

with Fix:
![GEnProjOpenApiIssue_After](https://github.com/user-attachments/assets/e4a9fdfb-cef9-4514-a8ec-1fec533a0448)
