### PR TITLE
Fixing the missing option from vscode "create project from database"

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -477,7 +477,7 @@
         },
         {
           "command": "sqlDatabaseProjects.createProjectFromDatabase",
-          "when": "!azdataAvailable && view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
+          "when": "!azdataAvailable && view == objectExplorer",
           "group": "sqldbproj@1"
         },
         {


### PR DESCRIPTION
…/server nodes

# Pull Request Template – Azure Data Studio
This pull request includes a small change to the `extensions/sql-database-projects/package.json` file. The change simplifies the `when` condition for the `sqlDatabaseProjects.createProjectFromDatabase` command by removing specific `viewItem` constraints.

## Description

'Create project from database' option is not visible to the users in vscode with one of the recent releases. This PR fixes the issue by removing the `viewItem` constraint from the `when` condition for the `sqlDatabaseProjects.createProjectFromDatabase` command in the `package.json` file that is stopping the option being visible, as viewItem is not supported context key for the vscode.

Issue: https://github.com/microsoft/azuredatastudio/issues/26309

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)

Before: VsCode
<img width="237" alt="image" src="https://github.com/user-attachments/assets/bb3df749-bc5c-4815-a070-4f7c70ec3404" />
<img width="241" alt="image" src="https://github.com/user-attachments/assets/18d8f39d-b63d-4980-90a2-d100230a62dc" />

After: VsCode
<img width="240" alt="image" src="https://github.com/user-attachments/assets/6b4d4e60-ba6b-4f6d-9171-5fef67e93d28" />
<img width="230" alt="image" src="https://github.com/user-attachments/assets/1b9a3f95-4e1a-4a51-8717-9c325c43834e" />

