### PR TITLE
Fixing Issue with 'Run Task' displaying wrong folder

### DIFF
--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -72,6 +72,10 @@ describe('Sql Database Projects Task Provider', function (): void {
 		should(buildTask?.definition.type).equal('sqlproj-build');
 		should(buildWithCodeAnalysisTask?.definition.type).equal('sqlproj-build');
 
+		// Assert: tasks should have the correct workspace folder scope
+		should(buildTask?.scope).equal(workspaceFolder);
+		should(buildWithCodeAnalysisTask?.scope).equal(workspaceFolder);
+
 		// Assert: problemMatchers should be arrays and contain the expected matcher
 		should(buildTask?.problemMatchers).be.Array();
 		should(buildWithCodeAnalysisTask?.problemMatchers).be.Array();
@@ -128,6 +132,10 @@ describe('Sql Database Projects Task Provider', function (): void {
 			// Assert: task definitions should have the correct type
 			should(buildTask?.definition.type).equal('sqlproj-build');
 			should(buildWithCodeAnalysisTask?.definition.type).equal('sqlproj-build');
+
+			// Assert: tasks should have the correct workspace folder scope
+			should(buildTask?.scope).equal(workspaceFolder);
+			should(buildWithCodeAnalysisTask?.scope).equal(workspaceFolder);
 
 			// Assert: problemMatchers should be arrays and contain the expected matcher
 			should(buildTask?.problemMatchers).be.Array();


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description
This pull request introduces updates to the `SqlDatabaseProjectTaskProvider` to enhance task definitions by including workspace folder information, ensuring tasks are scoped correctly, and improving test coverage to validate these changes.

### Enhancements to task definitions:

* Updated the `SqlprojTaskDefinition` interface to include a new `workspaceFolder` property, allowing tasks to be associated with specific workspace folders. (`extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts`, [extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.tsL11-R17](diffhunk://#diff-f9833e3d86511c7f549499ec32465a660037a0343e85b374d3216e5c9ed6a5a1L11-R17))
* Modified the logic for task creation to utilize the `workspaceFolder` property, replacing the previous approach of using `vscode.TaskScope.Workspace` as the default scope. (`extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts`, [[1]](diffhunk://#diff-f9833e3d86511c7f549499ec32465a660037a0343e85b374d3216e5c9ed6a5a1L96-R107) [[2]](diffhunk://#diff-f9833e3d86511c7f549499ec32465a660037a0343e85b374d3216e5c9ed6a5a1L151-R146)

### Improvements to test coverage:

* Added assertions in unit tests to verify that tasks are correctly scoped to their respective workspace folders. (`extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts`, [[1]](diffhunk://#diff-51ed535718a59f520daf12b5e7ca21f8725e55dc68a5dd74c4db720804683e7aR75-R78) [[2]](diffhunk://#diff-51ed535718a59f520daf12b5e7ca21f8725e55dc68a5dd74c4db720804683e7aR136-R139)

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)

**Issue 1:** Run Task build tasks displays 1st workspace folder for all project tasks, below are the images for references.
Before:
<img width="464" alt="foldername issue before fixed" src="https://github.com/user-attachments/assets/890d5ef3-5427-4fc3-b71a-d0d374e14a29" />

After:
<img width="454" alt="foldername issue fixed" src="https://github.com/user-attachments/assets/f83dff93-4f35-44cc-bcf8-5c842828b900" />

**Issue 2:** Run task/ Run Build task from terminal, building the correct project but displaying the wrong workspace folder in the terminal information.
Before:
<img width="860" alt="projbuild before fix" src="https://github.com/user-attachments/assets/eac71c37-77ce-4de5-95f8-84e879e3241b" />

After:
<img width="826" alt="projbuild after fix1" src="https://github.com/user-attachments/assets/c4f4ea52-9c96-4318-b8e7-5a0df2856441" />
<img width="859" alt="projbuild after fix" src="https://github.com/user-attachments/assets/51748caa-5d1a-47ee-b9ae-07fd881ae6bc" />

