### PR TITLE
Port_ Fix for sqlproject file extension being included in the file name

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -819,6 +819,11 @@ export class ProjectsController {
 			return; // user cancelled
 		}
 
+		// Check if itemObjectName contains the file extension, remove the last occurrence
+		if (itemObjectName.toLowerCase().endsWith(fileExtension.toLowerCase())) {
+			itemObjectName = itemObjectName?.slice(0, -fileExtension.length).trim();
+		}
+
 		const relativeFilePath = path.join(relativePath, itemObjectName + fileExtension);
 
 		const telemetryProps: Record<string, string> = { itemType: itemType.type };

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -1218,6 +1218,58 @@ describe('ProjectsController', function (): void {
 			should(project.sqlCmdVariables.size).equal(2, 'The project should still have 2 sqlcmd variables');
 			should(project.sqlCmdVariables.get(sqlcmdVarToUpdate.friendlyName)).equal(updatedValue, 'The value of the sqlcmd variable should have been updated');
 		});
+
+		it('Should remove file extensions from user input when creating files', async function (): Promise<void> {
+			const projController = new ProjectsController(testContext.outputChannel);
+			let project = await testUtils.createTestProject(this.test, baselines.newProjectFileBaseline);
+
+			// Test cases for different extension scenarios
+			const testCases = [
+				{ input: 'TableName.sql', expected: 'TableName', extension: constants.sqlFileExtension },
+				{ input: 'TableName.sql.sql', expected: 'TableName.sql', extension: constants.sqlFileExtension },
+				{ input: 'MyTable', expected: 'MyTable', extension: constants.sqlFileExtension }, // no extension
+				{ input: 'MyTable.SQL', expected: 'MyTable', extension: constants.sqlFileExtension }, // uppercase extension
+				{ input: 'MyTable .Sql', expected: 'MyTable', extension: constants.sqlFileExtension }, // mixed case extension
+				{ input: 'PubProfile.publish.xml', expected: 'PubProfile', extension: constants.publishProfileExtension },
+				{ input: 'PubProfile.publish.xml.publish.xml', expected: 'PubProfile.publish.xml', extension: constants.publishProfileExtension }
+			];
+
+			for (const testCase of testCases) {
+				// Mock the user input
+				sinon.stub(vscode.window, 'showInputBox').resolves(testCase.input);
+				sinon.stub(utils, 'sanitizeStringForFilename').returns(testCase.input);
+
+				// Add item to project
+				if (testCase.extension === constants.sqlFileExtension) {
+					await projController.addItemPrompt(project, '', { itemType: ItemType.script });
+				} else {
+					await projController.addItemPrompt(project, '', { itemType: ItemType.publishProfile });
+				}
+
+				// Reload project to get updated state
+				project = await Project.openProject(project.projectFilePath);
+
+				// Find the created file
+				const expectedFileName = `${testCase.expected}${testCase.extension}`;
+
+				// Find the file project entry
+				let fileProjectEntry = project.sqlObjectScripts;
+				if (testCase.extension === constants.publishProfileExtension) {
+					fileProjectEntry = project.publishProfiles;
+				}
+
+				// Get the created file
+				const createdFile = fileProjectEntry.find(f => path.basename(f.relativePath) === expectedFileName);
+
+				// Assert the created file exists
+				should(createdFile).not.be.undefined();
+				should(await utils.exists(path.join(project.projectFolderPath, expectedFileName))).be.true(`File ${expectedFileName} should exist on disk for input ${testCase.input}`);
+
+				// Clean up for next iteration
+				await project.deleteSqlObjectScript(createdFile!.relativePath);
+				sinon.restore();
+			}
+		});
 	});
 });
 


### PR DESCRIPTION
* Removing the fileextension from the object name

* verifying the publish.xml file creation

* validating project profile file creation too

* removing the extra logic and modifying tests

# Pull Request Template – Azure Data Studio

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
