### PR TITLE
[PORT] Removing the verbosity property from the dotnet build command

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -2,7 +2,7 @@
   "name": "data-workspace",
   "displayName": "Data Workspace",
   "description": "Additional common functionality for database projects",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "publisher": "Microsoft",
   "preview": true,
 	"license": "SEE LICENSE IN LICENSE.txt",

--- a/extensions/sql-bindings/package.json
+++ b/extensions/sql-bindings/package.json
@@ -2,7 +2,7 @@
   "name": "sql-bindings-vscode",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "ms-mssql",
   "preview": true,
   "engines": {

--- a/extensions/sql-database-projects/CHANGELOG.md
+++ b/extensions/sql-database-projects/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to the SQL Database Projects extension will be documented in this file.
+
+*The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
+
+## [Unreleased]
+
+## [1.5.4] - 2025-09-11
+
+- Adds support for updating a SQL project from an existing database with 'Update project from database' option.
+
+## [1.5.3] - 2025-06-18
+
+- Adds support for SQL project build as a VS Code task.
+
+## [1.5.2] - 2025-05-19
+
+- Fixed an issue where the menu item for creating a project from an OpenAPI definition was appearing in multiple places.
+
+## [1.5.1] - 2025-04-30
+
+- Fixed an issue where the license for the extension was not being displayed correctly in the marketplace.
+- Fixed an issue where projects created from SQL database in Fabric had the target platform incorrectly configured.
+
+## [1.5.0] - 2025-03-31
+
+- Bumped the minimum required version of the .NET SDK to 8.0.0.
+- Bumped the axios and @babel/runtime dependencies.
+- Fixed download path for Microsoft.Build.Sql binaries to ensure proper installation and compatibility.
+- Fixed labels for the container created during deployment of a local development environment with a SQL project.
+- Modified the behavior of creating a new SQL project to specify a default SDK version from the extension. [#25797](https://github.com/microsoft/azuredatastudio/issues/25797)
+- Updated the label on the `SqlDbFabric` target platform to match the product name "SQL database in Fabric".
+- Updated the default Microsoft.Build.Sql version to 1.0.0 for new projects and building original-style projects.
+
+## [1.4.6] - 2025-02-21
+
+- Fixed an issue where the SQL Database Projects extension was not correctly uninstalling in VS Code. [#26215](https://github.com/microsoft/vscode-mssql/issues/18822)
+
+## [1.4.5] - 2024-12-18
+
+- Fixed an issue where the extension in VS Code was not correctly setting the target platform for SQL projects created from existing databases and defaulted to SQL Server 2022 for all projects.
+- Updated the default Microsoft.Build.Sql version to 0.2.5-preview for new projects and building original-style projects.

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -580,44 +580,6 @@
       }
     ]
   },
