### PR TITLE
Bump SlickGrid.ADS dependency to version 2.3.49

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "rxjs": "5.4.0",
     "sanitize-html": "1.19.1",
     "semver-umd": "^5.5.7",
-    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.45",
+    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.49",
     "tas-client-umd": "0.1.8",
     "turndown": "^7.0.0",
     "turndown-plugin-gfm": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10352,9 +10352,9 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.45":
-  version "2.3.45"
-  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/90adbec2fdc4d83b2201f3dd3d3110109599da67"
+"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.49":
+  version "2.3.49"
+  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/a3c833d6d0c9e629a064975f146bb648206bc7b8"
 
 smart-buffer@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description

This PR bumps the SlickGrid.ADS version to 2.3.49

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
