### PR TITLE
Fixing Tasks related issues found while testing

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -28,7 +28,8 @@ export const databaseSchemaProvider = 'DatabaseSchemaProvider';
 export const sqlProjectSdk = 'Microsoft.Build.Sql';
 export const problemMatcher = '$sqlproj-problem-matcher';
 export const sqlProjTaskType = 'sqlproj-build';
-export const dotnetBuild = 'dotnet build';
+export const dotnet = 'dotnet';
+export const build = 'build';
 export const runCodeAnalysisParam = '/p:RunSqlCodeAnalysis=true';
 export const detailedVerbose = '-v:detailed';
 

--- a/extensions/sql-database-projects/src/extension.ts
+++ b/extensions/sql-database-projects/src/extension.ts
@@ -23,8 +23,7 @@ export function activate(context: vscode.ExtensionContext): Promise<SqlDatabaseP
 	context.subscriptions.push(TelemetryReporter);
 
 	// Register the Sql project task provider
-	const workspaceFolders = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders?.length > 0 ? vscode.workspace.workspaceFolders : undefined;
-	const taskProvider = vscode.tasks.registerTaskProvider(constants.sqlProjTaskType, new SqlDatabaseProjectTaskProvider(workspaceFolders));
+	const taskProvider = vscode.tasks.registerTaskProvider(constants.sqlProjTaskType, new SqlDatabaseProjectTaskProvider());
 	context.subscriptions.push(taskProvider);
 
 	return mainController.activate();

