### PR TITLE
VBump SDK to 2.0 and ScriptDom to 170

### DIFF
--- a/extensions/sql-database-projects/README.md
+++ b/extensions/sql-database-projects/README.md
@@ -53,7 +53,7 @@ The extension will prompt to install the [.NET SDK](https://aka.ms/sqlprojects-d
 ### General Settings
 
 - `sqlDatabaseProjects.dotnetSDK Location`: The path to the folder containing the `dotnet` folder for the .NET SDK. If not set, the extension will attempt to find the .NET SDK on the system.
-- `sqlDatabaseProjects.microsoftBuildSqlVersion`: Version of Microsoft.Build.Sql binaries used when building SQL projects that are not SDK-style SQL projects. If not set, the extension will use Microsoft.Build.Sql 1.0.0.
+- `sqlDatabaseProjects.microsoftBuildSqlVersion`: Version of Microsoft.Build.Sql binaries used when building SQL projects that are not SDK-style SQL projects. If not set, the extension will use Microsoft.Build.Sql 2.0.0.
 - `sqlDatabaseProjects.netCoreDoNotAsk`: When true, no longer prompts to install .NET SDK when a supported installation is not found.
 - `sqlDatabaseProjects.collapseProjectNodes`: Option to set the default state of the project nodes in the database projects view to collapsed. If not set, the extension will default to expanded.
 

--- a/extensions/sql-database-projects/resources/templates/newSdkSqlProjectTemplate.xml
+++ b/extensions/sql-database-projects/resources/templates/newSdkSqlProjectTemplate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <Sdk Name="Microsoft.Build.Sql" Version="2.0.0" />
   <PropertyGroup>
     <Name>@@PROJECT_NAME@@</Name>
     <ProjectGuid>{@@PROJECT_GUID@@}</ProjectGuid>

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -202,7 +202,8 @@ export class ProjectsController {
 		let result: azdataType.ResultStatus | mssqlVscode.ResultStatus;
 
 		const sqlProjectsService = await utils.getSqlProjectsService();
-		const microsoftBuildSqlSDKStyleDefaultVersion = '1.0.0'; // default version of Microsoft.Build.Sql for SDK style projects, update in README when updating this
+		// default version of Microsoft.Build.Sql for SDK style projects, update in README when updating this, and buildHelper.cs for legacy projects SDK support
+		const microsoftBuildSqlSDKStyleDefaultVersion = '2.0.0';
 		if (utils.getAzdataApi()) {
 			const projectStyle = creationParams.sdkStyle ? mssql.ProjectType.SdkStyle : mssql.ProjectType.LegacyStyle;
 			result = await (sqlProjectsService as mssql.ISqlProjectsService).createProject(newProjFilePath, projectStyle, targetPlatform, microsoftBuildSqlSDKStyleDefaultVersion);

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -56,7 +56,7 @@ export class BuildHelper {
 
 	public async ensureDacFxDllsPresence(outputChannel: vscode.OutputChannel): Promise<boolean> {
 		const sdkName = 'Microsoft.Build.Sql';
-		const microsoftBuildSqlDefaultVersion = '1.0.0'; // default version of Microsoft.Build.Sql nuget to use for building legacy style projects, update in README when updating this
+		const microsoftBuildSqlDefaultVersion = '2.0.0'; // default version of Microsoft.Build.Sql nuget to use for building legacy style projects, update in README when updating this
 
 		const dacFxBuildFiles: string[] = [
 			'Microsoft.Data.SqlClient.dll',
@@ -83,7 +83,7 @@ export class BuildHelper {
 	public async ensureScriptDomDllPresence(outputChannel: vscode.OutputChannel): Promise<boolean> {
 		const scriptdomNugetPkgName = 'Microsoft.SqlServer.TransactSql.ScriptDom';
 		const scriptDomDll = 'Microsoft.SqlServer.TransactSql.ScriptDom.dll';
-		const scriptDomNugetVersion = '161.9142.1'; // TODO: make this a configurable setting, like the Microsoft.Build.Sql version
+		const scriptDomNugetVersion = '170.128.0'; // TODO: make this a configurable setting, like the Microsoft.Build.Sql version
 		const scriptDomDllLocation = path.join('lib', 'netstandard2.1');
 
 		return this.ensureNugetAndFilesPresence(scriptdomNugetPkgName, scriptDomNugetVersion, [scriptDomDll], scriptDomDllLocation, outputChannel);


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description

This PR updates the versions for the below packages
Microsoft.Build.Sql - 2.0.0
Microsoft.SqlServer.TransactSql.ScriptDom - 170.128.0

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)
