### PR TITLE
Fix for " Database Project Publish or GenScripts does not wait for build to run with newly added changes"

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -343,7 +343,7 @@ export class ProjectsController {
 
 			// Wait for the task to finish
 			await new Promise<void>((resolve) => {
-				const disposable = vscode.tasks.onDidEndTask(e => {
+				const disposable = vscode.tasks.onDidEndTaskProcess(e => {
 					if (e.execution === execution) {
 						disposable.dispose();
 						if (e.execution.task === vscodeTask) {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -341,14 +341,15 @@ export class ProjectsController {
 			// Execute the task and wait for it to complete
 			const execution = await vscode.tasks.executeTask(vscodeTask);
 
-			// Wait for the task to finish
+			// Wait until the build task instance is finishes.
+			// `onDidEndTaskProcess` fires for every task in the workspace, so Filtering events to the exact TaskExecution
+			// object we kicked off (`e.execution === execution`), ensuring we don't resolve because some other task ended.
 			await new Promise<void>((resolve) => {
 				const disposable = vscode.tasks.onDidEndTaskProcess(e => {
 					if (e.execution === execution) {
+						// Once we get the matching event, dispose the listener to avoid leaks and resolve the promise.
 						disposable.dispose();
-						if (e.execution.task === vscodeTask) {
-							resolve();
-						}
+						resolve();
 					}
 				});
 			});


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description

This PR fixes the publish/genScript issue with any sqlobject added and publish the project without building it. Publish will take care of the build, but here the issue is scripting database is not waiting for the build task to complete and it uses the available old dacpac to generate the script.

Issue:  https://github.com/microsoft/vscode-mssql/issues/19991 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)

Issue:
![PublishIssue_BeforeFix](https://github.com/user-attachments/assets/a04a1419-cc4b-45c9-b45f-754d4fd76580)
After Fix:
![PublishIssue_AfterFix](https://github.com/user-attachments/assets/7fc2933b-967a-40d8-9e99-38fda36a24d7)

