### PR TITLE
Port_ Fix for " Database Project Publish or GenScripts does not wait for bu…

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -337,8 +337,22 @@ export class ProjectsController {
 			// Check if the dotnet core is installed and if not, prompt the user to install it
 			// If the user does not have .NET Core installed, we will throw an error and stops building the project
 			await this.netCoreTool.verifyNetCoreInstallation()
-			// If vscodeTask is defined, run it, otherwise run the dotnet command directly
-			await vscode.tasks.executeTask(vscodeTask);
+
+			// Execute the task and wait for it to complete
+			const execution = await vscode.tasks.executeTask(vscodeTask);
+
+			// Wait until the build task instance is finishes.
+			// `onDidEndTaskProcess` fires for every task in the workspace, so Filtering events to the exact TaskExecution
+			// object we kicked off (`e.execution === execution`), ensuring we don't resolve because some other task ended.
+			await new Promise<void>((resolve) => {
+				const disposable = vscode.tasks.onDidEndTaskProcess(e => {
+					if (e.execution === execution) {
+						// Once we get the matching event, dispose the listener to avoid leaks and resolve the promise.
+						disposable.dispose();
+						resolve();
+					}
+				});
+			});
 
 			// If the build was successful, we will get the path to the built dacpac
 			const timeToBuild = new Date().getTime() - startTime.getTime();


### PR DESCRIPTION
…ild to run with newly added changes" (#26390)

* adding event listener for to wait for the task to fisnish

* using onDidEndTaskProcess instead of onDidEndTask

* updating comment and removing reduntant check

# Pull Request Template – Azure Data Studio

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
