### PR TITLE
Bump slickgrid to version 2.3.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "rxjs": "5.4.0",
     "sanitize-html": "1.19.1",
     "semver-umd": "^5.5.7",
-    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.45",
+    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.50",
     "tas-client-umd": "0.1.8",
     "turndown": "^7.0.0",
     "turndown-plugin-gfm": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10302,9 +10302,9 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.45":
-  version "2.3.45"
-  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/90adbec2fdc4d83b2201f3dd3d3110109599da67"
+"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.50":
+  version "2.3.50"
+  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/86afb942cd645fbdef2df0939f26a2aae5e2d209"
 
 smart-buffer@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description

This PR updates the slickgrid version used by Azure Data Studio.

Multiple query results continue to work as expected with the changes made to slickgrid.ads:
<img width="1613" height="922" alt="image" src="https://github.com/user-attachments/assets/73b08df6-0c0a-4875-93da-92c495d56b0d" />

Editing table data also continues to work as expected with the changes made to slickgrid.ads:
<img width="632" height="267" alt="image" src="https://github.com/user-attachments/assets/7ab93936-10da-4f60-afe4-c6b3aded6f52" />


This PR updates the slickgrid.ads version being used.

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced
- [x] Logging/telemetry updated if applicable
- [x] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
