### PR TITLE
Removing the fileextension from the object name

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -819,6 +819,11 @@ export class ProjectsController {
 			return; // user cancelled
 		}
 
+		// Check if itemObjectName contains the file extension, remove it if so
+		while (itemObjectName.toLowerCase().endsWith(fileExtension.toLowerCase())) {
+			itemObjectName = itemObjectName?.slice(0, -fileExtension.length).trim();
+		}
+
 		const relativeFilePath = path.join(relativePath, itemObjectName + fileExtension);
 
 		const telemetryProps: Record<string, string> = { itemType: itemType.type };

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -819,8 +819,8 @@ export class ProjectsController {
 			return; // user cancelled
 		}
 
-		// Check if itemObjectName contains the file extension, remove it if so
-		while (itemObjectName.toLowerCase().endsWith(fileExtension.toLowerCase())) {
+		// Check if itemObjectName contains the file extension, remove the last occurrence
+		if (itemObjectName.toLowerCase().endsWith(fileExtension.toLowerCase())) {
 			itemObjectName = itemObjectName?.slice(0, -fileExtension.length).trim();
 		}
 

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -1226,13 +1226,12 @@ describe('ProjectsController', function (): void {
 			// Test cases for different extension scenarios
 			const testCases = [
 				{ input: 'TableName.sql', expected: 'TableName', extension: constants.sqlFileExtension },
-				{ input: 'TableName.sql.sql.sql', expected: 'TableName', extension: constants.sqlFileExtension },
-				{ input: 'TableName .sql .sql .sql', expected: 'TableName', extension: constants.sqlFileExtension },
+				{ input: 'TableName.sql.sql', expected: 'TableName.sql', extension: constants.sqlFileExtension },
 				{ input: 'MyTable', expected: 'MyTable', extension: constants.sqlFileExtension }, // no extension
 				{ input: 'MyTable.SQL', expected: 'MyTable', extension: constants.sqlFileExtension }, // uppercase extension
 				{ input: 'MyTable .Sql', expected: 'MyTable', extension: constants.sqlFileExtension }, // mixed case extension
 				{ input: 'PubProfile.publish.xml', expected: 'PubProfile', extension: constants.publishProfileExtension },
-				{ input: 'PubProfile.publish.xml.publish.xml', expected: 'PubProfile', extension: constants.publishProfileExtension }
+				{ input: 'PubProfile.publish.xml.publish.xml', expected: 'PubProfile.publish.xml', extension: constants.publishProfileExtension }
 			];
 
 			for (const testCase of testCases) {

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -1220,7 +1220,6 @@ describe('ProjectsController', function (): void {
 		});
 
 		it('Should remove file extensions from user input when creating files', async function (): Promise<void> {
-			this.timeout(300000)
 			const projController = new ProjectsController(testContext.outputChannel);
 			let project = await testUtils.createTestProject(this.test, baselines.newProjectFileBaseline);
 
@@ -1242,9 +1241,9 @@ describe('ProjectsController', function (): void {
 				sinon.stub(utils, 'sanitizeStringForFilename').returns(testCase.input);
 
 				// Add item to project
-				if (testCase.extension === constants.sqlFileExtension){
+				if (testCase.extension === constants.sqlFileExtension) {
 					await projController.addItemPrompt(project, '', { itemType: ItemType.script });
-				}else{
+				} else {
 					await projController.addItemPrompt(project, '', { itemType: ItemType.publishProfile });
 				}
 
@@ -1253,8 +1252,17 @@ describe('ProjectsController', function (): void {
 
 				// Find the created file
 				const expectedFileName = `${testCase.expected}${testCase.extension}`;
-				const createdFile = project.sqlObjectScripts.find(f => path.basename(f.relativePath) === expectedFileName);
 
+				// Find the file project entry
+				let fileProjectEntry = project.sqlObjectScripts;
+				if (testCase.extension === constants.publishProfileExtension) {
+					fileProjectEntry = project.publishProfiles;
+				}
+
+				// Get the created file
+				const createdFile = fileProjectEntry.find(f => path.basename(f.relativePath) === expectedFileName);
+
+				// Assert the created file exists
 				should(createdFile).not.be.undefined();
 				should(await utils.exists(path.join(project.projectFolderPath, expectedFileName))).be.true(`File ${expectedFileName} should exist on disk for input ${testCase.input}`);
 


### PR DESCRIPTION
This pull request improves the handling of file extensions when users create new files through the project controller. Now, any file extension (such as `.sql`) that users include in their input will be automatically removed, even if repeated or in different cases. This ensures that files are not created with redundant extensions. Additionally, comprehensive tests have been added to verify this behavior.

File extension handling improvements:

* Updated `ProjectsController` to strip any file extension (case-insensitive and repeated) from the user-provided file name before creating the file. This prevents files from being created with multiple or incorrect extensions.

Testing enhancements:

* Added a new test in `projectController.test.ts` to verify that file extensions are correctly removed from various user input scenarios, including repeated, spaced, and mixed-case extensions.# Pull Request Template – Azure Data Studio
## Issue: https://github.com/microsoft/vscode-mssql/issues/19817
## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
