### PR TITLE
introducing default build property with create project quickpics

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -57,6 +57,7 @@ export const SdkStyleProject = localize('dataworkspace.sdkStyleProject', "SDK-st
 export const LearnMore = localize('dataworkspace.learnMore', "Learn More");
 export const YesRecommended = localize('dataworkspace.yesRecommended', "Yes (Recommended)");
 export const No = localize('dataworkspace.no', "No");
+export const Yes = localize('dataworkspace.yes', "Yes");
 export const SdkLearnMorePlaceholder = localize('dataworkspace.sdkLearnMorePlaceholder', "Click \"Learn More\" button for more information about SDK-style projects");
 export const Default = localize('dataworkspace.default', "Default");
 export const SelectTargetPlatform = localize('dataworkspace.selectTargetPlatform', "Select Target Platform");
@@ -69,6 +70,7 @@ export const reservedWindowsFilenameErrorMessage = localize('reservedWindowsFile
 export const reservedValueErrorMessage = localize('reservedValueErrorMessage', "Reserved file name. Choose another name and try again");
 export const trailingWhitespaceErrorMessage = localize('trailingWhitespaceErrorMessage', "File name cannot start or end with whitespace");
 export const tooLongFilenameErrorMessage = localize('tooLongFilenameErrorMessage', "File name cannot be over 255 characters");
+export const confirmCreateProjectWithBuildTaskDialogName = localize('confirmCreateProjectWithBuildTaskDialogName', "Do you want to configure SQL project build as the default build configuration for this folder?");
 
 //Open Existing Dialog
 export const OpenExistingDialogTitle = localize('dataworkspace.openExistingDialogTitle', "Open Existing Project");

--- a/extensions/data-workspace/src/common/interfaces.ts
+++ b/extensions/data-workspace/src/common/interfaces.ts
@@ -75,8 +75,9 @@ export interface IWorkspaceService {
 	 * @param projectTypeId The project type id
 	 * @param projectTargetPlatform The target platform of the project
 	 * @param sdkStyleProject Whether or not the project is SDK-style
+	 * @param configureDefaultBuild Whether or not to configure the default build
 	 */
-	createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetPlatform?: string, sdkStyleProject?: boolean): Promise<vscode.Uri>;
+	createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetPlatform?: string, sdkStyleProject?: boolean, configureDefaultBuild?: boolean): Promise<vscode.Uri>;
 
 	/**
 	 * Clones git repository and adds projects to workspace

--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -99,8 +99,9 @@ declare module 'dataworkspace' {
 		 * @param projectTypeId the identifier of the selected project type
 		 * @param projectTargetPlatform the target platform of the project
 		 * @param sdkStyleProject whether or not a project is SDK-style
+		 * @param configureDefaultBuild whether or not to configure default build
 		 */
-		createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetPlatform?: string, sdkStyleProject?: boolean): Promise<vscode.Uri>;
+		createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetPlatform?: string, sdkStyleProject?: boolean, configureDefaultBuild?: boolean): Promise<vscode.Uri>;
 
 		/**
 		 * Gets the project data corresponding to the project file, to be placed in the dashboard container
@@ -189,6 +190,11 @@ declare module 'dataworkspace' {
 		 * Location where clicking on the Learn More to know more about project type will go
 		 */
 		readonly learnMoreUrl?: string
