### PR TITLE
VsCode Tasks PR2: Adding sqlproj-build Task Definition and Problem Matcher to Extension Package

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -9,7 +9,7 @@
     "vscode": "^1.30.1",
     "azdata": ">=1.47.0"
   },
-	"license": "SEE LICENSE IN LICENSE.txt",
+  "license": "SEE LICENSE IN LICENSE.txt",
   "icon": "images/sqlDatabaseProjects.png",
   "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
   "activationEvents": [
@@ -526,6 +526,22 @@
       ]
     }
   },
+  "problemMatchers": [
+    {
+      "name": "sqlproj-problem-matcher",
+      "owner": "sqlproj-builder",
+      "fileLocation": "absolute",
+      "pattern": {
+        "regexp": "^(.*\\.sql)\\((\\d+),(\\d+),(\\d+),(\\d+)\\):\\s+\\w+\\s+(warning|error)\\s+(\\w+):\\s+(.*?)?$",
+        "file": 1,
+        "line": 2,
+        "column": 3,
+        "severity": 6,
+        "code": 7,
+        "message": 8
+      }
+    }
+  ],
   "dependencies": {
     "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@xmldom/xmldom": "0.8.4",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -542,6 +542,28 @@
       }
     }
   ],
+  "taskDefinitions": [
+    {
+      "type": "sqlproj-build",
+      "required": [
+        "filePath"
+      ],
+      "properties": {
+        "filePath": {
+          "type": "string",
+          "description": "The path to the .sqlproj file."
+        },
+        "fileDisplayName": {
+          "type": "string",
+          "description": "The display name of the .sqlproj file."
+        },
+        "runCodeAnalysis": {
+          "type": "boolean",
+          "description": "Run code analysis on the SQLProj file. Optional, default is true."
+        }
+      }
+    }
+  ],
   "dependencies": {
     "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@xmldom/xmldom": "0.8.4",

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -26,6 +26,10 @@ export const msdb = 'msdb';
 export const MicrosoftDatatoolsSchemaSqlSql = 'Microsoft.Data.Tools.Schema.Sql.Sql';
 export const databaseSchemaProvider = 'DatabaseSchemaProvider';
 export const sqlProjectSdk = 'Microsoft.Build.Sql';
+export const problemMatcher = '$sqlproj-problem-matcher';
+export const sqlProjTaskType = 'sqlproj-build'
+export const dotnetBuild = 'dotnet build';
+export const runCodeAnalysisParam = '/p:RunSqlCodeAnalysis=true';
 
 //#endregion
 
@@ -346,6 +350,8 @@ export const YesRecommended = localize('yesRecommended', "Yes (Recommended)");
 export const SdkLearnMorePlaceholder = localize('sdkLearnMorePlaceholder', "Click \"Learn More\" button for more information about SDK-style projects");
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
 export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };
+export const buildTaskName = localize('buildTaskName', "Build");
+export const buildWithCodeAnalysisTaskName = localize('buildWithCodeAnalysisTaskName', "Build with Code Analysis");
 
 //#endregion
 

--- a/extensions/sql-database-projects/src/extension.ts
+++ b/extensions/sql-database-projects/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext): Promise<SqlDatabaseP
 	context.subscriptions.push(TelemetryReporter);
 
 	// Register the Sql project task provider
-	const workspaceFolders = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0 ? vscode.workspace.workspaceFolders : undefined;
+	const workspaceFolders = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders?.length > 0 ? vscode.workspace.workspaceFolders : undefined;
 	const taskProvider = vscode.tasks.registerTaskProvider(constants.sqlProjTaskType, new SqlDatabaseProjectTaskProvider(workspaceFolders));
 	context.subscriptions.push(taskProvider);
 

--- a/extensions/sql-database-projects/src/extension.ts
+++ b/extensions/sql-database-projects/src/extension.ts
@@ -4,10 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as constants from './common/constants';
 import { getAzdataApi } from './common/utils';
 import MainController from './controllers/mainController';
 import { SqlDatabaseProjectProvider } from './projectProvider/projectProvider';
 import { TelemetryReporter } from './common/telemetry';
+import { SqlDatabaseProjectTaskProvider } from './tasks/sqlDatabaseProjectTaskProvider';
 
 let controllers: MainController[] = [];
 
@@ -18,6 +20,12 @@ export function activate(context: vscode.ExtensionContext): Promise<SqlDatabaseP
 	controllers.push(mainController);
 	context.subscriptions.push(mainController);
 	context.subscriptions.push(TelemetryReporter);