-  "problemMatchers": [
-    {
-      "name": "sqlproj-problem-matcher",
-      "owner": "sqlproj-builder",
-      "fileLocation": "absolute",
-      "pattern": {
-        "regexp": "^(.*\\.sql)\\((\\d+),(\\d+),(\\d+),(\\d+)\\):\\s+\\w+\\s+(warning|error)\\s+(\\w+):\\s+(.*?)?$",
-        "file": 1,
-        "line": 2,
-        "column": 3,
-        "severity": 6,
-        "code": 7,
-        "message": 8
-      }
-    }
-  ],
-  "taskDefinitions": [
-    {
-      "type": "sqlproj-build",
-      "required": [
-        "filePath"
-      ],
-      "properties": {
-        "filePath": {
-          "type": "string",
-          "description": "The path to the .sqlproj file."
-        },
-        "fileDisplayName": {
-          "type": "string",
-          "description": "The display name of the .sqlproj file."
-        },
-        "runCodeAnalysis": {
-          "type": "boolean",
-          "description": "Run code analysis on the SQLProj file. Optional, default is true."
-        }
-      }
-    }
-  ],
   "dependencies": {
     "@microsoft/ads-extension-telemetry": "^3.0.1",
     "@xmldom/xmldom": "0.8.4",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -309,8 +309,7 @@
           "command": "sqlDatabaseProjects.createProjectFromDatabase"
         },
         {
-          "command": "sqlDatabaseProjects.updateProjectFromDatabase",
-          "when": "false"
+          "command": "sqlDatabaseProjects.updateProjectFromDatabase"
         },
         {
           "command": "sqlDatabaseProjects.addDatabaseReference",
@@ -383,12 +382,12 @@
         },
         {
           "command": "sqlDatabaseProjects.schemaCompare",
-          "when": "view == dataworkspace.views.main && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/ && azdataAvailable",
+          "when": "view == dataworkspace.views.main && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/",
           "group": "1_dbProjectsFirst@4"
         },
         {
           "command": "sqlDatabaseProjects.updateProjectFromDatabase",
-          "when": "view == dataworkspace.views.main && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/ && azdataAvailable",
+          "when": "view == dataworkspace.views.main && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/",
           "group": "1_dbProjectsFirst@5"
         },
         {
@@ -495,6 +494,11 @@
           "command": "sqlDatabaseProjects.createProjectFromDatabase",
           "when": "!azdataAvailable && view == objectExplorer && viewItem =~ /\\btype=(disconnectedServer|Server|Database)\\b/",
           "group": "sqldbproj@1"
+        },
+        {
+          "command": "sqlDatabaseProjects.updateProjectFromDatabase",
+          "when": "!azdataAvailable && view == objectExplorer && viewItem =~ /\\btype=(disconnectedServer|Server|Database)\\b/",
+          "group": "sqldbproj@2"
         },
         {
           "command": "sqlDatabaseProjects.editSqlCmdVariable",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "Enables users to develop and publish database schemas for MSSQL Databases",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "publisher": "Microsoft",
   "preview": false,
   "engines": {

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -87,6 +87,7 @@ export const at = localize('at', "at");
 export const revealFileInOsCommand = 'revealFileInOS';
 export const schemaCompareStartCommand = 'schemaCompare.start';
 export const schemaCompareRunComparisonCommand = 'schemaCompare.runComparison';
+export const mssqlSchemaCompareCommand = 'mssql.schemaCompare';
 export const vscodeOpenCommand = 'vscode.open';
 export const refreshDataWorkspaceCommand = 'dataworkspace.refresh';
 
@@ -370,6 +371,7 @@ export const compareActionRadioButtonLabel = localize('compareActionRadiButtonLa
 export const updateActionRadioButtonLabel = localize('updateActionRadiButtonLabel', "Apply all changes");
 export const actionLabel = localize('actionLabel', "Action");
 export const applyConfirmation: string = localize('applyConfirmation', "Are you sure you want to update the target project?");
+export const selectProjectFile: string = localize('selectProjectFile', "Select project file");
 
 //#endregion
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -31,7 +31,6 @@ export const sqlProjTaskType = 'sqlproj-build';
 export const dotnet = 'dotnet';
 export const build = 'build';
 export const runCodeAnalysisParam = '/p:RunSqlCodeAnalysis=true';
-export const detailedVerbose = '-v:detailed';
 
 //#endregion
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -316,7 +316,7 @@ export class ProjectsController {
 			}
 		}
 
-		// Load tasks from tasks.json and create a new vscode.task if it exist
+		// Get the build arguments from buildhelper method and create a new vscode.task
 		const buildArgs: string[] = this.buildHelper.constructBuildArguments(this.buildHelper.extensionBuildDirPath, project.sqlProjStyle);
 		const vscodeTask: vscode.Task = await this.createVsCodeTask(project, codeAnalysis, buildArgs);
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -337,8 +337,22 @@ export class ProjectsController {
 			// Check if the dotnet core is installed and if not, prompt the user to install it
 			// If the user does not have .NET Core installed, we will throw an error and stops building the project
 			await this.netCoreTool.verifyNetCoreInstallation()
-			// If vscodeTask is defined, run it, otherwise run the dotnet command directly
-			await vscode.tasks.executeTask(vscodeTask);
+
+			// Execute the task and wait for it to complete
+			const execution = await vscode.tasks.executeTask(vscodeTask);
+
+			// Wait until the build task instance is finishes.
+			// `onDidEndTaskProcess` fires for every task in the workspace, so Filtering events to the exact TaskExecution
+			// object we kicked off (`e.execution === execution`), ensuring we don't resolve because some other task ended.
+			await new Promise<void>((resolve) => {
+				const disposable = vscode.tasks.onDidEndTaskProcess(e => {
+					if (e.execution === execution) {
+						// Once we get the matching event, dispose the listener to avoid leaks and resolve the promise.
+						disposable.dispose();
+						resolve();
+					}
+				});
+			});
 
 			// If the build was successful, we will get the path to the built dacpac
 			const timeToBuild = new Date().getTime() - startTime.getTime();

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -39,6 +39,7 @@ import { DeployService } from '../models/deploy/deployService';
 import { AddItemOptions, EntryType, GenerateProjectFromOpenApiSpecOptions, IDatabaseReferenceProjectEntry, ISqlProject, ItemType, SqlTargetPlatform } from 'sqldbproj';
 import { AutorestHelper } from '../tools/autorestHelper';
 import { createNewProjectFromDatabaseWithQuickpick } from '../dialogs/createProjectFromDatabaseQuickpick';
+import { UpdateProjectFromDatabaseWithQuickpick } from '../dialogs/updateProjectFromDatabaseQuickpick';
 import { addDatabaseReferenceQuickpick } from '../dialogs/addDatabaseReferenceQuickpick';
 import { ISqlDbDeployProfile } from '../models/deploy/deployProfile';
 import { FileProjectEntry, SqlProjectReferenceProjectEntry } from '../models/projectEntry';
@@ -702,19 +703,25 @@ export class ProjectsController {
 	 */
 	public async schemaCompare(source: dataworkspace.WorkspaceTreeItem | azdataType.IConnectionProfile, targetParam: any = undefined): Promise<void> {
 		try {
-			// check if schema compare extension is installed
-			if (vscode.extensions.getExtension(constants.schemaCompareExtensionId)) {
+			// check if schema compare service is available
+			const service = await utils.getSchemaCompareService();
+			if (service) {
 				let sourceParam;
-
 				if (source as dataworkspace.WorkspaceTreeItem) {
 					sourceParam = (await this.getProjectFromContext(source as dataworkspace.WorkspaceTreeItem)).projectFilePath;
 				} else {
 					sourceParam = source as azdataType.IConnectionProfile;
 				}
-
 				try {
 					TelemetryReporter.sendActionEvent(TelemetryViews.ProjectController, TelemetryActions.projectSchemaCompareCommandInvoked);
-					await vscode.commands.executeCommand(constants.schemaCompareStartCommand, sourceParam, targetParam, undefined);
+					if (utils.getAzdataApi()) {
+						// ADS Environment
+
+						await vscode.commands.executeCommand(constants.schemaCompareStartCommand, sourceParam, targetParam, undefined);
+					} else {
+						// Vscode Environment
+						await vscode.commands.executeCommand(constants.mssqlSchemaCompareCommand, sourceParam, undefined, undefined);
+					}
 				} catch (e) {
 					throw new Error(constants.buildFailedCannotStartSchemaCompare);
 				}
@@ -1799,7 +1806,7 @@ export class ProjectsController {
 	/**
 	 * Display dialog for user to configure existing SQL Project with the changes/differences from a database
 	 */
-	public async updateProjectFromDatabase(context: azdataType.IConnectionProfile | mssqlVscode.ITreeNodeInfo | dataworkspace.WorkspaceTreeItem): Promise<UpdateProjectFromDatabaseDialog> {
+	public async updateProjectFromDatabase(context: azdataType.IConnectionProfile | mssqlVscode.ITreeNodeInfo | dataworkspace.WorkspaceTreeItem): Promise<UpdateProjectFromDatabaseDialog | undefined> {
 		let connection: azdataType.IConnectionProfile | mssqlVscode.IConnectionInfo | undefined;
 		let project: Project | undefined;
 
@@ -1816,13 +1823,34 @@ export class ProjectsController {
 		} catch { }
 
 		const workspaceProjects = await utils.getSqlProjectsInWorkspace();
-		const updateProjectFromDatabaseDialog = this.getUpdateProjectFromDatabaseDialog(connection, project, workspaceProjects);
-
-		updateProjectFromDatabaseDialog.updateProjectFromDatabaseCallback = async (model) => await this.updateProjectFromDatabaseCallback(model);
-
-		await updateProjectFromDatabaseDialog.openDialog();
-
-		return updateProjectFromDatabaseDialog;
+		if (utils.getAzdataApi()) {
+			const updateProjectFromDatabaseDialog = this.getUpdateProjectFromDatabaseDialog(connection, project, workspaceProjects);
+			updateProjectFromDatabaseDialog.updateProjectFromDatabaseCallback = async (model) => await this.updateProjectFromDatabaseCallback(model);
+			await updateProjectFromDatabaseDialog.openDialog();
+			return updateProjectFromDatabaseDialog;
+		} else {
+			let projectFilePath: string | undefined;
+			if (context) {
+				// VS Code's connection/profile may only represent the server-level connection and won't reflect
+				// the database selected in the MSSQL tree node that the user invoked the command from.
+				// In ADS the context can include the database info, but in VS Code we need to ask the MSSQL
+				// extension for the actual database name for this tree node and then update the connection object.
+				if (connection !== undefined) {
+					const treeNodeContext = context as mssqlVscode.ITreeNodeInfo;
+					const databaseName = (await utils.getVscodeMssqlApi()).getDatabaseNameFromTreeNode(treeNodeContext);
+					(connection as mssqlVscode.IConnectionInfo).database = databaseName;
+				} else {
+					// Check if it's a WorkspaceTreeItem by checking for the expected properties
+					const workspaceItem = context as dataworkspace.WorkspaceTreeItem;
+					if (workspaceItem.element && workspaceItem.treeDataProvider) {
+						const project = await this.getProjectFromContext(workspaceItem);
+						projectFilePath = project.projectFilePath;
+					}
+				}
+			}
+			await UpdateProjectFromDatabaseWithQuickpick(connection as mssqlVscode.IConnectionInfo, projectFilePath, (model: UpdateProjectDataModel) => this.updateProjectFromDatabaseCallback(model));
+			return undefined;
+		}
 	}
 
 	public getUpdateProjectFromDatabaseDialog(connection: azdataType.IConnectionProfile | mssqlVscode.IConnectionInfo | undefined, project: Project | undefined, workspaceProjects: vscode.Uri[]): UpdateProjectFromDatabaseDialog {
@@ -1850,7 +1878,13 @@ export class ProjectsController {
 	 */
 	public async updateProjectFromDatabaseApiCall(model: UpdateProjectDataModel): Promise<void> {
 		if (model.action === UpdateProjectAction.Compare) {
-			await vscode.commands.executeCommand(constants.schemaCompareRunComparisonCommand, model.sourceEndpointInfo, model.targetEndpointInfo, true, undefined);
+			if (utils.getAzdataApi()) {
+				// ADS environment
+				await vscode.commands.executeCommand(constants.schemaCompareRunComparisonCommand, model.sourceEndpointInfo, model.targetEndpointInfo, true, undefined);
+			} else {
+				// Vs Code environment
+				await vscode.commands.executeCommand(constants.mssqlSchemaCompareCommand, model.sourceEndpointInfo, model.targetEndpointInfo, true, undefined);
+			}
 		} else if (model.action === UpdateProjectAction.Update) {
 			await vscode.window.showWarningMessage(constants.applyConfirmation, { modal: true }, constants.yesString).then(async (result) => {
 				if (result === constants.yesString) {
@@ -1879,11 +1913,9 @@ export class ProjectsController {
 	 * @param source source for schema comparison
 	 * @param target target sql project for schema comparison to update
 	 */
-	private async schemaCompareAndUpdateProject(source: mssql.SchemaCompareEndpointInfo, target: mssql.SchemaCompareEndpointInfo): Promise<void> {
-		// Run schema comparison
-		const ext = vscode.extensions.getExtension(mssql.extension.name)!;
-		const service = (await ext.activate() as mssql.IExtension).schemaCompare;
-		const deploymentOptions = await service.schemaCompareGetDefaultOptions();
+	private async schemaCompareAndUpdateProject(source: mssql.SchemaCompareEndpointInfo | mssqlVscode.SchemaCompareEndpointInfo, target: mssql.SchemaCompareEndpointInfo | mssqlVscode.SchemaCompareEndpointInfo): Promise<void> {
+		// Run schema comparison - use the schema compare service
+		const service = await utils.getSchemaCompareService();
 		const operationId = UUID.generateUuid();
 
 		target.targetScripts = await this.getProjectScriptFiles(target.projectFilePath);
@@ -1891,10 +1923,22 @@ export class ProjectsController {
 
 		TelemetryReporter.sendActionEvent(TelemetryViews.ProjectController, TelemetryActions.SchemaComparisonStarted);
 
-		// Perform schema comparison.  Results are cached in SqlToolsService under the operationId
-		const comparisonResult: mssql.SchemaCompareResult = await service.schemaCompare(
-			operationId, source, target, utils.getAzdataApi()!.TaskExecutionMode.execute, deploymentOptions.defaultDeploymentOptions
-		);
+		const deploymentOptions = await service.schemaCompareGetDefaultOptions();
+
+		// Perform schema comparison based on environment
+		let comparisonResult: mssql.SchemaCompareResult | mssqlVscode.SchemaCompareResult;
+
+		if (utils.getAzdataApi()) {
+			// Azure Data Studio environment
+			comparisonResult = await (service as mssql.ISchemaCompareService).schemaCompare(
+				operationId, source as mssql.SchemaCompareEndpointInfo, target as mssql.SchemaCompareEndpointInfo, utils.getAzdataApi()!.TaskExecutionMode.execute, deploymentOptions.defaultDeploymentOptions
+			);
+		} else {
+			// VS Code environment
+			comparisonResult = await (service as mssqlVscode.ISchemaCompareService).compare(
+				operationId, source as mssqlVscode.SchemaCompareEndpointInfo, target as mssqlVscode.SchemaCompareEndpointInfo, mssqlVscode.TaskExecutionMode.execute, deploymentOptions.defaultDeploymentOptions
+			);
+		}
 
 		if (!comparisonResult || !comparisonResult.success) {
 			TelemetryReporter.createErrorEvent2(TelemetryViews.ProjectController, 'SchemaComparisonFailed')
@@ -1917,7 +1961,7 @@ export class ProjectsController {
 		}
 
 		// Publish the changes (retrieved from the cache by operationId)
-		const publishResult = await this.schemaComparePublishProjectChanges(operationId, target.projectFilePath, target.extractTarget);
+		const publishResult = await this.schemaComparePublishProjectChanges(operationId, target.projectFilePath, target.extractTarget as mssql.ExtractTarget);
 
 		if (publishResult.success) {
 			void vscode.window.showInformationMessage(constants.applySuccess);
@@ -1946,13 +1990,24 @@ export class ProjectsController {
 	 * @param folderStructure folder structure to use when updating the target project
 	 * @returns
 	 */
-	public async schemaComparePublishProjectChanges(operationId: string, projectFilePath: string, folderStructure: mssql.ExtractTarget): Promise<mssql.SchemaComparePublishProjectResult> {
-		const ext = vscode.extensions.getExtension(mssql.extension.name)!;
-		const service = (await ext.activate() as mssql.IExtension).schemaCompare;
-
+	public async schemaComparePublishProjectChanges(operationId: string, projectFilePath: string, folderStructure: mssql.ExtractTarget | mssqlVscode.ExtractTarget): Promise<mssql.SchemaComparePublishProjectResult> {
+		const service = await utils.getSchemaCompareService();
 		const projectPath = path.dirname(projectFilePath);
 
-		const result: mssql.SchemaComparePublishProjectResult = await service.schemaComparePublishProjectChanges(operationId, projectPath, folderStructure, utils.getAzdataApi()!.TaskExecutionMode.execute);
+		// Perform schema compare publish based on environment
+		let result: mssql.SchemaComparePublishProjectResult;
+
+		if (utils.getAzdataApi()) {
+			// Azure Data Studio environment
+			result = await (service as mssql.ISchemaCompareService).schemaComparePublishProjectChanges(
+				operationId, projectPath, folderStructure as mssql.ExtractTarget, utils.getAzdataApi()!.TaskExecutionMode.execute
+			);
+		} else {
+			// VS Code environment
+			result = await (service as mssqlVscode.ISchemaCompareService).publishProjectChanges(
+				operationId, projectPath, folderStructure as mssqlVscode.ExtractTarget, mssqlVscode.TaskExecutionMode.execute as any
+			);
+		}
 
 		if (!result.errorMessage) {
 			const project = await Project.openProject(projectFilePath);

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -819,6 +819,11 @@ export class ProjectsController {
 			return; // user cancelled
 		}
 
+		// Check if itemObjectName contains the file extension, remove the last occurrence
+		if (itemObjectName.toLowerCase().endsWith(fileExtension.toLowerCase())) {
+			itemObjectName = itemObjectName?.slice(0, -fileExtension.length).trim();
+		}
+
 		const relativeFilePath = path.join(relativePath, itemObjectName + fileExtension);
 
 		const telemetryProps: Record<string, string> = { itemType: itemType.type };

--- a/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/updateProjectFromDatabaseQuickpick.ts
@@ -1,0 +1,181 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as mssqlVscode from 'vscode-mssql';
+import * as constants from '../common/constants';
+import { getSqlProjectsInWorkspace, getVscodeMssqlApi } from '../common/utils';
+import { IConnectionInfo } from 'vscode-mssql';
+import { Project } from '../models/project';
+import { UpdateProjectDataModel, UpdateProjectAction } from '../models/api/updateProject';
+
+/**
+ * Create flow for update Project from existing database using only VS Code-native APIs such as QuickPick
+ *
+ * This helper drives a small, synchronous UX flow that:
+ *  1) Prompts (or reuses) a connection
+ *  2) Prompts for a database (if needed)
+ *  3) Lets the user select an existing .sqlproj in the workspace (or browse to one) if needed
+ *  4) Asks whether the user wants to Compare or Update the project
+ *  5) Constructs an UpdateProjectDataModel and passes it to the optional callback
+ *
+ * @param connectionInfo Optional connection info to use instead of prompting the user for a connection
+ * @param projectFilePath Optional project file path to use instead of prompting the user to select one
+ * @param updateProjectFromDatabaseCallback Optional callback function to update the project from the user inputs
+ */
+export async function UpdateProjectFromDatabaseWithQuickpick(connectionInfo?: IConnectionInfo, projectFilePath?: string, updateProjectFromDatabaseCallback?: (model: UpdateProjectDataModel) => Promise<void>
+): Promise<void> {
+	const vscodeMssqlApi = await getVscodeMssqlApi();
+
+	// Prompt 1a. Select connection (if not provided)
+	// If connectionInfo was passed in, reuse it; otherwise show the native mssql connection picker.
+	let connectionProfile: IConnectionInfo | undefined = connectionInfo ?? await vscodeMssqlApi.promptForConnection(true);
+	if (!connectionProfile) {
+		// User cancelled
+		return undefined;
+	}
+	let connectionUri: string = '';
+	let dbs: string[] | undefined = undefined;
+
+	// Prompt 1b. Select database (if not already specified in connection profile)
+	let selectedDatabase: string;
+	if (connectionProfile.database && connectionProfile.database !== constants.master) {
+		selectedDatabase = connectionProfile.database;
+		connectionUri = await vscodeMssqlApi.connect(connectionProfile);
+	} else {
+		// Need to get list of databases from the server and prompt the user
+		connectionUri = await vscodeMssqlApi.connect(connectionProfile);
+		dbs = (await vscodeMssqlApi.listDatabases(connectionUri))
+			.filter(db => !constants.systemDbs.includes(db));
+
+		const dbSelection = await vscode.window.showQuickPick(
+			dbs,
+			{ title: constants.selectDatabase, ignoreFocusOut: true });
+		if (!dbSelection) {
+			// User cancelled
+			return undefined;
+		}
+		selectedDatabase = dbSelection;
+	}
+
+	// Prompt 2. Browse and Select existing project file, when projectFilePath is not available
+	if (!projectFilePath) {
+		// Get workspace projects
+		const workspaceProjects = await getSqlProjectsInWorkspace();
+		const projectOptions: string[] = [constants.browseEllipsisWithIcon];
+
+		// Add workspace projects to the list
+		workspaceProjects.forEach(projectUri => {
+			projectOptions.push(projectUri.fsPath);
+		});
+
+		const projectSelection = await vscode.window.showQuickPick(
+			projectOptions,
+			{ title: constants.selectProjectFile, ignoreFocusOut: true });
+
+		if (!projectSelection) {
+			// User cancelled
+			return undefined;
+		}
+
+		if (projectSelection === constants.browseEllipsisWithIcon) {
+			// Show file browser
+			const projectFileUri = await vscode.window.showOpenDialog({
+				canSelectFiles: true,
+				canSelectFolders: false,
+				canSelectMany: false,
+				openLabel: constants.selectString,
+				title: constants.selectProjectFile,
+				filters: {
+					'SQL Projects': ['sqlproj']
+				}
+			});
+
+			if (!projectFileUri || projectFileUri.length === 0) {
+				// User cancelled
+				return undefined;
+			}
+			projectFilePath = projectFileUri[0].fsPath;
+		} else {
+			// User selected a workspace project
+			projectFilePath = projectSelection;
+		}
+	}
+
+	const project = await Project.openProject(projectFilePath);
+
+	//Prompt 3: Select the action
+	const actionSelection = await vscode.window.showQuickPick(
+		[constants.compareActionRadioButtonLabel, constants.updateActionRadioButtonLabel],
+		{
+			title: constants.actionLabel,
+			ignoreFocusOut: true
+		});
+	if (!actionSelection) {
+		// User cancelled
+		return undefined;
+	}
+
+	// Map the selected action to the enum
+	const selectedAction = actionSelection === constants.compareActionRadioButtonLabel
+		? UpdateProjectAction.Compare
+		: UpdateProjectAction.Update;
+
+	// Build the connectionDetails object expected by the schema-compare endpoints.
+	// This is a lightweight mapping that mirrors the shape used by the mssql/vscode-mssql APIs.
+	const connectionDetails = {
+		id: (connectionProfile as any).id,
+		userName: connectionProfile.user,
+		password: connectionProfile.password,
+		serverName: connectionProfile.server,
+		databaseName: selectedDatabase,
+		connectionName: connectionProfile.server,
+		providerName: 'MSSQL',
+		authenticationType: connectionProfile.authenticationType,
+		options: {}
+	};
+
+	// Construct the source endpoint (the database)
+	const sourceEndpointInfo: mssqlVscode.SchemaCompareEndpointInfo = {
+		endpointType: mssqlVscode.SchemaCompareEndpointType.Database,
+		databaseName: selectedDatabase,
+		serverDisplayName: connectionProfile.server,
+		serverName: connectionProfile.server,
+		connectionDetails: connectionDetails,
+		ownerUri: connectionUri,
+		projectFilePath: '',
+		extractTarget: mssqlVscode.ExtractTarget.schemaObjectType,
+		targetScripts: [],
+		dataSchemaProvider: '',
+		packageFilePath: '',
+		connectionName: connectionProfile.server
+	};
+
+	// Construct the target endpoint (the selected project)
+	const targetEndpointInfo: mssqlVscode.SchemaCompareEndpointInfo = {
+		endpointType: mssqlVscode.SchemaCompareEndpointType.Project,
+		projectFilePath: projectFilePath,
+		extractTarget: mssqlVscode.ExtractTarget.schemaObjectType,
+		targetScripts: [],
+		dataSchemaProvider: project.getProjectTargetVersion(),
+		connectionDetails: connectionDetails,
+		databaseName: '',
+		serverDisplayName: '',
+		serverName: '',
+		ownerUri: '',
+		packageFilePath: '',
+	};
+
+	const model: UpdateProjectDataModel = {
+		sourceEndpointInfo: sourceEndpointInfo,
+		targetEndpointInfo: targetEndpointInfo,
+		action: selectedAction
+	};
+	// Invoke the caller-provided callback with the collected model. The callback is responsible
+	//  for running the compare or update operation; this function only collects and returns inputs.
+	if (updateProjectFromDatabaseCallback) {
+		await updateProjectFromDatabaseCallback(model);
+	}
+}

--- a/extensions/sql-database-projects/src/models/api/updateProject.ts
+++ b/extensions/sql-database-projects/src/models/api/updateProject.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as mssql from 'mssql';
+import * as mssqlVscode from 'vscode-mssql';
 
 export interface UpdateProjectDataModel {
-	sourceEndpointInfo: mssql.SchemaCompareEndpointInfo;
-	targetEndpointInfo: mssql.SchemaCompareEndpointInfo;
+	sourceEndpointInfo: mssql.SchemaCompareEndpointInfo | mssqlVscode.SchemaCompareEndpointInfo;
+	targetEndpointInfo: mssql.SchemaCompareEndpointInfo | mssqlVscode.SchemaCompareEndpointInfo;
 	action: UpdateProjectAction;
 }
 

--- a/extensions/sql-database-projects/src/test/buildHelper.test.ts
+++ b/extensions/sql-database-projects/src/test/buildHelper.test.ts
@@ -19,7 +19,7 @@ describe('BuildHelper: Build Helper tests', function (): void {
 
 		// Check that it returns an array
 		should(resultArgs).be.Array();
-		should(resultArgs.length).equal(4); // 4 arguments for legacy projects
+		should(resultArgs.length).equal(3); // 3 arguments for legacy projects
 
 		// Check individual arguments
 		should(resultArgs[0]).equal('/p:NetCoreBuild=true');
@@ -31,8 +31,6 @@ describe('BuildHelper: Build Helper tests', function (): void {
 			should(resultArgs[1]).equal('/p:SystemDacpacsLocation="dummy/dll path"');
 			should(resultArgs[2]).equal('/p:NETCoreTargetsPath="dummy/dll path"');
 		}
-
-		should(resultArgs[3]).equal('-v:detailed');
 	});
 
 	it('Should get correct build arguments for SDK-style projects', function (): void {
@@ -42,7 +40,7 @@ describe('BuildHelper: Build Helper tests', function (): void {
 
 		// Check that it returns an array
 		should(resultArgs).be.Array();
-		should(resultArgs.length).equal(3); // 3 arguments for SDK projects (no NETCoreTargetsPath)
+		should(resultArgs.length).equal(2); // 2 arguments for SDK projects (no NETCoreTargetsPath)
 
 		// Check individual arguments
 		should(resultArgs[0]).equal('/p:NetCoreBuild=true');
@@ -52,8 +50,6 @@ describe('BuildHelper: Build Helper tests', function (): void {
 		} else {
 			should(resultArgs[1]).equal('/p:SystemDacpacsLocation="dummy/dll path"');
 		}
-
-		should(resultArgs[2]).equal('-v:detailed');
 	});
 
 	it('Should get correct build folder', async function (): Promise<void> {

--- a/extensions/sql-database-projects/src/test/dialogs/updateProjectFromDatabaseQuickpick.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/updateProjectFromDatabaseQuickpick.test.ts
@@ -1,0 +1,199 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as should from 'should';
+import * as sinon from 'sinon';
+import * as mssqlVscode from 'vscode-mssql';
+import * as baselines from '../baselines/baselines';
+import * as testUtils from '../testUtils';
+import * as utils from '../../common/utils';
+import * as constants from '../../common/constants';
+
+import { UpdateProjectFromDatabaseWithQuickpick } from '../../dialogs/updateProjectFromDatabaseQuickpick';
+import { UpdateProjectAction } from '../../models/api/updateProject';
+
+describe('Update Project From Database Quickpicks', () => {
+	before(async function (): Promise<void> {
+		await baselines.loadBaselines();
+	});
+
+	afterEach(function (): void {
+		sinon.restore();
+	});
+
+	after(async function (): Promise<void> {
+		await testUtils.deleteGeneratedTestFolder();
+	});
+
+	it('Should build UpdateProjectDataModel when user selects workspace project and Update action', async function (): Promise<void> {
+		// Arrange - create a test project and stub utils & quickpicks
+		const project = await testUtils.createTestProject(this.test, baselines.openProjectFileBaseline);
+		const projectFilePath = project.projectFilePath.toLowerCase();
+
+		// Stub workspace project enumeration to return the created project
+		sinon.stub(utils, 'getSqlProjectsInWorkspace').resolves([vscode.Uri.file(projectFilePath)]);
+
+		// Stub the vscode-mssql API provider used by the quickpick flow
+		const connectionProfile: any = {
+			user: 'user',
+			password: 'pw',
+			server: 'serverName',
+			database: 'TestDB',
+			authenticationType: 'SqlLogin',
+			options: { connectionName: 'MockConnection' }
+		};
+
+		sinon.stub(utils, 'getVscodeMssqlApi').resolves(({
+			promptForConnection: sinon.stub().resolves(connectionProfile),
+			connect: sinon.stub().resolves('MockUri'),
+			listDatabases: sinon.stub().resolves([connectionProfile.database])
+		} as unknown) as mssqlVscode.IExtension);
+
+		// Stub QuickPick flows:
+		// Call 0 -> project selection (workspace project)
+		// Call 1 -> action selection (Update)
+		const showQP = sinon.stub(vscode.window, 'showQuickPick');
+		showQP.onCall(0).resolves(projectFilePath as any);
+		showQP.onCall(1).resolves(constants.updateActionRadioButtonLabel as any);
+
+		// Capture the model produced by the callback
+		let capturedModel: any;
+		const cb = async (m: any): Promise<void> => { capturedModel = m; };
+
+		// Act - pass undefined for projectFilePath to trigger prompt
+		await UpdateProjectFromDatabaseWithQuickpick(undefined, undefined, cb);
+
+		// Assert
+		should(capturedModel).not.be.undefined();
+		should.equal(capturedModel.sourceEndpointInfo.databaseName, connectionProfile.database, 'Source database should match selected database');
+		should.equal(capturedModel.sourceEndpointInfo.serverDisplayName, connectionProfile.server, 'Source server display name should match connection profile server');
+		should.equal(capturedModel.targetEndpointInfo.projectFilePath, projectFilePath, 'Target project file path should be the selected workspace project');
+		should.equal(capturedModel.action, UpdateProjectAction.Update, 'Action should be Update');
+	});
+
+	it('Should not invoke callback when user cancels project selection', async function (): Promise<void> {
+		// Arrange - stub getVscodeMssqlApi to return a profile with a database (so no DB pick)
+		const connectionProfile: any = {
+			user: 'user',
+			password: 'pw',
+			server: 'serverName',
+			database: 'TestDB',
+			authenticationType: 'SqlLogin',
+			options: { connectionName: 'MockConnection' }
+		};
+
+		sinon.stub(utils, 'getVscodeMssqlApi').resolves(({
+			promptForConnection: sinon.stub().resolves(connectionProfile),
+			connect: sinon.stub().resolves('MockUri'),
+			listDatabases: sinon.stub().resolves([connectionProfile.database])
+		} as unknown) as mssqlVscode.IExtension);
+
+		// Workspace may contain projects, but user cancels at project selection
+		sinon.stub(utils, 'getSqlProjectsInWorkspace').resolves([]);
+
+		// Simulate user cancelling project quickpick
+		const showQP = sinon.stub(vscode.window, 'showQuickPick');
+		showQP.onCall(0).resolves(undefined); // user cancels at project selection
+
+		const spyCb = sinon.spy();
+
+		// Act - pass undefined for projectFilePath to trigger prompt
+		await UpdateProjectFromDatabaseWithQuickpick(undefined, undefined, spyCb as any);
+
+		// Assert - callback should not be called
+		should(spyCb.notCalled).be.true();
+	});
+
+	it('Should use provided project file path without prompting when passed as parameter', async function (): Promise<void> {
+		// Arrange - create a test project
+		const project = await testUtils.createTestProject(this.test, baselines.openProjectFileBaseline);
+		const providedProjectPath = project.projectFilePath.toLowerCase();
+
+		// Stub the vscode-mssql API provider
+		const connectionProfile: any = {
+			user: 'user',
+			password: 'pw',
+			server: 'serverName',
+			database: 'TestDB',
+			authenticationType: 'SqlLogin',
+			options: { connectionName: 'MockConnection' }
+		};
+
+		sinon.stub(utils, 'getVscodeMssqlApi').resolves(({
+			promptForConnection: sinon.stub().resolves(connectionProfile),
+			connect: sinon.stub().resolves('MockUri'),
+			listDatabases: sinon.stub().resolves([connectionProfile.database])
+		} as unknown) as mssqlVscode.IExtension);
+
+		// Stub QuickPick - should only be called once for action selection (not for project selection)
+		const showQP = sinon.stub(vscode.window, 'showQuickPick');
+		showQP.onCall(0).resolves(constants.compareActionRadioButtonLabel as any); // Only action selection
+
+		// Spy on getSqlProjectsInWorkspace to ensure it's NOT called when project path is provided
+		const getProjectsSpy = sinon.stub(utils, 'getSqlProjectsInWorkspace');
+
+		// Capture the model produced by the callback
+		let capturedModel: any;
+		const cb = async (m: any): Promise<void> => { capturedModel = m; };
+
+		// Act - pass the project file path as second parameter
+		await UpdateProjectFromDatabaseWithQuickpick(undefined, providedProjectPath, cb);
+
+		// Assert
+		should(capturedModel).not.be.undefined();
+		should.equal(capturedModel.targetEndpointInfo.projectFilePath, providedProjectPath,
+			'Target project file path should be the provided project path, not prompted');
+		should.equal(capturedModel.action, UpdateProjectAction.Compare, 'Action should be Compare');
+
+		// Verify that project selection was skipped
+		should(getProjectsSpy.notCalled).be.true('getSqlProjectsInWorkspace should not be called when project path is provided');
+		should.equal(showQP.callCount, 1, 'QuickPick should only be shown once (for action), not for project selection');
+	});
+
+	it('Should prompt for project when no project file path is provided as parameter', async function (): Promise<void> {
+		// Arrange - create a test project
+		const project = await testUtils.createTestProject(this.test, baselines.openProjectFileBaseline);
+		const workspaceProjectPath = project.projectFilePath.toLowerCase();
+
+		// Stub workspace project enumeration to return the created project
+		sinon.stub(utils, 'getSqlProjectsInWorkspace').resolves([vscode.Uri.file(workspaceProjectPath)]);
+
+		// Stub the vscode-mssql API provider
+		const connectionProfile: any = {
+			user: 'user',
+			password: 'pw',
+			server: 'serverName',
+			database: 'TestDB',
+			authenticationType: 'SqlLogin',
+			options: { connectionName: 'MockConnection' }
+		};
+
+		sinon.stub(utils, 'getVscodeMssqlApi').resolves(({
+			promptForConnection: sinon.stub().resolves(connectionProfile),
+			connect: sinon.stub().resolves('MockUri'),
+			listDatabases: sinon.stub().resolves([connectionProfile.database])
+		} as unknown) as mssqlVscode.IExtension);
+
+		// Stub QuickPick - should be called twice (project selection and action selection)
+		const showQP = sinon.stub(vscode.window, 'showQuickPick');
+		showQP.onCall(0).resolves(workspaceProjectPath as any); // Project selection
+		showQP.onCall(1).resolves(constants.updateActionRadioButtonLabel as any); // Action selection
+
+		// Capture the model produced by the callback
+		let capturedModel: any;
+		const cb = async (m: any): Promise<void> => { capturedModel = m; };
+
+		// Act - pass undefined for project file path to trigger prompt
+		await UpdateProjectFromDatabaseWithQuickpick(undefined, undefined, cb);
+
+		// Assert
+		should(capturedModel).not.be.undefined();
+		should.equal(capturedModel.targetEndpointInfo.projectFilePath, workspaceProjectPath,
+			'Target project file path should be the selected workspace project');
+		should.equal(capturedModel.action, UpdateProjectAction.Update, 'Action should be Update');
+		should.equal(showQP.callCount, 2, 'QuickPick should be shown twice (project and action selection)');
+	});
+});

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -1218,6 +1218,58 @@ describe('ProjectsController', function (): void {
 			should(project.sqlCmdVariables.size).equal(2, 'The project should still have 2 sqlcmd variables');
 			should(project.sqlCmdVariables.get(sqlcmdVarToUpdate.friendlyName)).equal(updatedValue, 'The value of the sqlcmd variable should have been updated');
 		});
+
+		it('Should remove file extensions from user input when creating files', async function (): Promise<void> {
+			const projController = new ProjectsController(testContext.outputChannel);
+			let project = await testUtils.createTestProject(this.test, baselines.newProjectFileBaseline);
+
+			// Test cases for different extension scenarios
+			const testCases = [
+				{ input: 'TableName.sql', expected: 'TableName', extension: constants.sqlFileExtension },
+				{ input: 'TableName.sql.sql', expected: 'TableName.sql', extension: constants.sqlFileExtension },
+				{ input: 'MyTable', expected: 'MyTable', extension: constants.sqlFileExtension }, // no extension
+				{ input: 'MyTable.SQL', expected: 'MyTable', extension: constants.sqlFileExtension }, // uppercase extension
+				{ input: 'MyTable .Sql', expected: 'MyTable', extension: constants.sqlFileExtension }, // mixed case extension
+				{ input: 'PubProfile.publish.xml', expected: 'PubProfile', extension: constants.publishProfileExtension },
+				{ input: 'PubProfile.publish.xml.publish.xml', expected: 'PubProfile.publish.xml', extension: constants.publishProfileExtension }
+			];
+
+			for (const testCase of testCases) {
+				// Mock the user input
+				sinon.stub(vscode.window, 'showInputBox').resolves(testCase.input);
+				sinon.stub(utils, 'sanitizeStringForFilename').returns(testCase.input);
+
+				// Add item to project
+				if (testCase.extension === constants.sqlFileExtension) {
+					await projController.addItemPrompt(project, '', { itemType: ItemType.script });
+				} else {
+					await projController.addItemPrompt(project, '', { itemType: ItemType.publishProfile });
+				}
+
+				// Reload project to get updated state
+				project = await Project.openProject(project.projectFilePath);
+
+				// Find the created file
+				const expectedFileName = `${testCase.expected}${testCase.extension}`;
+
+				// Find the file project entry
+				let fileProjectEntry = project.sqlObjectScripts;
+				if (testCase.extension === constants.publishProfileExtension) {
+					fileProjectEntry = project.publishProfiles;
+				}
+
+				// Get the created file
+				const createdFile = fileProjectEntry.find(f => path.basename(f.relativePath) === expectedFileName);
+
+				// Assert the created file exists
+				should(createdFile).not.be.undefined();
+				should(await utils.exists(path.join(project.projectFolderPath, expectedFileName))).be.true(`File ${expectedFileName} should exist on disk for input ${testCase.input}`);
+
+				// Clean up for next iteration
+				await project.deleteSqlObjectScript(createdFile!.relativePath);
+				sinon.restore();
+			}
+		});
 	});
 });
 

--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import * as should from 'should';
 import * as path from 'path';
+import * as vscodeMssql from 'vscode-mssql';
 import { SqlDatabaseProjectTaskProvider } from '../../tasks/sqlDatabaseProjectTaskProvider';
 
 describe('Sql Database Projects Task Provider', function (): void {
@@ -33,6 +34,19 @@ describe('Sql Database Projects Task Provider', function (): void {
 		sandbox.stub(vscode.workspace, 'findFiles').resolves(sqlProjUri);
 	}
 
+	// Helper to create and stub a mock project
+	function stubProjectOpenWithStyle(projectStyle: vscodeMssql.ProjectType) {
+		const mockProject = {
+			sqlProjStyle: projectStyle,
+			readProjFile: sandbox.stub().resolves()
+		};
+
+		const projectModule = require('../../models/project');
+		sandbox.stub(projectModule.Project, 'openProject').resolves(mockProject);
+
+		return mockProject;
+	}
+
 	beforeEach(() => {
 		// Create a new Sinon sandbox before each test
 		sandbox = sinon.createSandbox();
@@ -45,9 +59,12 @@ describe('Sql Database Projects Task Provider', function (): void {
 		sandbox.restore();
 	});
 
-	it('Should create build and buildWithCodeAnalysis tasks for .sqlproj file with correct properties', async function (): Promise<void> {
+	it('Should create build and buildWithCodeAnalysis tasks for .sqlproj file with correct properties for SDK style project', async function (): Promise<void> {
 		// Define mock .sqlproj file URIs for testing
 		stubWorkspaceAndFiles([sqlProjUris[0]]);
+
+		// Stub the project as SDK style
+		stubProjectOpenWithStyle(vscodeMssql.ProjectType.SdkStyle);
 
 		// Act: create tasks using the provider
 		const tasks = await taskProvider.createTasks();
@@ -93,12 +110,22 @@ describe('Sql Database Projects Task Provider', function (): void {
 			should(buildTask.execution.args).not.be.undefined();
 			should(buildTask.execution.args).be.Array();
 			should(buildTask.execution.args[0]).equal('build');
+
+			const argsString = buildTask.execution.args.join(' ');
+			should(argsString).containEql('/p:NetCoreBuild=true');
+			should(argsString).containEql('/p:SystemDacpacsLocation=');
+			should(argsString).not.containEql('/p:NETCoreTargetsPath='); // This should NOT be present for SDK projects
+			should(argsString).containEql('-v:detailed');
+
 		}
 	});
 
 	it('Should not create any tasks when no .sqlproj files are present in the workspace', async function (): Promise<void> {
 		// Define mock .sqlproj file URIs for testing
 		stubWorkspaceAndFiles([]);
+
+		// Stub the project as SDK style
+		stubProjectOpenWithStyle(vscodeMssql.ProjectType.SdkStyle);
 
 		// Act: Attempt to create tasks using the provider
 		const tasks = await taskProvider.createTasks();
@@ -111,6 +138,9 @@ describe('Sql Database Projects Task Provider', function (): void {
 	it('Should create build and buildWithCodeAnalysis tasks for multiple .sqlproj files with correct properties', async function (): Promise<void> {
 		// Define mock .sqlproj file URIs for testing
 		stubWorkspaceAndFiles(sqlProjUris);
+
+		// Stub the project as SDK style
+		stubProjectOpenWithStyle(vscodeMssql.ProjectType.SdkStyle);
 
 		// Act: create tasks using the provider
 		const tasks = await taskProvider.createTasks();
@@ -158,6 +188,45 @@ describe('Sql Database Projects Task Provider', function (): void {
 				should(buildTask.execution.args).be.Array();
 				should(buildTask.execution.args[0]).equal('build');
 			}
+		}
+	});
+
+	it('Should create tasks with correct build arguments for legacy-style project', async function (): Promise<void> {
+		// Define mock .sqlproj file URIs for testing
+		stubWorkspaceAndFiles([sqlProjUris[0]]);
+
+		// Stub the project as SDK style
+		stubProjectOpenWithStyle(vscodeMssql.ProjectType.LegacyStyle);
+
+		// Act: create tasks using the provider
+		const tasks = await taskProvider.createTasks();
+
+		// Assert: tasks should be defined and have the expected length
+		should(tasks).not.be.undefined();
+		should(tasks).be.Array().and.have.length(2);
+
+		// Find the build task
+		const buildTask = tasks.find(t => t.name === 'ProjectA.sqlproj - Build');
+
+		// Assert: build task should exist
+		should(buildTask).not.be.undefined();
+
+		// Assert: build task execution should contain legacy-style arguments
+		should(buildTask?.execution).not.be.undefined();
+		if (buildTask?.execution instanceof vscode.ShellExecution) {
+			should(buildTask.execution.command).equal('dotnet');
+			should(buildTask.execution.args).not.be.undefined();
+			should(buildTask.execution.args).be.Array();
+
+			// Verify it contains build command
+			should(buildTask.execution.args[0]).equal('build');
+
+			// Verify it contains legacy-style build arguments
+			const argsString = buildTask.execution.args.join(' ');
+			should(argsString).containEql('/p:NetCoreBuild=true');
+			should(argsString).containEql('/p:SystemDacpacsLocation=');
+			should(argsString).containEql('/p:NETCoreTargetsPath='); // This is only for legacy projects
+			should(argsString).containEql('-v:detailed');
 		}
 	});
 });

--- a/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
+++ b/extensions/sql-database-projects/src/test/tasks/sqlDatabaseProjectTaskProvider.test.ts
@@ -115,8 +115,6 @@ describe('Sql Database Projects Task Provider', function (): void {
 			should(argsString).containEql('/p:NetCoreBuild=true');
 			should(argsString).containEql('/p:SystemDacpacsLocation=');
 			should(argsString).not.containEql('/p:NETCoreTargetsPath='); // This should NOT be present for SDK projects
-			should(argsString).containEql('-v:detailed');
-
 		}
 	});
 
@@ -226,7 +224,6 @@ describe('Sql Database Projects Task Provider', function (): void {
 			should(argsString).containEql('/p:NetCoreBuild=true');
 			should(argsString).containEql('/p:SystemDacpacsLocation=');
 			should(argsString).containEql('/p:NETCoreTargetsPath='); // This is only for legacy projects
-			should(argsString).containEql('-v:detailed');
 		}
 	});
 });

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -200,9 +200,6 @@ export class BuildHelper {
 			args.push(`/p:NETCoreTargetsPath=${buildDirPath}`);
 		}
 
-		// Adding verbose flag
-		args.push(constants.detailedVerbose);
-
 		return args;
 	}
 }

--- a/extensions/types/vscode-mssql.d.ts
+++ b/extensions/types/vscode-mssql.d.ts
@@ -425,7 +425,9 @@ declare module 'vscode-mssql' {
 	}
 
 	export interface ISchemaCompareService {
+		compare(operationId: string, sourceEndpointInfo: SchemaCompareEndpointInfo, targetEndpointInfo: SchemaCompareEndpointInfo, taskExecutionMode: TaskExecutionMode, deploymentOptions: DeploymentOptions): Thenable<SchemaCompareResult>;
 		schemaCompareGetDefaultOptions(): Thenable<SchemaCompareOptionsResult>;
+		publishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: ExtractTarget, taskExecutionMode: TaskExecutionMode): Thenable<SchemaComparePublishProjectResult>;
 	}
 
 	export interface IDacFxService {
@@ -1144,6 +1146,65 @@ declare module 'vscode-mssql' {
 
 	export interface SchemaCompareOptionsResult extends ResultStatus {
 		defaultDeploymentOptions: DeploymentOptions;
+	}
+
+	export interface SchemaCompareResult extends ResultStatus {
+		operationId: string;
+		areEqual: boolean;
+		differences: DiffEntry[];
+	}
+
+	export interface DiffEntry {
+		updateAction: SchemaUpdateAction;
+		differenceType: SchemaDifferenceType;
+		name: string;
+		sourceValue: string[];
+		targetValue: string[];
+		parent: DiffEntry;
+		children: DiffEntry[];
+		sourceScript: string;
+		targetScript: string;
+		included: boolean;
+	}
+
+	export const enum SchemaUpdateAction {
+		Delete = 0,
+		Change = 1,
+		Add = 2
+	}
+
+	export const enum SchemaDifferenceType {
+		Object = 0,
+		Property = 1
+	}
+
+	export const enum SchemaCompareEndpointType {
+		Database = 0,
+		Dacpac = 1,
+		Project = 2,
+		// must be kept in-sync with SchemaCompareEndpointType in SQL Tools Service
+		// located at \src\Microsoft.SqlTools.ServiceLayer\SchemaCompare\Contracts\SchemaCompareRequest.cs
+	}
+
+	export interface SchemaCompareEndpointInfo {
+		endpointType: SchemaCompareEndpointType;
+		packageFilePath: string;
+		serverDisplayName: string;
+		serverName: string;
+		databaseName: string;
+		ownerUri: string;
+		connectionDetails: ConnectionDetails;
+		connectionName?: string;
+		projectFilePath: string;
+		targetScripts: string[];
+		extractTarget: ExtractTarget;
+		dataSchemaProvider: string;
+	}
+
+	export interface SchemaComparePublishProjectResult extends ResultStatus {
+		changedFiles: string[];
+		addedFiles: string[];
+		deletedFiles: string[];
 	}
 
 	export interface SavePublishProfileParams {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azuredatastudio",
-  "version": "1.53.0",
+  "version": "1.52.0",
   "distro": "46a82de8b3a0078fb54585b264fdd6fe9e41d33b",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description
This pull request removes the use of the detailed verbose flag from the SQL project build process. The change simplifies the build command by no longer including the -v:detailed flag when constructing build arguments. Having the verbose param generated huge dotnet build output that overruns the scroll limit. This issue is causing when user have the .NET 8 or below SDK versions only, with sdk9, the output is few lines only.

Build process simplification:
- Removed the detailedVerbose constant from constants.ts, eliminating the -v:detailed flag.
- Updated the BuildHelper class in buildHelper.ts to stop adding the verbose flag to build arguments.
- Updated the tests

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