+
+		/**
+		 * Whether or not the project has a default build configuration
+		 */
+		readonly configureDefaultBuild?: boolean;
 	}
 
 	/**

--- a/extensions/data-workspace/src/dialogs/newProjectDialog.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectDialog.ts
@@ -24,6 +24,7 @@ class NewProjectDialogModel {
 	location: string = '';
 	targetPlatform?: string;
 	sdkStyleProject?: boolean;
+	configureDefaultBuild: boolean = false;
 }
 
 export async function openSpecificProjectNewProjectDialog(projectType: IProjectType, workspaceService: WorkspaceService): Promise<vscode.Uri | undefined> {
@@ -90,7 +91,7 @@ export class NewProjectDialog extends DialogBase {
 				.withAdditionalProperties({ projectFileExtension: this.model.projectFileExtension, projectTemplateId: this.model.projectTypeId })
 				.send();
 
-			this.projectUri = await this.workspaceService.createProject(this.model.name, vscode.Uri.file(this.model.location), this.model.projectTypeId, this.model.targetPlatform, this.model.sdkStyleProject);
+			this.projectUri = await this.workspaceService.createProject(this.model.name, vscode.Uri.file(this.model.location), this.model.projectTypeId, this.model.targetPlatform, this.model.sdkStyleProject, this.model.configureDefaultBuild);
 			this.newProjectDialogComplete?.resolve();
 		}
 		catch (err) {

--- a/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectQuickpick.ts
@@ -175,7 +175,17 @@ export async function createNewProjectWithQuickpick(workspaceService: WorkspaceS
 		}
 	}
 
-	await workspaceService.createProject(projectName, vscode.Uri.file(projectLocation), projectType.id, targetPlatform, sdkStyle);
+	// 8. Configure Sql project default build or not
+	let configureDefaultBuild = await vscode.window.showQuickPick(
+		[constants.Yes, constants.No],
+		{ title: constants.confirmCreateProjectWithBuildTaskDialogName, ignoreFocusOut: true }
+	);
+
+	if (!configureDefaultBuild) {
+		// User cancelled
+		return;
+	}
+	await workspaceService.createProject(projectName, vscode.Uri.file(projectLocation), projectType.id, targetPlatform, sdkStyle, configureDefaultBuild === constants.Yes);
 
 	// Add info message with 'learn more' button if project type has a link
 	// for user to learn more about the project type

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -227,10 +227,10 @@ export class WorkspaceService implements IWorkspaceService {
 		return ProjectProviderRegistry.getProviderByProjectExtension(projectType);
 	}
 
-	async createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetVersion?: string, sdkStyleProject?: boolean): Promise<vscode.Uri> {
+	async createProject(name: string, location: vscode.Uri, projectTypeId: string, projectTargetVersion?: string, sdkStyleProject?: boolean, configureDefaultBuild?: boolean): Promise<vscode.Uri> {
 		const provider = ProjectProviderRegistry.getProviderByProjectType(projectTypeId);
 		if (provider) {
-			const projectFile = await provider.createProject(name, location, projectTypeId, projectTargetVersion, sdkStyleProject);
+			const projectFile = await provider.createProject(name, location, projectTypeId, projectTargetVersion, sdkStyleProject, configureDefaultBuild);
 			await this.addProjectsToWorkspace([projectFile]);
 			this._onDidWorkspaceProjectsChange.fire();
 			return projectFile;

--- a/extensions/data-workspace/src/test/workspaceService.test.ts
+++ b/extensions/data-workspace/src/test/workspaceService.test.ts
@@ -323,4 +323,38 @@ suite('WorkspaceService', function (): void {
 		should.strictEqual(updateWorkspaceFoldersStub.calledOnce, true, 'updateWorkspaceFolders should have been called');
 		onWorkspaceProjectsChangedDisposable.dispose();
 	});
+
+	test('createProject passes all property', async () => {
+		this.timeout(30000);
+		// Create a new instance of WorkspaceService
+		const service = new WorkspaceService();
+
+		// Stub the createProject method so we can verify how it's called
+		const createProjectStub = sinon.stub(service, 'createProject').resolves();
+
+		// Define test parameters
+		const name = 'TestProject';
+		const location = vscode.Uri.file('/tmp/TestProject');
+		const projectTypeId = 'sqlproj';
+		const projectTargetVersion = 'SqlAzureV12';
+		const sdkStyleProject = true;
+		const configureDefaultBuild = true;
+
+		// Call the method under test with all parameters, including configureDefaultBuild
+		await service.createProject(name, location, projectTypeId, projectTargetVersion, sdkStyleProject, configureDefaultBuild);
+
+		// Assert that createProject was called exactly once
+		should.strictEqual(createProjectStub.calledOnce, true, 'createProject should have been called once');
+
+		// Get the arguments with which createProject was called
+		const callArgs = createProjectStub.getCall(0).args;
+
+		// Assert each argument matches what we passed in
+		should.strictEqual(callArgs[0], name, 'name should match');
+		should.strictEqual(callArgs[1], location, 'location should match');
+		should.strictEqual(callArgs[2], projectTypeId, 'projectTypeId should match');
+		should.strictEqual(callArgs[3], projectTargetVersion, 'projectTargetVersion should match');
+		should.strictEqual(callArgs[4], sdkStyleProject, 'sdkStyleProject should match');
+		should.strictEqual(callArgs[5], configureDefaultBuild, 'configureDefaultBuild should be true');
+	});
 });


### PR DESCRIPTION
This pull request introduces support for configuring a default build task when creating new projects in the Data Workspace extension. The changes include updates to the `createProject` method to accept a new parameter, UI enhancements to prompt users for this configuration, and corresponding updates to the test suite.

### Enhancements to project creation:

* Added a new parameter, `configureDefaultBuild`, to the `createProject` method in the `IWorkspaceService` interface and its implementations. This parameter determines whether the default build configuration should be set for a new project. (`extensions/data-workspace/src/common/interfaces.ts` [[1]](diffhunk://#diff-4e860f90c054d24030e47c55e2f29714de9804c4f8d2e2a1da0d5777bfec79dbR78-R80) `extensions/data-workspace/src/services/workspaceService.ts` [[2]](diffhunk://#diff-8ce68880eade03f6db6555e985455913f50ef3804927f56d8596b98e4f2626c1L230-R233)

* Updated the `NewProjectDialogModel` class to include a `configureDefaultBuild` property, defaulting to `false`. This ensures the dialog model can store the user's choice for configuring the default build. (`extensions/data-workspace/src/dialogs/newProjectDialog.ts` [extensions/data-workspace/src/dialogs/newProjectDialog.tsR27](diffhunk://#diff-14d822f33e561196e019e12c240cb4d41d07402da8fbbea0a468fb7192f18c79R27))

* Modified the `NewProjectDialog` and `createNewProjectWithQuickpick` flows to prompt the user with a Yes/No dialog for configuring the default build task. The user's choice is passed to the `createProject` method. (`extensions/data-workspace/src/dialogs/newProjectDialog.ts` [[1]](diffhunk://#diff-14d822f33e561196e019e12c240cb4d41d07402da8fbbea0a468fb7192f18c79L93-R94) `extensions/data-workspace/src/dialogs/newProjectQuickpick.ts` [[2]](diffhunk://#diff-6bc1a332c02e4ef4f5f6c07e87349281ddc99584b45d6160eaf129ffec9cb1ccL178-R188)

### Localization updates:

* Added new localized strings for the Yes/No options and the confirmation message for configuring the default build task. (`extensions/data-workspace/src/common/constants.ts` [[1]](diffhunk://#diff-b9a2047976ecf8a03f1b3d70d55c8364b64877a08558ae77698bf1cf782f2f46R60) [[2]](diffhunk://#diff-b9a2047976ecf8a03f1b3d70d55c8364b64877a08558ae77698bf1cf782f2f46R73)

### Test coverage:

* Added a new unit test to verify that the `createProject` method correctly passes all parameters, including `configureDefaultBuild`, to the underlying implementation. (`extensions/data-workspace/src/test/workspaceService.test.ts` [extensions/data-workspace/src/test/workspaceService.test.tsR326-R359](diffhunk://#diff-193ff25c79b9f11392a4504f15df3d8201b9e43c1b903863565df663df840f7fR326-R359))# Pull Request Template – Azure Data Studio

## Description

This PR adds the ability provide a quickpick option to the user to select whether they want to have a default build configuration during the creation of the new sql project as shown in below image
![image](https://github.com/user-attachments/assets/ca82bb59-88c0-4d6a-a3ca-0435dcff7565)


## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