+
+	// Register the Sql project task provider
+	const workspaceFolders = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0 ? vscode.workspace.workspaceFolders : undefined;
+	const taskProvider = vscode.tasks.registerTaskProvider(constants.sqlProjTaskType, new SqlDatabaseProjectTaskProvider(workspaceFolders));
+	context.subscriptions.push(taskProvider);
+
 	return mainController.activate();
 }
 

--- a/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
+++ b/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as constants from '../common/constants';
+
+/**
+ * Extends to vscode.TaskDefinition to add the filePath and fileDisplayName properties.
+ * This is used to identify the task and provide the file path and display name for the task.
+ */
+interface SqlprojTaskDefinition extends vscode.TaskDefinition {
+	fileDisplayName: string;
+	runCodeAnalysis?: boolean;
+}
+
+/**
+ * This class implements the vscode.TaskProvider interface to provide tasks for SQL database projects.
+ * It creates tasks for building SQL database projects and running code analysis on them.
+ */
+export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
+	private watchers: vscode.FileSystemWatcher[] = [];
+	private sqlTasks: Thenable<vscode.Task[]> | undefined = undefined;
+
+	/**
+	 * This method is used to create a file system watcher for the .sqlproj files in the workspace.
+	 * It is used to watch for changes to the .sqlproj files and update the tasks accordingly.
+	 * @param workspaceRoots The workspace roots to watch for .sqlproj files
+	 * @returns A file system watcher for the .sqlproj files
+	 * @throws Error if the workspace root is not a valid path
+	 * @throws Error if the file system watcher cannot be created
+	 * @throws Error if the file system watcher is not supported
+	 * */
+	constructor(workspaceRoots: readonly vscode.WorkspaceFolder[] | undefined) {
+		if (!workspaceRoots) {
+			return;
+		}
+
+		for (const root of workspaceRoots) {
+			const pattern = path.join(root.uri.fsPath, '**', '*.sqlproj');
+			const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+			watcher.onDidChange(() => this.sqlTasks = undefined);
+			watcher.onDidCreate(() => this.sqlTasks = undefined);
+			watcher.onDidDelete(() => this.sqlTasks = undefined);
+			this.watchers.push(watcher);
+		}
+	}
+
+	/**
+	 * This method is used to dispose of the file system watcher.
+	 * It is called when the task provider is disposed.
+	 */
+	public dispose() {
+		this.watchers?.forEach(watcher => watcher.dispose());
+	}
+
+	/**
+	 * This method is called when the task provider is registered.
+	 * It is used to provide the tasks for the provider.
+	 * @returns The task type for this provider
+	 */
+	public provideTasks(): Thenable<vscode.Task[]> | undefined {
+		if (!this.sqlTasks) {
+			this.sqlTasks = this.createTasks();
+		}
+		return this.sqlTasks;
+	}
+
+	/*
+	 * This method is called when the task is resolved.
+	 * It is used to resolve the task and return the task object.
+	 */
+	public resolveTask(task: vscode.Task): vscode.Task | undefined {
+		if (task.definition.type === constants.sqlProjTaskType) {
+			const definition: SqlprojTaskDefinition = <any>task.definition
+			if (!definition.filePath || !definition.fileDisplayName) {
+				return undefined;
+			}
+			return this.getTask(definition);
+		}
+		return undefined;
+	}
+
+	/**
+	 * This method is used to create the tasks for the provider.
+	 * @returns A promise that resolves to an array of tasks
+	 */
+	public async createTasks(): Promise<vscode.Task[]> {
+		const tasks: vscode.Task[] = [];
+		const workspaceFolders = vscode.workspace.workspaceFolders;
+		if (workspaceFolders === undefined) {
+			return tasks; // No workspace folders
+		}
+
+		// Get all the .sqlproj files in the workspace folders
+		let sqlProjUris: vscode.Uri[] = [];
+		for (const workspaceFolder of workspaceFolders) {
+			const folderPath = workspaceFolder.uri.fsPath;
+			if (!folderPath) {
+				continue;
+			}
+			const sqlProjPaths = await vscode.workspace.findFiles(new vscode.RelativePattern(folderPath, '**/*.sqlproj'));
+			for (const uri of sqlProjPaths) {
+				sqlProjUris.push(uri);
+			}
+
+		}
+
+		if (sqlProjUris.length !== 0) {
+			for (const sqlProjUri of sqlProjUris) {
+				const taskDefinition: SqlprojTaskDefinition = {
+					type: constants.sqlProjTaskType,
+					fileDisplayName: path.basename(sqlProjUri.fsPath),
+				};
+
+				// Create a Build task
+				let task = this.getTask(taskDefinition);
+				tasks.push(task);
+
+				// Create a Build with Code Analysis task
+				task = this.getTask(taskDefinition, true);
+				tasks.push(task);
+			}
+		}
+		return tasks;
+	}
+
+	/**
+	 * This method is used to create the task for the provider. Here we create a build task for the sqlproj file using the vscode.Task.
+	 * Alternatively we can get the same info from tasks.json file, but the existing projects might not have the tasks.json file.
+	 * @param definition The task definition
+	 * @param runCodeAnalysis Whether to run code analysis or not
+	 * @returns The task object
+	 */
+	public getTask(definition: SqlprojTaskDefinition, runCodeAnalysis: boolean = false): vscode.Task {
+		// Set the runCodeAnalysis flag in the definition
+		definition.runCodeAnalysis = runCodeAnalysis;
+
+		// Construct the shell command
+		const shellCommand = runCodeAnalysis
+			? `${constants.dotnetBuild}  ${constants.runCodeAnalysisParam}`
+			: `${constants.dotnetBuild}`;
+
+		// Construct the task name
+		const taskName = runCodeAnalysis
+			? `${definition.fileDisplayName} - ${constants.buildWithCodeAnalysisTaskName}`
+			: `${definition.fileDisplayName} - ${constants.buildTaskName}`;
+
+		// Create and return the task with the build group set in the constructor
+		const task = new vscode.Task(
+			definition,
+			vscode.TaskScope.Workspace,
+			taskName,
+			constants.sqlProjTaskType,
+			new vscode.ShellExecution(shellCommand),
+			constants.problemMatcher
+		);
+		task.group = vscode.TaskGroup.Build;
+		return task;
+	}
+}

