### PR TITLE
Cleans up HTML rendering

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -2186,8 +2186,13 @@ async function webviewPreloads(ctx: PreloadContext) {
 			if (!el) {
 				return;
 			}
-			const trustedHtml = ttPolicy?.createHTML(html) ?? html;
-			el.innerHTML = trustedHtml as string;
+			const trustedHtml = ttPolicy?.createHTML(html);
+			if (trustedHtml) {
+				el.innerHTML = trustedHtml as unknown as string;
+			} else {
+				// Fallback: use textContent to safely insert content without HTML execution
+				el.textContent = html;
+			}
 			const root = el.getRootNode();
 			if (root instanceof ShadowRoot) {
 				if (!root.adoptedStyleSheets.includes(tokenizationStyle)) {
@@ -2665,8 +2670,13 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 			this._content = { preferredRendererId, preloadErrors };
 			if (content.type === 0 /* RenderOutputType.Html */) {
-				const trustedHtml = ttPolicy?.createHTML(content.htmlContent) ?? content.htmlContent; // CodeQL [SM03712] The content comes from renderer extensions, not from direct user input.
-				this.element.innerHTML = trustedHtml as string;
+				const trustedHtml = ttPolicy?.createHTML(content.htmlContent);
+				if (trustedHtml) {
+					this.element.innerHTML = trustedHtml as unknown as string;
+				} else {
+					// Fallback: use textContent to safely insert content without HTML execution
+					this.element.textContent = content.htmlContent;
+				}
 			} else if (preloadErrors.some(e => e instanceof Error)) {
 				const errors = preloadErrors.filter((e): e is Error => e instanceof Error);
 				showRenderError(`Error loading preloads`, this.element, errors);


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description

This PR improves HTML rendering by sanitizing string text before adding it to the DOM.

Notebook HTML rendering continues to work as expected:
<img width="918" height="311" alt="image" src="https://github.com/user-attachments/assets/21ade563-e852-41d3-b819-643a3fcd2285" />


*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced
- [x] Logging/telemetry updated if applicable
- [x] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