--- a/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
+++ b/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
@@ -67,7 +67,7 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 	}
 
 	/**
-	 * This method is used to invalidate the tasks cache.
+	 * Invalidates the tasks cache, ensuring tasks are rebuilt when needed.
 	 */
 	private invalidateTasks() {
 		this.sqlTasks = undefined;

--- a/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
+++ b/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
@@ -27,6 +27,12 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 	private watchers: vscode.FileSystemWatcher[] = [];
 	private sqlTasks: Thenable<vscode.Task[]> | undefined = undefined;
 	private _onDidChangeTasks = new vscode.EventEmitter<void>();
+	private workspaceFoldersListener: vscode.Disposable | undefined;
+
+	/**
+	 * Event that fires when the tasks change (e.g., when .sqlproj files are created, modified, or deleted)
+	 */
+	public readonly onDidChangeTasks: vscode.Event<void> = this._onDidChangeTasks.event;
 
 	/**
 	 * Constructor for setting up file system watchers on .sqlproj files within the workspace folders.
@@ -35,7 +41,7 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 	 */
 	constructor() {
 		// Watch for workspace folder changes
-		vscode.workspace.onDidChangeWorkspaceFolders(() => {
+		this.workspaceFoldersListener = vscode.workspace.onDidChangeWorkspaceFolders(() => {
 			this.invalidateTasks();
 			this.setupWatchers();
 		});
@@ -81,6 +87,7 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 	 */
 	public dispose() {
 		this.watchers?.forEach(watcher => watcher.dispose());
+		this.workspaceFoldersListener?.dispose();
 		this._onDidChangeTasks.dispose();
 	}
 

--- a/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
+++ b/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
@@ -9,10 +9,11 @@ import * as constants from '../common/constants';
 
 /**
  * Extends to vscode.TaskDefinition to add task definition properties.
- * This is used to identify the task and provide the file display name, workspace folder and runcode analysis for the task.
+ * This is used to identify the task and provide the fileDisplayName, filePath, workspaceFolder and runCodeAnalysis for the task.
  */
 interface SqlprojTaskDefinition extends vscode.TaskDefinition {
 	fileDisplayName: string;
+	filePath: string;
 	runCodeAnalysis?: boolean;
 	workspaceFolder?: vscode.WorkspaceFolder;
 }
@@ -24,26 +25,53 @@ interface SqlprojTaskDefinition extends vscode.TaskDefinition {
 export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 	private watchers: vscode.FileSystemWatcher[] = [];
 	private sqlTasks: Thenable<vscode.Task[]> | undefined = undefined;
+	private _onDidChangeTasks = new vscode.EventEmitter<void>();
 
 	/**
-	 * Constructor for setting up file system watchers on .sqlproj files within the provided workspace folders.
-	 * @param workspaceRoots - An array of workspace folders to watch. If undefined, no watchers are created.
+	 * Constructor for setting up file system watchers on .sqlproj files within the workspace folders.
 	 * For each workspace folder, this sets up a file system watcher that listens for changes, creations,
 	 * or deletions of `.sqlproj` files. When any of these events occur, the `sqlTasks` cache is invalidated.
 	 */
-	constructor(workspaceRoots: readonly vscode.WorkspaceFolder[] | undefined) {
-		if (!workspaceRoots) {
+	constructor() {
+		// Watch for workspace folder changes
+		vscode.workspace.onDidChangeWorkspaceFolders(() => {
+			this.invalidateTasks();
+			this.setupWatchers();
+		});
+
+		this.setupWatchers();
+	}
+
+	/**
+	 * Sets up file system watchers for all `.sqlproj` files in the workspace folders.
+	 * @returns An event that fires when the tasks change.
+	 */
+	private setupWatchers() {
+		// Dispose existing watchers
+		this.watchers.forEach(watcher => watcher.dispose());
+		this.watchers = [];
+
+		const workspaceFolders = vscode.workspace.workspaceFolders;
+		if (!workspaceFolders) {
 			return;
 		}
 
-		for (const root of workspaceRoots) {
+		for (const root of workspaceFolders) {
 			const pattern = path.join(root.uri.fsPath, '**', '*.sqlproj');
 			const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-			watcher.onDidChange(() => this.sqlTasks = undefined);
-			watcher.onDidCreate(() => this.sqlTasks = undefined);
-			watcher.onDidDelete(() => this.sqlTasks = undefined);
+			watcher.onDidChange(() => this.invalidateTasks());
+			watcher.onDidCreate(() => this.invalidateTasks());
+			watcher.onDidDelete(() => this.invalidateTasks());
 			this.watchers.push(watcher);
 		}
+	}
+
+	/**
+	 * This method is used to invalidate the tasks cache.
+	 */
+	private invalidateTasks() {
+		this.sqlTasks = undefined;
+		this._onDidChangeTasks.fire();
 	}
 
 	/**
@@ -52,6 +80,7 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 	 */
 	public dispose() {
 		this.watchers?.forEach(watcher => watcher.dispose());
+		this._onDidChangeTasks.dispose();
 	}
 
 	/**
@@ -81,9 +110,13 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 		return undefined;
 	}
 
-
 	/**
 	 * This method is used to create the tasks for the provider.
+	 * What we do here is to find all the .sqlproj files in the workspace folders and create a task for each of them.
+	 * For each .sqlproj file, we create two tasks: one for building the project and another for building with code analysis.
+	 * This way, we can run the build and code analysis tasks directly from the command palette or the task runner.
+	 * If there are no workspace folders, it returns an empty array.
+	 * This method also ensures that we do not create duplicate tasks for the same .sqlproj file.
 	 * @returns A promise that resolves to an array of tasks
 	 */
 	public async createTasks(): Promise<vscode.Task[]> {
@@ -93,6 +126,9 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 			return tasks; // No workspace folders
 		}
 
+		// Keep track of already processed .sqlproj files to avoid duplicates
+		const processedFiles = new Set<string>();
+
 		// Get all the .sqlproj files in the workspace folders
 		for (const workspaceFolder of workspaceFolders) {
 			const folderPath = workspaceFolder.uri.fsPath;
@@ -101,8 +137,18 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 			}
 			const sqlProjPaths = await vscode.workspace.findFiles(new vscode.RelativePattern(folderPath, '**/*.sqlproj'));
 			for (const uri of sqlProjPaths) {
+				// Skip if we've already processed this file
+				if (processedFiles.has(uri.fsPath)) {
+					continue;
+				}
+
+				// Add the file to the processed set to avoid duplicates
+				processedFiles.add(uri.fsPath);
+
+				// Create a task definition for the .sqlproj file
 				const taskDefinition: SqlprojTaskDefinition = {
 					type: constants.sqlProjTaskType,
+					filePath: uri.fsPath,
 					fileDisplayName: path.basename(uri.fsPath),
 					workspaceFolder: workspaceFolder
 				};
@@ -130,23 +176,33 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 		// Set the runCodeAnalysis flag in the definition
 		definition.runCodeAnalysis = runCodeAnalysis;
 
-		// Construct the shell command
-		const shellCommand = runCodeAnalysis
-			? `${constants.dotnetBuild} ${constants.runCodeAnalysisParam}`
-			: `${constants.dotnetBuild}`;
-
 		// Construct the task name
 		const taskName = runCodeAnalysis
 			? `${definition.fileDisplayName} - ${constants.buildWithCodeAnalysisTaskName}`
 			: `${definition.fileDisplayName} - ${constants.buildTaskName}`;
 
-		// Create and return the task with the build group set in the constructor
+		// Build the argument list instead of a single shell command string
+		const args: string[] = [
+			constants.build,
+			definition.filePath, // vscode shell execution handles the quotes around the file path
+		];
+
+		if (runCodeAnalysis) {
+			args.push(constants.runCodeAnalysisParam);
+		}
+
+		// Create the ShellExecution with command and args
+		const shellExec = new vscode.ShellExecution(constants.dotnet, args, {
+			cwd: definition.workspaceFolder?.uri.fsPath
+		});
+
+		// Create and return the task
 		const task = new vscode.Task(
 			definition,
 			definition.workspaceFolder ?? vscode.TaskScope.Workspace,
 			taskName,
 			constants.sqlProjTaskType,
-			new vscode.ShellExecution(shellCommand),
+			shellExec,
 			constants.problemMatcher
 		);
 		task.group = vscode.TaskGroup.Build;

--- a/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
+++ b/extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as constants from '../common/constants';
+import * as utils from '../common/utils';
 
 /**
  * Extends to vscode.TaskDefinition to add task definition properties.
@@ -148,7 +149,7 @@ export class SqlDatabaseProjectTaskProvider implements vscode.TaskProvider {
 				// Create a task definition for the .sqlproj file
 				const taskDefinition: SqlprojTaskDefinition = {
 					type: constants.sqlProjTaskType,
-					filePath: uri.fsPath,
+					filePath: utils.getNonQuotedPath(uri.fsPath),
 					fileDisplayName: path.basename(uri.fsPath),
 					workspaceFolder: workspaceFolder
 				};

--- a/extensions/sql-database-projects/src/test/buildHelper.test.ts
+++ b/extensions/sql-database-projects/src/test/buildHelper.test.ts
@@ -15,7 +15,7 @@ describe('BuildHelper: Build Helper tests', function (): void {
 	it('Should get correct build arguments for legacy-style projects', function (): void {
 		// update settings and validate
 		const buildHelper = new BuildHelper();
-		const resultArg = buildHelper.constructBuildArguments('dummy\\project path\\more space in path', 'dummy\\dll path', ProjectType.LegacyStyle);
+		const resultArg = buildHelper.constructBuildArguments('dummy\\dll path', ProjectType.LegacyStyle);
 
 		if (os.platform() === 'win32') {
 			should(resultArg).startWith('/p:NetCoreBuild=true /p:NETCoreTargetsPath="dummy\\\\dll path" /p:SystemDacpacsLocation="dummy\\\\dll path"');
@@ -28,7 +28,7 @@ describe('BuildHelper: Build Helper tests', function (): void {
 	it('Should get correct build arguments for SDK-style projects', function (): void {
 		// update settings and validate
 		const buildHelper = new BuildHelper();
-		const resultArg = buildHelper.constructBuildArguments('dummy\\project path\\more space in path', 'dummy\\dll path', ProjectType.SdkStyle);
+		const resultArg = buildHelper.constructBuildArguments('dummy\\dll path', ProjectType.SdkStyle);
 
 		if (os.platform() === 'win32') {
 			should(resultArg).startWith('/p:NetCoreBuild=true /p:SystemDacpacsLocation="dummy\\\\dll path"');

--- a/extensions/sql-database-projects/src/test/buildHelper.test.ts
+++ b/extensions/sql-database-projects/src/test/buildHelper.test.ts
@@ -15,27 +15,45 @@ describe('BuildHelper: Build Helper tests', function (): void {
 	it('Should get correct build arguments for legacy-style projects', function (): void {
 		// update settings and validate
 		const buildHelper = new BuildHelper();
-		const resultArg = buildHelper.constructBuildArguments('dummy\\dll path', ProjectType.LegacyStyle);
+		const resultArgs = buildHelper.constructBuildArguments('dummy\\dll path', ProjectType.LegacyStyle);
+
+		// Check that it returns an array
+		should(resultArgs).be.Array();
+		should(resultArgs.length).equal(4); // 4 arguments for legacy projects
+
+		// Check individual arguments
+		should(resultArgs[0]).equal('/p:NetCoreBuild=true');
 
 		if (os.platform() === 'win32') {
-			should(resultArg).startWith('/p:NetCoreBuild=true /p:NETCoreTargetsPath="dummy\\\\dll path" /p:SystemDacpacsLocation="dummy\\\\dll path"');
+			should(resultArgs[1]).equal('/p:SystemDacpacsLocation="dummy\\\\dll path"');
+			should(resultArgs[2]).equal('/p:NETCoreTargetsPath="dummy\\\\dll path"');
+		} else {
+			should(resultArgs[1]).equal('/p:SystemDacpacsLocation="dummy/dll path"');
+			should(resultArgs[2]).equal('/p:NETCoreTargetsPath="dummy/dll path"');
 		}
-		else {
-			should(resultArg).startWith('/p:NetCoreBuild=true /p:NETCoreTargetsPath="dummy/dll path" /p:SystemDacpacsLocation="dummy/dll path"');
-		}
+
+		should(resultArgs[3]).equal('-v:detailed');
 	});
 
 	it('Should get correct build arguments for SDK-style projects', function (): void {
 		// update settings and validate
 		const buildHelper = new BuildHelper();
-		const resultArg = buildHelper.constructBuildArguments('dummy\\dll path', ProjectType.SdkStyle);
+		const resultArgs = buildHelper.constructBuildArguments('dummy\\dll path', ProjectType.SdkStyle);
+
+		// Check that it returns an array
+		should(resultArgs).be.Array();
+		should(resultArgs.length).equal(3); // 3 arguments for SDK projects (no NETCoreTargetsPath)
+
+		// Check individual arguments
+		should(resultArgs[0]).equal('/p:NetCoreBuild=true');
 
 		if (os.platform() === 'win32') {
-			should(resultArg).startWith('/p:NetCoreBuild=true /p:SystemDacpacsLocation="dummy\\\\dll path"');
+			should(resultArgs[1]).equal('/p:SystemDacpacsLocation="dummy\\\\dll path"');
+		} else {
+			should(resultArgs[1]).equal('/p:SystemDacpacsLocation="dummy/dll path"');
 		}
-		else {
-			should(resultArg).startWith('/p:NetCoreBuild=true /p:SystemDacpacsLocation="dummy/dll path"');
-		}
+
+		should(resultArgs[2]).equal('-v:detailed');
 	});
 
 	it('Should get correct build folder', async function (): Promise<void> {

--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -36,8 +36,8 @@ describe('Sql Database Projects Task Provider', function (): void {
 	beforeEach(() => {
 		// Create a new Sinon sandbox before each test
 		sandbox = sinon.createSandbox();
-		// Instantiate the task provider with the mock workspace folder
-		taskProvider = new SqlDatabaseProjectTaskProvider([workspaceFolder]);
+		// Instantiate the task provider
+		taskProvider = new SqlDatabaseProjectTaskProvider();
 	});
 
 	afterEach(() => {
@@ -86,10 +86,13 @@ describe('Sql Database Projects Task Provider', function (): void {
 		should(buildTask?.group).not.be.undefined();
 		should(buildTask?.group).have.property('label', 'Build');
 
-		// Assert: build task execution should be defined and use 'dotnet build'
+		// Assert: build task execution should be defined and use 'dotnet' command with 'build' argument
 		should(buildTask?.execution).not.be.undefined();
 		if (buildTask?.execution instanceof vscode.ShellExecution) {
-			should(buildTask.execution.commandLine).containEql('dotnet build');
+			should(buildTask.execution.command).equal('dotnet');
+			should(buildTask.execution.args).not.be.undefined();
+			should(buildTask.execution.args).be.Array();
+			should(buildTask.execution.args[0]).equal('build');
 		}
 	});
 
@@ -147,13 +150,14 @@ describe('Sql Database Projects Task Provider', function (): void {
 			should(buildTask?.group).not.be.undefined();
 			should(buildTask?.group).have.property('label', 'Build');
 
-			// Assert: build task execution should be defined and use 'dotnet build'
+			// Assert: build task execution should be defined and use 'dotnet' command with 'build' argument
 			should(buildTask?.execution).not.be.undefined();
 			if (buildTask?.execution instanceof vscode.ShellExecution) {
-				should(buildTask.execution.commandLine).containEql('dotnet build');
+				should(buildTask.execution.command).equal('dotnet');
+				should(buildTask.execution.args).not.be.undefined();
+				should(buildTask.execution.args).be.Array();
+				should(buildTask.execution.args[0]).equal('build');
 			}
 		}
 	});
-
-
 });

--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -24,7 +24,7 @@ describe('Sql Database Projects Task Provider', function (): void {
 	const sqlProjUris = [
 		vscode.Uri.file('/SqlProjFolder/ProjectA/ProjectA.sqlproj'),
 		vscode.Uri.file('/SqlProjFolder/ProjectB/ProjectB.sqlproj'),
-		vscode.Uri.file('/SqlProjFolder/ProjectC/ProjectC.sqlproj')
+		vscode.Uri.file('/SqlProjFolder/Project C/ProjectC.sqlproj')
 	];
 
 	// Helper to stub VS Code workspace APIs for consistent test environment

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -178,8 +178,7 @@ export class BuildHelper {
 		return this.extensionBuildDir;
 	}
 
-	public constructBuildArguments(projectPath: string, buildDirPath: string, sqlProjStyle: ProjectType): string {
-		projectPath = utils.getQuotedPath(projectPath);
+	public constructBuildArguments(buildDirPath: string, sqlProjStyle: ProjectType): string {
 		buildDirPath = utils.getQuotedPath(buildDirPath);
 
 		// Right now SystemDacpacsLocation and NETCoreTargetsPath get set to the same thing, but separating them out for if we move

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -178,25 +178,28 @@ export class BuildHelper {
 		return this.extensionBuildDir;
 	}
 
-	public constructBuildArguments(buildDirPath: string, sqlProjStyle: ProjectType): string {
+	public constructBuildArguments(buildDirPath: string, sqlProjStyle: ProjectType): string[] {
 		buildDirPath = utils.getQuotedPath(buildDirPath);
+		const args: string[] = [
+			'/p:NetCoreBuild=true',
+			`/p:SystemDacpacsLocation=${buildDirPath}`
+		];
 
-		// Right now SystemDacpacsLocation and NETCoreTargetsPath get set to the same thing, but separating them out for if we move
-		// the system dacpacs somewhere else and also so that the variable name makes more sense if building from the commandline,
-		// since SDK style projects don't to specify the targets path, just where the system dacpacs are
+		// Adding NETCoreTargetsPath only for non-SDK style projects
 		if (utils.getAzdataApi()) {
-			if (sqlProjStyle === mssql.ProjectType.SdkStyle) {
-				return `/p:NetCoreBuild=true /p:SystemDacpacsLocation=${buildDirPath} ${constants.detailedVerbose}`;
-			} else {
-				return `/p:NetCoreBuild=true /p:NETCoreTargetsPath=${buildDirPath} /p:SystemDacpacsLocation=${buildDirPath} ${constants.detailedVerbose}`;
+			if (sqlProjStyle !== mssql.ProjectType.SdkStyle) {
+				args.push(`/p:NETCoreTargetsPath=${buildDirPath}`);
 			}
 		} else {
-			if (sqlProjStyle === vscodeMssql.ProjectType.SdkStyle) {
-				return `/p:NetCoreBuild=true /p:SystemDacpacsLocation=${buildDirPath} ${constants.detailedVerbose}`;
-			} else {
-				return `/p:NetCoreBuild=true /p:NETCoreTargetsPath=${buildDirPath} /p:SystemDacpacsLocation=${buildDirPath} ${constants.detailedVerbose}`;
+			if (sqlProjStyle !== vscodeMssql.ProjectType.SdkStyle) {
+				args.push(`/p:NETCoreTargetsPath=${buildDirPath}`);
 			}
 		}
+
+		// Adding verbose flag
+		args.push(constants.detailedVerbose);
+
+		return args;
 	}
 }
 

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -178,6 +178,12 @@ export class BuildHelper {
 		return this.extensionBuildDir;
 	}
 
+	/**
+	 * Constructs the build arguments for building a sqlproj file
+	 * @param buildDirPath The path to the build directory where the dlls and targets are located
+	 * @param sqlProjStyle The type of the sqlproj project (LegacyStyle or SdkStyle)
+	 * @returns An array of arguments to be used for building the sqlproj file
+	 */
 	public constructBuildArguments(buildDirPath: string, sqlProjStyle: ProjectType): string[] {
 		buildDirPath = utils.getQuotedPath(buildDirPath);
 		const args: string[] = [
@@ -186,14 +192,12 @@ export class BuildHelper {
 		];
 
 		// Adding NETCoreTargetsPath only for non-SDK style projects
-		if (utils.getAzdataApi()) {
-			if (sqlProjStyle !== mssql.ProjectType.SdkStyle) {
-				args.push(`/p:NETCoreTargetsPath=${buildDirPath}`);
-			}
-		} else {
-			if (sqlProjStyle !== vscodeMssql.ProjectType.SdkStyle) {
-				args.push(`/p:NETCoreTargetsPath=${buildDirPath}`);
-			}
+		const isSdkStyle = utils.getAzdataApi()
+			? sqlProjStyle === mssql.ProjectType.SdkStyle
+			: sqlProjStyle === vscodeMssql.ProjectType.SdkStyle;
+
+		if (!isSdkStyle) {
+			args.push(`/p:NETCoreTargetsPath=${buildDirPath}`);
 		}
 
 		// Adding verbose flag


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description

This pull request refactors the build and task handling logic for SQL database projects to improve modularity, reduce redundancy, and enhance maintainability. Key changes include splitting the `dotnet build` command into separate command and arguments, simplifying task provider initialization, and improving test coverage to reflect these updates.

## Issues
1. SQL Project file path has space.
2. Duplicate tasks are shown in the RunTask command pallet view, for `.sqlproj` files when workspace folders are parent-child hierarchy.
3. Opening existing projects should create 'RunTask' tasks instantly without reloading the vs code instance.

### Refactoring of Build Command Handling:
* Replaced the single `dotnet build` command string with separate `dotnet` and `build` constants in `constants.ts`. Updated related logic to use an array of arguments instead of a single command string.

### Task Provider Improvements:
* Simplified the `SqlDatabaseProjectTaskProvider` constructor by removing the need for workspace folder arguments and dynamically handling workspace changes. Added logic to prevent duplicate tasks for `.sqlproj` files. 
* Introduced a `_onDidChangeTasks` event emitter to notify when tasks change, ensuring better integration with the VS Code task system. (`[extensions/sql-database-projects/src/tasks/sqlDatabaseProjectTaskProvider.tsR28-R83]

### Test Updates:
* Updated unit tests to reflect the new separation of `dotnet` and `build` in task execution. Added assertions to verify the use of command and arguments arrays instead of a single command string.
* Adjusted tests for the `SqlDatabaseProjectTaskProvider` to align with the updated constructor and task creation logic. (`[extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.tsL39-R40]

### Build Argument Refactoring:
* Modified `BuildHelper.constructBuildArguments` to remove the `projectPath` parameter, as it is no longer needed, simplifying the method's signature. (`[extensions/sql-database-projects/src/tools/buildHelper.tsL181-R181]

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
