### PR TITLE
Removing the verbosity property from the dotnet build command

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -31,7 +31,6 @@ export const sqlProjTaskType = 'sqlproj-build';
 export const dotnet = 'dotnet';
 export const build = 'build';
 export const runCodeAnalysisParam = '/p:RunSqlCodeAnalysis=true';
-export const detailedVerbose = '-v:detailed';
 
 //#endregion
 

--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -115,8 +115,6 @@ describe('Sql Database Projects Task Provider', function (): void {
 			should(argsString).containEql('/p:NetCoreBuild=true');
 			should(argsString).containEql('/p:SystemDacpacsLocation=');
 			should(argsString).not.containEql('/p:NETCoreTargetsPath='); // This should NOT be present for SDK projects
-			should(argsString).containEql('-v:detailed');
-
 		}
 	});
 
@@ -226,7 +224,6 @@ describe('Sql Database Projects Task Provider', function (): void {
 			should(argsString).containEql('/p:NetCoreBuild=true');
 			should(argsString).containEql('/p:SystemDacpacsLocation=');
 			should(argsString).containEql('/p:NETCoreTargetsPath='); // This is only for legacy projects
-			should(argsString).containEql('-v:detailed');
 		}
 	});
 });

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -200,9 +200,6 @@ export class BuildHelper {
 			args.push(`/p:NETCoreTargetsPath=${buildDirPath}`);
 		}
 
-		// Adding verbose flag
-		args.push(constants.detailedVerbose);
-
 		return args;
 	}
 }


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description
This pull request removes the use of the detailed verbose flag from the SQL project build process. The change simplifies the build command by no longer including the `-v:detailed` flag when constructing build arguments. Having the verbose param generated huge dotnet build output that overruns the scroll limit. This issue is causing when user have the .NET 8 or below SDK versions only, with sdk9, the output is few line only.

Build process simplification:
* Removed the `detailedVerbose` constant from `constants.ts`, eliminating the `-v:detailed` flag.
* Updated the `BuildHelper` class in `buildHelper.ts` to stop adding the verbose flag to build arguments.
* Updated the tests

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