--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -38,7 +38,6 @@ describe('Sql Database Projects Task Provider', function (): void {
 	afterEach(() => {
 		// Restore the Sinon sandbox and any stubs after each test
 		sandbox.restore();
-		sinon.restore();
 	});
 
 	it('Should create build and buildWithCodeAnalysis tasks for .sqlproj files with correct properties', async function (): Promise<void> {

--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import * as should from 'should';
+import { SqlDatabaseProjectTaskProvider } from '../../tasks/sqlDatabaseProjectTaskProvider';
+
+describe('Sql Database Projects Task Provider', function (): void {
+	let sandbox: sinon.SinonSandbox;
+	let taskProvider: SqlDatabaseProjectTaskProvider;
+
+	// Define a mock workspace folder for testing
+	const workspaceFolder: vscode.WorkspaceFolder = {
+		uri: vscode.Uri.file('/SqlProjFolder'),
+		name: 'SqlProjFolder',
+		index: 0
+	};
+
+	// Define a mock .sqlproj file URI for testing
+	const sqlProjUri = vscode.Uri.file('/SqlProjFolder/MyProject/MyProject.sqlproj');
+
+	// Helper to stub VS Code workspace APIs for consistent test environment
+	function stubWorkspaceAndFiles() {
+		sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder]);
+		sandbox.stub(vscode.workspace, 'findFiles').resolves([sqlProjUri]);
+	}
+
+	beforeEach(() => {
+		// Create a new Sinon sandbox before each test
+		sandbox = sinon.createSandbox();
+		// Instantiate the task provider with the mock workspace folder
+		taskProvider = new SqlDatabaseProjectTaskProvider([workspaceFolder]);
+	});
+
+	afterEach(() => {
+		// Restore the Sinon sandbox and any stubs after each test
+		sandbox.restore();
+		sinon.restore();
+	});
+
+	it('Should create build and buildWithCodeAnalysis tasks for .sqlproj files with correct properties', async function (): Promise<void> {
+		stubWorkspaceAndFiles();
+		this.timeout(30000); // Set timeout to 30 seconds for this test
+
+		// Act: create tasks using the provider
+		const tasks = await taskProvider.createTasks();
+
+		// Assert: tasks should be defined and have the expected length
+		should(tasks).not.be.undefined();
+		should(tasks).be.Array().and.have.length(2);
+
+		// Find the build and buildWithCodeAnalysis tasks by name
+		const buildTask = tasks.find(t => t.name === 'MyProject.sqlproj - Build');
+		const buildWithCodeAnalysisTask = tasks.find(t => t.name === 'MyProject.sqlproj - Build with Code Analysis');
+
+		// Assert: both tasks should exist
+		should(buildTask).not.be.undefined();
+		should(buildWithCodeAnalysisTask).not.be.undefined();
+
+		// Assert: task names should contain expected substrings
+		should(buildTask?.name).containEql('Build');
+		should(buildWithCodeAnalysisTask?.name).containEql('Build with Code Analysis');
+
+		// Assert: task definitions should have the correct type
+		should(buildTask?.definition.type).equal('sqlproj-build');
+		should(buildWithCodeAnalysisTask?.definition.type).equal('sqlproj-build');
+
+		// Assert: problemMatchers should be arrays and contain the expected matcher
+		should(buildTask?.problemMatchers).be.Array();
+		should(buildWithCodeAnalysisTask?.problemMatchers).be.Array();
+		should(buildTask?.problemMatchers).containEql('$sqlproj-problem-matcher');
+		should(buildWithCodeAnalysisTask?.problemMatchers).containEql('$sqlproj-problem-matcher');
+
+		// Assert: build task should have a group with label 'Build'
+		should(buildTask?.group).not.be.undefined();
+		should(buildTask?.group).have.property('label', 'Build');
+
+		// Assert: build task execution should be defined and use 'dotnet build'
+		should(buildTask?.execution).not.be.undefined();
+		if (buildTask?.execution instanceof vscode.ShellExecution) {
+			should(buildTask.execution.commandLine).containEql('dotnet build');
+		}
+	});
+});

--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -42,7 +42,6 @@ describe('Sql Database Projects Task Provider', function (): void {
 
 	it('Should create build and buildWithCodeAnalysis tasks for .sqlproj files with correct properties', async function (): Promise<void> {
 		stubWorkspaceAndFiles();
-		this.timeout(30000); // Set timeout to 30 seconds for this test
 
 		// Act: create tasks using the provider
 		const tasks = await taskProvider.createTasks();


### PR DESCRIPTION
This pull request introduces task provider support for SQL database projects in Visual Studio Code. It adds functionality to define, register, and manage tasks for building `.sqlproj` files, including tasks with optional code analysis. It also includes tests to validate the new functionality. Below are the most important changes grouped by theme:

### Task Provider Implementation:
* Introduced a new `SqlDatabaseProjectTaskProvider` class to provide tasks for `.sqlproj` files. It supports creating build tasks and build-with-code-analysis tasks, leveraging `vscode.Task` and `vscode.ShellExecution`. The class also includes file system watchers to dynamically update tasks when `.sqlproj` files are added, modified, or removed. (`extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts`)

### Configuration and Constants:
* Added task definitions and problem matchers to the `package.json` file for `.sqlproj` tasks, enabling integration with the VS Code task system. (`extensions/sql-database-projects/package.json`)
* Defined new constants for task types, problem matchers, and build-related parameters in `constants.ts`. These constants are used throughout the task provider implementation. (`extensions/sql-database-projects/src/common/constants.ts`) [[1]](diffhunk://#diff-67a66cf506adb71499bd2102cc7a0524b8a64a9ca44415777e3730d04087ffb5R29-R32) [[2]](diffhunk://#diff-67a66cf506adb71499bd2102cc7a0524b8a64a9ca44415777e3730d04087ffb5R353-R354)

### Extension Activation:
* Updated the extension activation logic to register the `SqlDatabaseProjectTaskProvider` as a task provider when the extension is activated. (`extensions/sql-database-projects/src/extension.ts`) [[1]](diffhunk://#diff-c0cff5f0ead0504e0263c43382ed58ea8073acd43c27bd576bd0e48756515bfbR7-R12) [[2]](diffhunk://#diff-c0cff5f0ead0504e0263c43382ed58ea8073acd43c27bd576bd0e48756515bfbR23-R28)

### Unit Tests:
* Added unit tests for the `SqlDatabaseProjectTaskProvider` to ensure tasks are created correctly for `.sqlproj` files. The tests validate task properties, such as task names, problem matchers, and execution commands. (`extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts`)# Pull Request Template – Azure Data Studio

## Description

This PR adds the ability of creating sql-proj build and build with code analysis tasks during the project creation and can be run from 'Run tasks' option.
![Pr2_vscodeRunTsks](https://github.com/user-attachments/assets/d4292d62-f972-450e-b39d-4f18d3be43b6)


## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
